### PR TITLE
Chore: Update Besu to 25.6.0-linea1 and artifacts Maven coordinates

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/build.gradle
+++ b/besu-plugins/linea-sequencer/acceptance-tests/build.gradle
@@ -46,7 +46,9 @@ tasks.register('acceptanceTests', Test) {
     includeTags("AcceptanceTest")
   }
 
-  maxParallelForks Runtime.runtime.availableProcessors()
+  // Configure resource limits
+  boolean isCiServer = System.getenv().containsKey("CI")
+  maxParallelForks = isCiServer ? Runtime.runtime.availableProcessors() : 2
   systemProperties["junit.jupiter.execution.parallel.enabled"] = false
 }
 
@@ -58,14 +60,14 @@ dependencies {
   testImplementation project("${lineaSequencerProjectPath}:sequencer")
 
   testImplementation "${besuArtifactGroup}:besu-datatypes"
-  testImplementation "${besuArtifactGroup}.internal:clique"
-  testImplementation "${besuArtifactGroup}.internal:api"
-  testImplementation "${besuArtifactGroup}.internal:core"
-  testImplementation "${besuArtifactGroup}.internal:dsl"
-  testImplementation "${besuArtifactGroup}.internal:eth"
-  testImplementation "${besuArtifactGroup}.internal:metrics-core"
-  testImplementation "${besuArtifactGroup}.internal:services"
-  testImplementation group: "${besuArtifactGroup}.internal", name: "core", classifier: "test-support"
+  testImplementation "${besuArtifactGroup}.internal:besu-consensus-clique"
+  testImplementation "${besuArtifactGroup}.internal:besu-ethereum-api"
+  testImplementation "${besuArtifactGroup}.internal:besu-ethereum-core"
+  testImplementation "${besuArtifactGroup}.internal:besu-acceptance-tests-dsl"
+  testImplementation "${besuArtifactGroup}.internal:besu-ethereum-eth"
+  testImplementation "${besuArtifactGroup}.internal:besu-metrics-core"
+  testImplementation "${besuArtifactGroup}.internal:besu-crypto-services"
+  testImplementation group: "${besuArtifactGroup}.internal", name: "besu-ethereum-core", classifier: "test-support"
 
   testImplementation 'net.consensys.linea.zktracer:arithmetization'
 

--- a/besu-plugins/linea-sequencer/gradle/dependency-management.gradle
+++ b/besu-plugins/linea-sequencer/gradle/dependency-management.gradle
@@ -68,3 +68,38 @@ dependencyManagement {
     dependency "org.wiremock:wiremock:${libs.versions.wiremock.get()}"
   }
 }
+
+configurations.all {
+  // transitive versions conflict new Besu coordinates
+  exclude group: "${besuArtifactGroup}.internal", module: 'dsl'
+  exclude group: "${besuArtifactGroup}.internal", module: 'besu'
+  exclude group: "${besuArtifactGroup}.internal", module: 'config'
+  exclude group: "${besuArtifactGroup}.internal", module: 'clique'
+  exclude group: "${besuArtifactGroup}.internal", module: 'common'
+  exclude group: "${besuArtifactGroup}.internal", module: 'ibft'
+  exclude group: "${besuArtifactGroup}.internal", module: 'ibftlegacy'
+  exclude group: "${besuArtifactGroup}.internal", module: 'merge'
+  exclude group: "${besuArtifactGroup}.internal", module: 'qbft'
+  exclude group: "${besuArtifactGroup}.internal", module: 'qbft-core'
+  exclude group: "${besuArtifactGroup}.internal", module: 'algorithms'
+  exclude group: "${besuArtifactGroup}.internal", module: 'services'
+  exclude group: "${besuArtifactGroup}.internal", module: 'api'
+  exclude group: "${besuArtifactGroup}.internal", module: 'blockcreation'
+  exclude group: "${besuArtifactGroup}.internal", module: 'core'
+  exclude group: "${besuArtifactGroup}.internal", module: 'eth'
+  exclude group: "${besuArtifactGroup}.internal", module: 'p2p'
+  exclude group: "${besuArtifactGroup}.internal", module: 'permissioning'
+  exclude group: "${besuArtifactGroup}.internal", module: 'referencetests'
+  exclude group: "${besuArtifactGroup}.internal", module: 'rlp'
+  exclude group: "${besuArtifactGroup}.internal", module: 'trie'
+  exclude group: "${besuArtifactGroup}", module: 'evm'
+  exclude group: "${besuArtifactGroup}.internal", module: 'metrics-core'
+  exclude group: "${besuArtifactGroup}", module: 'plugin-api'
+  exclude group: "${besuArtifactGroup}.internal", module: 'testutil'
+  exclude group: "${besuArtifactGroup}.internal", module: 'util'
+  exclude group: "${besuArtifactGroup}.internal", module: 'nat'
+  exclude group: "${besuArtifactGroup}.internal", module: 'tasks'
+  exclude group: "${besuArtifactGroup}.internal", module: 'pipeline'
+  exclude group: "${besuArtifactGroup}.internal", module: 'kvstore'
+  exclude group: "${besuArtifactGroup}.internal", module: 'enclave'
+}

