### PR TITLE
Feat: linea_sendBundle add validation of transactions

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/AbstractSendBundleTest.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/AbstractSendBundleTest.java
@@ -27,7 +27,7 @@ import org.web3j.utils.Numeric;
 
 public class AbstractSendBundleTest extends LineaPluginTestBase {
   protected static final BigInteger TRANSFER_GAS_LIMIT = BigInteger.valueOf(100_000L);
-  protected static final BigInteger MULMOD_GAS_LIMIT = BigInteger.valueOf(10_000_000L);
+  protected static final BigInteger MULMOD_GAS_LIMIT = BigInteger.valueOf(9_000_000L);
   protected static final BigInteger GAS_PRICE = BigInteger.TEN.pow(9);
 
   protected TokenTransfer transferTokens(
@@ -61,6 +61,15 @@ public class AbstractSendBundleTest extends LineaPluginTestBase {
 
   protected MulmodCall mulmodOperation(
       final MulmodExecutor executor, final Account sender, final int nonce, final int iterations) {
+    return mulmodOperation(executor, sender, nonce, iterations, MULMOD_GAS_LIMIT);
+  }
+
+  protected MulmodCall mulmodOperation(
+      final MulmodExecutor executor,
+      final Account sender,
+      final int nonce,
+      final int iterations,
+      final BigInteger gasLimit) {
     final var operationCalldata =
         executor.executeMulmod(BigInteger.valueOf(iterations)).encodeFunctionCall();
 
@@ -68,7 +77,7 @@ public class AbstractSendBundleTest extends LineaPluginTestBase {
         RawTransaction.createTransaction(
             CHAIN_ID,
             BigInteger.valueOf(nonce),
-            MULMOD_GAS_LIMIT,
+            gasLimit,
             executor.getContractAddress(),
             BigInteger.ZERO,
             operationCalldata,

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorCliOptions.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorCliOptions.java
@@ -10,7 +10,15 @@
 package net.consensys.linea.config;
 
 import com.google.common.base.MoreObjects;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.consensys.linea.plugins.LineaCliOptions;
+import org.hyperledger.besu.datatypes.Address;
 import picocli.CommandLine;
 
 /** The Linea CLI options. */
@@ -117,6 +125,7 @@ public class LineaTransactionPoolValidatorCliOptions implements LineaCliOptions 
   public LineaTransactionPoolValidatorConfiguration toDomainObject() {
     return new LineaTransactionPoolValidatorConfiguration(
         denyListPath,
+        parseDeniedAddresses(),
         maxTxGasLimit,
         maxTxCallDataSize,
         txPoolSimulationCheckApiEnabled,
@@ -132,5 +141,15 @@ public class LineaTransactionPoolValidatorCliOptions implements LineaCliOptions 
         .add(TX_POOL_ENABLE_SIMULATION_CHECK_API, txPoolSimulationCheckApiEnabled)
         .add(TX_POOL_ENABLE_SIMULATION_CHECK_P2P, txPoolSimulationCheckP2pEnabled)
         .toString();
+  }
+
+  private Set<Address> parseDeniedAddresses() {
+    try (Stream<String> lines = Files.lines(Path.of(new File(denyListPath).toURI()))) {
+      return lines
+          .map(l -> Address.fromHexString(l.trim()))
+          .collect(Collectors.toUnmodifiableSet());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorConfiguration.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorConfiguration.java
@@ -9,8 +9,10 @@
 
 package net.consensys.linea.config;
 
+import java.util.Set;
 import lombok.Builder;
 import net.consensys.linea.plugins.LineaOptionsConfiguration;
+import org.hyperledger.besu.datatypes.Address;
 
 /**
  * The Linea transaction pool validation configuration.
@@ -22,6 +24,7 @@ import net.consensys.linea.plugins.LineaOptionsConfiguration;
 @Builder(toBuilder = true)
 public record LineaTransactionPoolValidatorConfiguration(
     String denyListPath,
+    Set<Address> deniedAddresses,
     int maxTxGasLimit,
     int maxTxCalldataSize,
     boolean txPoolSimulationCheckApiEnabled,

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 import org.hyperledger.besu.plugin.services.rpc.RpcMethodError;
+import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -44,9 +45,13 @@ public class LineaSendBundle {
           .build();
   private final BlockchainService blockchainService;
   private BundlePoolService bundlePool;
+  private PluginTransactionPoolValidator txPoolValidator;
 
-  public LineaSendBundle init(BundlePoolService bundlePoolService) {
+  public LineaSendBundle init(
+      final BundlePoolService bundlePoolService,
+      final PluginTransactionPoolValidator txPoolValidator) {
     this.bundlePool = bundlePoolService;
+    this.txPoolValidator = txPoolValidator;
     return this;
   }
 
@@ -88,6 +93,8 @@ public class LineaSendBundle {
                         .map(DomainObjectDecodeUtils::decodeRawTransaction)
                         .toList();
 
+                validateTransactions(txs);
+
                 bundlePool.putOrReplace(
                     bundleHash,
                     new TransactionBundle(
@@ -125,7 +132,7 @@ public class LineaSendBundle {
     final var chainHeadBlockNumber = blockchainService.getChainHeadHeader().getNumber();
     if (bundleParams.blockNumber() <= chainHeadBlockNumber) {
       throw new IllegalArgumentException(
-          "bundle block number "
+          "Bundle block number "
               + bundleParams.blockNumber()
               + " is not greater than current chain head block number "
               + chainHeadBlockNumber);
@@ -138,7 +145,7 @@ public class LineaSendBundle {
               final var now = Instant.now().getEpochSecond();
               if (maxTimestamp < now) {
                 throw new IllegalArgumentException(
-                    "bundle max timestamp "
+                    "Bundle max timestamp "
                         + maxTimestamp
                         + " is in the past, current timestamp is "
                         + now);
@@ -152,11 +159,24 @@ public class LineaSendBundle {
       return param;
     } catch (Exception e) {
       log.atError()
-          .setMessage("[{}] failed to parse linea_sendBundle request")
+          .setMessage("[{}] Failed to parse linea_sendBundle request")
           .addArgument(logId)
           .setCause(e)
           .log();
-      throw new RuntimeException("malformed linea_sendBundle json param");
+      throw new RuntimeException("Malformed linea_sendBundle json param");
+    }
+  }
+
+  private void validateTransactions(final List<Transaction> txs) {
+    for (final Transaction tx : txs) {
+      final var maybeInvalidReason = txPoolValidator.validateTransaction(tx, true, false);
+      if (maybeInvalidReason.isPresent()) {
+        throw new IllegalArgumentException(
+            "Invalid transaction in bundle: hash "
+                + tx.getHash()
+                + ", reason: "
+                + maybeInvalidReason.get());
+      }
     }
   }
 

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorFactory.java
@@ -11,7 +11,6 @@ package net.consensys.linea.sequencer.txpoolvalidation;
 
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.Set;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
@@ -22,7 +21,6 @@ import net.consensys.linea.sequencer.txpoolvalidation.validators.CalldataValidat
 import net.consensys.linea.sequencer.txpoolvalidation.validators.GasLimitValidator;
 import net.consensys.linea.sequencer.txpoolvalidation.validators.ProfitabilityValidator;
 import net.consensys.linea.sequencer.txpoolvalidation.validators.SimulationValidator;
-import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.TransactionSimulationService;
@@ -37,7 +35,6 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
   private final TransactionSimulationService transactionSimulationService;
   private final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
   private final LineaProfitabilityConfiguration profitabilityConf;
-  private final Set<Address> denied;
   private final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration;
   private final LineaTracerConfiguration tracerConfiguration;
   private final Optional<JsonRpcManager> rejectedTxJsonRpcManager;
@@ -48,7 +45,6 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
       final TransactionSimulationService transactionSimulationService,
       final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf,
       final LineaProfitabilityConfiguration profitabilityConf,
-      final Set<Address> deniedAddresses,
       final LineaTracerConfiguration tracerConfiguration,
       final LineaL1L2BridgeSharedConfiguration l1L2BridgeConfiguration,
       final Optional<JsonRpcManager> rejectedTxJsonRpcManager) {
@@ -57,7 +53,6 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
     this.transactionSimulationService = transactionSimulationService;
     this.txPoolValidatorConf = txPoolValidatorConf;
     this.profitabilityConf = profitabilityConf;
-    this.denied = deniedAddresses;
     this.tracerConfiguration = tracerConfiguration;
     this.l1L2BridgeConfiguration = l1L2BridgeConfiguration;
     this.rejectedTxJsonRpcManager = rejectedTxJsonRpcManager;
@@ -73,9 +68,9 @@ public class LineaTransactionPoolValidatorFactory implements PluginTransactionPo
   public PluginTransactionPoolValidator createTransactionValidator() {
     final var validators =
         new PluginTransactionPoolValidator[] {
-          new AllowedAddressValidator(denied),
-          new GasLimitValidator(txPoolValidatorConf),
-          new CalldataValidator(txPoolValidatorConf),
+          new AllowedAddressValidator(txPoolValidatorConf.deniedAddresses()),
+          new GasLimitValidator(txPoolValidatorConf.maxTxGasLimit()),
+          new CalldataValidator(txPoolValidatorConf.maxTxCalldataSize()),
           new ProfitabilityValidator(besuConfiguration, blockchainService, profitabilityConf),
           new SimulationValidator(
               blockchainService,

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/LineaTransactionPoolValidatorPlugin.java
@@ -12,20 +12,13 @@ package net.consensys.linea.sequencer.txpoolvalidation;
 import static net.consensys.linea.metrics.LineaMetricCategory.TX_POOL_PROFITABILITY;
 
 import com.google.auto.service.AutoService;
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.AbstractLineaRequiredPlugin;
 import net.consensys.linea.config.LineaRejectedTxReportingConfiguration;
 import net.consensys.linea.jsonrpc.JsonRpcManager;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
 import net.consensys.linea.sequencer.txpoolvalidation.metrics.TransactionPoolProfitabilityMetrics;
-import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuEvents;
@@ -76,12 +69,7 @@ public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPl
       throw new IllegalArgumentException("L1L2 bridge settings have not been defined.");
     }
 
-    try (Stream<String> lines =
-        Files.lines(
-            Path.of(new File(transactionPoolValidatorConfiguration().denyListPath()).toURI()))) {
-      final Set<Address> deniedAddresses =
-          lines.map(l -> Address.fromHexString(l.trim())).collect(Collectors.toUnmodifiableSet());
-
+    try {
       // start the optional json rpc manager for rejected tx reporting
       final LineaRejectedTxReportingConfiguration lineaRejectedTxReportingConfiguration =
           rejectedTxReportingConfiguration();
@@ -102,7 +90,6 @@ public class LineaTransactionPoolValidatorPlugin extends AbstractLineaRequiredPl
               transactionSimulationService,
               transactionPoolValidatorConfiguration(),
               profitabilityConfiguration(),
-              deniedAddresses,
               tracerConfiguration(),
               l1L2BridgeSharedConfiguration(),
               rejectedTxJsonRpcManager));

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidator.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidator.java
@@ -11,7 +11,6 @@ package net.consensys.linea.sequencer.txpoolvalidation.validators;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
@@ -19,15 +18,14 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
 @Slf4j
 @RequiredArgsConstructor
 public class CalldataValidator implements PluginTransactionPoolValidator {
-  final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
+  final int maxTxCalldataSize;
 
   @Override
   public Optional<String> validateTransaction(
       final Transaction transaction, final boolean isLocal, final boolean hasPriority) {
-    if (transaction.getPayload().size() > txPoolValidatorConf.maxTxCalldataSize()) {
+    if (transaction.getPayload().size() > maxTxCalldataSize) {
       final String errMsg =
-          "Calldata of transaction is greater than the allowed max of "
-              + txPoolValidatorConf.maxTxCalldataSize();
+          "Calldata of transaction is greater than the allowed max of " + maxTxCalldataSize;
       log.debug(errMsg);
       return Optional.of(errMsg);
     }

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
@@ -11,7 +11,6 @@ package net.consensys.linea.sequencer.txpoolvalidation.validators;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
 
@@ -22,15 +21,14 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
 @Slf4j
 @RequiredArgsConstructor
 public class GasLimitValidator implements PluginTransactionPoolValidator {
-  final LineaTransactionPoolValidatorConfiguration txPoolValidatorConf;
+  final int maxTxGasLimit;
 
   @Override
   public Optional<String> validateTransaction(
       final Transaction transaction, final boolean isLocal, final boolean hasPriority) {
-    if (transaction.getGasLimit() > txPoolValidatorConf.maxTxGasLimit()) {
+    if (transaction.getGasLimit() > maxTxGasLimit) {
       final String errMsg =
-          "Gas limit of transaction is greater than the allowed max of "
-              + txPoolValidatorConf.maxTxGasLimit();
+          "Gas limit of transaction is greater than the allowed max of " + maxTxGasLimit;
       log.debug(errMsg);
       return Optional.of(errMsg);
     }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidatorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/CalldataValidatorTest.java
@@ -12,7 +12,6 @@ package net.consensys.linea.sequencer.txpoolvalidation.validators;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionPoolValidatorCliOptions;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.Assertions;
@@ -27,11 +26,7 @@ public class CalldataValidatorTest {
 
   @BeforeEach
   public void initialize() {
-    calldataValidator =
-        new CalldataValidator(
-            LineaTransactionPoolValidatorCliOptions.create().toDomainObject().toBuilder()
-                .maxTxCalldataSize(MAX_TX_CALLDATA_SIZE)
-                .build());
+    calldataValidator = new CalldataValidator(MAX_TX_CALLDATA_SIZE);
   }
 
   @Test

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
@@ -12,7 +12,6 @@ package net.consensys.linea.sequencer.txpoolvalidation.validators;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.consensys.linea.config.LineaTransactionPoolValidatorCliOptions;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Wei;
 import org.junit.jupiter.api.Assertions;
@@ -27,11 +26,7 @@ public class GasLimitValidatorTest {
 
   @BeforeEach
   public void initialize() {
-    gasLimitValidator =
-        new GasLimitValidator(
-            LineaTransactionPoolValidatorCliOptions.create().toDomainObject().toBuilder()
-                .maxTxGasLimit(MAX_TX_GAS_LIMIT)
-                .build());
+    gasLimitValidator = new GasLimitValidator(MAX_TX_GAS_LIMIT);
   }
 
   @Test


### PR DESCRIPTION
This PR implements issue(s) #

This PR adds validation of transactions contained in a bundle, according to Linea rules: allowed address, gas limit per tx, calldata per tx, excluding for the moment the profitability and the simulation check, that can be added later.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.