### PR TITLE
Prover: the controller skips waiting for the sub-process to yield on a SIGTERM in spot-instance mode

### DIFF
--- a/prover/cmd/controller/controller/controller.go
+++ b/prover/cmd/controller/controller/controller.go
@@ -199,6 +199,13 @@ func runController(ctx context.Context, cfg *config.Config) {
 					)
 				}
 
+				// As an edge-case, it's possible (in theory) that the process
+				// completes exactly when we receive the kill signal. So we
+				// could end up in a situation where the tmp-response file
+				// exists. In that case, we simply delete it before exiting to
+				// keep the FS clean.
+				os.Remove(job.TmpResponseFile(cfg))
+
 			// Failure case
 			default:
 				// Move the inprogress to the done directory

--- a/prover/cmd/controller/controller/controller.go
+++ b/prover/cmd/controller/controller/controller.go
@@ -50,7 +50,12 @@ func runController(ctx context.Context, cfg *config.Config) {
 		// SIGTERM is received, there would be no log entry about the signal
 		// until the proof completes.
 		<-ctx.Done()
-		cLog.Infoln("Received cancellation request, will exit as soon as possible or once current proof task is complete.")
+
+		if cfg.Controller.SpotInstanceMode {
+			cLog.Infoln("Received cancellation request. Killing the ongoing process and exiting immediately after.")
+		} else {
+			cLog.Infoln("Received cancellation request, will exit as soon as possible or once current proof task is complete.")
+		}
 	}()
 
 	for {


### PR DESCRIPTION
This PR makes sure that the controller handles SIGTERM faster by not waiting for the subprocess to yield on a SIGKILL

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.