### PR TITLE
Feat: Introduce bundle with priority

### DIFF
--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/bundles/BundleForwarder.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/bundles/BundleForwarder.java
@@ -90,7 +90,7 @@ public class BundleForwarder
       }
 
       final long reqId = reqIdProvider.getAndIncrement();
-      final var jsonRpcRequest = new JsonRpcEnvelope(reqId, bundle.toBundleParameter(false));
+      final var jsonRpcRequest = new JsonRpcEnvelope(reqId, bundle.toBundleParameter());
 
       log.trace("Forwarding request {}, retry count {}", jsonRpcRequest, retryCount);
 

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/bundles/TransactionBundle.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/bundles/TransactionBundle.java
@@ -9,12 +9,24 @@
 
 package net.consensys.linea.bundles;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.SequencedMap;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.EqualsAndHashCode;
@@ -23,49 +35,57 @@ import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.datatypes.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
 /** TransactionBundle class representing a collection of pending transactions with metadata. */
 @Accessors(fluent = true)
 @Getter
 @EqualsAndHashCode
 @ToString
+@JsonInclude(NON_ABSENT)
+@JsonPropertyOrder({"blockNumber", "minTimestamp", "maxTimestamp"})
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class TransactionBundle {
   private static final AtomicLong BUNDLE_COUNT = new AtomicLong(0L);
-  private final long sequence = BUNDLE_COUNT.incrementAndGet();
+  private final transient long sequence = BUNDLE_COUNT.incrementAndGet();
   private final Hash bundleIdentifier;
-  private final List<PendingBundleTx> pendingTransactions;
+  private final List<? extends PendingBundleTx> pendingTransactions;
   private final Long blockNumber;
   private final Optional<Long> minTimestamp;
   private final Optional<Long> maxTimestamp;
   private final Optional<List<Hash>> revertingTxHashes;
   private final Optional<UUID> replacementUUID;
+  private final boolean hasPriority;
 
+  @JsonCreator
   public TransactionBundle(
-      final Hash bundleIdentifier,
-      final List<Transaction> transactions,
-      final Long blockNumber,
-      final Optional<Long> minTimestamp,
-      final Optional<Long> maxTimestamp,
-      final Optional<List<Hash>> revertingTxHashes,
-      final Optional<UUID> replacementUUID) {
+      @JsonProperty("bundleIdentifier") final Hash bundleIdentifier,
+      @JsonProperty("pendingTransactions") final List<Transaction> transactions,
+      @JsonProperty("blockNumber") final Long blockNumber,
+      @JsonProperty("minTimestamp") final Optional<Long> minTimestamp,
+      @JsonProperty("maxTimestamp") final Optional<Long> maxTimestamp,
+      @JsonProperty("revertingTxHashes") final Optional<List<Hash>> revertingTxHashes,
+      @JsonProperty("replacementUUID") final Optional<UUID> replacementUUID,
+      @JsonProperty("hasPriority") final boolean hasPriority) {
     this.bundleIdentifier = bundleIdentifier;
-    this.pendingTransactions = transactions.stream().map(PendingBundleTx::new).toList();
+    this.pendingTransactions =
+        transactions.stream()
+            .map(hasPriority ? PriorityPendingBundleTx::new : NormalPendingBundleTx::new)
+            .toList();
     this.blockNumber = blockNumber;
     this.minTimestamp = minTimestamp;
     this.maxTimestamp = maxTimestamp;
     this.revertingTxHashes = revertingTxHashes;
     this.replacementUUID = replacementUUID;
+    this.hasPriority = hasPriority;
   }
 
-  public BundleParameter toBundleParameter(final boolean compact) {
+  public BundleParameter toBundleParameter() {
     return new BundleParameter(
         pendingTransactions.stream()
-            .map(
-                ptx ->
-                    compact ? ptx.toBase64String() : ptx.getTransaction().encoded().toHexString())
+            .map(ptx -> ptx.getTransaction().encoded().toHexString())
             .toList(),
         new UnsignedLongParameter(blockNumber),
         minTimestamp,
@@ -75,53 +95,159 @@ public class TransactionBundle {
         Optional.empty());
   }
 
-  @JsonValue
-  public Map<Hash, BundleParameter> serialize() {
-    return Map.of(bundleIdentifier, toBundleParameter(true));
-  }
-
-  @JsonCreator
-  public static TransactionBundle deserialize(
-      final SequencedMap<Hash, BundleParameter> serialized) {
-    final var entry = serialized.firstEntry();
-    final var hash = entry.getKey();
-    final var parameters = entry.getValue();
-
-    return new TransactionBundle(
-        hash,
-        parameters.txs().stream().map(Bytes::fromBase64String).map(Transaction::readFrom).toList(),
-        parameters.blockNumber(),
-        parameters.minTimestamp(),
-        parameters.maxTimestamp(),
-        parameters.revertingTxHashes(),
-        parameters.replacementUUID().map(UUID::fromString));
-  }
-
   /** A pending transaction contained in a bundle. */
-  public class PendingBundleTx
-      extends org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.Local {
+  public interface PendingBundleTx extends PendingTransaction {
+    TransactionBundle getBundle();
 
-    public PendingBundleTx(final Transaction transaction) {
+    default String toBase64String() {
+      return getTransaction().encoded().toBase64String();
+    }
+
+    default boolean isBundleStart() {
+      return getBundle().pendingTransactions().getFirst().equals(this);
+    }
+  }
+
+  /** A pending transaction contained in a bundle without priority. */
+  private class NormalPendingBundleTx
+      extends org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.Local
+      implements PendingBundleTx {
+
+    public NormalPendingBundleTx(final Transaction transaction) {
       super(transaction);
     }
 
+    @Override
     public TransactionBundle getBundle() {
       return TransactionBundle.this;
-    }
-
-    public boolean isBundleStart() {
-      return getBundle().pendingTransactions().getFirst().equals(this);
     }
 
     @Override
     public String toTraceLog() {
       return "Bundle tx: " + super.toTraceLog();
     }
+  }
 
-    String toBase64String() {
-      final var rlpOutput = new BytesValueRLPOutput();
-      getTransaction().writeTo(rlpOutput);
-      return rlpOutput.encoded().toBase64String();
+  /** A pending transaction contained in a bundle with priority. */
+  private class PriorityPendingBundleTx
+      extends org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction.Local.Priority
+      implements PendingBundleTx {
+
+    public PriorityPendingBundleTx(final Transaction transaction) {
+      super(transaction);
+    }
+
+    @Override
+    public TransactionBundle getBundle() {
+      return TransactionBundle.this;
+    }
+
+    @Override
+    public String toTraceLog() {
+      return "Priority bundle tx: " + super.toTraceLog();
+    }
+  }
+
+  public static class HashSerializer extends StdSerializer<Hash> {
+    public HashSerializer() {
+      this(null);
+    }
+
+    public HashSerializer(final Class<Hash> t) {
+      super(t);
+    }
+
+    @Override
+    public void serialize(
+        final Hash value, final JsonGenerator gen, final SerializerProvider provider)
+        throws IOException {
+      gen.writeString(value.toHexString());
+    }
+  }
+
+  public static class HashDeserializer extends StdDeserializer<Hash> {
+    public HashDeserializer() {
+      this(null);
+    }
+
+    @Override
+    public Hash deserialize(final JsonParser p, final DeserializationContext ctxt)
+        throws IOException {
+      return Hash.fromHexString(p.getValueAsString());
+    }
+
+    public HashDeserializer(final Class<Hash> t) {
+      super(t);
+    }
+  }
+
+  public static class PendingBundleTxSerializer extends StdSerializer<PendingBundleTx> {
+    public PendingBundleTxSerializer() {
+      this(null);
+    }
+
+    public PendingBundleTxSerializer(final Class<PendingBundleTx> t) {
+      super(t);
+    }
+
+    @Override
+    public void serialize(
+        final PendingBundleTx pendingBundleTx,
+        final JsonGenerator gen,
+        final SerializerProvider serializerProvider)
+        throws IOException {
+      gen.writeString(pendingBundleTx.toBase64String());
+    }
+  }
+
+  public static class PendingBundleTxDeserializer extends StdDeserializer<Transaction> {
+    public PendingBundleTxDeserializer() {
+      this(null);
+    }
+
+    public PendingBundleTxDeserializer(final Class<?> vc) {
+      super(vc);
+    }
+
+    @Override
+    public Transaction deserialize(
+        final JsonParser jsonParser, final DeserializationContext deserializationContext)
+        throws IOException {
+      return Transaction.readFrom(Bytes.fromBase64String(jsonParser.getValueAsString()));
+    }
+  }
+
+  public static class TransactionBundleDeserializerV1 extends StdDeserializer<TransactionBundle> {
+    private static final TypeReference<Map.Entry<Hash, BundleParameter>> TYPE_REFERENCE =
+        new TypeReference<>() {};
+
+    public TransactionBundleDeserializerV1() {
+      this(null);
+    }
+
+    public TransactionBundleDeserializerV1(final Class<?> vc) {
+      super(vc);
+    }
+
+    @Override
+    public TransactionBundle deserialize(final JsonParser p, final DeserializationContext ctxt)
+        throws IOException {
+      @SuppressWarnings("unchecked")
+      final var entry = (Map.Entry<Hash, BundleParameter>) p.readValueAs(TYPE_REFERENCE);
+      final var hash = entry.getKey();
+      final var parameters = entry.getValue();
+      return new TransactionBundle(
+          hash,
+          parameters.txs().stream()
+              .map(Bytes::fromBase64String)
+              .map(Transaction::readFrom)
+              .toList(),
+          parameters.blockNumber(),
+          parameters.minTimestamp(),
+          parameters.maxTimestamp(),
+          parameters.revertingTxHashes(),
+          parameters.replacementUUID().map(UUID::fromString),
+          false);
     }
   }
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaSendBundle.java
@@ -104,7 +104,8 @@ public class LineaSendBundle {
                         bundleParams.minTimestamp(),
                         bundleParams.maxTimestamp(),
                         bundleParams.revertingTxHashes(),
-                        optBundleUUID));
+                        optBundleUUID,
+                        false));
                 return new BundleResponse(bundleHash.toHexString());
               })
           .orElseThrow(

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/bundles/AbstractBundleTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/bundles/AbstractBundleTest.java
@@ -9,8 +9,6 @@
 
 package net.consensys.linea.bundles;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
@@ -23,8 +21,6 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 
 abstract class AbstractBundleTest {
-  protected static final ObjectMapper OBJECT_MAPPER =
-      new ObjectMapper().registerModule(new Jdk8Module());
   protected static final KeyPair KEY_PAIR =
       new KeyPair(
           SECPPrivateKey.create(BigInteger.valueOf(Long.MAX_VALUE), SignatureAlgorithm.ALGORITHM),
@@ -39,6 +35,11 @@ abstract class AbstractBundleTest {
 
   protected TransactionBundle createBundle(
       Hash hash, long blockNumber, List<Transaction> maybeTxs) {
+    return createBundle(hash, blockNumber, maybeTxs, false);
+  }
+
+  protected TransactionBundle createBundle(
+      Hash hash, long blockNumber, List<Transaction> maybeTxs, boolean hasPriority) {
     return new TransactionBundle(
         hash,
         maybeTxs,
@@ -46,6 +47,7 @@ abstract class AbstractBundleTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        hasPriority);
   }
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/bundles/BundleForwarderTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/bundles/BundleForwarderTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.lenient;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
@@ -65,6 +67,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @WireMockTest
 @ExtendWith(MockitoExtension.class)
 class BundleForwarderTest extends AbstractBundleTest {
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new Jdk8Module());
   private static final AtomicLong REQ_ID_COUNT = new AtomicLong(0);
   private static final Duration RPC_CALL_TIMEOUT = Duration.ofSeconds(2);
   private static final long CHAIN_HEAD_BLOCK_NUMBER = 5L;
@@ -276,7 +280,7 @@ class BundleForwarderTest extends AbstractBundleTest {
           "params": [<params>]
         }
         """
-            .replace("<params>", OBJECT_MAPPER.writeValueAsString(bundle.toBundleParameter(false)))
+            .replace("<params>", OBJECT_MAPPER.writeValueAsString(bundle.toBundleParameter()))
             .replace("<reqId>", String.valueOf(reqId));
     return expectedRequest;
   }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/bundles/TransactionBundleTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/bundles/TransactionBundleTest.java
@@ -14,14 +14,31 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.util.List;
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.datatypes.PendingTransaction;
+import org.hyperledger.besu.datatypes.Transaction;
 import org.junit.jupiter.api.Test;
 
 class TransactionBundleTest extends AbstractBundleTest {
+  private static final SimpleModule BUNDLE_MODULE = new SimpleModule();
+
+  static {
+    BUNDLE_MODULE.addSerializer(
+        TransactionBundle.PendingBundleTx.class, new TransactionBundle.PendingBundleTxSerializer());
+    BUNDLE_MODULE.addSerializer(Hash.class, new TransactionBundle.HashSerializer());
+    BUNDLE_MODULE.addDeserializer(
+        org.hyperledger.besu.ethereum.core.Transaction.class,
+        new TransactionBundle.PendingBundleTxDeserializer());
+    BUNDLE_MODULE.addDeserializer(Hash.class, new TransactionBundle.HashDeserializer());
+  }
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new Jdk8Module()).registerModule(BUNDLE_MODULE);
 
   @Test
   void serializeToJson() throws JsonProcessingException {
@@ -32,7 +49,7 @@ class TransactionBundleTest extends AbstractBundleTest {
     assertThat(OBJECT_MAPPER.writeValueAsString(bundle1))
         .isEqualTo(
             """
-            {"0x0000000000000000000000000000000000000000000000000000000000001234":{"blockNumber":1,"txs":["+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7","+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"]}}""");
+            {"blockNumber":1,"bundleIdentifier":"0x0000000000000000000000000000000000000000000000000000000000001234","pendingTransactions":["+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7","+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"],"hasPriority":false}""");
   }
 
   @Test
@@ -40,7 +57,7 @@ class TransactionBundleTest extends AbstractBundleTest {
     TransactionBundle bundle =
         OBJECT_MAPPER.readValue(
             """
-            {"0x0000000000000000000000000000000000000000000000000000000000001234":{"blockNumber":1,"txs":["+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7","+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"]}}""",
+            {"blockNumber":1,"bundleIdentifier":"0x0000000000000000000000000000000000000000000000000000000000001234","pendingTransactions":["+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7","+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"],"hasPriority":true}""",
             TransactionBundle.class);
 
     assertThat(bundle.blockNumber()).isEqualTo(1);
@@ -57,10 +74,10 @@ class TransactionBundleTest extends AbstractBundleTest {
             () ->
                 OBJECT_MAPPER.readValue(
                     """
-            {"0x0000000000000000000000000000000000000000000000000000000000001234":{"wrong":1,"txs":["+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7","+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"]}}""",
+            {"wrong":1,"bundleIdentifier":"0x0000000000000000000000000000000000000000000000000000000000001234","pendingTransactions":["+E+AghOIglIIgASAggqWoHNvbkX5jC5D+Q0GW88l7bP45W+b8oubebJsfXgE+lRzoAVzHPSnS/zQmUxq3Hg9UHQ3p51KWM6dyYuqKVM7HYz7","+E8BghOIglIIgASAggqVoGgwjcqbkx9qWzUse4MmYxq5fGYo617lp3j9YAj74GDhoFrjtX1uTIbDgflVrS1EPJv2jmbGV2NbxukBL0sNVpBf"],"hasPriority":true}""",
                     TransactionBundle.class))
-        .isInstanceOf(ValueInstantiationException.class)
-        .hasMessageContaining("because \"blockNumber\" is null");
+        .isInstanceOf(UnrecognizedPropertyException.class)
+        .hasMessageContaining("Unrecognized field \"wrong\"");
   }
 
   @Test
@@ -74,5 +91,14 @@ class TransactionBundleTest extends AbstractBundleTest {
         .isInstanceOf(JsonParseException.class)
         .hasMessageStartingWith(
             "Unexpected character ('{' (code 123)): was expecting double-quote to start field name");
+  }
+
+  @Test
+  void prioritizedBundleHasPriorityTxs() {
+    Hash hash = Hash.fromHexStringLenient("0x1234");
+    TransactionBundle bundle = createBundle(hash, 1, List.of(TX1, TX2), true);
+
+    assertThat(bundle.pendingTransactions().stream().allMatch(PendingTransaction::hasPriority))
+        .isTrue();
   }
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendBundleTest.java
@@ -26,9 +26,9 @@ import java.util.Optional;
 import java.util.UUID;
 import net.consensys.linea.bundles.BundleParameter;
 import net.consensys.linea.bundles.LineaLimitedBundlePool;
-import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.crypto.SignatureAlgorithmType;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.plugin.services.BesuEvents;
@@ -167,7 +167,7 @@ class LineaSendBundleTest {
     // assert the new block number:
     assertTrue(
         bundlePool.get(expectedUUIDBundleHash).blockNumber().equals(CHAIN_HEAD_BLOCK_NUMBER + 2));
-    List<TransactionBundle.PendingBundleTx> pts =
+    List<? extends PendingTransaction> pts =
         bundlePool.get(expectedUUIDBundleHash).pendingTransactions();
     // assert the new tx2 is present
     assertTrue(pts.stream().map(pt -> pt.getTransaction()).anyMatch(t -> t.equals(mockTX2)));

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
@@ -177,7 +177,8 @@ class LineaTransactionSelectorFactoryTest {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        false);
   }
 
   static class FailedTransactionSelectionResultProvider implements ArgumentsProvider {

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelectorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/BundleConstraintTransactionSelectorTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import net.consensys.linea.bundles.TransactionBundle;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -101,11 +102,12 @@ class BundleConstraintTransactionSelectorTest {
         Optional.ofNullable(minTimestamp),
         Optional.ofNullable(maxTimestamp),
         Optional.empty(),
-        Optional.empty());
+        Optional.empty(),
+        false);
   }
 
   private TransactionEvaluationContext mockTransactionEvaluationContext(
-      BlockHeader blockHeader, TransactionBundle.PendingBundleTx pendingTransaction) {
+      BlockHeader blockHeader, PendingTransaction pendingTransaction) {
     return new TestTransactionEvaluationContext(blockHeader, pendingTransaction, Wei.ONE, Wei.ONE);
   }
 

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleBlockGasTransactionSelectorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/MaxBundleBlockGasTransactionSelectorTest.java
@@ -91,7 +91,8 @@ public class MaxBundleBlockGasTransactionSelectorTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            false);
     final var evaluationContexts =
         bundle.pendingTransactions().stream()
             .map(pt -> new TestTransactionEvaluationContext(mock(ProcessableBlockHeader.class), pt))


### PR DESCRIPTION
With this PR is it possible to create a bundle with priority, that means that all the pending transactions it contains have priority, thus they will not need to respect all the gas pricing constraints that normal pending transactions have.

At the moment it is only possible to create bundles with priority internally, bundles that arrives via RPC are always without priority.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.