### PR TITLE
fix: dictionary assignment

### DIFF
--- a/prover/circuits/blobdecompression/v1/circuit.go
+++ b/prover/circuits/blobdecompression/v1/circuit.go
@@ -257,6 +257,7 @@ func AssignFPI(blobBytes []byte, dictStore dictionary.Store, eip4844Enabled bool
 	if err != nil {
 		return
 	}
+	dict = r.Dict
 
 	if len(r.RawPayload) > blob.MaxUncompressedBytes {
 		err = fmt.Errorf("decompression circuit assignment: blob payload too large : %d. max %d", len(r.RawPayload), blob.MaxUncompressedBytes)


### PR DESCRIPTION
This PR fixes a bug in a recent decompressor refactoring that removed the dictionary assignment of the decompression circuit.