### PR TITLE
[Fix] - Remove proxy admin from remote tokenbridge script

### DIFF
--- a/contracts/docs/linea-token-bridge.md
+++ b/contracts/docs/linea-token-bridge.md
@@ -61,7 +61,7 @@ To deploy the contracts, you will need to run the Bridged Token, Token Bridge, a
 You can refer to the following links that describe the usage of these scripts. <br />
 - [Bridged Token Deployment Script](./deployment.md#bridgedtoken) <br />
 - [Token Bridge Deployment Script](./deployment.md#tokenbridge) <br />
-- [Operational Script](./operational.md#transferownershipandsetremotetokenbridge)
+- [Operational Script](./operational.md#setRemoteTokenBridge)
 
 
 All addresses created will be stored in the deployments folder as a separate file. `./contracts/deployment/<network_name>`

--- a/contracts/docs/operational.md
+++ b/contracts/docs/operational.md
@@ -226,7 +226,7 @@ npx hardhat setVerifierAddress \
 <br />
 <br />
 
-### transferOwnershipAndSetRemoteTokenBridge
+### setRemoteTokenBridge
 
 <br />
 Parameters that should be filled either in .env or passed as CLI arguments:
@@ -238,7 +238,6 @@ Parameters that should be filled either in .env or passed as CLI arguments:
 | REMOTE_TOKEN_BRIDGE_ADDRESS   | true  | address   | Token Bridge address deployed on the `--remote-network`. It must be provided as CLI argument using the `--remote-token-bridge-address` flag. If not found, the script will also check .env. variable `TOKEN_BRIDGE_ADDRESS`. If the .env variable doesn't exist, it will also check the `deployments/<remote-network>` folder and try to use that address. Otherwise it will throw an error.  |
 | TOKEN_BRIDGE_ADDRESS  | true  |   address | Token Bridge address deployed on current network. It must be provided as CLI argument using the `--token-bridge-address` flag. If not found, the script will also check .env. variable `TOKEN_BRIDGE_ADDRESS`. If the .env variable doesn't exist, it will also check the `deployments/<network_name>` folder and try to use that address. Otherwise it will throw an error.  |
 | --token-bridge-proxy-admin-address    | true  |   address | TokenBridge Proxy Admin address. If not provided as a CLI argument, the script will also check the `deployments/<network_name>` folder and try to use that address if it exists. Otherwise it will throw an error. |
-| --safe-address    | true  |   address | Safe address. It must be provided as CLI argument using the `--safe-address` flag  otherwise the script will throw an error. |
 | --remote-network  | true  |   string   | Network name. It must be provided as CLI argument using the `--safe-address` flag  otherwise the script will throw an error. |
 
 <br />
@@ -251,7 +250,7 @@ e.g. `--remote-network linea_sepolia --network sepolia` or vice-versa.
 Base command:
 
 ```shell
-npx hardhat transferOwnershipAndSetRemoteTokenBridge --safe-address <address> --remote-network sepolia --network linea_sepolia
+npx hardhat setRemoteTokenBridge --remote-network sepolia --network linea_sepolia
 ```
 
 Base command with cli arguments:
@@ -259,11 +258,9 @@ Base command with cli arguments:
 ```shell
 SEPOLIA_PRIVATE_KEY=<key> \
 INFURA_API_KEY=<key> \
-npx hardhat transferOwnershipAndSetRemoteTokenBridge \
---safe-address <address> \
+npx hardhat setRemoteTokenBridge \
 --remote-token-bridge-address <address> \
 --token-bridge-address <address> \
---token-bridge-proxy-admin-address <address> \
 --remote-network sepolia \
 --network linea_sepolia
 ```

--- a/contracts/docs/operational.md
+++ b/contracts/docs/operational.md
@@ -237,7 +237,6 @@ Parameters that should be filled either in .env or passed as CLI arguments:
 | INFURA_API_KEY     | true     | key | Infura API Key |
 | REMOTE_TOKEN_BRIDGE_ADDRESS   | true  | address   | Token Bridge address deployed on the `--remote-network`. It must be provided as CLI argument using the `--remote-token-bridge-address` flag. If not found, the script will also check .env. variable `TOKEN_BRIDGE_ADDRESS`. If the .env variable doesn't exist, it will also check the `deployments/<remote-network>` folder and try to use that address. Otherwise it will throw an error.  |
 | TOKEN_BRIDGE_ADDRESS  | true  |   address | Token Bridge address deployed on current network. It must be provided as CLI argument using the `--token-bridge-address` flag. If not found, the script will also check .env. variable `TOKEN_BRIDGE_ADDRESS`. If the .env variable doesn't exist, it will also check the `deployments/<network_name>` folder and try to use that address. Otherwise it will throw an error.  |
-| --token-bridge-proxy-admin-address    | true  |   address | TokenBridge Proxy Admin address. If not provided as a CLI argument, the script will also check the `deployments/<network_name>` folder and try to use that address if it exists. Otherwise it will throw an error. |
 | --remote-network  | true  |   string   | Network name. It must be provided as CLI argument using the `--safe-address` flag  otherwise the script will throw an error. |
 
 <br />

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -12,7 +12,7 @@ import "./scripts/operational/grantContractRolesTask";
 import "./scripts/operational/renounceContractRolesTask";
 import "./scripts/operational/setRateLimitTask";
 import "./scripts/operational/setVerifierAddressTask";
-import "./scripts/operational/transferOwnershipAndSetRemoteTokenBridgeTask";
+import "./scripts/operational/setRemoteTokenBridgeTask";
 import "./scripts/operational/setMessageServiceOnTokenBridgeTask";
 
 import "solidity-docgen";

--- a/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
+++ b/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
@@ -12,7 +12,6 @@ import { getDeployedContractOnNetwork } from "../../common/helpers/readAddress";
     SEPOLIA_PRIVATE_KEY=<key> \
     INFURA_API_KEY=<key> \
     npx hardhat setRemoteTokenBridge \
-    --safe-address <address> \
     --remote-token-bridge-address <address> \
     --token-bridge-address <address> \
     --remote-network sepolia \

--- a/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
+++ b/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
@@ -35,16 +35,16 @@ task("setRemoteTokenBridge", "Sets the remoteTokenBridge address.")
 
     let tokenBridgeAddress = getTaskCliOrEnvValue(taskArgs, "tokenBridgeAddress", "TOKEN_BRIDGE_ADDRESS");
 
-    if (tokenBridgeAddress === undefined) {
+    if (!tokenBridgeAddress) {
       tokenBridgeAddress = await getDeployedContractOnNetwork(hre.network.name, "TokenBridge");
-      if (tokenBridgeAddress === undefined) {
+      if (!tokenBridgeAddress) {
         throw "tokenBridgeAddress is undefined";
       }
     }
 
-    if (remoteTokenBridgeAddress === undefined) {
+    if (!remoteTokenBridgeAddress) {
       remoteTokenBridgeAddress = await getDeployedContractOnNetwork(taskArgs.remoteNetwork, "TokenBridge");
-      if (remoteTokenBridgeAddress === undefined) {
+      if (!remoteTokenBridgeAddress) {
         throw "remoteTokenBridgeAddress is undefined";
       }
     }

--- a/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
+++ b/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
@@ -24,7 +24,6 @@ task(
   "setRemoteTokenBridge",
   "Sets the remoteTokenBridge address.",
 )
-  .addParam("safeAddress")
   .addOptionalParam("remoteTokenBridgeAddress")
   .addOptionalParam("tokenBridgeAddress")
   .addParam("remoteNetwork")

--- a/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
+++ b/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
@@ -22,7 +22,7 @@ import { getDeployedContractOnNetwork } from "../../common/helpers/readAddress";
 
 task(
   "setRemoteTokenBridge",
-  "Transfers the ownership of TokenBridge and Proxy Admin to the Safe address and also sets the remoteTokenBridge address.",
+  "Sets the remoteTokenBridge address.",
 )
   .addParam("safeAddress")
   .addOptionalParam("remoteTokenBridgeAddress")

--- a/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
+++ b/contracts/scripts/operational/setRemoteTokenBridgeTask.ts
@@ -20,10 +20,7 @@ import { getDeployedContractOnNetwork } from "../../common/helpers/readAddress";
     *******************************************************************************************
 */
 
-task(
-  "setRemoteTokenBridge",
-  "Sets the remoteTokenBridge address.",
-)
+task("setRemoteTokenBridge", "Sets the remoteTokenBridge address.")
   .addOptionalParam("remoteTokenBridgeAddress")
   .addOptionalParam("tokenBridgeAddress")
   .addParam("remoteNetwork")

--- a/contracts/scripts/operational/transferProxyAdminOwnership.ts
+++ b/contracts/scripts/operational/transferProxyAdminOwnership.ts
@@ -11,8 +11,9 @@ import { requireEnv } from "../hardhat/utils";
     NB: Be sure of who owns the Timelock before transferring admin to the
     timelock controller. There is the potential to brick ownership
 
+    
     *******************************************************************************************
-    npx hardhat run --network zkevm_dev scripts/operational/transferProxyAdminOwnership.ts
+    PROXY_ADMIN_OWNER_ADDRESS=0x.. PROXY_ADDRESS=0x.. CONTRACT_TYPE=TokenBridge npx hardhat run --network zkevm_dev scripts/operational/transferProxyAdminOwnership.ts
     *******************************************************************************************
 */
 


### PR DESCRIPTION
Note: This was done because of two reasons:

1. The new TokenBridge deploy sets the admin as the safe which is required for the token bridge remote bridge setting and cannot be used in conjunction with the proxy admin owner setting
2. Reusing existing script

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.