### PR TITLE
docs: enhance INITIAL_FROM_BLOCK configuration documentation

### DIFF
--- a/docker/config/postman/env
+++ b/docker/config/postman/env
@@ -6,7 +6,7 @@ L1_LISTENER_INTERVAL=2000
 # Starting block for L1 event fetching. Controls from which block the Postman service starts fetching events.
 # Options: -1 = current latest block (default), 0 = from genesis (all historical events),
 # specific number = custom starting block (e.g., 18500000)
-# Note: Only applies when database is empty; otherwise resumes from last processed block
+# Note: This value is always prioritized when set, even if database contains previously processed messages
 L1_LISTENER_INITIAL_FROM_BLOCK=0
 L1_LISTENER_BLOCK_CONFIRMATION=1
 L1_MAX_BLOCKS_TO_FETCH_LOGS=1000
@@ -19,7 +19,7 @@ L2_LISTENER_INTERVAL=2000
 # Starting block for L2 event fetching. Controls from which block the Postman service starts fetching events.
 # Options: -1 = current latest block (default), 0 = from genesis (all historical events),
 # specific number = custom starting block (e.g., 1000000)
-# Note: Only applies when database is empty; otherwise resumes from last processed block
+# Note: This value is always prioritized when set, even if database contains previously processed messages
 L2_LISTENER_INITIAL_FROM_BLOCK=0
 L2_LISTENER_BLOCK_CONFIRMATION=0 # set confirmation as zero since L2 block won't auto increase
 L2_MAX_BLOCKS_TO_FETCH_LOGS=1000

--- a/docker/config/postman/env
+++ b/docker/config/postman/env
@@ -3,6 +3,10 @@ L1_CONTRACT_ADDRESS=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
 # WARNING=FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
 L1_SIGNER_PRIVATE_KEY=0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba
 L1_LISTENER_INTERVAL=2000
+# Starting block for L1 event fetching. Controls from which block the Postman service starts fetching events.
+# Options: -1 = current latest block (default), 0 = from genesis (all historical events),
+# specific number = custom starting block (e.g., 18500000)
+# Note: Only applies when database is empty; otherwise resumes from last processed block
 L1_LISTENER_INITIAL_FROM_BLOCK=0
 L1_LISTENER_BLOCK_CONFIRMATION=1
 L1_MAX_BLOCKS_TO_FETCH_LOGS=1000
@@ -12,6 +16,10 @@ L2_CONTRACT_ADDRESS=0xe537D669CA013d86EBeF1D64e40fC74CADC91987
 # WARNING=FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
 L2_SIGNER_PRIVATE_KEY=0xfcf854e0a0bc6fd7e97d7050e61a362c915cecd6767a32267b22e8b7af572e58
 L2_LISTENER_INTERVAL=2000
+# Starting block for L2 event fetching. Controls from which block the Postman service starts fetching events.
+# Options: -1 = current latest block (default), 0 = from genesis (all historical events),
+# specific number = custom starting block (e.g., 1000000)
+# Note: Only applies when database is empty; otherwise resumes from last processed block
 L2_LISTENER_INITIAL_FROM_BLOCK=0
 L2_LISTENER_BLOCK_CONFIRMATION=0 # set confirmation as zero since L2 block won't auto increase
 L2_MAX_BLOCKS_TO_FETCH_LOGS=1000

--- a/postman/README.md
+++ b/postman/README.md
@@ -53,7 +53,7 @@ All messages are stored in a configurable Postgres DB.
 - `L2_SIGNER_PRIVATE_KEY`: Private key for L2 transactions
 - `L2_LISTENER_INTERVAL`: Block listening interval (ms)
 - `L2_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events when it first starts up or when there are no previously processed messages in the database.
-  - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain
+  - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain or from the latest processed block if there are previously processed messages in the database.
   - **Custom block number**: Set to a specific block number (e.g., `5432100`) to start fetching events from that block
   - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain
   - **Priority order**: The service determines the starting block using the following priority:

--- a/postman/README.md
+++ b/postman/README.md
@@ -24,7 +24,15 @@ All messages are stored in a configurable Postgres DB.
 - `L1_CONTRACT_ADDRESS`: Address of the LineaRollup contract on L1
 - `L1_SIGNER_PRIVATE_KEY`: Private key for L1 transactions
 - `L1_LISTENER_INTERVAL`: Block listening interval (ms)
-- `L1_LISTENER_INITIAL_FROM_BLOCK`: Starting block for event listening (optional)
+- `L1_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events when it first starts up or when there are no previously processed messages in the database.
+  - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain
+  - **Custom block number**: Set to a specific block number (e.g., `12345678`) to start fetching events from that block
+  - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain
+  - **Priority order**: The service determines the starting block using the following priority:
+    1. If there are previously processed messages in the database, resume from the last processed block
+    2. If `L1_LISTENER_INITIAL_FROM_BLOCK` is set to a value greater than `-1`, use that block number
+    3. Otherwise, start from the current latest block on the chain
+  - **⚠️ Performance Note**: Setting this to `0` or a very low block number may result in long initial sync times as the service will process all historical events
 - `L1_LISTENER_BLOCK_CONFIRMATION`: Required block confirmations
 - `L1_MAX_BLOCKS_TO_FETCH_LOGS`: Maximum blocks to fetch in one request
 - `L1_MAX_GAS_FEE_ENFORCED`: Enable/disable gas fee enforcement
