### PR TITLE
feat: update L1FinalizationTagUpdaterPlugin to use linea-besu:plugin-…

### DIFF
--- a/finalized-tag-updater/build.gradle
+++ b/finalized-tag-updater/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
   compileOnly 'com.google.auto.service:auto-service:1.1.1'
   compileOnly 'com.google.auto.service:auto-service-annotations:1.1.1'
-  compileOnly 'io.consensys.linea-besu:plugin-api:24.7-develop-c0029e6'
+  compileOnly 'io.consensys.linea-besu:plugin-api:24.11-delivery39'
   compileOnly 'info.picocli:picocli:4.7.6'
   compileOnly 'io.vertx:vertx-core'
 
@@ -44,10 +44,9 @@ dependencies {
   implementation ("org.web3j:core:${libs.versions.web3j.get()}") {
     exclude group: 'org.slf4j', module: 'slf4j-nop'
   }
-  testImplementation 'io.consensys.linea-besu:plugin-api:24.7-develop-c0029e6'
+  testImplementation 'io.consensys.linea-besu:plugin-api:24.11-delivery39'
   testImplementation 'info.picocli:picocli:4.7.6'
   testImplementation 'io.vertx:vertx-core'
-  testImplementation "org.hyperledger.besu:besu-datatypes:${libs.versions.besu.get()}"
 }
 
 tasks.register('copyShadowJarToLocalBesu', Copy) {

--- a/finalized-tag-updater/src/main/java/net/consensys/linea/consensus/L1FinalizationTagUpdaterPlugin.java
+++ b/finalized-tag-updater/src/main/java/net/consensys/linea/consensus/L1FinalizationTagUpdaterPlugin.java
@@ -7,6 +7,7 @@ import net.consensys.linea.LineaL1FinalizationUpdaterService;
 import net.consensys.linea.PluginCliOptions;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
@@ -18,15 +19,15 @@ public class L1FinalizationTagUpdaterPlugin implements BesuPlugin {
 	private LineaL1FinalizationUpdaterService service;
 	private BlockchainService blockchainService;
 
-	@Override
-	public void register(BesuContext context) {
-		final PicoCLIOptions cmdlineOptions = context.getService(PicoCLIOptions.class)
-			.orElseThrow(() -> new IllegalStateException("Failed to obtain PicoCLI options from the BesuContext"));
-		cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, cliOptions);
+  @Override
+  public void register(final ServiceManager serviceManager) {
+    final PicoCLIOptions cmdlineOptions = serviceManager.getService(PicoCLIOptions.class)
+      .orElseThrow(() -> new IllegalStateException("Failed to obtain PicoCLI options from the BesuContext"));
+    cmdlineOptions.addPicoCLIOptions(CLI_OPTIONS_PREFIX, cliOptions);
 
-		blockchainService = context.getService(BlockchainService.class)
-			.orElseThrow(() -> new RuntimeException("Failed to obtain BlockchainService from the BesuContext."));
-	}
+    blockchainService = serviceManager.getService(BlockchainService.class)
+      .orElseThrow(() -> new RuntimeException("Failed to obtain BlockchainService from the BesuContext."));
+  }
 
 	@Override
 	public void start() {


### PR DESCRIPTION
…api:24.11-delivery39

Update finalized-tag-updater to use `linea-besu:plugin-api:24.11-delivery39` to prepare for the upcoming besu upgrade
to `24.11-delivery39`; otherwise, the besu nodes with current finalized-tag-updater plugin after the besu upgrade would fail to run due to incompatibility.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.