### PR TITLE
fixed newHash assignment

### DIFF
--- a/prover/zkevm/prover/ecdsa/antichamber_test.go
+++ b/prover/zkevm/prover/ecdsa/antichamber_test.go
@@ -167,5 +167,5 @@ func generateDeterministicSignature(txHash []byte) (pk *ecdsa.PublicKey, r, s, v
 
 var testCaseAntiChamber = makeTestCase{
 	HashNum: []int{1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2},
-	ToHash:  []int{1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1},
+	ToHash:  []int{1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1},
 }

--- a/prover/zkevm/prover/hash/generic/gen_byte_module.go
+++ b/prover/zkevm/prover/hash/generic/gen_byte_module.go
@@ -46,6 +46,7 @@ func (gdm *GenDataModule) ScanStreams(run *wizard.ProverRuntime) [][]byte {
 
 	var (
 		numRow      = gdm.Limb.Size()
+		index       = gdm.Index.GetColAssignment(run).IntoRegVecSaveAlloc()
 		limbs       = gdm.Limb.GetColAssignment(run).IntoRegVecSaveAlloc()
 		toHash      = gdm.ToHash.GetColAssignment(run).IntoRegVecSaveAlloc()
 		hashNum     = gdm.HashNum.GetColAssignment(run).IntoRegVecSaveAlloc()
@@ -61,7 +62,7 @@ func (gdm *GenDataModule) ScanStreams(run *wizard.ProverRuntime) [][]byte {
 			continue
 		}
 
-		if hashNum[row] != currHashNum {
+		if index[row].IsZero() {
 			if !currHashNum.IsZero() {
 				streams = append(streams, buffer.Bytes())
 				buffer = &bytes.Buffer{}

--- a/prover/zkevm/prover/hash/generic/gen_byte_module_test.go
+++ b/prover/zkevm/prover/hash/generic/gen_byte_module_test.go
@@ -32,6 +32,7 @@ func TestScanByteStream(t *testing.T) {
 			Limb:    build.RegisterCommit("B", 32),
 			ToHash:  build.RegisterCommit("C", 32),
 			NBytes:  build.RegisterCommit("D", 32),
+			Index:   build.RegisterCommit("E", 32),
 		}
 	})
 
@@ -57,9 +58,11 @@ func assignGdbFromStream(run *wizard.ProverRuntime, gdm *GenDataModule, stream [
 		hashNum = common.NewVectorBuilder(gdm.HashNum)
 		nbBytes = common.NewVectorBuilder(gdm.NBytes)
 		toHash  = common.NewVectorBuilder(gdm.ToHash)
+		index   = common.NewVectorBuilder(gdm.Index)
 	)
 
 	for hashID := range stream {
+		ctr := 0
 
 		currStream := stream[hashID]
 		for i := 0; i < len(currStream); i += 2 {
@@ -73,8 +76,10 @@ func assignGdbFromStream(run *wizard.ProverRuntime, gdm *GenDataModule, stream [
 			copy(currLimbLA[16:], currLimb[:currNbBytes])
 			limbs.PushLo(currLimbLA)
 			hashNum.PushInt(hashID + 1)
+			index.PushInt(ctr)
 			nbBytes.PushInt(currNbBytes)
 			toHash.PushOne()
+			ctr++
 		}
 
 	}
@@ -83,4 +88,5 @@ func assignGdbFromStream(run *wizard.ProverRuntime, gdm *GenDataModule, stream [
 	hashNum.PadAndAssign(run, field.Zero())
 	nbBytes.PadAndAssign(run, field.Zero())
 	toHash.PadAndAssign(run, field.Zero())
+	index.PadAndAssign(run)
 }

--- a/prover/zkevm/prover/hash/importpad/import_pad.go
+++ b/prover/zkevm/prover/hash/importpad/import_pad.go
@@ -251,11 +251,11 @@ func (imp *importation) Run(run *wizard.ProverRuntime) {
 
 		sha2Count++
 
-		if i > 0 && currHashNum != hashNum[i] && !currHashNum.IsZero() {
+		if i > 0 && index[i].IsZero() && !currHashNum.IsZero() {
 			imp.padder.pushPaddingRows(currByteSize, &iab)
 		}
 
-		if currHashNum != hashNum[i] {
+		if index[i].IsZero() {
 			currHashNum = hashNum[i]
 			currByteSize = 0
 			iab.IsNewHash.PushOne()

--- a/prover/zkevm/prover/hash/importpad/import_pad_test.go
+++ b/prover/zkevm/prover/hash/importpad/import_pad_test.go
@@ -114,6 +114,7 @@ func checkPaddingAssignment(t *testing.T, run *wizard.ProverRuntime, paddingFunc
 			Limb:    mod.Limbs,
 			NBytes:  mod.NBytes,
 			ToHash:  mod.IsActive,
+			Index:   mod.Index,
 		}
 
 		inputStreams        = mod.Inputs.Src.Data.ScanStreams(run)

--- a/prover/zkevm/prover/hash/keccak/keccak_zkevm_test.go
+++ b/prover/zkevm/prover/hash/keccak/keccak_zkevm_test.go
@@ -73,11 +73,11 @@ var testCasesGBMMultiProvider = []makeTestCaseGBM{
 	{
 		Name:     "GenDataModule1",
 		SizeData: 8,
-		HashNum:  []int{1, 1, 1, 1, 2},
-		ToHash:   []int{1, 0, 1, 0, 1},
+		HashNum:  []int{1, 1, 1, 1},
+		ToHash:   []int{1, 0, 1, 0},
 		SizeInfo: 4,
-		IsHashHi: []int{0, 1, 0, 1}, // # ones = number of hash from above
-		IsHashLo: []int{1, 0, 0, 1},
+		IsHashHi: []int{0, 1, 0, 0}, // # ones = number of hash from above
+		IsHashLo: []int{1, 0, 0, 0},
 	},
 	{
 		Name:     "GenDataModule2",


### PR DESCRIPTION
This PR fixes the bug in the padding module. On the prover side, the NewHash Column should be assigned based on the index column. When the index becomes zero a newHash is launched. In the previous implementation, NewHash was assigned via HashNum which was not correct. Due to the required change, some testes are not passing since they have empty or incorrect indexes. these tests are also fixed. 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.