### PR TITLE
fix: add binary constraints for accumulators first lines

### DIFF
--- a/prover/zkevm/prover/ecpair/ecpair_constraints.go
+++ b/prover/zkevm/prover/ecpair/ecpair_constraints.go
@@ -29,6 +29,8 @@ func (ec *ECPair) csBinaryConstraints(comp *wizard.CompiledIOP) {
 	common.MustBeBinary(comp, ec.UnalignedG2MembershipData.IsPulling)
 	common.MustBeBinary(comp, ec.UnalignedG2MembershipData.IsComputed)
 	common.MustBeBinary(comp, ec.UnalignedG2MembershipData.ToG2MembershipCircuitMask)
+	common.MustBeBinary(comp, ec.UnalignedPairingData.IsFirstLineOfPrevAccumulator)
+	common.MustBeBinary(comp, ec.UnalignedPairingData.IsFirstLineOfCurrAccumulator)
 }
 
 func (ec *ECPair) csFlagConsistency(comp *wizard.CompiledIOP) {


### PR DESCRIPTION
This PR fixes LA audit report Issue I.

In the ECPair module we have a column indicating if the current limb is the first line of the current or previous accumulator. As this is natively a boolean condition then we need to enforce it as a constraint to ensure the soundness in case of malicious prover.

Depends on #172. That one needs to be merged first and then the base branch of this one update to main.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.