### PR TITLE
fix: broken link in docs/audits.md

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -51,7 +51,7 @@
 ### Second Audit Round
 
 **Diligence**
-- Proof aggregation, data compression and message service updates Audit: [https://consensys.io/diligence/audits/2024/01/)linea-contracts-update/](https://consensys.io/diligence/audits/2024/01/)linea-contracts-update/)
+- Proof aggregation, data compression and message service updates Audit: [https://consensys.io/diligence/audits/2024/01/linea-contracts-update/](https://consensys.io/diligence/audits/2024/01/linea-contracts-update/)
 
 **OpenZeppelin**
 


### PR DESCRIPTION
Hi! I fixed a broken link in `docs/audits.md` pointing to the ConsenSys audit — removed an extra parenthesis so the URL now works properly.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.