### PR TITLE
Chore: fix staticcheck `prealloc` complaints

### DIFF
--- a/prover/circuits/aggregation/circuit_test.go
+++ b/prover/circuits/aggregation/circuit_test.go
@@ -96,9 +96,9 @@ func testAggregation(t *testing.T, nCircuits int, ncs ...int) {
 	}
 
 	// This collects the verifying keys from the public parameters
-	var vkeys []plonk.VerifyingKey
-	for _, setup := range innerSetups {
-		vkeys = append(vkeys, setup.VerifyingKey)
+	vkeys := make([]plonk.VerifyingKey, len(innerSetups))
+	for i := range innerSetups {
+		vkeys[i] = innerSetups[i].VerifyingKey
 	}
 
 	aggregationPIBytes := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}

--- a/prover/zkevm/prover/hash/keccak/keccak_zkevm.go
+++ b/prover/zkevm/prover/hash/keccak/keccak_zkevm.go
@@ -35,37 +35,31 @@ func NewKeccakZkEVM(comp *wizard.CompiledIOP, settings Settings, providersFromEc
 func newKeccakZkEvm(comp *wizard.CompiledIOP, settings Settings, providers []generic.GenericByteModule) *KeccakZkEVM {
 
 	// create the list of  [generic.GenDataModule] and [generic.GenInfoModule]
-	var (
-		gdm []generic.GenDataModule
-		gim []generic.GenInfoModule
-	)
 
-	for i := range providers {
-		gdm = append(gdm, providers[i].Data)
-		gim = append(gim, providers[i].Info)
+	inpAcc := gen_acc.GenericAccumulatorInputs{
+		MaxNumKeccakF: settings.MaxNumKeccakf,
+		ProvidersData: make([]generic.GenDataModule, len(providers)),
+		ProvidersInfo: make([]generic.GenInfoModule, len(providers)),
 	}
 
-	var (
-		inpAcc = gen_acc.GenericAccumulatorInputs{
-			MaxNumKeccakF: settings.MaxNumKeccakf,
-			ProvidersData: gdm,
-			ProvidersInfo: gim,
-		}
+	for i := range providers {
+		inpAcc.ProvidersData[i] = providers[i].Data
+		inpAcc.ProvidersInfo[i] = providers[i].Info
+	}
 
-		// unify the data from different providers in a single provider
-		accData = gen_acc.NewGenericDataAccumulator(comp, inpAcc)
-		// unify the info from different providers in a single provider
-		accInfo = gen_acc.NewGenericInfoAccumulator(comp, inpAcc)
+	// unify the data from different providers in a single provider
+	accData := gen_acc.NewGenericDataAccumulator(comp, inpAcc)
+	// unify the info from different providers in a single provider
+	accInfo := gen_acc.NewGenericInfoAccumulator(comp, inpAcc)
 
-		keccakInp = KeccakSingleProviderInput{
-			Provider: generic.GenericByteModule{
-				Data: accData.Provider,
-				Info: accInfo.Provider,
-			},
-			MaxNumKeccakF: settings.MaxNumKeccakf,
-		}
-		keccak = NewKeccakSingleProvider(comp, keccakInp)
-	)
+	keccakInp := KeccakSingleProviderInput{
+		Provider: generic.GenericByteModule{
+			Data: accData.Provider,
+			Info: accInfo.Provider,
+		},
+		MaxNumKeccakF: settings.MaxNumKeccakf,
+	}
+	keccak := NewKeccakSingleProvider(comp, keccakInp)
 
 	res := &KeccakZkEVM{
 		pa_accData: accData,


### PR DESCRIPTION
golangci-lint now doesn't like the following pattern:
```go
var slice2 []T

for i := range slice1 {
  slice2 = append(slice2, something)
}
```
and prefers
```go
slice2 := make([]T, len(slice1))

for i := range slice1 {
  slice2[i] = something
}
```