### PR TITLE
Standardize terminology in contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you already have an understanding of the tech stack, use our [Get Started](do
 
 Linea's stack is made up of multiple repositories, these include:
 
-- This repo, [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network
+- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network
 - [linea-besu](https://github.com/Consensys/linea-besu): Fork of Besu to implement the Linea-Besu client
 - [linea-sequencer](https://github.com/Consensys/linea-sequencer): A set of Linea-Besu plugins for the sequencer and RPC nodes
 - [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover


### PR DESCRIPTION
This pull request addresses issue #254 by removing the informal term "repo" from the contribution guidelines. This change aligns the language with the use of "repository" throughout the document, enhancing consistency and professionalism.

### Changes Made:
- Removed the term "repo" to ensure all references are consistently "repository."

This improves the clarity and uniformity of the documentation.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.