### PR TITLE
(fix): docker build err: bump up go version

### DIFF
--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -6,7 +6,7 @@
 # G O + R U S T   B U I L D E R
 #
 ###############################
-FROM golang:1.22.7-alpine AS go-builder
+FROM golang:1.24.0-alpine AS go-builder
 
 RUN apk add --no-cache rust cargo bash make
 


### PR DESCRIPTION
This PR implements issue(s) #

Bumps up go version in docker prover build