### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/prover/lib/compressor/blob/v0/compress/lzss/compress.go
+++ b/prover/lib/compressor/blob/v0/compress/lzss/compress.go
@@ -2,6 +2,7 @@ package lzss
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/bits"
 
@@ -352,7 +353,7 @@ func (compressor *Compressor) WrittenBytes() []byte {
 // between any two calls to Revert, a call to Reset or Write should be made
 func (compressor *Compressor) Revert() error {
 	if compressor.lastInLen == -1 {
-		return fmt.Errorf("cannot revert twice in a row")
+		return errors.New("cannot revert twice in a row")
 	}
 
 	compressor.inBuf.Truncate(compressor.lastInLen)

--- a/prover/lib/compressor/blob/v0/encode.go
+++ b/prover/lib/compressor/blob/v0/encode.go
@@ -185,7 +185,7 @@ func DecodeTxFromUncompressed(r *bytes.Reader, from *common.Address) (types.TxDa
 func decodeLegacyTx(fields []any, from *common.Address) (types.TxData, error) {
 
 	if len(fields) != 7 {
-		return nil, fmt.Errorf("unexpected number of field")
+		return nil, errors.New("unexpected number of field")
 	}
 
 	tx := new(types.LegacyTx)
@@ -204,7 +204,7 @@ func decodeLegacyTx(fields []any, from *common.Address) (types.TxData, error) {
 func decodeAccessListTx(fields []any, from *common.Address) (types.TxData, error) {
 
 	if len(fields) != 8 {
-		return nil, fmt.Errorf("invalid number of field for a dynamic transaction")
+		return nil, errors.New("invalid number of field for a dynamic transaction")
 	}
 
 	tx := new(types.AccessListTx)
@@ -225,7 +225,7 @@ func decodeAccessListTx(fields []any, from *common.Address) (types.TxData, error
 func decodeDynamicFeeTx(fields []any, from *common.Address) (types.TxData, error) {
 
 	if len(fields) != 9 {
-		return nil, fmt.Errorf("invalid number of field for a dynamic transaction")
+		return nil, errors.New("invalid number of field for a dynamic transaction")
 	}
 
 	tx := new(types.DynamicFeeTx)

--- a/prover/lib/compressor/blob/v0/header.go
+++ b/prover/lib/compressor/blob/v0/header.go
@@ -127,7 +127,7 @@ func (s *Header) WriteTo(w io.Writer) (int64, error) {
 		// write nbBlocksInBatch (uint16)
 		nbBlocksInBatch := uint16(len(batch))
 		if int(nbBlocksInBatch) != len(batch) {
-			return written, fmt.Errorf("nb blocks in batch too big: bigger than uint16")
+			return written, errors.New("nb blocks in batch too big: bigger than uint16")
 		}
 
 		if err := binary.Write(w, binary.LittleEndian, nbBlocksInBatch); err != nil {
@@ -139,7 +139,7 @@ func (s *Header) WriteTo(w io.Writer) (int64, error) {
 		for _, blockLength := range batch {
 			const maxUint24 = 1<<24 - 1
 			if blockLength > maxUint24 {
-				return written, fmt.Errorf("block length too big: bigger than uint24")
+				return written, errors.New("block length too big: bigger than uint24")
 			}
 
 			// write the blockLength on 3 bytes as a uint24 (LittleEndian)

--- a/prover/lib/compressor/blob/v1/encode.go
+++ b/prover/lib/compressor/blob/v1/encode.go
@@ -18,11 +18,11 @@ import (
 func EncodeBlockForCompression(block *types.Block, w io.Writer) error {
 
 	if block == nil {
-		return fmt.Errorf("block is nil")
+		return errors.New("block is nil")
 	}
 
 	if block.Transactions() == nil {
-		return fmt.Errorf("block has nil transactions")
+		return errors.New("block has nil transactions")
 	}
 
 	var (
@@ -54,7 +54,7 @@ func EncodeBlockForCompression(block *types.Block, w io.Writer) error {
 // encodeTransaction encodes a single transaction
 func EncodeTxForCompression(tx *types.Transaction, w io.Writer) error {
 	if tx == nil {
-		return fmt.Errorf("transactions is nil")
+		return errors.New("transactions is nil")
 	}
 
 	var (


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters