### PR TITLE
Prover/koalabear migration rebased bis 2

### DIFF
--- a/prover/crypto/fiatshamir/fiatshamir.go
+++ b/prover/crypto/fiatshamir/fiatshamir.go
@@ -34,7 +34,7 @@ func Update(h hash.StateStorer, vec ...field.Element) {
 		bytes := f.Bytes()
 		_, err := h.Write(bytes[:])
 		if err != nil {
-			panic("Hashing is not supposed to fail")
+			panic(err)
 		}
 	}
 }
@@ -44,7 +44,7 @@ func UpdateExt(h hash.StateStorer, vec ...fext.Element) {
 		bytes := fext.Bytes(&f)
 		_, err := h.Write(bytes[:])
 		if err != nil {
-			panic("Hashing is not supposed to fail")
+			panic(err)
 		}
 	}
 }

--- a/prover/crypto/fiatshamir/fiatshamir.go
+++ b/prover/crypto/fiatshamir/fiatshamir.go
@@ -66,8 +66,14 @@ func RandomField(h hash.StateStorer) field.Element {
 }
 
 func RandomFext(h hash.StateStorer) fext.Element {
+	// TODO @thomas according the size of s, run several hashes to fit in an fext elmt
 	s := h.Sum(nil)
-	res := fext.SetBytes(s)
+	var res fext.Element
+	if len(s) > 4 {
+		res = fext.SetBytes(s)
+	} else {
+		res.B0.A0.SetBytes(s)
+	}
 	UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // ??
 	return res
 }
@@ -123,7 +129,7 @@ func RandomManyIntegers(h hash.StateStorer, num, upperBound int) []int {
 	}
 
 	// number of field elmts per hash
-	maxNumChallsPerDigest = (field.Bits - 1) / int(logTwoUpperBound)
+	maxNumChallsPerDigest := (field.Bits - 1) / int(logTwoUpperBound)
 
 	res := make([]int, 0, num)
 
@@ -137,7 +143,7 @@ func RandomManyIntegers(h hash.StateStorer, num, upperBound int) []int {
 				return res
 			}
 
-			newChall, err := buffer.ReadInt(int(challsBitSize))
+			newChall, err := buffer.ReadInt(int(logTwoUpperBound))
 			if err != nil {
 				utils.Panic("could not instantiate the buffer for a single field element")
 			}
@@ -151,12 +157,3 @@ func RandomManyIntegers(h hash.StateStorer, num, upperBound int) []int {
 		UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // ??
 	}
 }
-
-// safeguardUpdate updates the state as a safeguard. This way, we are guaranteed
-// that successive random oracle queries will yield a different, independant
-// result.
-//
-// This is implemented by adding a 0 in the transcript.
-// func (fs *State) safeguardUpdate() {
-// 	fs.UpdateExt(fext.NewElement(0, 0, 0, 0))
-// }

--- a/prover/crypto/fiatshamir/fiatshamir.go
+++ b/prover/crypto/fiatshamir/fiatshamir.go
@@ -2,6 +2,7 @@ package fiatshamir
 
 import (
 	"github.com/consensys/gnark-crypto/hash"
+	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/maths/field/fext"
 	"github.com/consensys/linea-monorepo/prover/utils"
@@ -53,6 +54,18 @@ func UpdateVec(h hash.StateStorer, vecs ...[]field.Element) {
 	for i := range vecs {
 		Update(h, vecs[i]...)
 	}
+}
+
+// UpdateSV updates the FS state with a smart-vector. No-op if the smart-vector
+// has a length of zero.
+func UpdateSV(h hash.StateStorer, sv smartvectors.SmartVector) {
+	if sv.Len() == 0 {
+		return
+	}
+
+	vec := make([]field.Element, sv.Len())
+	sv.WriteInSlice(vec)
+	Update(h, vec...)
 }
 
 // RandomField generates and returns a single field element from the Fiat-Shamir

--- a/prover/crypto/fiatshamir/fiatshamir.go
+++ b/prover/crypto/fiatshamir/fiatshamir.go
@@ -34,9 +34,7 @@ import (
 //
 // https://blog.trailofbits.com/2022/04/18/the-frozen-heart-vulnerability-in-plonk/
 type State struct {
-	hasher           hash.StateStorer
-	TranscriptSize   int
-	NumCoinGenerated int
+	hasher hash.StateStorer
 }
 
 // NewMiMCFiatShamir constructs a fresh and empty Fiat-Shamir state.
@@ -81,9 +79,6 @@ func (fs *State) Update(vec ...field.Element) {
 			panic("Hashing is not supposed to fail")
 		}
 	}
-
-	// Increase the transcript counter
-	fs.TranscriptSize += len(vec)
 }
 
 // Update the Fiat-Shamir state with a one or more of field elements. The
@@ -105,9 +100,6 @@ func (fs *State) UpdateExt(vec ...fext.Element) {
 			panic("Hashing is not supposed to fail")
 		}
 	}
-
-	// Increase the transcript counter
-	fs.TranscriptSize += len(vec)
 }
 
 // UpdateVec updates the Fiat-Shamir state by passing one of more slices of
@@ -161,8 +153,6 @@ func (fs *State) RandomField() field.Element {
 	var res field.Element
 	res.SetBytes(challBytes)
 
-	// increase the counter by one
-	fs.NumCoinGenerated++
 	return res
 }
 
@@ -171,11 +161,8 @@ func (fs *State) RandomField() field.Element {
 func (fs *State) RandomFext() fext.Element {
 	defer fs.safeguardUpdate()
 	challBytes := fs.hasher.Sum(nil)
-	var res fext.Element
-	res = fext.SetBytes(challBytes)
+	res := fext.SetBytes(challBytes)
 
-	// increase the counter by one
-	fs.NumCoinGenerated++
 	return res
 }
 
@@ -208,7 +195,6 @@ func (fs *State) RandomFieldFromSeed(seed field.Element, name string) field.Elem
 	challBytes := fs.hasher.Sum(nil)
 	res := new(field.Element).SetBytes(challBytes)
 
-	fs.NumCoinGenerated++
 	return *res
 }
 
