### PR TITLE
Feat: Add a transfer bot to keep alive block production on e2e network

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -590,3 +590,17 @@ services:
       - --trace-start-block-number=0
     volumes:
       - ./config/shomei/log4j.xml:/log4j.xml:ro
+
+  transfer-bot:
+    build: transfer-bot
+    container_name: eth-transfer-bot
+    restart: unless-stopped
+    environment:
+      - RPC_URL=http://sequencer:8545
+      - PRIVATE_KEY=0x7303d2fadd895018075cbe76d8a700bc65b4a1b8641b97d660533f0e029e3954
+      - TO_ADDRESS=0xb3c150df38e91149e260c3233f3121810d4d2976
+      - TRANSFER_AMOUNT=0.001
+      - INTERVAL_MS=2000
+      - LOG_TO_FILE=false
+    networks:
+      - linea

--- a/docker/compose-tracing-v2-ci-extension.yml
+++ b/docker/compose-tracing-v2-ci-extension.yml
@@ -27,3 +27,7 @@ services:
       file: compose-spec-l2-services.yml
       service: transaction-exclusion-api
 
+  transfer-bot:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: transfer-bot

--- a/docker/transfer-bot/Dockerfile
+++ b/docker/transfer-bot/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy application code
+COPY . .
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001
+
+# Change ownership of the app directory
+RUN chown -R nodejs:nodejs /app
+USER nodejs
+
+# Expose port (optional, for health checks)
+EXPOSE 3000
+
+# Run the application
+CMD ["node", "transfer-script.js"]

