### PR TITLE
Prover: build docker wo rust corset

### DIFF
--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -9,15 +9,6 @@
 FROM golang:1.22.7-alpine AS go-builder
 
 RUN apk add --no-cache rust cargo bash make
-WORKDIR /usr/src/
-COPY --from=corset . ./corset
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-ENV CARGO_HOME=/usr/local/cargo
-
-WORKDIR /usr/src/corset/
-
-# Caching our beloved 75sec rust build process.
-RUN cargo build --release
 
 WORKDIR /usr/src/
 COPY --from=prover go.mod .


### PR DESCRIPTION
Corset takes up 2 min of docker build on the CI and we don't use it in the prover directly anymore.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.