--- a/besu-plugins/linea-sequencer/sequencer/build.gradle
+++ b/besu-plugins/linea-sequencer/sequencer/build.gradle
@@ -33,13 +33,13 @@ dependencies {
   api "build.linea.internal:kotlin:${libs.versions.lineaKotlin.get()}"
 
   implementation "${besuArtifactGroup}:besu-datatypes"
-  implementation "${besuArtifactGroup}:evm"
-  implementation "${besuArtifactGroup}:plugin-api"
-  implementation "${besuArtifactGroup}.internal:algorithms"
-  implementation "${besuArtifactGroup}.internal:api"
-  implementation "${besuArtifactGroup}.internal:core"
-  implementation "${besuArtifactGroup}.internal:eth"
-  implementation "${besuArtifactGroup}.internal:rlp"
+  implementation "${besuArtifactGroup}:besu-evm"
+  implementation "${besuArtifactGroup}:besu-plugin-api"
+  implementation "${besuArtifactGroup}.internal:besu-crypto-algorithms"
+  implementation "${besuArtifactGroup}.internal:besu-ethereum-api"
+  implementation "${besuArtifactGroup}.internal:besu-ethereum-core"
+  implementation "${besuArtifactGroup}.internal:besu-ethereum-eth"
+  implementation "${besuArtifactGroup}.internal:besu-ethereum-rlp"
 
   implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
 
@@ -57,8 +57,8 @@ dependencies {
 
   implementation 'org.hibernate.validator:hibernate-validator'
 
-  testImplementation "${besuArtifactGroup}.internal:besu"
-  testImplementation group: "${besuArtifactGroup}.internal", name: "core", classifier: "test-support"
+  testImplementation "${besuArtifactGroup}.internal:besu-app"
+  testImplementation group: "${besuArtifactGroup}.internal", name: "besu-ethereum-core", classifier: "test-support"
 
   testImplementation 'org.awaitility:awaitility'
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
@@ -11,7 +11,6 @@ package net.consensys.linea.rpc.methods;
 import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture.SIGNATURE_ALGORITHM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,6 +27,7 @@ import java.util.UUID;
 import net.consensys.linea.bundles.BundleParameter;
 import net.consensys.linea.bundles.LineaLimitedBundlePool;
 import net.consensys.linea.bundles.TransactionBundle;
+import org.hyperledger.besu.crypto.SignatureAlgorithmType;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
@@ -50,13 +50,15 @@ class LineaSendBundleTest {
       new TransactionTestFixture()
           .nonce(1)
           .gasLimit(21000)
-          .createTransaction(SIGNATURE_ALGORITHM.get().generateKeyPair());
+          .createTransaction(
+              SignatureAlgorithmType.DEFAULT_SIGNATURE_ALGORITHM_TYPE.get().generateKeyPair());
 
   private Transaction mockTX2 =
       new TransactionTestFixture()
           .nonce(1)
           .gasLimit(21000)
-          .createTransaction(SIGNATURE_ALGORITHM.get().generateKeyPair());
+          .createTransaction(
+              SignatureAlgorithmType.DEFAULT_SIGNATURE_ALGORITHM_TYPE.get().generateKeyPair());
 
   @BeforeEach
   void setup() {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@ task compileAll
 def allowCompilationWarnings = System.getenv('LINEA_DEV_ALLOW_WARNINGS') != null
 
 allprojects {
-  repositories { mavenCentral() }
+  repositories {
+    mavenCentral()
+    mavenLocal()
+  }
 
   apply plugin: 'java' // do not add kotlin plugin here, it will add unnecessary Kotlin runtime dependencies
   apply plugin: 'jacoco'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ logcaptor = "2.11.0"
 
 # Runtime
 arithmetization="beta-v3.1-rc3"
-besu = "25.5.0-linea3"
+besu = "25.6.0-linea1"
 blobCompressor = "1.2.2"
 blobShnarfCalculator = "1.2.0"
 bouncycastle = "1.79"

--- a/jvm-libs/linea/besu-libs/build.gradle
+++ b/jvm-libs/linea/besu-libs/build.gradle
@@ -9,21 +9,21 @@ dependencies {
   api("${besuArtifactGroup}:besu-datatypes:${besuVersion}") {
     transitive = false
   }
-  api("${besuArtifactGroup}:evm:${besuVersion}") {
+  api("${besuArtifactGroup}:besu-evm:${besuVersion}") {
     transitive = false
   }
-  api("${besuArtifactGroup}.internal:core:${besuVersion}") {
+  api("${besuArtifactGroup}.internal:besu-ethereum-core:${besuVersion}") {
     transitive = false
   }
-  api("${besuArtifactGroup}.internal:algorithms:${besuVersion}") {
-    transitive = false
-  }
-
-  api("${besuArtifactGroup}:plugin-api:${besuVersion}") {
+  api("${besuArtifactGroup}.internal:besu-crypto-algorithms:${besuVersion}") {
     transitive = false
   }
 
-  api("${besuArtifactGroup}.internal:rlp:${besuVersion}") {
+  api("${besuArtifactGroup}:besu-plugin-api:${besuVersion}") {
+    transitive = false
+  }
+
+  api("${besuArtifactGroup}.internal:besu-ethereum-rlp:${besuVersion}") {
     transitive = false
   }
 


### PR DESCRIPTION
This PR implements issue(s) #

Besu for Linea version 25.6.0-linea1 includes the change https://github.com/hyperledger/besu/pull/8589, that renames Maven coordinates for most artifacts, [see here for a translation map](https://github.com/hyperledger/besu/blob/main/CHANGELOG.md#appendix-a), this PR updates Besu and all projects that depends on Besu artifacts to the new coordinates.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.