### PR TITLE
chore: update actions/stale to v9

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           # Issues
           days-before-issue-stale: -1 # Deactivate stale issues


### PR DESCRIPTION
Update GitHub Actions stale workflow to use the latest major version (v9) for improved Node.js 20 support and maintenance updates.

https://github.com/actions/stale/releases/tag/v9.1.0

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.