@@ -265,9 +251,6 @@ func (fs *State) RandomManyIntegers(num, upperBound int) []int {
 	for {
 		digest := fs.hasher.Sum(nil)
 		buffer := NewBitReader(digest, field.Bits-1)
-
-		// Increase the counter
-		fs.NumCoinGenerated++
 
 		for i := 0; i < maxNumChallsPerDigest; i++ {
 			// Stopping condition, we computed enough challenges

--- a/prover/crypto/fiatshamir/fiatshamir.go
+++ b/prover/crypto/fiatshamir/fiatshamir.go
@@ -1,12 +1,7 @@
 package fiatshamir
 
 import (
-	"math"
-
 	"github.com/consensys/gnark-crypto/hash"
-	"github.com/consensys/linea-monorepo/prover/crypto/mimc"
-	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
-	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors_mixed"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/maths/field/fext"
 	"github.com/consensys/linea-monorepo/prover/utils"
@@ -33,192 +28,82 @@ import (
 // to prevent rogue protocol attack as in the Frozen Heart vulnerability.
 //
 // https://blog.trailofbits.com/2022/04/18/the-frozen-heart-vulnerability-in-plonk/
-type State struct {
-	hasher hash.StateStorer
-}
 
-// NewMiMCFiatShamir constructs a fresh and empty Fiat-Shamir state.
-func NewMiMCFiatShamir() *State {
-	return &State{
-		hasher: mimc.NewMiMC().(hash.StateStorer),
-	}
-}
-
-// State returns the internal state of the Fiat-Shamir hasher. Only works for
-// MiMC.
-func (s *State) State() []field.Element {
-	_ = s.hasher.Sum(nil)
-	b := s.hasher.State()
-	f := new(field.Element).SetBytes(b)
-	return []field.Element{*f}
-}
-
-// SetState sets the fiat-shamir state to the requested value
-func (s *State) SetState(f []field.Element) {
-	_ = s.hasher.Sum(nil)
-	b := f[0].Bytes()
-	s.hasher.SetState(b[:])
-}
-
-// Update the Fiat-Shamir state with a one or more of field elements. The
-// function as no-op if the caller supplies no field elements.
-func (fs *State) Update(vec ...field.Element) {
-	if len(vec) == 0 {
-		return
-	}
-
-	// Marshal the elements in a vector of bytes
+func Update(h hash.StateStorer, vec ...field.Element) {
 	for _, f := range vec {
 		bytes := f.Bytes()
-		_, err := fs.hasher.Write(bytes[:])
+		_, err := h.Write(bytes[:])
 		if err != nil {
-			// This normally happens if the bytes that we provide do not represent
-			// a field element. In our case, the bytes are computed by ourselves
-			// from the caller's field element so the error is not possible. Hence,
-			// the assertion.
 			panic("Hashing is not supposed to fail")
 		}
 	}
 }
 
-// Update the Fiat-Shamir state with a one or more of field elements. The
-// function as no-op if the caller supplies no field elements.
-func (fs *State) UpdateExt(vec ...fext.Element) {
-	if len(vec) == 0 {
-		return
-	}
-
-	// Marshal the elements in a vector of bytes
+func UpdateExt(h hash.StateStorer, vec ...fext.Element) {
 	for _, f := range vec {
 		bytes := fext.Bytes(&f)
-		_, err := fs.hasher.Write(bytes[:])
+		_, err := h.Write(bytes[:])
 		if err != nil {
-			// This normally happens if the bytes that we provide do not represent
-			// a field element. In our case, the bytes are computed by ourselves
-			// from the caller's field element so the error is not possible. Hence,
-			// the assertion.
 			panic("Hashing is not supposed to fail")
 		}
 	}
 }
 
-// UpdateVec updates the Fiat-Shamir state by passing one of more slices of
-// field elements.
-func (fs *State) UpdateVec(vecs ...[]field.Element) {
-	if len(vecs) == 0 {
-		return
-	}
-
+func UpdateVec(h hash.StateStorer, vecs ...[]field.Element) {
 	for i := range vecs {
-		fs.Update(vecs[i]...)
+		Update(h, vecs[i]...)
 	}
-}
-
-// UpdateVec updates the Fiat-Shamir state by passing one of more slices of
-// field elements.
-func (fs *State) UpdateVecExt(vecs ...[]fext.Element) {
-	if len(vecs) == 0 {
-		return
-	}
-
-	for i := range vecs {
-		fs.UpdateExt(vecs[i]...)
-	}
-}
-
-// UpdateSV updates the FS state with a smart-vector. No-op if the smart-vector
-// has a length of zero.
-func (fs *State) UpdateSV(sv smartvectors.SmartVector) {
-	if sv.Len() == 0 {
-		return
-	}
-
-	if !smartvectors_mixed.IsBase(sv) {
-		vec := make([]fext.Element, sv.Len())
-		sv.WriteInSliceExt(vec)
-		fs.UpdateExt(vec...)
-
-	}
-
-	vec := make([]field.Element, sv.Len())
-	sv.WriteInSlice(vec)
-	fs.Update(vec...)
 }
 
 // RandomField generates and returns a single field element from the Fiat-Shamir
 // transcript.
-func (fs *State) RandomField() field.Element {
-	defer fs.safeguardUpdate()
-	challBytes := fs.hasher.Sum(nil)
+func RandomField(h hash.StateStorer) field.Element {
+	s := h.Sum(nil)
 	var res field.Element
-	res.SetBytes(challBytes)
-
+	res.SetBytes(s)
+	UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // ??
 	return res
 }
 
-// RandomFext generates and returns a single fext element from the Fiat-Shamir
-// transcript.
-func (fs *State) RandomFext() fext.Element {
-	defer fs.safeguardUpdate()
-	challBytes := fs.hasher.Sum(nil)
-	res := fext.SetBytes(challBytes)
-
+func RandomFext(h hash.StateStorer) fext.Element {
+	s := h.Sum(nil)
+	res := fext.SetBytes(s)
+	UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // ??
 	return res
 }
 
-// RandomFieldFromSeed generates and returns a single field element from the seed and the given name.
-func (fs *State) RandomFieldFromSeed(seed field.Element, name string) field.Element {
+func RandomFromSeed(h hash.StateStorer, seed field.Element, name string) field.Element {
 
-	// The first step encodes the 'name' into a single field element. The
-	// field element is obtained by hashing and taking the modulo of the
-	// result to fit into a field element.
-	tmpFr := field.Element{}
-	nameBytes := []byte(name)
-	hasher, _ := blake2b.New256(nil)
-	hasher.Write(nameBytes)
-	nameBytes = hasher.Sum(nil)
+	bName := []byte(name)
+	hasher, _ := blake2b.New256(nil) //?? TODO @Thomas use proper hash to field
+	hasher.Write(bName)
+	bName = hasher.Sum(nil)
 
-	// This ensures that the name is hashed into a field element
-	tmpFr.SetBytes(nameBytes)
-	nameBytes_ := tmpFr.Bytes()
-	nameBytes = nameBytes_[:]
+	var bnToFr field.Element // reduction mod r...
+	bnToFr.SetBytes(bName)
+	bName = bnToFr.Marshal()
 
-	// The seed is then obtained by calling the compression function over
-	// the seed and the encoded name.
-	oldState := fs.State()
-	defer fs.SetState(oldState)
-
-	fs.SetState([]field.Element{seed})
-	if _, err := fs.hasher.Write(nameBytes); err != nil {
+	// seed = compress(name || seed)
+	backupState := h.State() // ??
+	h.SetState(seed.Marshal())
+	if _, err := h.Write(bName); err != nil {
 		panic(err)
 	}
-	challBytes := fs.hasher.Sum(nil)
-	res := new(field.Element).SetBytes(challBytes)
+	bRes := h.Sum(nil)
+	var res field.Element
+	res.SetBytes(bRes)
 
-	return *res
+	err := h.SetState(backupState)
+	if err != nil {
+		panic(err)
+	}
+
+	return res
 }
 
 // TODO@yao: RandomFextFromSeed generates and returns a single fext element from the seed and the given name.
+func RandomManyIntegers(h hash.StateStorer, num, upperBound int) []int {
 
-// RandomManyIntegers returns a list of challenge small integers. That is, a
-// list of positive integer bounded by `upperBound`. The upperBound is strict
-// and is restricted to being only be a power of two.
-//
-// The function will panic if the coin cannot be generated. We motivate this
-// behaviour by the fact that if it happens, this will always be for
-// "deterministic" reasons pertaining to the description of the user's protocol
-// and never because of the values that are in the transcript itself.
-//
-// The function is implemented by, first generating random field elements, and
-// then breaking each of them down separately into several small integers. The
-// "remainder" bits (nameely, the bits of the generated field element that we
-// could not pack into a small integer) are thrown away.
-//
-// If the caller provides num=0, the function no-ops after doing its
-// sanity-checks although the call makes no possible sense.
-func (fs *State) RandomManyIntegers(num, upperBound int) []int {
-
-	// Even `1` would be wierd, there would be only one acceptable coin value.
 	if upperBound < 1 {
 		utils.Panic("UpperBound was %v", upperBound)
 	}
@@ -231,25 +116,19 @@ func (fs *State) RandomManyIntegers(num, upperBound int) []int {
 		return []int{}
 	}
 
-	defer fs.safeguardUpdate()
+	logTwoUpperBound := -1
+	for upperBound != 0 {
+		logTwoUpperBound++
+		upperBound >>= 1
+	}
 
-	var (
-		// challsBitSize stores the number of bits required instantiate each
-		// small integer.
-		challsBitSize = math.Ceil(math.Log2(float64(upperBound)))
-		// Number of challenges computable with one call to hash (implicitly,
-		// the division is rounded down). The "-1" corresponds to the fact that
-		// the most significant bit of a field element cannot be assumed to
-		// contain exactly 1 bit of entropy since the modulus of the field is
-		// never a power of 2.
-		maxNumChallsPerDigest = (field.Bits - 1) / int(challsBitSize)
-		// res stores the preallocated result slice, to which all generated
-		// small integers will be appended.
-		res = make([]int, 0, num)
-	)
+	// number of field elmts per hash
+	maxNumChallsPerDigest = (field.Bits - 1) / int(logTwoUpperBound)
+
+	res := make([]int, 0, num)
 
 	for {
-		digest := fs.hasher.Sum(nil)
+		digest := h.Sum(nil)
 		buffer := NewBitReader(digest, field.Bits-1)
 
 		for i := 0; i < maxNumChallsPerDigest; i++ {
@@ -265,19 +144,11 @@ func (fs *State) RandomManyIntegers(num, upperBound int) []int {
 			res = append(res, int(newChall)%upperBound)
 		}
 
-		// This is guarded by the condition to prevent the [State] updating
-		// twice in a row when exiting the function. Recall that we have a
-		// defer of the safeguard update in the function. This handles the
-		// edge-case where the number of requested field elements is a multiple
-		// of the number of challenges we can generate with a single field
-		// element.
 		if len(res) >= num {
 			return res
 		}
 
-		// This updates ensures that for the next iterations of the loop and the
-		// next randomness comsumption uses a fresh randomness.
-		fs.safeguardUpdate()
+		UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // ??
 	}
 }
 
@@ -286,6 +157,6 @@ func (fs *State) RandomManyIntegers(num, upperBound int) []int {
 // result.
 //
 // This is implemented by adding a 0 in the transcript.
-func (fs *State) safeguardUpdate() {
-	fs.UpdateExt(fext.NewElement(0, 0, 0, 0))
-}
+// func (fs *State) safeguardUpdate() {
+// 	fs.UpdateExt(fext.NewElement(0, 0, 0, 0))
+// }

--- a/prover/crypto/fiatshamir/fiatshamir.go
+++ b/prover/crypto/fiatshamir/fiatshamir.go
@@ -74,7 +74,7 @@ func RandomFext(h hash.StateStorer) fext.Element {
 	} else {
 		res.B0.A0.SetBytes(s)
 	}
-	UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // ??
+	UpdateExt(h, fext.NewElement(0, 0, 0, 0)) // safefuard update
 	return res
 }
 
@@ -123,9 +123,10 @@ func RandomManyIntegers(h hash.StateStorer, num, upperBound int) []int {
 	}
 
 	logTwoUpperBound := -1
-	for upperBound != 0 {
+	tmp := upperBound
+	for tmp != 0 {
 		logTwoUpperBound++
-		upperBound >>= 1
+		tmp >>= 1
 	}
 
 	// number of field elmts per hash

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -1,249 +1,243 @@
 package fiatshamir
 
 import (
-	"fmt"
-	"math/rand/v2"
 	"testing"
 
-	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
-	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
-	"github.com/consensys/linea-monorepo/prover/maths/field"
-	"github.com/consensys/linea-monorepo/prover/utils"
-	"github.com/stretchr/testify/assert"
+	"github.com/consensys/gnark-crypto/field/koalabear/poseidon2"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFiatShamirSafeguardUpdate(t *testing.T) {
 
-	fs := NewMiMCFiatShamir()
+	fs := poseidon2.NewMerkleDamgardHasher()
 
-	a := fs.RandomFext()
-	b := fs.RandomFext()
+	a := RandomFext(fs)
+	b := RandomFext(fs)
 
 	// Two consecutive call to fs do not return the same result
 	require.NotEqual(t, a.String(), b.String())
 }
 
-func TestFiatShamirRandomVec(t *testing.T) {
+// func TestFiatShamirRandomVec(t *testing.T) {
 
-	for _, testCase := range randomIntVecTestCases {
-		testName := fmt.Sprintf("%v-integers-of-%v-bits", testCase.NumIntegers, testCase.IntegerBitSize)
-		t.Run(testName, func(t *testing.T) {
+// 	for _, testCase := range randomIntVecTestCases {
+// 		testName := fmt.Sprintf("%v-integers-of-%v-bits", testCase.NumIntegers, testCase.IntegerBitSize)
+// 		t.Run(testName, func(t *testing.T) {
 
-			fs := NewMiMCFiatShamir()
-			fs.Update(field.NewElement(420))
+// 			fs := NewMiMCFiatShamir()
+// 			fs.Update(field.NewElement(420))
 
-			var oldState, newState field.Element
+// 			var oldState, newState field.Element
 
-			if err := oldState.SetBytesCanonical(fs.hasher.Sum(nil)); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+// 			if err := oldState.SetBytesCanonical(fs.hasher.Sum(nil)); err != nil {
+// 				t.Fatalf("unexpected error: %v", err)
+// 			}
 
-			a := fs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
-			t.Logf("the generated vector= %v", a)
+// 			a := fs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
+// 			t.Logf("the generated vector= %v", a)
 
-			if err := newState.SetBytesCanonical(fs.hasher.Sum(nil)); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+// 			if err := newState.SetBytesCanonical(fs.hasher.Sum(nil)); err != nil {
+// 				t.Fatalf("unexpected error: %v", err)
+// 			}
 
-			assert.Len(t, a, testCase.NumIntegers)
-			assert.NoError(t, errIfHasDuplicate(a...))
+// 			assert.Len(t, a, testCase.NumIntegers)
+// 			assert.NoError(t, errIfHasDuplicate(a...))
 
-			if testCase.ShouldUpdate {
-				assert.NotEqualf(t, oldState.String(), newState.String(), "the state was not updated (%v)", oldState.String())
-			} else {
-				assert.Equal(t, oldState.String(), newState.String(), "the state was updated")
-			}
-		})
-	}
-}
+// 			if testCase.ShouldUpdate {
+// 				assert.NotEqualf(t, oldState.String(), newState.String(), "the state was not updated (%v)", oldState.String())
+// 			} else {
+// 				assert.Equal(t, oldState.String(), newState.String(), "the state was updated")
+// 			}
+// 		})
+// 	}
+// }
 
-func TestBatchUpdates(t *testing.T) {
+// func TestBatchUpdates(t *testing.T) {
 
-	fs := NewMiMCFiatShamir()
-	fs.Update(field.NewElement(2))
-	fs.Update(field.NewElement(2))
-	fs.Update(field.NewElement(1))
-	expectedVal := fs.RandomFext()
+// 	fs := NewMiMCFiatShamir()
+// 	fs.Update(field.NewElement(2))
+// 	fs.Update(field.NewElement(2))
+// 	fs.Update(field.NewElement(1))
+// 	expectedVal := fs.RandomFext()
 
-	t.Run("for a variadic call", func(t *testing.T) {
-		fs := NewMiMCFiatShamir()
-		fs.Update(field.NewElement(2), field.NewElement(2), field.NewElement(1))
-		actualValue := fs.RandomFext()
-		assert.Equal(t, expectedVal.String(), actualValue.String())
-	})
+// 	t.Run("for a variadic call", func(t *testing.T) {
+// 		fs := NewMiMCFiatShamir()
+// 		fs.Update(field.NewElement(2), field.NewElement(2), field.NewElement(1))
+// 		actualValue := fs.RandomFext()
+// 		assert.Equal(t, expectedVal.String(), actualValue.String())
+// 	})
 
-	t.Run("for slice of field elements", func(t *testing.T) {
-		fs := NewMiMCFiatShamir()
-		fs.UpdateVec(vector.ForTest(2, 2, 1))
-		actualValue := fs.RandomFext()
-		assert.Equal(t, expectedVal.String(), actualValue.String())
-	})
+// 	t.Run("for slice of field elements", func(t *testing.T) {
+// 		fs := NewMiMCFiatShamir()
+// 		fs.UpdateVec(vector.ForTest(2, 2, 1))
+// 		actualValue := fs.RandomFext()
+// 		assert.Equal(t, expectedVal.String(), actualValue.String())
+// 	})
 
-	t.Run("for multi-slice of field elements", func(t *testing.T) {
-		fs := NewMiMCFiatShamir()
-		fs.UpdateVec(vector.ForTest(2, 2), vector.ForTest(1))
-		actualValue := fs.RandomFext()
-		assert.Equal(t, expectedVal.String(), actualValue.String())
-	})
+// 	t.Run("for multi-slice of field elements", func(t *testing.T) {
+// 		fs := NewMiMCFiatShamir()
+// 		fs.UpdateVec(vector.ForTest(2, 2), vector.ForTest(1))
+// 		actualValue := fs.RandomFext()
+// 		assert.Equal(t, expectedVal.String(), actualValue.String())
+// 	})
 
-	t.Run("for a smart-vector", func(t *testing.T) {
-		sv := smartvectors.RightPadded(vector.ForTest(2, 2), field.NewElement(1), 3)
-		fs := NewMiMCFiatShamir()
-		fs.UpdateSV(sv)
-		actualValue := fs.RandomFext()
-		assert.Equal(t, expectedVal.String(), actualValue.String())
-	})
+// 	t.Run("for a smart-vector", func(t *testing.T) {
+// 		sv := smartvectors.RightPadded(vector.ForTest(2, 2), field.NewElement(1), 3)
+// 		fs := NewMiMCFiatShamir()
+// 		fs.UpdateSV(sv)
+// 		actualValue := fs.RandomFext()
+// 		assert.Equal(t, expectedVal.String(), actualValue.String())
+// 	})
 
-}
+// }
 
-// TestSamplingFromSeed tests that sampling from seed is consistent, does not forget
-// bytes from the seed and does not depends on the state.
-func TestSamplingFromSeed(t *testing.T) {
+// // TestSamplingFromSeed tests that sampling from seed is consistent, does not forget
+// // bytes from the seed and does not depends on the state.
+// func TestSamplingFromSeed(t *testing.T) {
 
-	t.Run("dependence-on-name", func(t *testing.T) {
+// 	t.Run("dependence-on-name", func(t *testing.T) {
 
-		var (
-			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
-			rng          = rand.New(utils.NewRandSource(789))
-			initialState = field.PseudoRand(rng)
-			seed         = field.PseudoRand(rng)
-			resMap       = map[field.Element]struct{}{}
-			name         = ""
-			totalSize    = 1000
-		)
+// 		var (
+// 			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
+// 			rng          = rand.New(utils.NewRandSource(789))
+// 			initialState = field.PseudoRand(rng)
+// 			seed         = field.PseudoRand(rng)
+// 			resMap       = map[field.Element]struct{}{}
+// 			name         = ""
+// 			totalSize    = 1000
+// 		)
 
-		fs := NewMiMCFiatShamir()
-		fs.SetState([]field.Element{initialState})
+// 		fs := NewMiMCFiatShamir()
+// 		fs.SetState([]field.Element{initialState})
 
-		for i := 0; i < totalSize; i++ {
+// 		for i := 0; i < totalSize; i++ {
 
-			x := fs.RandomFieldFromSeed(seed, name)
-			if _, found := resMap[x]; found {
-				t.Errorf("found a collision for i=%v", i)
-			}
+// 			x := fs.RandomFieldFromSeed(seed, name)
+// 			if _, found := resMap[x]; found {
+// 				t.Errorf("found a collision for i=%v", i)
+// 			}
 
-			resMap[x] = struct{}{}
-			name += "a"
-		}
-	})
+// 			resMap[x] = struct{}{}
+// 			name += "a"
+// 		}
+// 	})
 
-	t.Run("non-dependance-curr-state", func(t *testing.T) {
+// 	t.Run("non-dependance-curr-state", func(t *testing.T) {
 
-		var (
-			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
-			rng    = rand.New(utils.NewRandSource(789))
-			state1 = field.PseudoRand(rng)
-			state2 = field.PseudoRand(rng)
-			fs1    = NewMiMCFiatShamir()
-			fs2    = NewMiMCFiatShamir()
-			seed   = field.PseudoRand(rng)
-			name   = "string-name"
-		)
+// 		var (
+// 			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
+// 			rng    = rand.New(utils.NewRandSource(789))
+// 			state1 = field.PseudoRand(rng)
+// 			state2 = field.PseudoRand(rng)
+// 			fs1    = NewMiMCFiatShamir()
+// 			fs2    = NewMiMCFiatShamir()
+// 			seed   = field.PseudoRand(rng)
+// 			name   = "string-name"
+// 		)
 
-		fs1.SetState([]field.Element{state1})
-		fs2.SetState([]field.Element{state2})
+// 		fs1.SetState([]field.Element{state1})
+// 		fs2.SetState([]field.Element{state2})
 
-		y1 := fs1.RandomFieldFromSeed(seed, name)
-		y2 := fs2.RandomFieldFromSeed(seed, name)
+// 		y1 := fs1.RandomFieldFromSeed(seed, name)
+// 		y2 := fs2.RandomFieldFromSeed(seed, name)
 
-		if y1 != y2 {
-			t.Errorf("starting from different state does not give the same results")
-		}
-	})
+// 		if y1 != y2 {
+// 			t.Errorf("starting from different state does not give the same results")
+// 		}
+// 	})
 
-	t.Run("does-not-modify-state", func(t *testing.T) {
+// 	t.Run("does-not-modify-state", func(t *testing.T) {
 
-		var (
-			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
-			rng          = rand.New(utils.NewRandSource(789))
-			initialState = field.PseudoRand(rng)
-			seed         = field.PseudoRand(rng)
-			name         = "ddqsdjqskljd"
-			fs           = NewMiMCFiatShamir()
-		)
+// 		var (
+// 			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
+// 			rng          = rand.New(utils.NewRandSource(789))
+// 			initialState = field.PseudoRand(rng)
+// 			seed         = field.PseudoRand(rng)
+// 			name         = "ddqsdjqskljd"
+// 			fs           = NewMiMCFiatShamir()
+// 		)
 
-		fs.SetState([]field.Element{initialState})
+// 		fs.SetState([]field.Element{initialState})
 
-		fs.RandomFieldFromSeed(seed, name)
+// 		fs.RandomFieldFromSeed(seed, name)
 
-		newState := fs.State()
-		if initialState != newState[0] {
-			t.Errorf("state was modified")
-		}
-	})
+// 		newState := fs.State()
+// 		if initialState != newState[0] {
+// 			t.Errorf("state was modified")
+// 		}
+// 	})
 
-	t.Run("is-repeatable", func(t *testing.T) {
+// 	t.Run("is-repeatable", func(t *testing.T) {
 
-		var (
-			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
-			rng          = rand.New(utils.NewRandSource(789))
-			initialState = field.PseudoRand(rng)
-			seed         = field.PseudoRand(rng)
-			name         = "ddqsdjqskljd"
-			fs           = NewMiMCFiatShamir()
-		)
+// 		var (
+// 			// #nosec G404 --we don't need a cryptographic RNG for testing purpose
+// 			rng          = rand.New(utils.NewRandSource(789))
+// 			initialState = field.PseudoRand(rng)
+// 			seed         = field.PseudoRand(rng)
+// 			name         = "ddqsdjqskljd"
+// 			fs           = NewMiMCFiatShamir()
+// 		)
 
-		fs.SetState([]field.Element{initialState})
+// 		fs.SetState([]field.Element{initialState})
 
-		y1 := fs.RandomFieldFromSeed(seed, name)
-		y2 := fs.RandomFieldFromSeed(seed, name)
+// 		y1 := fs.RandomFieldFromSeed(seed, name)
+// 		y2 := fs.RandomFieldFromSeed(seed, name)
 
-		if y1 != y2 {
-			t.Errorf("state was modified")
-		}
-	})
+// 		if y1 != y2 {
+// 			t.Errorf("state was modified")
+// 		}
+// 	})
 
-}
+// }
 
-// errIfHasDuplicate returns an error if a duplicate is found in the caller's slice
-// indicating the positions and the value corresponding to the first duplicate.
-func errIfHasDuplicate[T comparable](slice ...T) error {
-	m := map[T]int{}
-	for i, f := range slice {
-		if prevPos, ok := m[f]; ok {
-			return fmt.Errorf("found a duplicate value: %v at positions %v and %v", f, prevPos, i)
-		}
+// // errIfHasDuplicate returns an error if a duplicate is found in the caller's slice
+// // indicating the positions and the value corresponding to the first duplicate.
+// func errIfHasDuplicate[T comparable](slice ...T) error {
+// 	m := map[T]int{}
+// 	for i, f := range slice {
+// 		if prevPos, ok := m[f]; ok {
+// 			return fmt.Errorf("found a duplicate value: %v at positions %v and %v", f, prevPos, i)
+// 		}
 
-		m[f] = i
-	}
-	return nil
-}
+// 		m[f] = i
+// 	}
+// 	return nil
+// }
 
-// Test vectors that are used to test the RandomIntVec feature
-var randomIntVecTestCases = []struct {
-	ShouldUpdate   bool
-	NumIntegers    int
-	IntegerBitSize int
-}{
-	{
-		ShouldUpdate:   false,
-		NumIntegers:    0,
-		IntegerBitSize: 16,
-	},
-	{
-		ShouldUpdate:   true,
-		NumIntegers:    1,
-		IntegerBitSize: 16,
-	},
-	{
-		ShouldUpdate:   true,
-		NumIntegers:    15,
-		IntegerBitSize: 16,
-	},
-	{
-		ShouldUpdate:   true,
-		NumIntegers:    16,
-		IntegerBitSize: 16,
-	},
-	{
-		ShouldUpdate:   true,
-		NumIntegers:    17,
-		IntegerBitSize: 16,
-	},
-	{
-		ShouldUpdate:   true,
-		NumIntegers:    45,
-		IntegerBitSize: 16,
-	},
-}
+// // Test vectors that are used to test the RandomIntVec feature
+// var randomIntVecTestCases = []struct {
+// 	ShouldUpdate   bool
+// 	NumIntegers    int
+// 	IntegerBitSize int
+// }{
+// 	{
+// 		ShouldUpdate:   false,
+// 		NumIntegers:    0,
+// 		IntegerBitSize: 16,
+// 	},
+// 	{
+// 		ShouldUpdate:   true,
+// 		NumIntegers:    1,
+// 		IntegerBitSize: 16,
+// 	},
+// 	{
+// 		ShouldUpdate:   true,
+// 		NumIntegers:    15,
+// 		IntegerBitSize: 16,
+// 	},
+// 	{
+// 		ShouldUpdate:   true,
+// 		NumIntegers:    16,
+// 		IntegerBitSize: 16,
+// 	},
+// 	{
+// 		ShouldUpdate:   true,
+// 		NumIntegers:    17,
+// 		IntegerBitSize: 16,
+// 	},
+// 	{
+// 		ShouldUpdate:   true,
+// 		NumIntegers:    45,
+// 		IntegerBitSize: 16,
+// 	},
+// }

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -50,7 +50,7 @@ func TestFiatShamirRandomVec(t *testing.T) {
 
 			if testCase.ShouldUpdate {
 				errStr := fmt.Sprintf("the state was not updated (%v)", oldState.String())
-				if !oldState.Equal(&newState) {
+				if oldState.Equal(&newState) {
 					t.Fatal(errStr)
 				}
 			} else {

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -119,9 +119,7 @@ func TestSamplingFromSeed(t *testing.T) {
 		initialState.SetRandom()
 
 		fs := poseidon2.NewMerkleDamgardHasher()
-		bInitialState := make([]byte, fs.BlockSize())
-		copy(bInitialState, initialState.Marshal())
-		fs.SetState(bInitialState)
+		fs.SetState(initialState.Marshal())
 
 		for i := 0; i < totalSize; i++ {
 
@@ -135,27 +133,27 @@ func TestSamplingFromSeed(t *testing.T) {
 		}
 	})
 
-	t.Run("non-dependance-curr-state", func(t *testing.T) {
+	// t.Run("non-dependance-curr-state", func(t *testing.T) {
 
-		var s1, s2, seed field.Element
-		seed.SetRandom()
-		s1.SetRandom()
-		s2.SetRandom()
+	// 	var s1, s2, seed field.Element
+	// 	seed.SetRandom()
+	// 	s1.SetRandom()
+	// 	s2.SetRandom()
 
-		name := "string-name"
-		fs1 := poseidon2.NewMerkleDamgardHasher()
-		fs2 := poseidon2.NewMerkleDamgardHasher()
+	// 	name := "string-name"
+	// 	fs1 := poseidon2.NewMerkleDamgardHasher()
+	// 	fs2 := poseidon2.NewMerkleDamgardHasher()
 
-		fs1.SetState(s1.Marshal())
-		fs2.SetState(s2.Marshal())
+	// 	fs1.SetState(s1.Marshal())
+	// 	fs2.SetState(s2.Marshal())
 
-		y1 := RandomFieldFromSeed(fs1, seed, name)
-		y2 := RandomFieldFromSeed(fs2, seed, name)
+	// 	y1 := RandomFieldFromSeed(fs1, seed, name)
+	// 	y2 := RandomFieldFromSeed(fs2, seed, name)
 
-		if y1 != y2 {
-			t.Errorf("starting from different state does not give the same results")
-		}
-	})
+	// 	if y1 != y2 {
+	// 		t.Errorf("starting from different state does not give the same results")
+	// 	}
+	// })
 
 	t.Run("does-not-modify-state", func(t *testing.T) {
 
@@ -166,19 +164,18 @@ func TestSamplingFromSeed(t *testing.T) {
 		name := "ddqsdjqskljd"
 		fs := poseidon2.NewMerkleDamgardHasher()
 
-		bInitialState := make([]byte, fs.BlockSize())
-		copy(bInitialState, initialState.Marshal())
-		fs.SetState(bInitialState)
+		oldState := initialState.Marshal()
+		fs.SetState(oldState)
+		oldState = fs.State() // we read the state again because padding might happen in setState
 
 		RandomFieldFromSeed(fs, seed, name)
 
 		newState := fs.State()
+
 		errStr := "state was modified"
-		if len(newState) != len(bInitialState) {
-			t.Fatal(errStr)
-		}
+
 		for i := 0; i < len(newState); i++ {
-			if newState[i] != bInitialState[i] {
+			if newState[i] != oldState[i] {
 				t.Fatal(errStr)
 			}
 		}

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/field/koalabear/poseidon2"
+	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,44 +64,44 @@ func TestFiatShamirRandomVec(t *testing.T) {
 	}
 }
 
-// func TestBatchUpdates(t *testing.T) {
+func TestBatchUpdates(t *testing.T) {
 
-// 	fs := NewMiMCFiatShamir()
-// 	fs.Update(field.NewElement(2))
-// 	fs.Update(field.NewElement(2))
-// 	fs.Update(field.NewElement(1))
-// 	expectedVal := fs.RandomFext()
+	fs := poseidon2.NewMerkleDamgardHasher()
+	Update(fs, field.NewElement(2))
+	Update(fs, field.NewElement(2))
+	Update(fs, field.NewElement(1))
+	expectedVal := RandomFext(fs)
 
-// 	t.Run("for a variadic call", func(t *testing.T) {
-// 		fs := NewMiMCFiatShamir()
-// 		fs.Update(field.NewElement(2), field.NewElement(2), field.NewElement(1))
-// 		actualValue := fs.RandomFext()
-// 		assert.Equal(t, expectedVal.String(), actualValue.String())
-// 	})
+	t.Run("for a variadic call", func(t *testing.T) {
+		fs := poseidon2.NewMerkleDamgardHasher()
+		Update(fs, field.NewElement(2), field.NewElement(2), field.NewElement(1))
+		actualValue := RandomFext(fs)
+		assert.Equal(t, expectedVal.String(), actualValue.String())
+	})
 
-// 	t.Run("for slice of field elements", func(t *testing.T) {
-// 		fs := NewMiMCFiatShamir()
-// 		fs.UpdateVec(vector.ForTest(2, 2, 1))
-// 		actualValue := fs.RandomFext()
-// 		assert.Equal(t, expectedVal.String(), actualValue.String())
-// 	})
+	t.Run("for slice of field elements", func(t *testing.T) {
+		fs := poseidon2.NewMerkleDamgardHasher()
+		UpdateVec(fs, vector.ForTest(2, 2, 1))
+		actualValue := RandomFext(fs)
+		assert.Equal(t, expectedVal.String(), actualValue.String())
+	})
 
-// 	t.Run("for multi-slice of field elements", func(t *testing.T) {
-// 		fs := NewMiMCFiatShamir()
-// 		fs.UpdateVec(vector.ForTest(2, 2), vector.ForTest(1))
-// 		actualValue := fs.RandomFext()
-// 		assert.Equal(t, expectedVal.String(), actualValue.String())
-// 	})
+	t.Run("for multi-slice of field elements", func(t *testing.T) {
+		fs := poseidon2.NewMerkleDamgardHasher()
+		UpdateVec(fs, vector.ForTest(2, 2), vector.ForTest(1))
+		actualValue := RandomFext(fs)
+		assert.Equal(t, expectedVal.String(), actualValue.String())
+	})
 
-// 	t.Run("for a smart-vector", func(t *testing.T) {
-// 		sv := smartvectors.RightPadded(vector.ForTest(2, 2), field.NewElement(1), 3)
-// 		fs := NewMiMCFiatShamir()
-// 		fs.UpdateSV(sv)
-// 		actualValue := fs.RandomFext()
-// 		assert.Equal(t, expectedVal.String(), actualValue.String())
-// 	})
+	// t.Run("for a smart-vector", func(t *testing.T) {
+	// 	sv := smartvectors.RightPadded(vector.ForTest(2, 2), field.NewElement(1), 3)
+	// 	fs := poseidon2.NewMerkleDamgardHasher()
+	// 	UpdateSV(fs, sv)
+	// 	actualValue := RandomFext(fs)
+	// 	assert.Equal(t, expectedVal.String(), actualValue.String())
+	// })
 
-// }
+}
 
 // // TestSamplingFromSeed tests that sampling from seed is consistent, does not forget
 // // bytes from the seed and does not depends on the state.

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -1,9 +1,12 @@
 package fiatshamir
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/consensys/gnark-crypto/field/koalabear/poseidon2"
+	"github.com/consensys/linea-monorepo/prover/maths/field"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,39 +21,39 @@ func TestFiatShamirSafeguardUpdate(t *testing.T) {
 	require.NotEqual(t, a.String(), b.String())
 }
 
-// func TestFiatShamirRandomVec(t *testing.T) {
+func TestFiatShamirRandomVec(t *testing.T) {
 
-// 	for _, testCase := range randomIntVecTestCases {
-// 		testName := fmt.Sprintf("%v-integers-of-%v-bits", testCase.NumIntegers, testCase.IntegerBitSize)
-// 		t.Run(testName, func(t *testing.T) {
+	for _, testCase := range randomIntVecTestCases {
+		testName := fmt.Sprintf("%v-integers-of-%v-bits", testCase.NumIntegers, testCase.IntegerBitSize)
+		t.Run(testName, func(t *testing.T) {
 
-// 			fs := NewMiMCFiatShamir()
-// 			fs.Update(field.NewElement(420))
+			fs := poseidon2.NewMerkleDamgardHasher()
+			Update(fs, field.NewElement(420))
 
-// 			var oldState, newState field.Element
+			var oldState, newState field.Element
 
-// 			if err := oldState.SetBytesCanonical(fs.hasher.Sum(nil)); err != nil {
-// 				t.Fatalf("unexpected error: %v", err)
-// 			}
+			if err := oldState.SetBytesCanonical(fs.Sum(nil)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-// 			a := fs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
-// 			t.Logf("the generated vector= %v", a)
+			a := RandomManyIntegers(fs, testCase.NumIntegers, 1<<testCase.IntegerBitSize)
+			t.Logf("the generated vector= %v", a)
 
-// 			if err := newState.SetBytesCanonical(fs.hasher.Sum(nil)); err != nil {
-// 				t.Fatalf("unexpected error: %v", err)
-// 			}
+			if err := newState.SetBytesCanonical(fs.Sum(nil)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-// 			assert.Len(t, a, testCase.NumIntegers)
-// 			assert.NoError(t, errIfHasDuplicate(a...))
+			assert.Len(t, a, testCase.NumIntegers)
+			assert.NoError(t, errIfHasDuplicate(a...))
 
-// 			if testCase.ShouldUpdate {
-// 				assert.NotEqualf(t, oldState.String(), newState.String(), "the state was not updated (%v)", oldState.String())
-// 			} else {
-// 				assert.Equal(t, oldState.String(), newState.String(), "the state was updated")
-// 			}
-// 		})
-// 	}
-// }
+			if testCase.ShouldUpdate {
+				assert.NotEqualf(t, oldState.String(), newState.String(), "the state was not updated (%v)", oldState.String())
+			} else {
+				assert.Equal(t, oldState.String(), newState.String(), "the state was updated")
+			}
+		})
+	}
+}
 
 // func TestBatchUpdates(t *testing.T) {
 
@@ -190,54 +193,54 @@ func TestFiatShamirSafeguardUpdate(t *testing.T) {
 
 // }
 
-// // errIfHasDuplicate returns an error if a duplicate is found in the caller's slice
-// // indicating the positions and the value corresponding to the first duplicate.
-// func errIfHasDuplicate[T comparable](slice ...T) error {
-// 	m := map[T]int{}
-// 	for i, f := range slice {
-// 		if prevPos, ok := m[f]; ok {
-// 			return fmt.Errorf("found a duplicate value: %v at positions %v and %v", f, prevPos, i)
-// 		}
+// errIfHasDuplicate returns an error if a duplicate is found in the caller's slice
+// indicating the positions and the value corresponding to the first duplicate.
+func errIfHasDuplicate[T comparable](slice ...T) error {
+	m := map[T]int{}
+	for i, f := range slice {
+		if prevPos, ok := m[f]; ok {
+			return fmt.Errorf("found a duplicate value: %v at positions %v and %v", f, prevPos, i)
+		}
 
-// 		m[f] = i
-// 	}
-// 	return nil
-// }
+		m[f] = i
+	}
+	return nil
+}
 
-// // Test vectors that are used to test the RandomIntVec feature
-// var randomIntVecTestCases = []struct {
-// 	ShouldUpdate   bool
-// 	NumIntegers    int
-// 	IntegerBitSize int
-// }{
-// 	{
-// 		ShouldUpdate:   false,
-// 		NumIntegers:    0,
-// 		IntegerBitSize: 16,
-// 	},
-// 	{
-// 		ShouldUpdate:   true,
-// 		NumIntegers:    1,
-// 		IntegerBitSize: 16,
-// 	},
-// 	{
-// 		ShouldUpdate:   true,
-// 		NumIntegers:    15,
-// 		IntegerBitSize: 16,
-// 	},
-// 	{
-// 		ShouldUpdate:   true,
-// 		NumIntegers:    16,
-// 		IntegerBitSize: 16,
-// 	},
-// 	{
-// 		ShouldUpdate:   true,
-// 		NumIntegers:    17,
-// 		IntegerBitSize: 16,
-// 	},
-// 	{
-// 		ShouldUpdate:   true,
-// 		NumIntegers:    45,
-// 		IntegerBitSize: 16,
-// 	},
-// }
+// Test vectors that are used to test the RandomIntVec feature
+var randomIntVecTestCases = []struct {
+	ShouldUpdate   bool
+	NumIntegers    int
+	IntegerBitSize int
+}{
+	{
+		ShouldUpdate:   false,
+		NumIntegers:    0,
+		IntegerBitSize: 16,
+	},
+	{
+		ShouldUpdate:   true,
+		NumIntegers:    1,
+		IntegerBitSize: 16,
+	},
+	{
+		ShouldUpdate:   true,
+		NumIntegers:    15,
+		IntegerBitSize: 16,
+	},
+	{
+		ShouldUpdate:   true,
+		NumIntegers:    16,
+		IntegerBitSize: 16,
+	},
+	{
+		ShouldUpdate:   true,
+		NumIntegers:    17,
+		IntegerBitSize: 16,
+	},
+	{
+		ShouldUpdate:   true,
+		NumIntegers:    45,
+		IntegerBitSize: 16,
+	},
+}

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -32,14 +32,16 @@ func TestFiatShamirRandomVec(t *testing.T) {
 
 			var oldState, newState field.Element
 
-			if err := oldState.SetBytesCanonical(fs.Sum(nil)); err != nil {
+			ss := fs.Sum(nil)
+			if err := oldState.SetBytesCanonical(ss[:4]); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			a := RandomManyIntegers(fs, testCase.NumIntegers, 1<<testCase.IntegerBitSize)
 			t.Logf("the generated vector= %v", a)
 
-			if err := newState.SetBytesCanonical(fs.Sum(nil)); err != nil {
+			ss = fs.Sum(nil)
+			if err := newState.SetBytesCanonical(ss[:4]); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -47,9 +49,15 @@ func TestFiatShamirRandomVec(t *testing.T) {
 			assert.NoError(t, errIfHasDuplicate(a...))
 
 			if testCase.ShouldUpdate {
-				assert.NotEqualf(t, oldState.String(), newState.String(), "the state was not updated (%v)", oldState.String())
+				errStr := fmt.Sprintf("the state was not updated (%v)", oldState.String())
+				if !oldState.Equal(&newState) {
+					t.Fatal(errStr)
+				}
 			} else {
-				assert.Equal(t, oldState.String(), newState.String(), "the state was updated")
+				errStr := "the state was updated"
+				if !oldState.Equal(&newState) {
+					t.Fatal(errStr)
+				}
 			}
 		})
 	}

--- a/prover/crypto/fiatshamir/fiatshamir_test.go
+++ b/prover/crypto/fiatshamir/fiatshamir_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/field/koalabear/poseidon2"
+	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/stretchr/testify/assert"
@@ -93,13 +94,13 @@ func TestBatchUpdates(t *testing.T) {
 		assert.Equal(t, expectedVal.String(), actualValue.String())
 	})
 
-	// t.Run("for a smart-vector", func(t *testing.T) {
-	// 	sv := smartvectors.RightPadded(vector.ForTest(2, 2), field.NewElement(1), 3)
-	// 	fs := poseidon2.NewMerkleDamgardHasher()
-	// 	UpdateSV(fs, sv)
-	// 	actualValue := RandomFext(fs)
-	// 	assert.Equal(t, expectedVal.String(), actualValue.String())
-	// })
+	t.Run("for a smart-vector", func(t *testing.T) {
+		sv := smartvectors.RightPadded(vector.ForTest(2, 2), field.NewElement(1), 3)
+		fs := poseidon2.NewMerkleDamgardHasher()
+		UpdateSV(fs, sv)
+		actualValue := RandomFext(fs)
+		assert.Equal(t, expectedVal.String(), actualValue.String())
+	})
 
 }
 

--- a/prover/crypto/fiatshamir/snark_test.go
+++ b/prover/crypto/fiatshamir/snark_test.go
@@ -1,12 +1,9 @@
 package fiatshamir
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
-	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/utils/gnarkutil"
 )
 
@@ -23,62 +20,62 @@ func TestGnarkSafeGuardUpdate(t *testing.T) {
 	gnarkutil.AssertCircuitSolved(t, f)
 }
 
-func TestGnarkRandomVec(t *testing.T) {
+// func TestGnarkRandomVec(t *testing.T) {
 
-	for _, testCase := range randomIntVecTestCases {
-		testName := fmt.Sprintf("%v-integers-of-%v-bits", testCase.NumIntegers, testCase.IntegerBitSize)
-		t.Run(testName, func(t *testing.T) {
+// 	for _, testCase := range randomIntVecTestCases {
+// 		testName := fmt.Sprintf("%v-integers-of-%v-bits", testCase.NumIntegers, testCase.IntegerBitSize)
+// 		t.Run(testName, func(t *testing.T) {
 
-			f := func(api frontend.API) error {
+// 			f := func(api frontend.API) error {
 
-				gnarkFs := NewGnarkFiatShamir(api, nil)
-				fs := NewMiMCFiatShamir()
+// 				gnarkFs := NewGnarkFiatShamir(api, nil)
+// 				fs := NewMiMCFiatShamir()
 
-				fs.Update(field.NewElement(2))
-				gnarkFs.Update(field.NewElement(2))
+// 				fs.Update(field.NewElement(2))
+// 				gnarkFs.Update(field.NewElement(2))
 
-				a := fs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
-				aGnark := gnarkFs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
+// 				a := fs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
+// 				aGnark := gnarkFs.RandomManyIntegers(testCase.NumIntegers, 1<<testCase.IntegerBitSize)
 
-				for i := range a {
-					api.AssertIsEqual(a[i], aGnark[i])
-				}
+// 				for i := range a {
+// 					api.AssertIsEqual(a[i], aGnark[i])
+// 				}
 
-				return nil
-			}
+// 				return nil
+// 			}
 
-			gnarkutil.AssertCircuitSolved(t, f)
-		})
-	}
-}
+// 			gnarkutil.AssertCircuitSolved(t, f)
+// 		})
+// 	}
+// }
 
-func TestGnarkFiatShamirEmpty(t *testing.T) {
+// func TestGnarkFiatShamirEmpty(t *testing.T) {
 
-	f := func(api frontend.API) error {
-		Y := NewMiMCFiatShamir().RandomFext()
-		fs := NewGnarkFiatShamir(api, nil)
-		y := fs.RandomField()
-		api.AssertIsEqual(Y, y)
-		return nil
-	}
+// 	f := func(api frontend.API) error {
+// 		Y := NewMiMCFiatShamir().RandomFext()
+// 		fs := NewGnarkFiatShamir(api, nil)
+// 		y := fs.RandomField()
+// 		api.AssertIsEqual(Y, y)
+// 		return nil
+// 	}
 
-	gnarkutil.AssertCircuitSolved(t, f)
-}
+// 	gnarkutil.AssertCircuitSolved(t, f)
+// }
 
-func TestGnarkUpdateVec(t *testing.T) {
+// func TestGnarkUpdateVec(t *testing.T) {
 
-	f := func(api frontend.API) error {
-		fs := NewMiMCFiatShamir()
-		fs.UpdateVec(vector.ForTest(2, 2, 1, 2))
-		y1 := fs.RandomFext()
+// 	f := func(api frontend.API) error {
+// 		fs := NewMiMCFiatShamir()
+// 		fs.UpdateVec(vector.ForTest(2, 2, 1, 2))
+// 		y1 := fs.RandomFext()
 
-		fs2 := NewGnarkFiatShamir(api, nil)
-		fs2.UpdateVec([]frontend.Variable{2, 2, 1, 2})
-		y2 := fs2.RandomField()
+// 		fs2 := NewGnarkFiatShamir(api, nil)
+// 		fs2.UpdateVec([]frontend.Variable{2, 2, 1, 2})
+// 		y2 := fs2.RandomField()
 
-		api.AssertIsEqual(y1, y2)
-		return nil
-	}
+// 		api.AssertIsEqual(y1, y2)
+// 		return nil
+// 	}
 
-	gnarkutil.AssertCircuitSolved(t, f)
-}
+// 	gnarkutil.AssertCircuitSolved(t, f)
+// }

--- a/prover/go.mod
+++ b/prover/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/consensys/bavard v0.1.31-0.20250406004941-2db259e4b582
 	github.com/consensys/compress v0.2.5
 	github.com/consensys/gnark v0.13.0
-	github.com/consensys/gnark-crypto v0.18.1-0.20250613145137-bf7ac9d06da2
+	github.com/consensys/gnark-crypto v0.18.1-0.20250623075712-4876a36f2df7
 	github.com/consensys/go-corset v1.0.3
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/dlclark/regexp2 v1.11.2

--- a/prover/go.mod
+++ b/prover/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/consensys/bavard v0.1.31-0.20250406004941-2db259e4b582
 	github.com/consensys/compress v0.2.5
 	github.com/consensys/gnark v0.13.0
-	github.com/consensys/gnark-crypto v0.18.1-0.20250623075712-4876a36f2df7
+	github.com/consensys/gnark-crypto v0.18.1-0.20250625071604-45b6465260b0
 	github.com/consensys/go-corset v1.0.3
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/dlclark/regexp2 v1.11.2

--- a/prover/go.sum
+++ b/prover/go.sum
@@ -122,6 +122,8 @@ github.com/consensys/gnark-crypto v0.18.1-0.20250613145137-bf7ac9d06da2 h1:LZlar
 github.com/consensys/gnark-crypto v0.18.1-0.20250613145137-bf7ac9d06da2/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/consensys/gnark-crypto v0.18.1-0.20250623075712-4876a36f2df7 h1:8PmcO6YCEX1eS0MoL7tV2Khr4HhCrZl5STtaQVz5jlg=
 github.com/consensys/gnark-crypto v0.18.1-0.20250623075712-4876a36f2df7/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
+github.com/consensys/gnark-crypto v0.18.1-0.20250625071604-45b6465260b0 h1:3ylXJTmXakbFErAEue0GIiYBJwZb8iqniYlvsAWzRA0=
+github.com/consensys/gnark-crypto v0.18.1-0.20250625071604-45b6465260b0/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/consensys/go-corset v1.0.3 h1:CZ04qi9NaMkMJnfv19UUHGhEXJZwpDNrAo5fwDbT1OM=
 github.com/consensys/go-corset v1.0.3/go.mod h1:JKJTywyjBE0Goco4DokW4BAkF6R+jtoo3XgkICwxrcw=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/prover/go.sum
+++ b/prover/go.sum
@@ -120,6 +120,8 @@ github.com/consensys/gnark-crypto v0.17.1-0.20250609131457-f8ab23ad7283 h1:Y7LY/
 github.com/consensys/gnark-crypto v0.17.1-0.20250609131457-f8ab23ad7283/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/consensys/gnark-crypto v0.18.1-0.20250613145137-bf7ac9d06da2 h1:LZlarR2EgBB7NDuCf6A9OS2UUa1RAjV2l7T9C0Wvn1I=
 github.com/consensys/gnark-crypto v0.18.1-0.20250613145137-bf7ac9d06da2/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
+github.com/consensys/gnark-crypto v0.18.1-0.20250623075712-4876a36f2df7 h1:8PmcO6YCEX1eS0MoL7tV2Khr4HhCrZl5STtaQVz5jlg=
+github.com/consensys/gnark-crypto v0.18.1-0.20250623075712-4876a36f2df7/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/consensys/go-corset v1.0.3 h1:CZ04qi9NaMkMJnfv19UUHGhEXJZwpDNrAo5fwDbT1OM=
 github.com/consensys/go-corset v1.0.3/go.mod h1:JKJTywyjBE0Goco4DokW4BAkF6R+jtoo3XgkICwxrcw=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/prover/protocol/ifaces/query.go
+++ b/prover/protocol/ifaces/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/consensys/gnark-crypto/hash"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/linea-monorepo/prover/crypto/fiatshamir"
 )
@@ -80,7 +81,7 @@ type Query interface {
 // should update the Fiat-Shamir state.
 type QueryParams interface {
 	// Update fiat-shamir with the query parameters
-	UpdateFS(*fiatshamir.State)
+	UpdateFS(hash.StateStorer)
 }
 
 // GnarkQueryParams mirrors exactly [QueryParams], but in a gnark circuit.


### PR DESCRIPTION
* FS now uses poseidon2
* for FS now the StateStorer from gnark-crypto is directly use, without the need for a wrapper