--- a/docker/transfer-bot/package-lock.json
+++ b/docker/transfer-bot/package-lock.json
@@ -1,0 +1,134 @@
+{
+  "name": "eth-transfer-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eth-transfer-bot",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.3.1",
+        "ethers": "^6.8.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.14.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.14.4.tgz",
+      "integrity": "sha512-Jm/dzRs2Z9iBrT6e9TvGxyb5YVKAPLlpna7hjxH7KH/++DSh2T/JVmQUv7iHI5E55hDbp/gEVvstWYXVxXFzsA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/docker/transfer-bot/package.json
+++ b/docker/transfer-bot/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "eth-transfer-bot",
+  "version": "1.0.0",
+  "description": "Ethereum transfer bot for devnet testing",
+  "main": "transfer-script.js",
+  "scripts": {
+    "start": "node transfer-script.js"
+  },
+  "dependencies": {
+    "ethers": "^6.8.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/docker/transfer-bot/transfer-script.js
+++ b/docker/transfer-bot/transfer-script.js
@@ -1,0 +1,240 @@
+const { ethers } = require('ethers');
+const fs = require('fs');
+const path = require('path');
+
+// Configuration with environment variables
+const config = {
+  rpcUrl: process.env.RPC_URL || 'http://localhost:8545',
+  privateKey: process.env.PRIVATE_KEY,
+  toAddress: process.env.TO_ADDRESS,
+  transferAmount: process.env.TRANSFER_AMOUNT || '0.001',
+  intervalMs: parseInt(process.env.INTERVAL_MS) || 1000,
+  logToFile: process.env.LOG_TO_FILE === 'true'
+};
+
+class Logger {
+  constructor() {
+    this.logDir = '/app/logs';
+    if (config.logToFile) {
+      this.ensureLogDir();
+      this.logFile = path.join(this.logDir, `transfer-${new Date().toISOString().split('T')[0]}.log`);
+    }
+  }
+
+  ensureLogDir() {
+    if (!fs.existsSync(this.logDir)) {
+      fs.mkdirSync(this.logDir, { recursive: true });
+    }
+  }
+
+  log(message) {
+    const timestamp = new Date().toISOString();
+    const logMessage = `[${timestamp}] ${message}`;
+
+    console.log(logMessage);
+
+    if (config.logToFile && this.logFile) {
+      fs.appendFileSync(this.logFile, logMessage + '\n');
+    }
+  }
+
+  error(message) {
+    const timestamp = new Date().toISOString();
+    const logMessage = `[${timestamp}] ERROR: ${message}`;
+
+    console.error(logMessage);
+
+    if (config.logToFile && this.logFile) {
+      fs.appendFileSync(this.logFile, logMessage + '\n');
+    }
+  }
+}
+
+class TransferBot {
+  constructor() {
+    this.logger = new Logger();
+    this.provider = new ethers.JsonRpcProvider(config.rpcUrl);
+    this.wallet = new ethers.Wallet(config.privateKey, this.provider);
+    this.isRunning = false;
+    this.transactionCount = 0;
+    this.startTime = Date.now();
+  }
+
+  async initialize() {
+    try {
+      // Test connection with timeout
+      const networkPromise = this.provider.getNetwork();
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('Connection timeout')), 10000)
+      );
+
+      const network = await Promise.race([networkPromise, timeoutPromise]);
+      this.logger.log(`Connected to network: ${network.name} (Chain ID: ${network.chainId})`);
+
+      // Check wallet balance
+      const balance = await this.provider.getBalance(this.wallet.address);
+      this.logger.log(`Wallet address: ${this.wallet.address}`);
+      this.logger.log(`Wallet balance: ${ethers.formatEther(balance)} ETH`);
+
+      if (balance === 0n) {
+        throw new Error('Wallet has no balance');
+      }
+
+      // Validate recipient address
+      if (!ethers.isAddress(config.toAddress)) {
+        throw new Error('Invalid recipient address');
+      }
+
+      return true;
+    } catch (error) {
+      this.logger.error(`Initialization failed: ${error.message}`);
+      return false;
+    }
+  }
+
+  async sendTransfer() {
+    try {
+      const tx = {
+        to: config.toAddress,
+        value: ethers.parseEther(config.transferAmount),
+        gasLimit: 21000,
+      };
+
+      this.logger.log(`Sending transaction #${this.transactionCount + 1}...`);
+
+      const txResponse = await this.wallet.sendTransaction(tx);
+      this.transactionCount++;
+
+      this.logger.log(`✅ Transaction sent: ${txResponse.hash}`);
+      this.logger.log(`   Amount: ${config.transferAmount} ETH | To: ${config.toAddress}`);
+
+      return txResponse;
+    } catch (error) {
+      this.logger.error(`Transaction failed: ${error.message}`);
+
+      if (error.code === 'INSUFFICIENT_FUNDS') {
+        this.logger.log('⚠️  Insufficient funds. Stopping bot...');
+        this.stop();
+      }
+    }
+  }
+
+  start() {
+    if (this.isRunning) {
+      this.logger.log('Bot is already running');
+      return;
+    }
+
+    this.isRunning = true;
+    this.logger.log('🚀 Starting transfer bot...');
+    this.logger.log(`   Sending ${config.transferAmount} ETH every ${config.intervalMs}ms`);
+    this.logger.log(`   From: ${this.wallet.address}`);
+    this.logger.log(`   To: ${config.toAddress}`);
+
+    this.intervalId = setInterval(async () => {
+      if (this.isRunning) {
+        await this.sendTransfer();
+      }
+    }, config.intervalMs);
+
+    // Log stats every minute
+    this.statsInterval = setInterval(() => {
+      const uptime = Math.floor((Date.now() - this.startTime) / 1000);
+      const rate = this.transactionCount / (uptime / 60);
+      this.logger.log(`📊 Stats: ${this.transactionCount} transactions | ${uptime}s uptime | ${rate.toFixed(2)} tx/min`);
+    }, 60000);
+  }
+
+  stop() {
+    if (!this.isRunning) {
+      return;
+    }
+
+    this.isRunning = false;
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+    if (this.statsInterval) {
+      clearInterval(this.statsInterval);
+    }
+
+    const uptime = Math.floor((Date.now() - this.startTime) / 1000);
+    this.logger.log(`🛑 Bot stopped. Total: ${this.transactionCount} transactions in ${uptime}s`);
+  }
+
+  // Health check endpoint
+  getStatus() {
+    return {
+      running: this.isRunning,
+      transactionCount: this.transactionCount,
+      uptime: Date.now() - this.startTime
+    };
+  }
+}
+
+// Health check server (optional)
+if (process.env.ENABLE_HEALTH_CHECK === 'true') {
+  const http = require('http');
+  let botInstance;
+
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      const status = botInstance ? botInstance.getStatus() : { running: false };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(status));
+    } else {
+      res.writeHead(404);
+      res.end('Not Found');
+    }
+  });
+
+  server.listen(3000, () => {
+    console.log('Health check server running on port 3000');
+  });
+}
+
+// Main execution
+async function main() {
+  // Validate required environment variables
+  if (!config.privateKey) {
+    console.error('❌ PRIVATE_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  if (!config.toAddress) {
+    console.error('❌ TO_ADDRESS environment variable is required');
+    process.exit(1);
+  }
+
+  const bot = new TransferBot();
+
+  // Make bot available for health checks
+  if (process.env.ENABLE_HEALTH_CHECK === 'true') {
+    global.botInstance = bot;
+  }
+
+  // Initialize the bot
+  const initialized = await bot.initialize();
+  if (!initialized) {
+    process.exit(1);
+  }
+
+  // Start the bot
+  bot.start();
+
+  // Handle graceful shutdown
+  const shutdown = (signal) => {
+    console.log(`\n📡 Received ${signal} signal...`);
+    bot.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+// Run the script
+main().catch(error => {
+  console.error('Script failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
When debugging e2e tests about bundles, I found that if you try to run only that test in isolation 
```
pnpm run -F e2e test:e2e:local -- e2e/src/send-bundle.spec.ts
```
it will never work, since bundles are specific for inclusion in a future block, but since there is no traffic, due to no other e2e running in parallel, bundle tests just wait in vain for the right block to be built.

So I added a simple bot that just sends a transfer every 2 seconds to keep alive block production.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.