### PR TITLE
Prover: adds field dict_path in config

### DIFF
--- a/docker/config/prover/v3/prover-config.toml
+++ b/docker/config/prover/v3/prover-config.toml
@@ -13,6 +13,7 @@ requests_root_dir = "/data/prover/v3/execution"
 [blob_decompression]
 prover_mode = "dev"
 requests_root_dir = "/data/prover/v3/compression"
+dict_path = "/opt/linea/prover/lib/compressor/compressor_dict.bin"
 
 [aggregation]
 prover_mode = "dev"

--- a/prover/backend/blobdecompression/prove.go
+++ b/prover/backend/blobdecompression/prove.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	blob_v0 "github.com/consensys/linea-monorepo/prover/lib/compressor/blob/v0"
 	blob_v1 "github.com/consensys/linea-monorepo/prover/lib/compressor/blob/v1"
@@ -69,7 +68,7 @@ func Prove(cfg *config.Config, req *Request) (*Response, error) {
 		return nil, fmt.Errorf("unsupported blob version: %v", version)
 	}
 
-	dictPath := filepath.Join(cfg.PathForSetup(string(circuitID)), config.DictionaryFileName)
+	dictPath := cfg.BlobDecompressionDictPath(string(circuitID))
 
 	logrus.Infof("reading the dictionary at %v", dictPath)
 

--- a/prover/cmd/prover/cmd/setup.go
+++ b/prover/cmd/prover/cmd/setup.go
@@ -138,7 +138,7 @@ func Setup(context context.Context, args SetupArgs) error {
 		}
 		if dict != nil {
 			// we save the dictionary to disk
-			dictPath := filepath.Join(cfg.PathForSetup(string(c)), config.DictionaryFileName)
+			dictPath := cfg.BlobDecompressionDictPath(string(c))
 			if err := os.WriteFile(dictPath, dict, 0600); err != nil {
 				return fmt.Errorf("%s failed to write dictionary file: %w", cmdName, err)
 			}

--- a/prover/config/config.go
+++ b/prover/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"text/template"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -216,6 +217,11 @@ type BlobDecompression struct {
 
 	// ProverMode stores the kind of prover to use.
 	ProverMode ProverMode `mapstructure:"prover_mode" validate:"required,oneof=dev full"`
+
+	// DictPath is an optional parameters allowing the user to specificy explicitly
+	// where to look for the compression dictionary. If the input is not provided
+	// then the dictionary will be fetched in <assets_dir>/<version>/<>
+	DictPath string `mapstructure:"dict_path"`
 }
 
 type Aggregation struct {
@@ -269,4 +275,17 @@ type PublicInput struct {
 	ChainID          uint64         // duplicate from Config
 	L2MsgServiceAddr common.Address // duplicate from Config
 
+}
+
+// BlobDecompressionDictPath returns the filepath where to look for the blob
+// decompression dictionary file. If provided in the config, the function returns
+// in priority the provided [BlobDecompression.DictPath] or it returns a path
+// prover assets depending on the provided circuitID.
+func (cfg *Config) BlobDecompressionDictPath(circuitID string) string {
+
+	if len(cfg.BlobDecompression.DictPath) > 0 {
+		return cfg.BlobDecompression.DictPath
+	}
+
+	return filepath.Join(cfg.PathForSetup(string(circuitID)), DefaultDictionaryFileName)
 }

--- a/prover/config/config.go
+++ b/prover/config/config.go
@@ -220,7 +220,10 @@ type BlobDecompression struct {
 
 	// DictPath is an optional parameters allowing the user to specificy explicitly
 	// where to look for the compression dictionary. If the input is not provided
-	// then the dictionary will be fetched in <assets_dir>/<version>/<>
+	// then the dictionary will be fetched in <assets_dir>/<version>/<circuitID>/compression_dict.bin.
+	//
+	// We stress that the feature should not be used in production and should
+	// only be used in E2E testing context.
 	DictPath string `mapstructure:"dict_path"`
 }
 

--- a/prover/config/config.go
+++ b/prover/config/config.go
@@ -279,8 +279,8 @@ type PublicInput struct {
 
 // BlobDecompressionDictPath returns the filepath where to look for the blob
 // decompression dictionary file. If provided in the config, the function returns
-// in priority the provided [BlobDecompression.DictPath] or it returns a path
-// prover assets depending on the provided circuitID.
+// in priority the provided [BlobDecompression.DictPath] or it returns a
+// prover assets path depending on the provided circuitID.
 func (cfg *Config) BlobDecompressionDictPath(circuitID string) string {
 
 	if len(cfg.BlobDecompression.DictPath) > 0 {

--- a/prover/config/constants.go
+++ b/prover/config/constants.go
@@ -1,11 +1,11 @@
 package config
 
 const (
-	VerifyingKeyFileName     = "verifying_key.bin"
-	CircuitFileName          = "circuit.bin"
-	VerifierContractFileName = "Verifier.sol"
-	ManifestFileName         = "manifest.json"
-	DictionaryFileName       = "compressor_dict.bin"
+	VerifyingKeyFileName      = "verifying_key.bin"
+	CircuitFileName           = "circuit.bin"
+	VerifierContractFileName  = "Verifier.sol"
+	ManifestFileName          = "manifest.json"
+	DefaultDictionaryFileName = "compressor_dict.bin"
 
 	RequestsFromSubDir = "requests"
 	RequestsToSubDir   = "responses"


### PR DESCRIPTION
This PR fixes the following issue in the PR:

```
Error: could not prove the blob decompression: error reading the dictionary: open /opt/linea/prover/prover-assets/3.0.0/integration-development/blob-decompression-v1/compressor_dict.bin: no such file or directory
Usage:
  prover prove [flags]

Flags:
  -h, --help         help for prove
      --in string    input file
      --large        run the large execution circuit
      --out string   output file

Global Flags:
      --config string   config file
```

This issue arised after an update on the decompression prover that updates how the dev prover computes its public input (which was different from how the full prover did). As a side-effect, this made the dev prover need to open the dictionary file
 (which was not the case before the issue happened) and this was not working because it tries to open an unexisting file at an incorrect location.
 
 As a fix, the PR adds a config field to let the user explicitly decide where to look for the dictionary file. This feature should not be used in production because in a production setting, we may want to switch between different dictionnary during a migration for instance.
 
### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.