### PR TITLE
smart-contract V6 review small tweaks

### DIFF
--- a/contracts/contracts/LineaRollup.sol
+++ b/contracts/contracts/LineaRollup.sol
@@ -224,7 +224,6 @@ contract LineaRollup is
 
     bytes32 currentDataEvaluationPoint;
     bytes32 currentDataHash;
-    uint256 lastFinalizedBlockNumber = currentL2BlockNumber;
 
     /// @dev Assigning in memory saves a lot of gas vs. calldata reading.
     BlobSubmissionData memory blobSubmissionData;
@@ -233,10 +232,10 @@ contract LineaRollup is
 
     uint256 blobFinalBlockNumber = shnarfFinalBlockNumbers[computedShnarf];
 
-    if (_blobSubmissionData[0].submissionData.firstBlockInData <= lastFinalizedBlockNumber) {
+    if (_blobSubmissionData[0].submissionData.firstBlockInData <= currentL2BlockNumber) {
       revert FirstBlockLessThanOrEqualToLastFinalizedBlock(
         _blobSubmissionData[0].submissionData.firstBlockInData,
-        lastFinalizedBlockNumber
+        currentL2BlockNumber
       );
     }
 

--- a/contracts/contracts/LineaRollup.sol
+++ b/contracts/contracts/LineaRollup.sol
@@ -230,11 +230,12 @@ contract LineaRollup is
 
     bytes32 computedShnarf = _parentShnarf;
 
+    uint256 blobFirstBlockNumber = _blobSubmissionData[0].submissionData.firstBlockInData;
     uint256 blobFinalBlockNumber = shnarfFinalBlockNumbers[computedShnarf];
 
-    if (_blobSubmissionData[0].submissionData.firstBlockInData <= currentL2BlockNumber) {
+    if (blobFirstBlockNumber <= currentL2BlockNumber) {
       revert FirstBlockLessThanOrEqualToLastFinalizedBlock(
-        _blobSubmissionData[0].submissionData.firstBlockInData,
+        blobFirstBlockNumber,
         currentL2BlockNumber
       );
     }
@@ -288,7 +289,7 @@ contract LineaRollup is
     shnarfFinalBlockNumbers[computedShnarf] = blobFinalBlockNumber;
 
     emit DataSubmittedV3(
-      _blobSubmissionData[0].submissionData.firstBlockInData,
+      blobFirstBlockNumber,
       blobFinalBlockNumber,
       _parentShnarf,
       computedShnarf,

--- a/contracts/contracts/interfaces/l1/ILineaRollup.sol
+++ b/contracts/contracts/interfaces/l1/ILineaRollup.sol
@@ -172,15 +172,15 @@ interface ILineaRollup {
   /**
    * @notice Emitted when compressed data is being submitted and verified succesfully on L1.
    * @dev The block range is indexed and parent shnarf included for state reconstruction simplicity.
-   * @param startBlock The indexed L2 block number indicating which block the data starts from.
-   * @param endBlock The indexed L2 block number indicating which block the data ends on.
+   * @param startBlockNumber The indexed L2 block number indicating which block the data starts from.
+   * @param endBlockNumber The indexed L2 block number indicating which block the data ends on.
    * @param parentShnarf The parent shnarf for the data being submitted.
    * @param shnarf The indexed shnarf for the data being submitted.
    * @param finalStateRootHash The L2 state root hash that the current blob submission ends on. NB: The last blob in the collection.
    */
   event DataSubmittedV3(
-    uint256 indexed startBlock,
-    uint256 indexed endBlock,
+    uint256 indexed startBlockNumber,
+    uint256 indexed endBlockNumber,
     bytes32 parentShnarf,
     bytes32 indexed shnarf,
     bytes32 finalStateRootHash


### PR DESCRIPTION
This PR
- improves DataSubmittedV3 names consistency,
- tries blob/data submission validation more efficient

Since we are making a change & audit, maybe it's a good opportunity to assess the following points

# Other Improvement Suggestions

## Blob Submission

#### Current Interface
```solidity
  function submitBlobs(
    BlobSubmissionData[] calldata _blobSubmissionData,
    bytes32 _parentShnarf,
    bytes32 _finalBlobShnarf
  ) external;

  struct BlobSubmissionData {
    SupportingSubmissionDataV2 submissionData;
    uint256 dataEvaluationClaim;
    bytes kzgCommitment;
    bytes kzgProof;
  }

  struct SupportingSubmissionDataV2 {
    bytes32 finalStateRootHash;
    uint256 firstBlockInData;
    uint256 finalBlockInData;
    bytes32 snarkHash;
  }
```

The list of SupportingSubmissionDataV2 has redundant fields (first/final)BlockInData, because `_blobSubmissionData[i].subissionData.firstBlockInData` must be equal to its ancestor `_blobSubmissionData[i-1].subissionData.finalBlockInData`; 
We can keep just finalBlockInData and pass only firstBlockInData for the first bock in `submitBlobs(..)`. SupportingSubmissionDataV2’s fields can be included in the parent struct BlobSubmissionData. 

This simplification will:

- allow to remove SupportingSubmissionDataV2 struct, which is sometimes confused with `SubmissionDataV2` struct used for blob submission as call data;
- save gas on call data by not sending redundant fields;
- simplify input validation code `_validateSubmissionData`, potentially saving more gas;

#### New Interface Suggestion
```solidity 
function submitBlobs(
  BlobSubmissionData[] calldata _blobSubmissionData,
  uint256 firstBlockInData;
  bytes32 _parentShnarf,
  bytes32 _finalBlobShnarf
) external;

struct BlobSubmissionDataV2 { 
  uint256 finalBlockInData;
  bytes32 finalStateRootHash;
  bytes32 snarkHash;
  uint256 dataEvaluationClaim;
  bytes kzgCommitment;
  bytes kzgProof;
}
```


## Block Finalization
`_computeLastFinalizedState` relies on "timestamp The final timestamp in the finalization.",  should it use finalStateRootHash? Sequencer(s) can have different blocks at same timestamp.
