### PR TITLE
Make MetricsCategory an interface and add default tags

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/linea/metrics/LineaMetricsCategory.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/linea/metrics/LineaMetricsCategory.kt
@@ -1,0 +1,9 @@
+package net.consensys.linea.metrics
+
+enum class LineaMetricsCategory : MetricsCategory {
+  AGGREGATION,
+  BATCH,
+  BLOB,
+  CONFLATION,
+  GAS_PRICE_CAP,
+}

--- a/jvm-libs/linea/core/metrics/src/main/kotlin/net/consensys/linea/metrics/MetricsFacade.kt
+++ b/jvm-libs/linea/core/metrics/src/main/kotlin/net/consensys/linea/metrics/MetricsFacade.kt
@@ -7,18 +7,8 @@ import java.util.function.Supplier
 
 data class Tag(val key: String, val value: String)
 
-enum class LineaMetricsCategory {
-  AGGREGATION,
-  BATCH,
-  BLOB,
-  CONFLATION,
-  GAS_PRICE_CAP,
-  TX_EXCLUSION_API,
-  ;
-
-  override fun toString(): String {
-    return this.name.replace('_', '.').lowercase()
-  }
+interface MetricsCategory {
+  val name: String
 }
 
 interface Counter {
@@ -38,7 +28,7 @@ interface TimerCapture<T> {
 
 interface MetricsFacade {
   fun createGauge(
-    category: LineaMetricsCategory? = null,
+    category: MetricsCategory? = null,
     name: String,
     description: String,
     measurementSupplier: Supplier<Number>,
@@ -46,14 +36,14 @@ interface MetricsFacade {
   )
 
   fun createCounter(
-    category: LineaMetricsCategory? = null,
+    category: MetricsCategory? = null,
     name: String,
     description: String,
     tags: List<Tag> = emptyList(),
   ): Counter
 
   fun createHistogram(
-    category: LineaMetricsCategory? = null,
+    category: MetricsCategory? = null,
     name: String,
     description: String,
     tags: List<Tag> = emptyList(),
@@ -62,14 +52,14 @@ interface MetricsFacade {
   ): Histogram
 
   fun <T> createSimpleTimer(
-    category: LineaMetricsCategory? = null,
+    category: MetricsCategory? = null,
     name: String,
     description: String,
     tags: List<Tag> = emptyList(),
   ): TimerCapture<T>
 
   fun <T> createDynamicTagTimer(
-    category: LineaMetricsCategory? = null,
+    category: MetricsCategory? = null,
     name: String,
     description: String,
     tagKey: String,

--- a/jvm-libs/linea/metrics/micrometer/src/main/kotlin/net/consensys/linea/metrics/micrometer/DynamicTagTimerCapture.kt
+++ b/jvm-libs/linea/metrics/micrometer/src/main/kotlin/net/consensys/linea/metrics/micrometer/DynamicTagTimerCapture.kt
@@ -21,10 +21,6 @@ class DynamicTagTimerCapture<T> : AbstractTimerCapture<T>, TimerCapture<T> {
   private var tagKey: String? = null
 
   constructor(meterRegistry: MeterRegistry, name: String) : super(meterRegistry, name)
-  constructor(
-    meterRegistry: MeterRegistry,
-    timerBuilder: Timer.Builder,
-  ) : super(meterRegistry, timerBuilder)
 
   override fun setDescription(description: String): DynamicTagTimerCapture<T> {
     super.setDescription(description)
@@ -32,9 +28,8 @@ class DynamicTagTimerCapture<T> : AbstractTimerCapture<T>, TimerCapture<T> {
   }
 
   override fun setTag(tagKey: String, tagValue: String): DynamicTagTimerCapture<T> {
-    throw NoSuchMethodException(
-      "If you need to set both value and key, please use ${SimpleTimerCapture::class.qualifiedName}",
-    )
+    super.setTag(tagKey, tagValue)
+    return this
   }
 
   override fun setClock(clock: Clock): DynamicTagTimerCapture<T> {

--- a/jvm-libs/linea/metrics/micrometer/src/main/kotlin/net/consensys/linea/metrics/micrometer/Extensions.kt
+++ b/jvm-libs/linea/metrics/micrometer/src/main/kotlin/net/consensys/linea/metrics/micrometer/Extensions.kt
@@ -1,0 +1,7 @@
+package net.consensys.linea.metrics.micrometer
+
+import net.consensys.linea.metrics.MetricsCategory
+
+fun MetricsCategory.toValidMicrometerName(): String {
+  return this.name.lowercase().replace('_', '.')
+}

--- a/jvm-libs/linea/metrics/micrometer/src/test/kotlin/net/consensys/linea/metrics/micrometer/MicrometerMetricsFacadeTest.kt
+++ b/jvm-libs/linea/metrics/micrometer/src/test/kotlin/net/consensys/linea/metrics/micrometer/MicrometerMetricsFacadeTest.kt
@@ -3,7 +3,7 @@ package net.consensys.linea.metrics.micrometer
 import io.micrometer.core.instrument.ImmutableTag
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import net.consensys.linea.metrics.LineaMetricsCategory
+import net.consensys.linea.metrics.MetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import org.assertj.core.api.Assertions.assertThat
@@ -16,10 +16,18 @@ class MicrometerMetricsFacadeTest {
   private lateinit var meterRegistry: MeterRegistry
   private lateinit var metricsFacade: MetricsFacade
 
+  enum class TestCategory : MetricsCategory {
+    TEST_CATEGORY,
+  }
+
   @BeforeEach
   fun beforeEach() {
     meterRegistry = SimpleMeterRegistry()
-    metricsFacade = MicrometerMetricsFacade(meterRegistry, "linea.test")
+    metricsFacade = MicrometerMetricsFacade(
+      meterRegistry,
+      metricsPrefix = "linea.test",
+      defaultTags = listOf(Tag("version", "1.0.1")),
+    )
   }
 
   @Test
@@ -27,19 +35,23 @@ class MicrometerMetricsFacadeTest {
     var metricMeasureValue = 0L
     val expectedTags = listOf(Tag("key1", "value1"), Tag("key2", "value2"))
     metricsFacade.createGauge(
-      category = LineaMetricsCategory.BATCH,
+      category = TestCategory.TEST_CATEGORY,
       name = "some.metric",
       description = "This is a test metric",
       measurementSupplier = { metricMeasureValue },
       tags = expectedTags,
     )
     metricMeasureValue = 13L
-    val createdGauge = meterRegistry.find("linea.test.batch.some.metric").gauge()
+    val createdGauge = meterRegistry.find("linea.test.test.category.some.metric").gauge()
     assertThat(createdGauge).isNotNull
     assertThat(createdGauge!!.value()).isEqualTo(13.0)
     metricMeasureValue = 2L
     assertThat(createdGauge.value()).isEqualTo(2.0)
-    assertThat(createdGauge.id.tags).isEqualTo(listOf(ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")))
+    assertThat(
+      createdGauge.id.tags,
+    ).containsAll(
+      listOf(ImmutableTag("version", "1.0.1"), ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")),
+    )
     assertThat(createdGauge.id.description).isEqualTo("This is a test metric")
   }
 
@@ -47,12 +59,12 @@ class MicrometerMetricsFacadeTest {
   fun `createCounter creates counter with specified parameters`() {
     val expectedTags = listOf(Tag("key1", "value1"), Tag("key2", "value2"))
     val counter = metricsFacade.createCounter(
-      category = LineaMetricsCategory.BATCH,
+      category = TestCategory.TEST_CATEGORY,
       name = "some.metric",
       description = "This is a test metric",
       tags = expectedTags,
     )
-    val createdCounter = meterRegistry.find("linea.test.batch.some.metric").counter()
+    val createdCounter = meterRegistry.find("linea.test.test.category.some.metric").counter()
     assertThat(createdCounter!!.count()).isEqualTo(0.0)
     assertThat(createdCounter).isNotNull
     counter.increment(13.0)
@@ -64,7 +76,11 @@ class MicrometerMetricsFacadeTest {
     assertThat(createdCounter.count()).isEqualTo(16.0)
     counter.increment(0.5)
     assertThat(createdCounter.count()).isEqualTo(16.5)
-    assertThat(createdCounter.id.tags).isEqualTo(listOf(ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")))
+    assertThat(
+      createdCounter.id.tags,
+    ).containsAll(
+      listOf(ImmutableTag("version", "1.0.1"), ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")),
+    )
     assertThat(createdCounter.id.description).isEqualTo("This is a test metric")
   }
 
@@ -72,18 +88,20 @@ class MicrometerMetricsFacadeTest {
   fun `createHistogram creates histogram with specified parameters`() {
     val expectedTags = listOf(Tag("key1", "value1"), Tag("key2", "value2"))
     val histogram = metricsFacade.createHistogram(
-      category = LineaMetricsCategory.BATCH,
+      category = TestCategory.TEST_CATEGORY,
       name = "some.metric",
       description = "This is a test metric",
       tags = expectedTags,
       baseUnit = "seconds",
     )
 
-    val createdHistogram = meterRegistry.find("linea.test.batch.some.metric").summary()
+    val createdHistogram = meterRegistry.find("linea.test.test.category.some.metric").summary()
     assertThat(createdHistogram).isNotNull
     assertThat(createdHistogram!!.id.description).isEqualTo("This is a test metric")
-    assertThat(createdHistogram.id.tags).isEqualTo(
-      listOf(ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")),
+    assertThat(
+      createdHistogram.id.tags,
+    ).containsAll(
+      listOf(ImmutableTag("version", "1.0.1"), ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")),
     )
     assertThat(createdHistogram.id.baseUnit).isEqualTo("seconds")
     assertThat(createdHistogram.count()).isEqualTo(0L)
@@ -122,7 +140,11 @@ class MicrometerMetricsFacadeTest {
     val createdTimer = meterRegistry.find("linea.test.some.timer.metric").timer()
     assertThat(createdTimer).isNotNull
     assertThat(createdTimer!!.id.description).isEqualTo("This is a test metric")
-    assertThat(createdTimer.id.tags).isEqualTo(listOf(ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")))
+    assertThat(
+      createdTimer.id.tags,
+    ).containsAll(
+      listOf(ImmutableTag("version", "1.0.1"), ImmutableTag("key1", "value1"), ImmutableTag("key2", "value2")),
+    )
     assertThat(createdTimer.max(TimeUnit.SECONDS)).isGreaterThan(0.2)
 
     timer.captureTime(::mockTimer)
@@ -149,7 +171,7 @@ class MicrometerMetricsFacadeTest {
     val createdTimer = meterRegistry.find("linea.test.some.dynamictag.timer.metric").timer()
     assertThat(createdTimer).isNotNull
     assertThat(createdTimer!!.id.description).isEqualTo("This is a test metric")
-    assertThat(createdTimer.id.tags).isEqualTo(listOf(ImmutableTag("key", "value")))
+    assertThat(createdTimer.id.tags).containsAll(listOf(ImmutableTag("version", "1.0.1"), ImmutableTag("key", "value")))
     assertThat(createdTimer.max(TimeUnit.SECONDS)).isGreaterThan(0.2)
 
     timer.captureTime(::mockTimer)

--- a/transaction-exclusion-api/app/src/main/kotlin/net/consensys/linea/metrics/LineaMetricsCategory.kt
+++ b/transaction-exclusion-api/app/src/main/kotlin/net/consensys/linea/metrics/LineaMetricsCategory.kt
@@ -1,0 +1,5 @@
+package net.consensys.linea.metrics
+
+enum class LineaMetricsCategory : MetricsCategory {
+  TX_EXCLUSION_API,
+}


### PR DESCRIPTION
This PR implements issue(s) https://github.com/Consensys/maru/issues/97

In this PR:
- Make metrics category an interface instead of an enum. This way services that import metrics package can define their own metrics category.
- Move LineaMetricsCategory enum out of the metrics package
- Add default tags to the Micrometer Metrics Facade. This is useful to set the service version or node id that is common for all metrics being published by the service.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.