### PR TITLE
fix don't assume zero-padded lanes

### DIFF
--- a/prover/circuits/pi-interconnection/keccak/snark.go
+++ b/prover/circuits/pi-interconnection/keccak/snark.go
@@ -2,6 +2,7 @@ package keccak
 
 import (
 	"errors"
+	"github.com/consensys/linea-monorepo/prover/circuits/internal"
 	"math/big"
 
 	"github.com/consensys/gnark/frontend"
@@ -264,15 +265,9 @@ func pad(api frontend.API, inputLanes []frontend.Variable, length frontend.Varia
 	}
 
 	//inInputRange := frontend.Variable(1)
+	inputRange := internal.NewRange(api, length, len(lanes))
 	for i := range lanes {
-
-		iEqualsLen := api.IsZero(api.Sub(length, i))
-
-		/*inInputRange = api.Sub(inInputRange, iEqualsLen)
-
-		lanes[i] = api.Mul(inInputRange, lanes[i]) // technically unnecessary if we say input must be zero-padded */
-
-		lanes[i] = api.Add(lanes[i], api.Mul(dstLane, iEqualsLen)) // first padding byte contribution
+		lanes[i] = api.Add(api.Mul(lanes[i], inputRange.InRange[i]), api.Mul(dstLane, inputRange.IsFirstBeyond[i])) // first padding byte contribution
 
 		if i%lanesPerBlock == lanesPerBlock-1 { // if it's the last byte of ANY block
 			isLastBlock := api.IsZero(api.Sub(i+1, api.Mul(nbBlocks, lanesPerBlock))) // TODO check the slice to IsZero involves one constraint only

--- a/prover/circuits/pi-interconnection/keccak/snark_test.go
+++ b/prover/circuits/pi-interconnection/keccak/snark_test.go
@@ -2,6 +2,7 @@ package keccak
 
 import (
 	"fmt"
+	"github.com/consensys/linea-monorepo/prover/circuits/internal/test_utils"
 	"math/big"
 	"testing"
 
@@ -302,4 +303,11 @@ func (c *testCreateColsBoundaryChecks) Define(api frontend.API) error {
 
 	hsh.createColumns()
 	return nil
+}
+
+func TestPadDirtyLanes(t *testing.T) {
+	test_utils.SnarkFunctionTest(func(api frontend.API) []frontend.Variable {
+		padded, _ := pad(api, []frontend.Variable{1, 0x123456}, 1)
+		return padded
+	}, 1, 0x100000000000000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80)(t)
 }


### PR DESCRIPTION
This PR fixes a bug in the interconnection circuit caused by the Keccak wrapper's naive assumption that input lanes are padded "cleanly", i.e. equal to zero past their actual lengths.