### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/prover/backend/files/files_test.go
+++ b/prover/backend/files/files_test.go
@@ -19,11 +19,7 @@ const (
 
 func TestCheckFilePath(t *testing.T) {
 	// Create a temporary directory and file for testing.
-	tmpDir, err := os.MkdirTemp("", "testdir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(tmpDir, "testfile")
 	if err != nil {
@@ -68,11 +64,7 @@ func TestCheckFilePath(t *testing.T) {
 
 func TestCheckDirPath(t *testing.T) {
 	// Create a temporary directory and file for testing.
-	tmpDir, err := os.MkdirTemp("", "testdir")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	tmpFile, err := os.CreateTemp(tmpDir, "testfile")
 	if err != nil {


### PR DESCRIPTION


`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir



### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.