### PR TITLE
Typos fix

### DIFF
--- a/bridge-ui/src/services/tokenService.ts
+++ b/bridge-ui/src/services/tokenService.ts
@@ -84,7 +84,7 @@ export async function fetchTokenInfo(
   if (!chainFound) {
     const chains: Chain[] = networkType === NetworkType.SEPOLIA ? [lineaSepolia, sepolia] : [linea, mainnet];
 
-    // Put the fromChain arg at the begining to take it as priority
+    // Put the fromChain arg at the beginning to take it as priority
     if (fromChain) chains.unshift(fromChain);
 
     for (const chain of chains) {

--- a/contracts/docs/contract-style-guide.md
+++ b/contracts/docs/contract-style-guide.md
@@ -38,7 +38,7 @@ Contracts and interfaces will use the [NatSpec](https://docs.soliditylang.org/en
 ## General
 - Avoid magic numbers by using constants
 - Name variables so that their intent is easy to understand
-- In assembly memory mappings use hexidecimal values for memory offsets - e.g `mstore(add(mPtr, 0x20), _varName)`
+- In assembly memory mappings use hexadecimal values for memory offsets - e.g `mstore(add(mPtr, 0x20), _varName)`
 
 ## Linting
 Be sure to run `pnpm run lint:fix` in the contracts folder or `pnpm run -F contracts lint:fix` from the repository root.

--- a/contracts/docs/deployment.md
+++ b/contracts/docs/deployment.md
@@ -39,7 +39,7 @@ Dependent on which network you are using, a specific network private key needs t
 ## Generalized Command Format
 
 ```shell
-<possible CLI environment arguments> npx hardhat deploy --network sepolia --tags <contract tags, comma delimitted list>
+<possible CLI environment arguments> npx hardhat deploy --network sepolia --tags <contract tags, comma delimited list>
 ```
 
 <br />


### PR DESCRIPTION
# Typos Fix

## Description
This pull request fixes several typos in the project across three files:
- **`tokenService.ts`**: Corrected "begining" to "beginning".
- **`contract-style-guide.md`**: Corrected "hexidecimal" to "hexadecimal".
- **`deployment.md`**: Corrected "delimitted" to "delimited".

## Changes
- Improved readability and accuracy in the code comments and documentation by fixing spelling errors.
- No functional changes were made.

## Testing
These updates only involve documentation and comments. All existing functionality remains unaffected, and no additional tests are required.

## Notes for Reviewers
Please ensure that the corrections are consistent with the project's style and do not inadvertently alter the intended meaning. Let me know if any further adjustments are needed. Thank you!
