### PR TITLE
L2 configs improvement

### DIFF
--- a/config/coordinator/coordinator-docker-testnet.config.overrides.toml
+++ b/config/coordinator/coordinator-docker-testnet.config.overrides.toml
@@ -6,10 +6,6 @@
 #engine-api="http://traces-node:8550"
 #eth-api="http://traces-node:8545"
 
-[zk-traces]
-eth-api="http://traces-node:8545"
-new-block-polling-interval="PT0S"
-
 # Config of Traces API Facade endpoint
 [traces]
 endpoints=["http://traces-api:8080/"]

--- a/config/coordinator/coordinator-docker-traces-v2-override.config.toml
+++ b/config/coordinator/coordinator-docker-traces-v2-override.config.toml
@@ -9,9 +9,6 @@ fs-responses-directory = "/data/prover/v3/compression/responses"
 fs-requests-directory = "/data/prover/v3/aggregation/requests"
 fs-responses-directory = "/data/prover/v3/aggregation/responses"
 
-[zk-traces]
-eth-api="http://traces-node-v2:8545"
-
 [traces]
 switch-to-linea-besu=true
 blob-compressor-version="V1_0_1"

--- a/config/coordinator/coordinator-docker.config.toml
+++ b/config/coordinator/coordinator-docker.config.toml
@@ -29,7 +29,6 @@ aggregation-coordinator-polling-interval="PT2S"
 deadline-check-interval="PT8S"
 #target-end-blocks=[33, 90, 93]
 
-
 [prover]
 fs-inprogress-request-writing-suffix = ".inprogress_coordinator_writing"
 fs-inprogress-proving-suffix-pattern = ".*\\.inprogress\\.prover.*"
@@ -57,7 +56,6 @@ fs-responses-directory = "/data/prover/v2/aggregation/responses"
 #fs-responses-directory = "/data/prover/v3/aggregation/responses"
 
 [zk-traces]
-eth-api="http://traces-node:8545"
 new-block-polling-interval="PT1S"
 
 [traces]

--- a/config/coordinator/coordinator-docker.config.toml
+++ b/config/coordinator/coordinator-docker.config.toml
@@ -55,9 +55,6 @@ fs-responses-directory = "/data/prover/v2/aggregation/responses"
 #fs-requests-directory = "/data/prover/v3/aggregation/requests"
 #fs-responses-directory = "/data/prover/v3/aggregation/responses"
 
-[zk-traces]
-new-block-polling-interval="PT1S"
-
 [traces]
 switch-to-linea-besu=false
 blob-compressor-version="V0_1_0"
@@ -148,6 +145,7 @@ max-receipt-retries=120
 # Coordinator will consider block as finalized after being included in the chain wtih children blocks-to-finalization
 # Recommended: Geth sequencer minimum of 2, Besu sequencer minimum of 1, 0 is safe localy
 blocks-to-finalization=0
+new-block-polling-interval="PT1S"
 
 [blob-submission]
 disabled=false

--- a/config/coordinator/coordinator-local-dev.config-traces-v2.overrides.toml
+++ b/config/coordinator/coordinator-local-dev.config-traces-v2.overrides.toml
@@ -9,9 +9,6 @@ fs-responses-directory = "tmp/local/prover/v3/compression/responses"
 fs-requests-directory = "tmp/local/prover/v3/aggregation/requests"
 fs-responses-directory = "tmp/local/prover/v3/aggregation/responses"
 
