### PR TITLE
[Fix] Remove targetExclude from Java linting config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ allprojects {
 
         java {
           target 'src/**/*.java'
-          targetExclude '**/src/test/java/**ReferenceTest**', '**/src/main/generated/**', '**/src/test/generated/**', '**/src/jmh/generated/**'
+          // Do not use 'targetExclude' with wildcard patterns, it will add minutes to the build
           removeUnusedImports()
           trimTrailingWhitespace()
           endWithNewline()


### PR DESCRIPTION
This PR implements issue(s) #1084 

Empirically on my local
- `./gradlew build -x test` takes ~10 seconds when `targetExclude` is removed. And ~3 minutes when it is present.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.