### PR TITLE
[Feat] Bridge UI v2 - Transaction List with CCTPV2 transactions

### DIFF
--- a/bridge-ui/src/abis/MessageTransmitterV2.json
+++ b/bridge-ui/src/abis/MessageTransmitterV2.json
@@ -1,0 +1,325 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        { "internalType": "uint32", "name": "_localDomain", "type": "uint32" },
+        { "internalType": "uint32", "name": "_version", "type": "uint32" }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": true, "internalType": "address", "name": "attester", "type": "address" }],
+      "name": "AttesterDisabled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": true, "internalType": "address", "name": "attester", "type": "address" }],
+      "name": "AttesterEnabled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "previousAttesterManager", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "newAttesterManager", "type": "address" }
+      ],
+      "name": "AttesterManagerUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": false, "internalType": "uint64", "name": "version", "type": "uint64" }],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": false, "internalType": "uint256", "name": "newMaxMessageBodySize", "type": "uint256" }],
+      "name": "MaxMessageBodySizeUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "caller", "type": "address" },
+        { "indexed": false, "internalType": "uint32", "name": "sourceDomain", "type": "uint32" },
+        { "indexed": true, "internalType": "bytes32", "name": "nonce", "type": "bytes32" },
+        { "indexed": false, "internalType": "bytes32", "name": "sender", "type": "bytes32" },
+        { "indexed": true, "internalType": "uint32", "name": "finalityThresholdExecuted", "type": "uint32" },
+        { "indexed": false, "internalType": "bytes", "name": "messageBody", "type": "bytes" }
+      ],
+      "name": "MessageReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": false, "internalType": "bytes", "name": "message", "type": "bytes" }],
+      "name": "MessageSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+      ],
+      "name": "OwnershipTransferStarted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    { "anonymous": false, "inputs": [], "name": "Pause", "type": "event" },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": true, "internalType": "address", "name": "newAddress", "type": "address" }],
+      "name": "PauserChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": true, "internalType": "address", "name": "newRescuer", "type": "address" }],
+      "name": "RescuerChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": false, "internalType": "uint256", "name": "oldSignatureThreshold", "type": "uint256" },
+        { "indexed": false, "internalType": "uint256", "name": "newSignatureThreshold", "type": "uint256" }
+      ],
+      "name": "SignatureThresholdUpdated",
+      "type": "event"
+    },
+    { "anonymous": false, "inputs": [], "name": "Unpause", "type": "event" },
+    {
+      "inputs": [],
+      "name": "NONCE_USED",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+      "inputs": [],
+      "name": "attesterManager",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "attester", "type": "address" }],
+      "name": "disableAttester",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "newAttester", "type": "address" }],
+      "name": "enableAttester",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "index", "type": "uint256" }],
+      "name": "getEnabledAttester",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getNumEnabledAttesters",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "owner_", "type": "address" },
+        { "internalType": "address", "name": "pauser_", "type": "address" },
+        { "internalType": "address", "name": "rescuer_", "type": "address" },
+        { "internalType": "address", "name": "attesterManager_", "type": "address" },
+        { "internalType": "address[]", "name": "attesters_", "type": "address[]" },
+        { "internalType": "uint256", "name": "signatureThreshold_", "type": "uint256" },
+        { "internalType": "uint256", "name": "maxMessageBodySize_", "type": "uint256" }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "initializedVersion",
+      "outputs": [{ "internalType": "uint64", "name": "", "type": "uint64" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "attester", "type": "address" }],
+      "name": "isEnabledAttester",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "localDomain",
+      "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "maxMessageBodySize",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    { "inputs": [], "name": "pause", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pauser",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pendingOwner",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "bytes", "name": "message", "type": "bytes" },
+        { "internalType": "bytes", "name": "attestation", "type": "bytes" }
+      ],
+      "name": "receiveMessage",
+      "outputs": [{ "internalType": "bool", "name": "success", "type": "bool" }],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract IERC20", "name": "tokenContract", "type": "address" },
+        { "internalType": "address", "name": "to", "type": "address" },
+        { "internalType": "uint256", "name": "amount", "type": "uint256" }
+      ],
+      "name": "rescueERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rescuer",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint32", "name": "destinationDomain", "type": "uint32" },
+        { "internalType": "bytes32", "name": "recipient", "type": "bytes32" },
+        { "internalType": "bytes32", "name": "destinationCaller", "type": "bytes32" },
+        { "internalType": "uint32", "name": "minFinalityThreshold", "type": "uint32" },
+        { "internalType": "bytes", "name": "messageBody", "type": "bytes" }
+      ],
+      "name": "sendMessage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "newMaxMessageBodySize", "type": "uint256" }],
+      "name": "setMaxMessageBodySize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "uint256", "name": "newSignatureThreshold", "type": "uint256" }],
+      "name": "setSignatureThreshold",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "signatureThreshold",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    { "inputs": [], "name": "unpause", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+      "inputs": [{ "internalType": "address", "name": "newAttesterManager", "type": "address" }],
+      "name": "updateAttesterManager",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "_newPauser", "type": "address" }],
+      "name": "updatePauser",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "newRescuer", "type": "address" }],
+      "name": "updateRescuer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+      "name": "usedNonces",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/bridge-ui/src/types/cctp.ts
+++ b/bridge-ui/src/types/cctp.ts
@@ -1,9 +1,11 @@
+export type CctpAttestationMessageStatus = "pending_confirmations" | "complete";
+
 type CctpAttestationMessage = {
   attestation: `0x${string}`;
   message: `0x${string}`;
   eventNonce: `0x${string}`;
   cctpVersion: 1 | 2;
-  status: "pending_confirmations" | "complete";
+  status: CctpAttestationMessageStatus;
 };
 
 export type CctpAttestationApiResponse = {

--- a/bridge-ui/src/types/events.ts
+++ b/bridge-ui/src/types/events.ts
@@ -41,3 +41,16 @@ export type DepositForBurnEvent = Log & {
     hookData: `0x${string}`;
   };
 };
