### PR TITLE
refactor: remove unneeded pattern for updated USDLR token image

### DIFF
--- a/bridge-ui/next.config.mjs
+++ b/bridge-ui/next.config.mjs
@@ -19,11 +19,6 @@ const nextConfig = {
         hostname: "coin-images.coingecko.com",
         pathname: "/coins/images/**",
       },
-      {
-        protocol: "https",
-        hostname: "storage.googleapis.com",
-        pathname: "/public.withstable.com/logos/**",
-      },
     ],
   },
   webpack: (config) => {


### PR DESCRIPTION
### Context:

Based on the updated logo for the USDLR token (https://github.com/Consensys/linea-token-list/pull/193), the pattern for public.withstable.com/logos is now redundant.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.