@@ -44,7 +52,15 @@ All messages are stored in a configurable Postgres DB.
 - `L2_CONTRACT_ADDRESS`: Address of the L2MessageService contract on L2
 - `L2_SIGNER_PRIVATE_KEY`: Private key for L2 transactions
 - `L2_LISTENER_INTERVAL`: Block listening interval (ms)
-- `L2_LISTENER_INITIAL_FROM_BLOCK`: Starting block for event listening (optional)
+- `L2_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events when it first starts up or when there are no previously processed messages in the database.
+  - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain
+  - **Custom block number**: Set to a specific block number (e.g., `5432100`) to start fetching events from that block
+  - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain
+  - **Priority order**: The service determines the starting block using the following priority:
+    1. If there are previously processed messages in the database, resume from the last processed block
+    2. If `L2_LISTENER_INITIAL_FROM_BLOCK` is set to a value greater than `-1`, use that block number
+    3. Otherwise, start from the current latest block on the chain
+  - **⚠️ Performance Note**: Setting this to `0` or a very low block number may result in long initial sync times as the service will process all historical events
 - `L2_LISTENER_BLOCK_CONFIRMATION`: Required block confirmations
 - `L2_MAX_BLOCKS_TO_FETCH_LOGS`: Maximum blocks to fetch in one request
 - `L2_MAX_GAS_FEE_ENFORCED`: Enable/disable gas fee enforcement
@@ -94,6 +110,48 @@ All messages are stored in a configurable Postgres DB.
 - `POSTGRES_USER`: Database user
 - `POSTGRES_PASSWORD`: Database password
 - `POSTGRES_DB`: Database name
+
+### Starting Block Configuration Examples
+
+The `L1_LISTENER_INITIAL_FROM_BLOCK` and `L2_LISTENER_INITIAL_FROM_BLOCK` configuration options are crucial for controlling event fetching behavior. Here are practical examples:
+
+#### Example 1: Development Setup (Default Behavior)
+```bash
+# For development, start from current block to avoid processing historical data
+L1_LISTENER_INITIAL_FROM_BLOCK=-1  # Default value
+L2_LISTENER_INITIAL_FROM_BLOCK=-1  # Default value
+```
+
+#### Example 2: Fresh Production Deployment from Genesis
+```bash
+# Process all historical events from the beginning of the chains
+L1_LISTENER_INITIAL_FROM_BLOCK=0
+L2_LISTENER_INITIAL_FROM_BLOCK=0
+```
+
+#### Example 3: Production Deployment from Specific Block Heights
+```bash
+# Start from specific block numbers to avoid processing unnecessary historical data
+L1_LISTENER_INITIAL_FROM_BLOCK=18500000  # Ethereum block number
+L2_LISTENER_INITIAL_FROM_BLOCK=1000000   # Linea block number
+```
+
+#### Example 4: Recovery from Known Good State
+```bash
+# After database restoration, resume from known block heights
+L1_LISTENER_INITIAL_FROM_BLOCK=18550000
+L2_LISTENER_INITIAL_FROM_BLOCK=1050000
+```
+
+#### Use Case Guidelines:
+
+- **New Development Environment**: Use default values (`-1`) to start fresh from current block
+- **Production Mainnet**: Set to specific block numbers where message bridge was deployed or activated
+- **Testing Historical Data**: Set to `0` or specific historical blocks (expect longer sync times)
+- **Database Recovery**: Set to last known good block numbers after database restoration
+- **Performance Optimization**: Use higher block numbers to skip irrelevant historical events
+
+**Note**: The configuration only takes effect when there are no existing messages in the database. If the database contains previously processed messages, the service will automatically resume from the last processed block regardless of these configuration values.
 
 ## Development
 

--- a/postman/README.md
+++ b/postman/README.md
@@ -52,7 +52,7 @@ All messages are stored in a configurable Postgres DB.
 - `L2_CONTRACT_ADDRESS`: Address of the L2MessageService contract on L2
 - `L2_SIGNER_PRIVATE_KEY`: Private key for L2 transactions
 - `L2_LISTENER_INTERVAL`: Block listening interval (ms)
-- `L2_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events when it first starts up or when there are no previously processed messages in the database.
+- `L2_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events.
   - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain or from the latest processed block if there are previously processed messages in the database.
   - **Custom block number**: Set to a specific block number (e.g., `5432100`) to start fetching events from that block
   - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain

--- a/postman/README.md
+++ b/postman/README.md
@@ -24,7 +24,7 @@ All messages are stored in a configurable Postgres DB.
 - `L1_CONTRACT_ADDRESS`: Address of the LineaRollup contract on L1
 - `L1_SIGNER_PRIVATE_KEY`: Private key for L1 transactions
 - `L1_LISTENER_INTERVAL`: Block listening interval (ms)
-- `L1_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events when it first starts up or when there are no previously processed messages in the database.
+- `L1_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events.
   - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain or from the latest processed block if there are previously processed messages in the database.
   - **Custom block number**: Set to a specific block number (e.g., `12345678`) to start fetching events from that block
   - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain

--- a/postman/README.md
+++ b/postman/README.md
@@ -29,8 +29,8 @@ All messages are stored in a configurable Postgres DB.
   - **Custom block number**: Set to a specific block number (e.g., `12345678`) to start fetching events from that block
   - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain
   - **Priority order**: The service determines the starting block using the following priority:
-    1. If there are previously processed messages in the database, resume from the last processed block
-    2. If `L1_LISTENER_INITIAL_FROM_BLOCK` is set to a value greater than `-1`, use that block number
+    1. If `L1_LISTENER_INITIAL_FROM_BLOCK` is set to a value greater than `-1`, use that block number
+    2. If there are previously processed messages in the database, resume from the last processed block
     3. Otherwise, start from the current latest block on the chain
   - **⚠️ Performance Note**: Setting this to `0` or a very low block number may result in long initial sync times as the service will process all historical events
 - `L1_LISTENER_BLOCK_CONFIRMATION`: Required block confirmations
@@ -57,8 +57,8 @@ All messages are stored in a configurable Postgres DB.
   - **Custom block number**: Set to a specific block number (e.g., `5432100`) to start fetching events from that block
   - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain
   - **Priority order**: The service determines the starting block using the following priority:
-    1. If there are previously processed messages in the database, resume from the last processed block
-    2. If `L2_LISTENER_INITIAL_FROM_BLOCK` is set to a value greater than `-1`, use that block number
+    1. If `L2_LISTENER_INITIAL_FROM_BLOCK` is set to a value greater than `-1`, use that block number
+    2. If there are previously processed messages in the database, resume from the last processed block
     3. Otherwise, start from the current latest block on the chain
   - **⚠️ Performance Note**: Setting this to `0` or a very low block number may result in long initial sync times as the service will process all historical events
 - `L2_LISTENER_BLOCK_CONFIRMATION`: Required block confirmations
@@ -118,8 +118,9 @@ The `L1_LISTENER_INITIAL_FROM_BLOCK` and `L2_LISTENER_INITIAL_FROM_BLOCK` config
 #### Example 1: Development Setup (Default Behavior)
 ```bash
 # For development, start from current block to avoid processing historical data
