### PR TITLE
chore: improve go-corset error code 77 visibility

### DIFF
--- a/prover/zkevm/arithmetization/assignment.go
+++ b/prover/zkevm/arithmetization/assignment.go
@@ -47,6 +47,7 @@ func AssignFromLtTraces(run *wizard.ProverRuntime, schema *air.Schema, expTraces
 	}
 
 	if err77 != nil {
+		logrus.Errorf("Error code 77: \n%v", err77)
 		os.Exit(TraceOverflowExitCode)
 	}
 


### PR DESCRIPTION
This PR prints out the missing code 77 error messages before os.Exit() to improve error visibility.

before this PR:
```
INFO[0157] module utilization module=add height=349814 limit=1048576 ratio=0.33360862731933594 
ERRO[0157] module utilization module=bin height=611820 limit=524288 ratio=1.1669540405273438 
INFO[0157] module utilization module=binreftable height=196875 limit=262144 ratio=0.7510185241699219 
INFO[0157] module utilization module=blake2fmodexpdata height=11 limit=32768 ratio=0.000335693359375 
...
ERRO[0157] module utilization module=stp height=70123 limit=65536 ratio=1.0699920654296875 
INFO[0157] module utilization module=trm height=14747 limit=65536 ratio=0.2250213623046875 
INFO[0157] module utilization module=txndata height=12207 limit=65536 ratio=0.1862640380859375 
INFO[0157] module utilization module=wcp height=853796 limit=1048576 ratio=0.8142433166503906 
```

after this PR:
```
INFO[0157] module utilization module=add height=349814 limit=1048576 ratio=0.33360862731933594 
ERRO[0157] module utilization module=bin height=611820 limit=524288 ratio=1.1669540405273438 
INFO[0157] module utilization module=binreftable height=196875 limit=262144 ratio=0.7510185241699219 
INFO[0157] module utilization module=blake2fmodexpdata height=11 limit=32768 ratio=0.000335693359375 
...
ERRO[0157] module utilization module=stp height=70123 limit=65536 ratio=1.0699920654296875 
INFO[0157] module utilization module=trm height=14747 limit=65536 ratio=0.2250213623046875 
INFO[0157] module utilization module=txndata height=12207 limit=65536 ratio=0.1862640380859375 
INFO[0157] module utilization module=wcp height=853796 limit=1048576 ratio=0.8142433166503906 
ERRO[0157] Error code 77: 
limit overflow: module "bin" overflows its limit height=611820 limit=524288 ratio=1.1669540405273438
limit overflow: module "mod" overflows its limit height=344004 limit=262144 ratio=1.3122711181640625
limit overflow: module "oob" overflows its limit height=1373579 limit=1048576 ratio=1.3099470138549805
limit overflow: module "stp" overflows its limit height=70123 limit=65536 ratio=1.0699920654296875 
```

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.