-[zk-traces]
-eth-api="http://127.0.0.1:8745"
-
 [dynamic-gas-price-service]
 geth-gas-price-update-recipients=[
   "http://127.0.0.1:8845"

--- a/config/coordinator/coordinator-local-dev.config.overrides.toml
+++ b/config/coordinator/coordinator-local-dev.config.overrides.toml
@@ -21,9 +21,6 @@ fs-responses-directory = "tmp/local/prover/v2/compression/responses"
 fs-requests-directory = "tmp/local/prover/v2/aggregation/requests"
 fs-responses-directory = "tmp/local/prover/v2/aggregation/responses"
 
-[zk-traces]
-eth-api="http://127.0.0.1:8645"
-
 # Config of Traces API Facade endpoint
 [traces]
 [traces.counters]

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/CoordinatorApp.kt
@@ -60,7 +60,7 @@ class CoordinatorApp(private val configs: CoordinatorConfig) {
     vertx
   )
   private val l2Web3jClient: Web3j = createWeb3jHttpClient(
-    rpcUrl = configs.zkTraces.ethApi.toString(),
+    rpcUrl = configs.l2.rpcEndpoint.toString(),
     log = LogManager.getLogger("clients.l2.eth-api.rpc-node"),
     pollingInterval = 1.seconds,
     requestResponseLogLevel = Level.TRACE,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -909,7 +909,7 @@ class L1DependentApp(
       blockCreationListener = block2BatchCoordinator,
       lastProvenBlockNumberProviderAsync = lastProvenBlockNumberProvider,
       config = BlockCreationMonitor.Config(
-        pollingInterval = configs.zkTraces.newBlockPollingInterval.toKotlinDuration(),
+        pollingInterval = configs.l2.newBlockPollingInterval.toKotlinDuration(),
         blocksToFinalization = configs.l2.blocksToFinalization.toLong(),
         blocksFetchLimit = configs.conflation.fetchBlocksLimit.toLong(),
         // We need to add 1 to l2InclusiveBlockNumberToStopAndFlushAggregation because conflation calculator requires

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -120,7 +120,7 @@ class L1DependentApp(
   private val batchesRepository: BatchesRepository,
   private val blobsRepository: BlobsRepository,
   private val aggregationsRepository: AggregationsRepository,
-  private val l1FeeHistoriesRepository: FeeHistoriesRepositoryWithCache,
+  l1FeeHistoriesRepository: FeeHistoriesRepositoryWithCache,
   private val smartContractErrors: SmartContractErrors,
   private val metricsFacade: MetricsFacade
 ) : LongRunningService {
@@ -154,13 +154,6 @@ class L1DependentApp(
 
   )
   private val l1Web3jService = Web3jBlobExtended(HttpService(configs.l1.ethFeeHistoryEndpoint.toString()))
-  private val l2ZkTracesWeb3jClient: Web3j = createWeb3jHttpClient(
-    rpcUrl = configs.zkTraces.ethApi.toString(),
-    log = LogManager.getLogger("clients.l2.eth-api.tracer-node"),
-    pollingInterval = 1.seconds,
-    requestResponseLogLevel = org.apache.logging.log4j.Level.TRACE,
-    failuresLogLevel = org.apache.logging.log4j.Level.DEBUG
-  )
 
   private val l1ChainId = l1Web3jClient.ethChainId().send().chainId.toLong()
 
@@ -175,7 +168,7 @@ class L1DependentApp(
     metricsFacade = metricsFacade
   )
 
-  private val l2ExtendedWeb3j = ExtendedWeb3JImpl(l2ZkTracesWeb3jClient)
+  private val l2ExtendedWeb3j = ExtendedWeb3JImpl(l2Web3jClient)
 
   private val finalizationTransactionManager = createTransactionManager(
     vertx,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfig.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfig.kt
@@ -73,10 +73,6 @@ data class ConflationConfig(
   val conflationTargetEndBlockNumbers: Set<ULong> = _conflationTargetEndBlockNumbers.map { it.toULong() }.toSet()
 }
 
-data class ZkTraces(
-  val newBlockPollingInterval: Duration
-)
-
 interface RetryConfig {
   val maxRetries: Int?
   val timeout: Duration?
@@ -312,7 +308,8 @@ data class L2Config(
   val blocksToFinalization: UInt,
   val lastHashSearchWindow: UInt,
   val anchoringReceiptPollingInterval: Duration,
-  val maxReceiptRetries: UInt
+  val maxReceiptRetries: UInt,
+  val newBlockPollingInterval: Duration
 ) {
   init {
     messageServiceAddress.assertIsValidAddress("messageServiceAddress")
@@ -512,7 +509,6 @@ data class TracesLimitsV2ConfigFile(val tracesLimits: Map<TracingModuleV2, UInt>
 // otherwise it's hard to test the configuration is loaded properly
 data class CoordinatorConfigTomlDto(
   val l2InclusiveBlockNumberToStopAndFlushAggregation: ULong? = null,
-  val zkTraces: ZkTraces,
   val blobCompression: BlobCompressionConfig,
   val proofAggregation: AggregationConfig,
   val traces: TracesConfig,
@@ -537,7 +533,6 @@ data class CoordinatorConfigTomlDto(
 ) {
   fun reified(): CoordinatorConfig = CoordinatorConfig(
     l2InclusiveBlockNumberToStopAndFlushAggregation = l2InclusiveBlockNumberToStopAndFlushAggregation,
-    zkTraces = zkTraces,
     blobCompression = blobCompression,
     proofAggregation = proofAggregation,
     traces = traces,
@@ -564,7 +559,6 @@ data class CoordinatorConfigTomlDto(
 
 data class CoordinatorConfig(
   val l2InclusiveBlockNumberToStopAndFlushAggregation: ULong? = null,
-  val zkTraces: ZkTraces,
   val blobCompression: BlobCompressionConfig,
   val proofAggregation: AggregationConfig,
   val traces: TracesConfig,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfig.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfig.kt
@@ -74,7 +74,6 @@ data class ConflationConfig(
 }
 
 data class ZkTraces(
-  val ethApi: URL,
   val newBlockPollingInterval: Duration
 )
 

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitor.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitor.kt
@@ -44,7 +44,7 @@ class BlockCreationMonitor(
   private val reorgDetected: AtomicBoolean = AtomicBoolean(false)
   private var statingBlockAvailabilityFuture: SafeFuture<*>? = null
 
-  val nexBlockNumberToFetch: Long
+  private val nexBlockNumberToFetch: Long
     get() = _nexBlockNumberToFetch.get()
 
   override fun handleError(error: Throwable) {

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfigTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfigTest.kt
@@ -50,10 +50,6 @@ class CoordinatorConfigTest {
       fetchBlocksLimit = 4000
     )
 
-    private val zkTracesConfig = ZkTraces(
-      Duration.parse("PT1S")
-    )
-
     private val proversConfig = ProversConfig(
       proverA = ProverConfig(
         execution = FileBasedProverConfig(
@@ -222,7 +218,8 @@ class CoordinatorConfigTest {
       blocksToFinalization = 0U,
       lastHashSearchWindow = 25U,
       anchoringReceiptPollingInterval = Duration.parse("PT01S"),
-      maxReceiptRetries = 120U
+      maxReceiptRetries = 120U,
+      newBlockPollingInterval = Duration.parse("PT1S")
     )
 
     private val finalizationSigner = SignerConfig(
@@ -352,7 +349,6 @@ class CoordinatorConfigTest {
     )
 
     private val coordinatorConfig = CoordinatorConfig(
-      zkTraces = zkTracesConfig,
       blobCompression = blobCompressionConfig,
       proofAggregation = aggregationConfig,
       traces = tracesConfig,

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfigTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/config/CoordinatorConfigTest.kt
@@ -51,7 +51,6 @@ class CoordinatorConfigTest {
     )
 
     private val zkTracesConfig = ZkTraces(
-      URI("http://traces-node:8545").toURL(),
       Duration.parse("PT1S")
     )
 
@@ -457,7 +456,6 @@ class CoordinatorConfigTest {
 
     val expectedConfig =
       coordinatorConfig.copy(
-        zkTraces = zkTracesConfig.copy(ethApi = URI("http://traces-node-v2:8545").toURL()),
         l2NetworkGasPricingService = l2NetworkGasPricingServiceConfig.copy(
           legacy =
           l2NetworkGasPricingServiceConfig.legacy.copy(

--- a/coordinator/app/src/test/resources/configs/coordinator-traces-v2-override.config.toml
+++ b/coordinator/app/src/test/resources/configs/coordinator-traces-v2-override.config.toml
@@ -9,9 +9,6 @@ fs-responses-directory = "/data/prover/v3/compression/responses"
 fs-requests-directory = "/data/prover/v3/aggregation/requests"
 fs-responses-directory = "/data/prover/v3/aggregation/responses"
 
-[zk-traces]
-eth-api="http://traces-node-v2:8545"
-
 [traces]
 switch-to-linea-besu=true
 blob-compressor-version="V1_0_1"

--- a/coordinator/app/src/test/resources/configs/coordinator.config.toml
+++ b/coordinator/app/src/test/resources/configs/coordinator.config.toml
@@ -37,10 +37,6 @@ handler-polling-interval="PT1S"
 # batches-limit must be less than or equal to aggregation-proofs-limit-1
 batches-limit=1
 
-[zk-traces]
-eth-api="http://traces-node:8545"
-new-block-polling-interval="PT1S"
-
 [traces]
 switch-to-linea-besu=false
 blob-compressor-version="V0_1_0"
@@ -131,6 +127,7 @@ max-receipt-retries=120
 # Coordinator will consider block as finalized after being included in the chain wtih children blocks-to-finalization
 # Recommended: Geth sequencer minimum of 2, Besu sequencer minimum of 1, 0 is safe localy
 blocks-to-finalization=0
+new-block-polling-interval="PT1S"
 
 [blob-submission]
 disabled=false


### PR DESCRIPTION
This PR implements issue(s) #

* Removes `zk-traces.eth-api`
* `l2.rpc-endpoint` is used in places where `zk-traces.eth-api` was used before (e.g. anchoring and block creation monitor)

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.