### PR TITLE
chore: disable gosec G115 int->uint conversion check

### DIFF
--- a/prover/.golangci.yml
+++ b/prover/.golangci.yml
@@ -31,3 +31,6 @@ linters-settings:
       - all
       - '-SA1019' # disable the rule against deprecated code
       - '-SA1006'
+  gosec:
+    excludes:
+      - G115 # Conversions from int -> uint etc


### PR DESCRIPTION
With updating golangci-lint to 1.61, it added new rule where int->uint conversions have to be explicitly checked. Currently they are false positives. The errors were:
```
::high file=prover/zkevm/prover/hash/keccak/base_conversion/lookups.go,line=49,col=40::G115: integer overflow conversion int -> uint64 (gosec)
  ::high file=prover/zkevm/prover/hash/keccak/base_conversion/lookups.go,line=64,col=31::G115: integer overflow conversion int -> uint64 (gosec)
  ::high file=prover/crypto/vortex/gnark_test.go,line=64,col=27::G115: integer overflow conversion int -> uint64 (gosec)
  ::high file=prover/zkevm/prover/hash/importpad/common.go,line=18,col=15::G115: integer overflow conversion int -> uint (gosec)
  ::high file=prover/circuits/blobdecompression/v0/compress/internal/io.go,line=128,col=[33](https://github.com/Consensys/linea-monorepo/actions/runs/10847901193/job/30103978328?pr=33#step:6:35)::G115: integer overflow conversion int -> uint (gosec)
  ::high file=prover/circuits/blobdecompression/v0/compress/internal/io.go,line=138,col=18::G115: integer overflow conversion int -> uint (gosec)
  ::high file=prover/backend/aggregation/craft.go,line=96,col=41::G115: integer overflow conversion int64 -> uint (gosec)
  ::high file=prover/utils/types/common.go,line=38,col=45::G115: integer overflow conversion int64 -> uint64 (gosec)
  ::high file=prover/crypto/ringsis/templates/generator.go,line=81,col=47::G115: integer overflow conversion int64 -> uint64 (gosec)
  ::high file=prover/zkevm/prover/statemanager/accumulator/assign.go,line=425,col=[36](https://github.com/Consensys/linea-monorepo/actions/runs/10847901193/job/30103978328?pr=33#step:6:38)::G115: integer overflow conversion int64 -> uint64 (gosec)
```

This is required to make staticcheck CI pass.

### Checklist

* [x] I have successfully ran tests, style checker and build against my new changes locally.
