### PR TITLE
typos fix

### DIFF
--- a/bridge-ui/README.md
+++ b/bridge-ui/README.md
@@ -168,7 +168,7 @@ The config variables are:
 | NEXT_PUBLIC_WALLET_CONNECT_ID                 | Wallet Connect Api Key                         |                                                                                                           |
 | NEXT_PUBLIC_INFURA_ID                         | Infura API Key                                 |                                                                                                           |
 | E2E_TEST_PRIVATE_KEY                          | Private key to execute e2e on Sepolia          |                                                                                                           |
-| NEXT_PUBLIC_STORAGE_MIN_VERSION               | Local storage version for reseting the storage | 1                                                                                                         |
+| NEXT_PUBLIC_STORAGE_MIN_VERSION               | Local storage version for resetting the storage | 1                                                                                                         |
 
 ## About
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -20,7 +20,7 @@ The L2MessageService is the L2 smart contract that is responsible for:
 
 ## Linea Canonical Token Bridge
 
-The Canonical Token Bridge (TokenBridge) is a canonical ERC20 token brige between Ethereum and Linea networks.
+The Canonical Token Bridge (TokenBridge) is a canonical ERC20 token bridge between Ethereum and Linea networks.
 
 The TokenBridge utilises the L1MessageService and the L2MessageService for the transmission of messages between each layer's TokenBridge.
 

--- a/contracts/docs/linea-token-bridge.md
+++ b/contracts/docs/linea-token-bridge.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-Token Bridge is a canonical brige between Ethereum and Linea networks.
+Token Bridge is a canonical bridge between Ethereum and Linea networks.
 
 ## Install
 


### PR DESCRIPTION
# Fix: Corrected typos in documentation

## What was changed
1. **Corrected typo** `reseting` to `resetting` in `bridge-ui\README.md` (line 171).
2. **Corrected typo** `brige` to `bridge` in `contracts\README.md` (line 23).
3. **Corrected typo** `brige` to `bridge` in `contracts\docs\linea-token-bridge.md` (line 5).

## Why these changes were made
- **Fixing typos** improves the clarity, readability, and professionalism of the documentation.
- Accurate documentation helps maintain high-quality standards and supports better understanding for contributors and users.

## Additional Notes
- These changes are limited to correcting typographical errors in the documentation and do not affect any code functionality.

