### PR TITLE
fix: allow cancel for manual triggered linea-besu-package action

### DIFF
--- a/.github/workflows/linea-besu-package-release.yml
+++ b/.github/workflows/linea-besu-package-release.yml
@@ -55,7 +55,7 @@ jobs:
 
   build-test-push:
     needs: [ filter-commit-changes ]
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/reuse-linea-besu-package-build-test-push.yml
     with:
       release_tag_prefix: ${{ inputs.release_tag_prefix }}

--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -82,7 +82,7 @@ jobs:
     if: ${{ inputs.run_test }}
     concurrency:
       group: run-test-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/reuse-linea-besu-package-run-test.yml
     with:
       dockerimage: ${{ needs.build-and-upload-artifact.outputs.dockerimage }}
@@ -92,7 +92,7 @@ jobs:
     if: ${{ inputs.run_e2e_test }}
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
     with:
       linea_besu_package_tag: ${{ needs.build-and-upload-artifact.outputs.linea_besu_package_tag }} 

--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -91,7 +91,7 @@ jobs:
 
   run-test:
     needs: [ build-and-upload-artifact ]
-    if: ${{ inputs.run_test }}
+    if: ${{ !cancelled() && inputs.run_test }}
     concurrency:
       group: run-test-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
@@ -101,7 +101,7 @@ jobs:
 
   run-e2e-tests:
     needs: [ build-and-upload-artifact ]
-    if: ${{ inputs.run_e2e_test }}
+    if: ${{ !cancelled() && inputs.run_e2e_test }}
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -30,18 +30,6 @@ jobs:
       expected_traces_api_version: ${{ steps.assemble.outputs.tracer_plugin_version }}
       dockerimage: ${{ steps.assemble.outputs.dockerimage }}
     steps:
-      - name: echo github variables
-        run: |
-          echo "github.run_id: ${{ github.run_id }}"
-          echo "github.workflow: ${{ github.workflow }}"
-          echo "github.ref: ${{ github.ref }}"
-          echo "github.ref_type: ${{ github.ref_type }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "rev-parse HEAD: $(git rev-parse --short HEAD)"
-          echo "github.sha: ${{ github.sha }}"
-          echo "rev-parse GITHUB_SHA: $(git rev-parse --short "$GITHUB_SHA")"
-      
       - name: checkout
         uses: actions/checkout@v4
 
@@ -91,7 +79,7 @@ jobs:
 
   run-test:
     needs: [ build-and-upload-artifact ]
-    if: ${{ !cancelled() && inputs.run_test }}
+    if: ${{ inputs.run_test }}
     concurrency:
       group: run-test-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
@@ -101,7 +89,7 @@ jobs:
 
   run-e2e-tests:
     needs: [ build-and-upload-artifact ]
-    if: ${{ !cancelled() && inputs.run_e2e_test }}
+    if: ${{ inputs.run_e2e_test }}
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -30,6 +30,18 @@ jobs:
       expected_traces_api_version: ${{ steps.assemble.outputs.tracer_plugin_version }}
       dockerimage: ${{ steps.assemble.outputs.dockerimage }}
     steps:
+      - name: echo github variables
+        run: |
+          echo "github.run_id: ${{ github.run_id }}"
+          echo "github.workflow: ${{ github.workflow }}"
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.ref_type: ${{ github.ref_type }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "rev-parse HEAD: $(git rev-parse --short HEAD)"
+          echo "github.sha: ${{ github.sha }}"
+          echo "rev-parse GITHUB_SHA: $(git rev-parse --short "$GITHUB_SHA")"
+      
       - name: checkout
         uses: actions/checkout@v4
 
@@ -102,7 +114,7 @@ jobs:
 
   build-and-push-dockerhub:
     needs: [ run-test, run-e2e-tests ]
-    if: ${{ always() && inputs.push_image && (needs.run-e2e-test.result == 'skipped' || needs.run-e2e-tests.outputs.tests_outcome == 'success') && (needs.run-test.result == 'skipped' || needs.run-test.result == 'success') }}
+    if: ${{ always() && !cancelled() && inputs.push_image && (needs.run-e2e-test.result == 'skipped' || needs.run-e2e-tests.outputs.tests_outcome == 'success') && (needs.run-test.result == 'skipped' || needs.run-test.result == 'success') }}
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     environment: dockerhub
     env:


### PR DESCRIPTION
This PR fixes the issue of `linea-besu-package-release` workflow not being able to be manually cancelled 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.