### PR TITLE
Chore: Remove concurrent contract compilation

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -5,7 +5,7 @@ compile:
 	npx hardhat run scripts/hardhat/postCompile.ts
 
 force-compile:
-	npx hardhat compile --concurrency 4 --force
+	npx hardhat compile --force
 	npx hardhat run scripts/hardhat/postCompile.ts
 
 clean:

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -5,7 +5,7 @@
     "pnpm": ">=9"
   },
   "scripts": {
-    "build": "npx hardhat compile --concurrency 4",
+    "build": "npx hardhat compile",
     "test": "npm run autoupdate && npx hardhat test",
     "test:reportgas": "REPORT_GAS=true npx hardhat test",
     "coverage": "npm run autoupdate && npx hardhat coverage --solcoverjs ./.solcover.js",


### PR DESCRIPTION
This PR removes the concurrent compilation of contracts as it looks like there is some intermittent file locking or partial file creation and usage in the CI.

```
 MalformedAbiError: Not a json
      at extractAbi (/home/runner/work/linea-monorepo/linea-monorepo/node_modules/.pnpm/typechain@8.3.2_typescript@5.5.4/node_modules/typechain/src/parser/abiParser.ts:362:11)
      at /home/runner/work/linea-monorepo/linea-monorepo/node_modules/.pnpm/typechain@8.3.2_typescript@5.5.4/node_modules/typechain/src/typechain/io.ts:45:31
      at Array.filter (<anonymous>)

```
      
### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.