### PR TITLE
Fix spelling errors in documentation 

### DIFF
--- a/bridge-ui/README.md
+++ b/bridge-ui/README.md
@@ -131,7 +131,7 @@ Frontend should be available at: http://localhost:3000
 ### End to end tests
 
 E2E tests are run in the CI but can also be run locally.  
-Make sure `E2E_TEST_PRIVATE_KEY` .env (The private key used needs to have some sepolia ETH, USDC and WETH to run the tests)
+Make sure `E2E_TEST_PRIVATE_KEY` .env (The private key used needs to have some Sepolia ETH, USDC and WETH to run the tests)
 
 1. Add `NEXT_PUBLIC_WALLET_CONNECT_ID` and `NEXT_PUBLIC_INFURA_ID` to your command line env
 2. Build the Bridge UI in local in a terminal: `npm run build`

--- a/bridge-ui/RELEASE-NOTES.md
+++ b/bridge-ui/RELEASE-NOTES.md
@@ -487,7 +487,7 @@ fetchNext() is called after clearing and when a transaction is onSuccess()
 
 ## Description:
 
-Readme technical documentation for deployment. Explains how to deploy the Bruidge ui on prod.
+Readme technical documentation for deployment. Explains how to deploy the Bridge ui on prod.
 
 # Feature:
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -20,7 +20,7 @@ The L2MessageService is the L2 smart contract that is responsible for:
 
 ## Linea Canonical Token Bridge
 
-The Canonical Token Bridge (TokenBridge) is a canonical ERC20 token brige between Ethereum and Linea networks.
+The Canonical Token Bridge (TokenBridge) is a canonical ERC20 token bridge between Ethereum and Linea networks.
 
 The TokenBridge utilises the L1MessageService and the L2MessageService for the transmission of messages between each layer's TokenBridge.
 


### PR DESCRIPTION
This pull request fixes the following spelling errors:

"sepolia" corrected to "Sepolia"
"Bruidge" corrected to "Bridge"
"brige" corrected to "bridge"