### PR TITLE
fix: use backported gnark-crypto neg-scalar glv fix

### DIFF
--- a/prover/go.mod
+++ b/prover/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/consensys/bavard v0.1.24
 	github.com/consensys/compress v0.2.5
 	github.com/consensys/gnark v0.11.1-0.20250107100237-2cb190338a01
-	github.com/consensys/gnark-crypto v0.14.1-0.20241217134352-810063550bd4
+	github.com/consensys/gnark-crypto v0.14.1-0.20250515163241-5b554443cce2
 	github.com/consensys/go-corset v1.0.3
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/dlclark/regexp2 v1.11.2

--- a/prover/go.sum
+++ b/prover/go.sum
@@ -98,8 +98,8 @@ github.com/consensys/compress v0.2.5 h1:gJr1hKzbOD36JFsF1AN8lfXz1yevnJi1YolffY19
 github.com/consensys/compress v0.2.5/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
 github.com/consensys/gnark v0.11.1-0.20250107100237-2cb190338a01 h1:YCHI04nMKFC60P78x+05QR3jxgBFlDXzJq+7bQOmbfs=
 github.com/consensys/gnark v0.11.1-0.20250107100237-2cb190338a01/go.mod h1:8YNyW/+XsYiLRzROLaj/PSktYO4VAdv6YW1b1P3UsZk=
-github.com/consensys/gnark-crypto v0.14.1-0.20241217134352-810063550bd4 h1:Kp6egjRqKZf4469dfAWqFe6gi3MRs4VvNHmTfEjUlS8=
-github.com/consensys/gnark-crypto v0.14.1-0.20241217134352-810063550bd4/go.mod h1:GMPeN3dUSslNBYJsK3WTjIGd3l0ccfMbcEh/d5knFrc=
+github.com/consensys/gnark-crypto v0.14.1-0.20250515163241-5b554443cce2 h1:N3OCv+VoCn4CEvhRc3vKXyE3S1Si7OSoFTO3bv6ZEgQ=
+github.com/consensys/gnark-crypto v0.14.1-0.20250515163241-5b554443cce2/go.mod h1:ePFa23CZLMRMHxQpY5nMaiAZ3yuEIayaB8ElEvlwLEs=
 github.com/consensys/go-corset v1.0.3 h1:CZ04qi9NaMkMJnfv19UUHGhEXJZwpDNrAo5fwDbT1OM=
 github.com/consensys/go-corset v1.0.3/go.mod h1:JKJTywyjBE0Goco4DokW4BAkF6R+jtoo3XgkICwxrcw=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=


### PR DESCRIPTION
See https://github.com/Consensys/gnark/pull/1487, https://github.com/Consensys/gnark/issues/1483, https://github.com/Consensys/gnark-crypto/pull/680.

Updates only the solver hint for gnark, so no circuit update needed.

~Do not merge to main! We should follow gnark and gnark-crypto master. This is only a backported fix.~