+
+export type CCTPMessageReceivedEvent = Log & {
+  blockNumber: bigint;
+  transactionHash: Address;
+  args: {
+    caller: Address;
+    sourceDomain: number;
+    nonce: `0x${string}`;
+    sender: `0x${string}`;
+    finalityThresholdExecuted: number;
+    messageBody: `0x${string}`;
+  };
+};

--- a/bridge-ui/src/types/index.ts
+++ b/bridge-ui/src/types/index.ts
@@ -4,3 +4,4 @@ export { type TransactionType, TransactionStatus } from "./transaction";
 export { type Token, type GithubTokenListToken, type NetworkTokens } from "./token";
 export { BridgeProvider, BridgeType } from "./providers";
 export { type MessageSentEvent, type BridgingInitiatedV2Event } from "./events";
+export { type CctpAttestationApiResponse, type CctpAttestationMessageStatus } from "./cctp";

--- a/bridge-ui/src/types/index.ts
+++ b/bridge-ui/src/types/index.ts
@@ -3,5 +3,10 @@ export { type Chain, ChainLayer } from "./chain";
 export { type TransactionType, TransactionStatus } from "./transaction";
 export { type Token, type GithubTokenListToken, type NetworkTokens } from "./token";
 export { BridgeProvider, BridgeType } from "./providers";
-export { type MessageSentEvent, type BridgingInitiatedV2Event } from "./events";
+export {
+  type MessageSentEvent,
+  type BridgingInitiatedV2Event,
+  type DepositForBurnEvent,
+  type CCTPMessageReceivedEvent,
+} from "./events";
 export { type CctpAttestationApiResponse, type CctpAttestationMessageStatus } from "./cctp";

--- a/bridge-ui/src/utils/cctp.ts
+++ b/bridge-ui/src/utils/cctp.ts
@@ -1,5 +1,37 @@
+import MessageTransmitterV2 from "@/abis/MessageTransmitterV2.json";
+import { TransactionStatus } from "@/types";
+import { CctpAttestationApiResponse, CctpAttestationMessageStatus } from "@/types/cctp";
+import { GetPublicClientReturnType } from "@wagmi/core";
 import { getAddress } from "viem";
 
