### PR TITLE
feat(traces): implement traces-only content filtering

### DIFF
--- a/traces-api-facade/app/src/main/kotlin/net/consensys/linea/traces/repository/FilesystemTracesRepositoryV1.kt
+++ b/traces-api-facade/app/src/main/kotlin/net/consensys/linea/traces/repository/FilesystemTracesRepositoryV1.kt
@@ -21,8 +21,14 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.nio.file.Path
 
 internal fun tracesOnlyFromContent(content: String): String {
-  // TODO: filter out from the file objects that are not traces
-  return content
+  return try {
+    val jsonRegex = """"traces":\s*(\[.*?\])""".toRegex(RegexOption.DOT_MATCHES_ALL)
+    val match = jsonRegex.find(content)
+    match?.groupValues?.get(1) ?: content
+  } catch (e: Exception) {
+    // In case of an error, return the original content
+    content
+  }
 }
 
 class FilesystemTracesRepositoryV1(


### PR DESCRIPTION
Implement the TODO in FilesystemTracesRepositoryV1 to filter out non-trace objects from the file content.
The implementation:
- Extracts only the "traces" array from JSON content
- Uses regex pattern matching for efficient filtering
- Includes error handling to maintain backward compatibility
- Returns original content if no traces field is found