### PR TITLE
Fix typo in troubleshooting command: 'make clean-environment'

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -29,7 +29,7 @@ pnpm run test:e2e:local
 To stop that stack run:
 
 ```
-make clean-enviroment
+make clean-environment
 ```
 
 While running the end2end tests, you should observe files being generated in `tmp/local/` directory.


### PR DESCRIPTION
Corrected the typo from 'make clean-enviroment' to 'make clean-environment' in the troubleshooting section to avoid command errors and ensure clarity.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.