+// TODO - Make dynamic based on user actions and current chain, rather than hard-coded
 export const CCTP_TOKEN_MESSENGER = getAddress("0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA");
 export const CCTP_TRANSFER_MAX_FEE = 500n;
 export const CCTP_MIN_FINALITY_THRESHOLD = 1000; // 1000 Fast transfer, 2000 Standard transfer
+export const CCTP_MESSAGE_TRANSMITTER = getAddress("0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275");
+
+// See CCTPV2 message encoding scheme at https://github.com/circlefin/evm-cctp-contracts/blob/6e7513cdb2bee6bb0cddf331fe972600fc5017c9/src/messages/v2/MessageV2.sol#L31-L41
+export const getCCTPMessageNonce = (message: string): string => {
+  if (message.length < 90) return "0x";
+  return "0x" + message.substring(26, 90);
+};
+
+export const isCCTPNonceUsed = async (client: GetPublicClientReturnType, nonce: string): Promise<boolean> => {
+  const resp = await client?.readContract({
+    address: CCTP_MESSAGE_TRANSMITTER,
+    abi: MessageTransmitterV2.abi,
+    functionName: "usedNonces",
+    args: [nonce],
+  });
+
+  return resp === 1n;
+};
+
+export const getCCTPTransactionStatus = (
+  cctpMessageStatus: CctpAttestationMessageStatus,
+  isNonceUsed: boolean,
+): TransactionStatus => {
+  if (cctpMessageStatus === "pending_confirmations") return TransactionStatus.PENDING;
+  if (!isNonceUsed) return TransactionStatus.READY_TO_CLAIM;
+  return TransactionStatus.COMPLETED;
+};

--- a/bridge-ui/src/utils/cctp.ts
+++ b/bridge-ui/src/utils/cctp.ts
@@ -1,20 +1,17 @@
 import MessageTransmitterV2 from "@/abis/MessageTransmitterV2.json";
-import { TransactionStatus } from "@/types";
-import { CctpAttestationApiResponse, CctpAttestationMessageStatus } from "@/types/cctp";
+import { CCTPMessageReceivedEvent, CctpAttestationMessageStatus, TransactionStatus } from "@/types";
 import { GetPublicClientReturnType } from "@wagmi/core";
 import { getAddress } from "viem";
+import { eventCCTPMessageReceived } from "./events";
 
-// TODO - Make dynamic based on user actions and current chain, rather than hard-coded
+// Contract for sending CCTP message, appears constant for each chain
 export const CCTP_TOKEN_MESSENGER = getAddress("0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA");
+// TODO - Find optimal value
 export const CCTP_TRANSFER_MAX_FEE = 500n;
