### PR TITLE
Use distribution artifact instead of uber jar for Tracer plugin

### DIFF
--- a/linea-besu-package/scripts/assemble-packages.sh
+++ b/linea-besu-package/scripts/assemble-packages.sh
@@ -26,8 +26,11 @@ wget -nv https://github.com/Consensys/linea-monorepo/releases/download/linea-fin
 echo "getting linea_staterecovery_plugin_version: $LINEA_STATERECOVERY_PLUGIN_VERSION"
 wget -nv https://github.com/Consensys/linea-monorepo/releases/download/linea-staterecovery-v$LINEA_STATERECOVERY_PLUGIN_VERSION/linea-staterecovery-besu-plugin-v$LINEA_STATERECOVERY_PLUGIN_VERSION.jar
 
-echo "getting linea_tracer_plugin_version: $LINEA_TRACER_PLUGIN_VERSION" 
+echo "getting linea_tracer_plugin_version: $LINEA_TRACER_PLUGIN_VERSION"
 wget -nv https://github.com/Consensys/linea-tracer/releases/download/$LINEA_TRACER_PLUGIN_VERSION/linea-tracer-$LINEA_TRACER_PLUGIN_VERSION.jar
+wget -nv https://github.com/Consensys/linea-tracer/releases/download/$LINEA_TRACER_PLUGIN_VERSION/linea-tracer-$LINEA_TRACER_PLUGIN_VERSION.zip
+unzip -o linea-tracer-$LINEA_TRACER_PLUGIN_VERSION.zip
+rm linea-tracer-$LINEA_TRACER_PLUGIN_VERSION.zip
 
 echo "getting shomei_plugin_version: $SHOMEI_PLUGIN_VERSION" 
 wget -nv https://github.com/Consensys/besu-shomei-plugin/releases/download/v$SHOMEI_PLUGIN_VERSION/besu-shomei-plugin-v$SHOMEI_PLUGIN_VERSION.jar


### PR DESCRIPTION
This PR implements issue(s) #

Since https://github.com/Consensys/linea-tracer/pull/1996 the Tracer is not publishing any more the uber jar, and the plugin is only available as a ZIP archive that needs to be unpacked in the `plugins` dir, this PR adjust the `linea-besu-package` to use the new distribution artifact.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.