### PR TITLE
[Fix] Use 0x20 vs. 32 for memory offset

### DIFF
--- a/contracts/contracts/LineaRollup.sol
+++ b/contracts/contracts/LineaRollup.sol
@@ -412,7 +412,7 @@ contract LineaRollup is
     uint256 fieldElements;
     uint256 blsCurveModulus;
     assembly {
-      fieldElements := mload(add(returnData, 32))
+      fieldElements := mload(add(returnData, 0x20))
       blsCurveModulus := mload(add(returnData, POINT_EVALUATION_RETURN_DATA_LENGTH))
     }
     if (fieldElements != POINT_EVALUATION_FIELD_ELEMENTS_LENGTH || blsCurveModulus != BLS_CURVE_MODULUS) {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.