### PR TITLE
Prover: fix type mismatch in TestOpBasicEdgeCases

### DIFF
--- a/prover/maths/common/smartvectors/arithmetic_test.go
+++ b/prover/maths/common/smartvectors/arithmetic_test.go
@@ -242,7 +242,6 @@ func TestOpBasicEdgeCases(t *testing.T) {
 	}
 }
 
-
 func TestInnerProduct(t *testing.T) {
 	testCases := []struct {
 		a, b SmartVector

--- a/prover/maths/common/smartvectors/arithmetic_test.go
+++ b/prover/maths/common/smartvectors/arithmetic_test.go
@@ -237,10 +237,11 @@ func TestOpBasicEdgeCases(t *testing.T) {
 		t.Run(fmt.Sprintf("case-%v", i), func(t *testing.T) {
 			t.Logf("test-case details: %v", testCase.explainer)
 			res := testCase.fn(testCase.inputs...).(*Pooled)
-			require.Equal(t, testCase.expectedRes, res.Regular, "expectedRes=%v\nres=%v", testCase.expectedRes.Pretty(), res.Pretty())
+			require.Equal(t, testCase.expectedRes, &res.Regular, "expectedRes=%v\nres=%v", testCase.expectedRes.Pretty(), res.Pretty())
 		})
 	}
 }
+
 
 func TestInnerProduct(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
This PR fixes a failing prover CI caused by a type mismatch in the TestOpBasicEdgeCases test.

```
# smartvectors % go test -run ^TestOpBasicEdgeCases 
PASS
ok      github.com/consensys/linea-monorepo/prover/maths/common/smartvectors    0.273s
```

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.