### PR TITLE
fix: improve null safety in RequestHandlersV1

### DIFF
--- a/transaction-exclusion-api/app/src/main/kotlin/net/consensys/linea/transactionexclusion/app/api/RequestHandlersV1.kt
+++ b/transaction-exclusion-api/app/src/main/kotlin/net/consensys/linea/transactionexclusion/app/api/RequestHandlersV1.kt
@@ -112,9 +112,8 @@ class SaveRejectedTransactionRequestHandlerV1(
       }
       if (parsingResult is Err) {
         return Future.succeededFuture(parsingResult)
-      } else {
-        parsingResult.get()!!
       }
+      parsingResult.get() ?: throw IllegalStateException("Unexpected null result after parsing")
     } catch (e: Exception) {
       return Future.succeededFuture(
         Err(
@@ -151,7 +150,8 @@ class GetTransactionExclusionStatusRequestHandlerV1(
         "The given request params list should have one argument"
       )
     }
-    return ArgumentParser.getTxHashInRawBytes(requestListParams[0].toString())
+    val param = requestListParams[0] ?: throw IllegalArgumentException("Transaction hash cannot be null")
+    return ArgumentParser.getTxHashInRawBytes(param.toString())
   }
 
   override fun invoke(


### PR DESCRIPTION
- Replace unsafe null assertions (!!) with proper null checks
- Add explicit null validation for transaction hash parameter
- Add descriptive error messages for null cases
- Improve error handling in parameter parsing

These changes make the code more robust by preventing potential NullPointerExceptions  and providing clearer error messages when invalid data is provided.

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.