-L1_LISTENER_INITIAL_FROM_BLOCK=-1  # Default value
-L2_LISTENER_INITIAL_FROM_BLOCK=-1  # Default value
+# These variables are optional - if not specified, default value -1 will be used
+L1_LISTENER_INITIAL_FROM_BLOCK=-1  # Default value (optional)
+L2_LISTENER_INITIAL_FROM_BLOCK=-1  # Default value (optional)
 ```
 
 #### Example 2: Fresh Production Deployment from Genesis
@@ -151,7 +152,7 @@ L2_LISTENER_INITIAL_FROM_BLOCK=1050000
 - **Database Recovery**: Set to last known good block numbers after database restoration
 - **Performance Optimization**: Use higher block numbers to skip irrelevant historical events
 
-**Note**: The configuration only takes effect when there are no existing messages in the database. If the database contains previously processed messages, the service will automatically resume from the last processed block regardless of these configuration values.
+**Note**: The `L1_LISTENER_INITIAL_FROM_BLOCK` and `L2_LISTENER_INITIAL_FROM_BLOCK` configuration values are always prioritized when set to a value greater than -1, even if the database contains previously processed messages.
 
 ## Development
 

--- a/postman/README.md
+++ b/postman/README.md
@@ -25,7 +25,7 @@ All messages are stored in a configurable Postgres DB.
 - `L1_SIGNER_PRIVATE_KEY`: Private key for L1 transactions
 - `L1_LISTENER_INTERVAL`: Block listening interval (ms)
 - `L1_LISTENER_INITIAL_FROM_BLOCK`: (optional) Starting block for event listening. This configuration option controls from which block the Postman service starts fetching events when it first starts up or when there are no previously processed messages in the database.
-  - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain
+  - **Default behavior**: If not specified or set to `-1` (default), the service will start from the current latest block on the chain or from the latest processed block if there are previously processed messages in the database.
   - **Custom block number**: Set to a specific block number (e.g., `12345678`) to start fetching events from that block
   - **From genesis**: Set to `0` to fetch all historical events from the beginning of the chain
   - **Priority order**: The service determines the starting block using the following priority:


### PR DESCRIPTION
This PR implements issue(s) #1175

## Changes
- Enhanced Docker config comments for `L1_LISTENER_INITIAL_FROM_BLOCK` and `L2_LISTENER_INITIAL_FROM_BLOCK` with detailed options and behavior explanation
- Added "(optional)" markers to README documentation for starting block parameters to clarify their optional nature
- Improved consistency between Docker configuration comments and README documentation

## Files Modified
- `docker/config/postman/env` - Enhanced configuration comments
- `postman/README.md` - Clarified optional parameter status

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.