-export const CCTP_MIN_FINALITY_THRESHOLD = 1000; // 1000 Fast transfer, 2000 Standard transfer
-export const CCTP_MESSAGE_TRANSMITTER = getAddress("0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275");
-
-// See CCTPV2 message encoding scheme at https://github.com/circlefin/evm-cctp-contracts/blob/6e7513cdb2bee6bb0cddf331fe972600fc5017c9/src/messages/v2/MessageV2.sol#L31-L41
-export const getCCTPMessageNonce = (message: string): string => {
-  if (message.length < 90) return "0x";
-  return "0x" + message.substring(26, 90);
-};
+// 1000 Fast transfer, 2000 Standard transfer
+export const CCTP_MIN_FINALITY_THRESHOLD = 1000;
+// Contract for receiving CCTP message, appears constant for each chain
+export const CCTP_MESSAGE_TRANSMITTER = getAddress("0xE737e5cEBEEBa77EFE34D4aa090756590b1CE275"); // Appears constant for each chain
 
 export const isCCTPNonceUsed = async (client: GetPublicClientReturnType, nonce: string): Promise<boolean> => {
   const resp = await client?.readContract({
@@ -34,4 +31,28 @@ export const getCCTPTransactionStatus = (
   if (cctpMessageStatus === "pending_confirmations") return TransactionStatus.PENDING;
   if (!isNonceUsed) return TransactionStatus.READY_TO_CLAIM;
   return TransactionStatus.COMPLETED;
+};
+
+export const getCCTPClaimTx = async (
+  client: GetPublicClientReturnType,
+  status: CctpAttestationMessageStatus,
+  isNonceUsed: boolean,
+  nonce: `0x${string}`,
+): Promise<string | undefined> => {
+  if (!client) return undefined;
+  if (!isNonceUsed) return undefined;
+
+  const messageReceivedEvents = <CCTPMessageReceivedEvent[]>await client.getLogs({
+    event: eventCCTPMessageReceived,
+    // TODO - Find more efficient `fromBlock` param than 'earliest'
+    fromBlock: "earliest",
+    toBlock: "latest",
+    address: CCTP_MESSAGE_TRANSMITTER,
+    args: {
+      nonce: nonce,
+    },
+  });
+
+  if (messageReceivedEvents.length === 0) return undefined;
+  return messageReceivedEvents[0].transactionHash;
 };

--- a/bridge-ui/src/utils/events/eventCCTPMessageReceived.ts
+++ b/bridge-ui/src/utils/events/eventCCTPMessageReceived.ts
@@ -1,0 +1,15 @@
+const eventCCTPMessageReceived = {
+  anonymous: false,
+  inputs: [
+    { indexed: true, internalType: "address", name: "caller", type: "address" },
+    { indexed: false, internalType: "uint32", name: "sourceDomain", type: "uint32" },
+    { indexed: true, internalType: "bytes32", name: "nonce", type: "bytes32" },
+    { indexed: false, internalType: "bytes32", name: "sender", type: "bytes32" },
+    { indexed: true, internalType: "uint32", name: "finalityThresholdExecuted", type: "uint32" },
+    { indexed: false, internalType: "bytes", name: "messageBody", type: "bytes" },
+  ],
+  name: "MessageReceived",
+  type: "event",
+} as const;
+
+export default eventCCTPMessageReceived;

--- a/bridge-ui/src/utils/events/index.ts
+++ b/bridge-ui/src/utils/events/index.ts
@@ -2,3 +2,4 @@ export { default as eventERC20 } from "./eventERC20";
 export { default as eventERC20V2 } from "./eventERC20V2";
 export { default as eventETH } from "./eventETH";
 export { default as eventUSDC } from "./eventUSDC";
+export { default as eventCCTPMessageReceived } from "./eventCCTPMessageReceived";

--- a/bridge-ui/src/utils/index.ts
+++ b/bridge-ui/src/utils/index.ts
@@ -6,3 +6,4 @@ export { fetchTransactionsHistory, type BridgeTransaction } from "./history";
 export { computeMessageHash, computeMessageStorageSlot } from "./message";
 export { isEth } from "./tokens";
 export { isEmptyObject } from "./utils";
+export { CCTP_TOKEN_MESSENGER, getCCTPMessageNonce, isCCTPNonceUsed, getCCTPTransactionStatus } from "./cctp";

--- a/bridge-ui/src/utils/index.ts
+++ b/bridge-ui/src/utils/index.ts
@@ -6,4 +6,4 @@ export { fetchTransactionsHistory, type BridgeTransaction } from "./history";
 export { computeMessageHash, computeMessageStorageSlot } from "./message";
 export { isEth } from "./tokens";
 export { isEmptyObject } from "./utils";
-export { CCTP_TOKEN_MESSENGER, getCCTPMessageNonce, isCCTPNonceUsed, getCCTPTransactionStatus } from "./cctp";
+export { CCTP_TOKEN_MESSENGER, getCCTPClaimTx, isCCTPNonceUsed, getCCTPTransactionStatus } from "./cctp";


### PR DESCRIPTION
This PR implements issue(s) #728 

## New features
- Feature toggle for transaction history, `isCCTPEnabled == false` -> No USDC transactions in the tx history list
- Implemented CCTPV2 transactions for transaction history. Implemented required utility functions including
    - `getCCTPTransactionStatus`
    - `getCCTPClaimTx`
    - `isCCTPNonceUsed`

## TODO next
- Claim transaction UI flow
- Handle corner case of expired CCTPV2 attestation message

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.