### PR TITLE
config: support new dictionary

### DIFF
--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -35,8 +35,9 @@ RUN mkdir -p /opt/linea/prover/lib/compressor /app/logs
 # Import the LICENSE
 COPY ./LICENSE /opt/linea/prover/
 
-# Copy the blob compressor dictionary
+# Copy the blob compressor dictionaries
 COPY --from=go-builder /usr/src/prover/lib/compressor/compressor_dict.bin /opt/linea/prover/lib/compressor/
+COPY --from=go-builder /usr/src/prover/lib/compressor/dict/25-04-21.bin /opt/linea/prover/lib/compressor/dict/
 
 # Import the prover
 COPY --from=go-builder /usr/src/prover/bin/prover /opt/linea/prover/prover

--- a/prover/config/config-mainnet-full.toml
+++ b/prover/config/config-mainnet-full.toml
@@ -15,7 +15,7 @@ requests_root_dir = "/home/ubuntu/testing-mainnet-beta-v2/prover-execution"
 [blob_decompression]
 prover_mode = "full"
 requests_root_dir = "/home/ubuntu/testing-mainnet-beta-v2/prover-compression"
-dict_paths = ["lib/compressor/compressor_dict.bin"]
+dict_paths = ["lib/compressor/compressor_dict.bin", "lib/compressor/dict/25-04-21.bin"]
 
 [aggregation]
 prover_mode = "full"

--- a/prover/config/config-sepolia-full.toml
+++ b/prover/config/config-sepolia-full.toml
@@ -15,7 +15,7 @@ requests_root_dir = "/home/ubuntu/testing-sepolia-0.8.0-rc8.1/prover-execution"
 [blob_decompression]
 prover_mode = "full"
 requests_root_dir = "/home/ubuntu/testing-sepolia-0.8.0-rc8.1/prover-compression"
-dict_paths = ["lib/compressor/compressor_dict.bin"]
+dict_paths = ["lib/compressor/compressor_dict.bin", "lib/compressor/dict/25-04-21.bin"]
 
 [aggregation]
 prover_mode = "full"


### PR DESCRIPTION
The prover on both testnet and mainnet must be able to accept blobs with both old and new dictionaries until the final blob compressed with the old dictionary has already been aggregated.