### PR TITLE
fix: Change prover config in Docker to include new compressor dict

### DIFF
--- a/docker/config/prover/v3/prover-config.toml
+++ b/docker/config/prover/v3/prover-config.toml
@@ -13,7 +13,7 @@ requests_root_dir = "/data/prover/v3/execution"
 [blob_decompression]
 prover_mode = "dev"
 requests_root_dir = "/data/prover/v3/compression"
-dict_paths = ["/opt/linea/prover/lib/compressor/compressor_dict.bin"]
+dict_paths = ["/opt/linea/prover/lib/compressor/compressor_dict.bin", "/opt/linea/prover/lib/compressor/dict/25-04-21.bin"]
 
 [aggregation]
 prover_mode = "dev"

--- a/prover/lib/compressor/blob/dictionary/dictionary.go
+++ b/prover/lib/compressor/blob/dictionary/dictionary.go
@@ -3,11 +3,13 @@ package dictionary
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"os"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/hash"
 	"github.com/consensys/gnark/std/compress"
 	"github.com/consensys/linea-monorepo/prover/lib/compressor/blob/encode"
-	"os"
 )
 
 // Checksum according to the given spec version
@@ -73,7 +75,7 @@ func (s Store) Get(checksum []byte, version uint16) ([]byte, error) {
 	}
 	res, ok := s[version][string(checksum)]
 	if !ok {
-		return nil, errors.New("dictionary not found")
+		return nil, fmt.Errorf("blob v%d: no dictionary found in store with checksum %x", version, checksum)
 	}
 	return res, nil
 }


### PR DESCRIPTION
* Add new compression dict path to `docker/config/prover/v3/prover-config.toml`
* Include more info in "dictionary not found" error