### PR TITLE
chore: switch to Consensys fork of Tuweni and update it to 2.7.0

### DIFF
--- a/besu-plugins/linea-sequencer/gradle/dependency-management.gradle
+++ b/besu-plugins/linea-sequencer/gradle/dependency-management.gradle
@@ -57,9 +57,9 @@ dependencyManagement {
 
     dependency "com.google.code.gson:gson:${libs.versions.gson.get()}"
 
-    dependency "io.tmio:tuweni-bytes:${libs.versions.tuweni.get()}"
-    dependency "io.tmio:tuweni-units:${libs.versions.tuweni.get()}"
-    dependency "io.tmio:tuweni-toml:${libs.versions.tuweni.get()}"
+    dependency "io.consensys.tuweni:tuweni-bytes:${libs.versions.tuweni.get()}"
+    dependency "io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}"
+    dependency "io.consensys.tuweni:tuweni-toml:${libs.versions.tuweni.get()}"
 
     // ToDo: remove when fixed in Besu, force version to avoid conflict with previous version
     dependency "org.apache.logging.log4j:log4j-api:${libs.versions.log4j.get()}"

--- a/besu-plugins/linea-sequencer/sequencer/build.gradle
+++ b/besu-plugins/linea-sequencer/sequencer/build.gradle
@@ -47,9 +47,9 @@ dependencies {
 
   implementation 'com.google.code.gson:gson'
 
-  implementation "io.tmio:tuweni-bytes"
-  implementation "io.tmio:tuweni-units"
-  implementation "io.tmio:tuweni-toml"
+  implementation "io.consensys.tuweni:tuweni-bytes"
+  implementation "io.consensys.tuweni:tuweni-units"
+  implementation "io.consensys.tuweni:tuweni-toml"
 
   implementation 'info.picocli:picocli'
 

--- a/coordinator/persistence/aggregation/build.gradle
+++ b/coordinator/persistence/aggregation/build.gradle
@@ -11,7 +11,7 @@ dependencies {
   testImplementation(project(":coordinator:persistence:batch"))
   testImplementation(project(":coordinator:persistence:blob"))
   testImplementation(project(":coordinator:persistence:db-common"))
-  testImplementation "io.tmio:tuweni-units:${libs.versions.tuweni.get()}"
+  testImplementation "io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}"
   testImplementation(testFixtures(project(":coordinator:core")))
   testImplementation(testFixtures(project(":coordinator:persistence:db-common")))
   testImplementation(testFixtures(project(":jvm-libs:generic:persistence:db")))

--- a/coordinator/persistence/blob/build.gradle
+++ b/coordinator/persistence/blob/build.gradle
@@ -13,7 +13,7 @@ dependencies {
   testImplementation("com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson.get()}")
   testImplementation("com.fasterxml.jackson.core:jackson-annotations:${libs.versions.jackson.get()}")
   testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:${libs.versions.jackson.get()}")
-  testImplementation "io.tmio:tuweni-units:${libs.versions.tuweni.get()}"
+  testImplementation "io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}"
   testImplementation(project(":coordinator:persistence:db-common"))
   testImplementation(testFixtures(project(":coordinator:core")))
   testImplementation(testFixtures(project(":jvm-libs:generic:extensions:kotlin")))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ netty = "4.1.92.Final"
 picoli = "4.7.6"
 slf4j="1.7.36"
 teku = "23.1.1"
-tuweni = "2.4.2"
+tuweni = "2.7.0"
 vertx = "4.5.14"
 web3j = "4.12.2"
 

--- a/jvm-libs/generic/extensions/tuweni/build.gradle
+++ b/jvm-libs/generic/extensions/tuweni/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description = "Tuweni bytes utilities"
 
 dependencies {
-  api "io.tmio:tuweni-bytes:${libs.versions.tuweni.get()}"
+  api "io.consensys.tuweni:tuweni-bytes:${libs.versions.tuweni.get()}"
   implementation(project(':jvm-libs:generic:extensions:kotlin'))
-  testImplementation "io.tmio:tuweni-units:${libs.versions.tuweni.get()}"
+  testImplementation "io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}"
 }

--- a/jvm-libs/linea/besu-libs/build.gradle
+++ b/jvm-libs/linea/besu-libs/build.gradle
@@ -27,11 +27,11 @@ dependencies {
     transitive = false
   }
 
-  api("io.tmio:tuweni-bytes:${libs.versions.tuweni.get()}") {
+  api("io.consensys.tuweni:tuweni-bytes:${libs.versions.tuweni.get()}") {
     transitive = false
   }
 
-  api("io.tmio:tuweni-units:${libs.versions.tuweni.get()}") {
+  api("io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}") {
     transitive = false
   }
 

--- a/jvm-libs/linea/blob-decompressor/build.gradle
+++ b/jvm-libs/linea/blob-decompressor/build.gradle
@@ -16,7 +16,7 @@ dependencies {
   testImplementation(testFixtures(project(":jvm-libs:linea:core:domain-models")))
   testImplementation(project(":jvm-libs:linea:besu-rlp-and-mappers"))
   testImplementation(project(":jvm-libs:linea:testing:file-system"))
-  testImplementation("io.tmio:tuweni-bytes:${libs.versions.tuweni.get()}")
+  testImplementation("io.consensys.tuweni:tuweni-bytes:${libs.versions.tuweni.get()}")
   testImplementation(project(":jvm-libs:linea:besu-libs"))
 }
 

--- a/jvm-libs/linea/clients/linea-state-manager/build.gradle
+++ b/jvm-libs/linea/clients/linea-state-manager/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   api project(':jvm-libs:generic:errors')
   api project(':jvm-libs:generic:extensions:futures')
   api project(':jvm-libs:generic:extensions:kotlin')
-  api "io.tmio:tuweni-bytes:${libs.versions.tuweni.get()}"
+  api "io.consensys.tuweni:tuweni-bytes:${libs.versions.tuweni.get()}"
 
   implementation "com.fasterxml.jackson.core:jackson-annotations:${libs.versions.jackson.get()}"
   implementation "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson.get()}"

--- a/jvm-libs/linea/core/traces/build.gradle
+++ b/jvm-libs/linea/core/traces/build.gradle
@@ -6,7 +6,7 @@ plugins {
 description="Linea Tracing utilities"
 
 dependencies {
-  implementation "io.tmio:tuweni-units:${libs.versions.tuweni.get()}"
+  implementation "io.consensys.tuweni:tuweni-units:${libs.versions.tuweni.get()}"
   implementation project(':jvm-libs:generic:extensions:kotlin')
   testImplementation project(':jvm-libs:linea:testing:file-system')
   testImplementation "com.sksamuel.hoplite:hoplite-core:${libs.versions.hoplite.get()}"


### PR DESCRIPTION
This PR implements issue(s) #

Requires #203 Update to Kotlin 2.X

Tuweni new development is now done in the Consensys fork https://github.com/Consensys/tuweni

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.