### PR TITLE
Optimize Timer instance creation in SimpleTimerCapture

### DIFF
--- a/jvm-libs/linea/metrics/micrometer/src/main/kotlin/net/consensys/linea/metrics/micrometer/SimpleTimerCapture.kt
+++ b/jvm-libs/linea/metrics/micrometer/src/main/kotlin/net/consensys/linea/metrics/micrometer/SimpleTimerCapture.kt
@@ -5,12 +5,12 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import java.util.concurrent.Callable
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * An abstract class which contains everything is needed to make pretty much any Timer capture.
  * Mimicks the Builder pattern and allows captureTime implementation to perform different kinds of
- * captures TODO: In order to improve performance, Timer instances can be cached into a thread safe
- * Map
+ * captures
  */
 class SimpleTimerCapture<T> : AbstractTimerCapture<T> {
   constructor(meterRegistry: MeterRegistry, name: String) : super(meterRegistry, name)
@@ -18,6 +18,10 @@ class SimpleTimerCapture<T> : AbstractTimerCapture<T> {
     meterRegistry: MeterRegistry,
     timerBuilder: Timer.Builder
   ) : super(meterRegistry, timerBuilder)
+
+  companion object {
+    private val timerCache = ConcurrentHashMap<Timer.Builder, Timer>()
+  }
 
   override fun setDescription(description: String): SimpleTimerCapture<T> {
     super.setDescription(description)
@@ -34,15 +38,21 @@ class SimpleTimerCapture<T> : AbstractTimerCapture<T> {
     return this
   }
 
+  private fun getOrCreateTimer(): Timer {
+    return timerCache.computeIfAbsent(timerBuilder) { builder ->
+      builder.register(meterRegistry)
+    }
+  }
+
   override fun captureTime(f: CompletableFuture<T>): CompletableFuture<T> {
-    val timer = timerBuilder.register(meterRegistry)
+    val timer = getOrCreateTimer()
     val timerSample = Timer.start(clock)
     f.whenComplete { _, _ -> timerSample.stop(timer) }
     return f
   }
 
   override fun captureTime(f: Callable<T>): T {
-    val timer = timerBuilder.register(meterRegistry)
+    val timer = getOrCreateTimer()
     val timerSample = Timer.start(clock)
     val result = f.call()
     timerSample.stop(timer)


### PR DESCRIPTION
- Add thread-safe Timer instance caching using ConcurrentHashMap
- Implement getOrCreateTimer() method for Timer instance reuse
- Modify captureTime methods to use cached Timer instances
- Remove TODO comment as the improvement has been implemented

This change improves performance by reducing the number of Timer instances created and reusing existing ones from a thread-safe cache.

This PR implements issue(s) # N/A

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.