### PR TITLE
feat: BLS12-381 precompiles glue

### DIFF
--- a/prover/zkevm/prover/bls/element.go
+++ b/prover/zkevm/prover/bls/element.go
@@ -1,0 +1,44 @@
+package bls
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_bls12381"
+	"github.com/consensys/gnark/std/math/emulated"
+)
+
+const (
+	// BLS base field is 381 bits, and we use 4 limbs of 128 bits to represent
+	// it. However, the highest limb is always zero, but the arithmetization
+	// keeps it for nice alignment. We pass it to the circuit but check
+	// explicitly that its 0.
+	nbFpLimbs = 4 // (x_3, x_2, x_1, x_0) MSB order
+
+	nbG1Limbs = 2 * nbFpLimbs  // (Ax, Ay)
+	nbG2Limbs = 4 * nbFpLimbs  // (BxIm, BxRe, ByIm, ByRe)
+	nbGtLimbs = 12 * nbFpLimbs // representation according to gnark - we don't use Gt in arithmetization, only in glue for accumulation
+
+)
+
+type g1ElementWizard struct {
+	P [nbG1Limbs]frontend.Variable
+}
+
+func (c *g1ElementWizard) ToG1Element(api frontend.API, fp *emulated.Field[sw_bls12381.BaseField]) sw_bls12381.G1Affine {
+	panic("todo")
+}
+
+type g2ElementWizard struct {
+	Q [nbG2Limbs]frontend.Variable
+}
+
+func (c *g2ElementWizard) ToG2Element(api frontend.API, fp *emulated.Field[sw_bls12381.BaseField]) sw_bls12381.G2Affine {
+	panic("todo")
+}
+
+type gtElementWizard struct {
+	T [nbGtLimbs]frontend.Variable
+}
+
+func (c *gtElementWizard) ToGTElement(api frontend.API, fp *emulated.Field[sw_bls12381.BaseField]) sw_bls12381.GTEl {
+	panic("todo")
+}


### PR DESCRIPTION
Adds glue for integrating BLS precompiles from gnark with the data provided in the arithmetization.

WIP

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.