### PR TITLE
[Fix] Remove _GITHUB_TOKEN_RELEASE_ACCESS from pull_request workflows

### DIFF
--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -23,7 +23,6 @@ jobs:
   run-tests:
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}
-      GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -71,7 +71,6 @@ jobs:
       PROVER_TAG: ${{ inputs.commit_tag }}
       TRACES_API_TAG: ${{ inputs.commit_tag }}
       TRANSACTION_EXCLUSION_API_TAG: ${{ inputs.commit_tag }}
-      GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:


### PR DESCRIPTION
This PR implements issue(s) #542 

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.