### PR TITLE
GitHub Actions URL

### DIFF
--- a/bridge-ui/README.md
+++ b/bridge-ui/README.md
@@ -11,9 +11,9 @@ Private configuration variables are store on GitHub Secrets.
 ### Get a Frontend Tag
 
 - Retrieve an existing tag.
-  - Get a Tag from [GitHub Actions](https://github.com/Consensys/zkevm-monorepo/actions) on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
+  - Get a Tag from [GitHub Actions]() on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
 - Or create a new tag.
-  - Create a PR and merge the last version to develop branch, and get a Tag from [GitHub Actions](https://github.com/Consensys/zkevm-monorepo/actions) on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
+  - Create a PR and merge the last version to develop branch, and get a Tag from [GitHub Actions]() on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
 
 Example:
 


### PR DESCRIPTION
Request for updated GitHub Actions URL

I have removed the outdated GitHub Actions URL:
- https://github.com/Consensys/zkevm-monorepo/actions

Could you please provide the current repository URL for GitHub Actions? This is needed to update the following sections in bridge-ui/README.md:

1. For retrieving existing tags:
- Get a Tag from [GitHub Actions] () on `Bridge UI Build and Publish` job

2. For creating new tags:
- Create a PR and merge the last version to develop branch, and get a Tag from [GitHub Actions] () on `Bridge UI Build and Publish` job

The correct URL is needed to ensure proper documentation and user guidance.