### PR TITLE
[Fix] CI warnings

### DIFF
--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -70,7 +70,7 @@ jobs:
           done
       - name: Cache common docker images
         continue-on-error: true
-        uses: actions/cache/restore@v4.2.0
+        uses: actions/cache/save@v4.2.0
         with:
           path: ~/docker-images
           key: cached-images

--- a/.github/workflows/cache-docker-images.yml
+++ b/.github/workflows/cache-docker-images.yml
@@ -70,7 +70,7 @@ jobs:
           done
       - name: Cache common docker images
         continue-on-error: true
-        uses: actions/cache/save@v4.0.2
+        uses: actions/cache/restore@v4.2.0
         with:
           path: ~/docker-images
           key: cached-images

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -41,7 +41,7 @@ jobs:
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 #v4.2.1
       - name: Restore cached images
         id: restore-cached-images
-        uses: actions/cache/restore@v4.0.2
+        uses: actions/cache/restore@v4.2.0
         with:
           path: ~/docker-images
           key: cached-images

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -21,6 +21,8 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: 1.23.x
+        cache-dependency-path: |
+              prover/go.sum
     - uses: actions/cache@v4.2.0
       with:
         path: |
@@ -63,6 +65,8 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
+        cache-dependency-path: |
+              prover/go.sum
     - uses: actions/cache@v4.2.0
       with:
         path: |

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/cache@v4
+    - uses: actions/cache@v4.2.0
       with:
         path: |
           ~/go/pkg/mod
@@ -63,7 +63,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: checkout code
       uses: actions/checkout@v4
-    - uses: actions/cache@v4
+    - uses: actions/cache@v4.2.0
       with:
         path: |
           ~/go/pkg/mod

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/cache@v4.2.0
       with:
         path: |
-          ~/go/pkg/mod
           ~/.cache/go-build
           ~/Library/Caches/go-build
           %LocalAppData%\go-build
@@ -70,7 +69,6 @@ jobs:
     - uses: actions/cache@v4.2.0
       with:
         path: |
-          ~/go/pkg/mod
           ~/.cache/go-build
           ~/Library/Caches/go-build
           %LocalAppData%\go-build

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04, X64, small]
     name: Prover static check
     steps:
-    - name: install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.23.x
     - name: checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.23.x
     - uses: actions/cache@v4.2.0
       with:
         path: |
@@ -57,12 +57,12 @@ jobs:
     needs:
       - staticcheck
     steps:
+    - name: checkout code
+      uses: actions/checkout@v4
     - name: install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: checkout code
-      uses: actions/checkout@v4
     - uses: actions/cache@v4.2.0
       with:
         path: |

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -98,7 +98,7 @@ jobs:
           chmod -R a+w tmp/local/traces/v2/conflated
       - name: Restore cached images
         id: restore-cached-images
-        uses: actions/cache/restore@v4.0.2
+        uses: actions/cache/restore@v4.2.0
         with:
           path: ~/docker-images
           key: cached-images

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -43,7 +43,7 @@ jobs:
           go-version: 1.23.x
           cache: false
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v4.2.0
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -41,12 +41,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.x
-          cache: false
+          cache-dependency-path: |
+                prover/go.sum
 
       - uses: actions/cache@v4.2.0
         with:
           path: |
-            ~/go/pkg/mod
             ~/.cache/go-build
             ~/Library/Caches/go-build
             %LocalAppData%\go-build

--- a/.github/workflows/staterecovery-testing.yml
+++ b/.github/workflows/staterecovery-testing.yml
@@ -42,7 +42,7 @@ jobs:
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 #v4.2.1
       - name: Restore cached images
         id: restore-cached-images
-        uses: actions/cache/restore@v4.0.2
+        uses: actions/cache/restore@v4.2.0
         with:
           path: ~/docker-images
           key: cached-images


### PR DESCRIPTION
This PR implements issue(s) #583 

- Updated `actions/cache` references to 4.2.0
- Use in-built caching for `setup-go`
- 'checkout' before 'setup-go' (https://github.com/actions/setup-go/issues/427#issuecomment-2273249463)

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.