### PR TITLE
Verifying Keys in aggregation manifest

### DIFF
--- a/prover/circuits/aggregation/prover.go
+++ b/prover/circuits/aggregation/prover.go
@@ -16,6 +16,7 @@ import (
 // corresponding proof.
 func MakeProof(
 	setup *circuits.Setup,
+	allowedVks []plonk.VerifyingKey, // optional parameter for debugging; safe to supply nil
 	maxNbProof int,
 	proofClaims []ProofClaimAssignment,
 	piInfo PiInfo,
@@ -32,6 +33,14 @@ func MakeProof(
 		piInfo,
 		publicInput,
 	)
+
+	assignment.verifyingKeys = make([]emVkey, len(allowedVks))
+	for i := range allowedVks {
+		var err error
+		if assignment.verifyingKeys[i], err = emPlonk.ValueOfVerifyingKey[emFr, emG1, emG2](allowedVks[i]); err != nil {
+			return nil, fmt.Errorf("while converting the verifying key #%v: %w", i, err)
+		}
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("while generating the aggregation circuit assignment: %w", err)

--- a/prover/integration/circuit-testing/aggregation/main.go
+++ b/prover/integration/circuit-testing/aggregation/main.go
@@ -164,7 +164,7 @@ func main() {
 		// Assigning the BW6 circuit
 		logrus.Infof("Generating the aggregation proof for arity %v", nc)
 
-		bw6Proof, err := aggregation.MakeProof(&ppBw6, nc, innerProofClaims, piInfo, aggregationPI)
+		bw6Proof, err := aggregation.MakeProof(&ppBw6, nil, nc, innerProofClaims, piInfo, aggregationPI)
 		assert.NoError(t, err)
 
 		bw6Proofs = append(bw6Proofs, bw6Proof)


### PR DESCRIPTION
For debugging, the `ProveCheck` method runs the gnark test engine if proof generation fails. This does not currently work well for aggregation, as the verifying keys are embedded in the constraints and are not an input to the circuit. Thus to reconstruct the circuit object correctly for the test engine, we need to store the entirety of the aggregating verifying keys, not only their checksums.