### PR TITLE
Broken Links

### DIFF
--- a/bridge-ui/README.md
+++ b/bridge-ui/README.md
@@ -11,9 +11,9 @@ Private configuration variables are store on GitHub Secrets.
 ### Get a Frontend Tag
 
 - Retrieve an existing tag.
-  - Get a Tag from [GitHub Actions](https://github.com/Consensys/zkevm-monorepo/actions) on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
+  - Get a Tag from [GitHub Actions]() on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
 - Or create a new tag.
-  - Create a PR and merge the last version to develop branch, and get a Tag from [GitHub Actions](https://github.com/Consensys/zkevm-monorepo/actions) on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
+  - Create a PR and merge the last version to develop branch, and get a Tag from [GitHub Actions]() on `Bridge UI Build and Publish` job, `Set Docker Tag` action.
 
 Example:
 


### PR DESCRIPTION
I noticed the GitHub Actions link in the bridge-ui/README.md was broken:
https://github.com/Consensys/zkevm-monorepo/actions → returns 404.

To prevent confusion, I’ve temporarily removed the dead link and kept the surrounding description intact using contextual references.

If there is a correct or updated GitHub Actions link you'd prefer, feel free to share — I'm happy to update it accordingly!