### PR TITLE
update prover to go v1.24.0

### DIFF
--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -41,9 +41,9 @@ jobs:
       working-directory: prover
       run: if [[ -n $(gofmt -l .) ]]; then echo "please run gofmt"; exit 1; fi
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v7 # update to v7 to support golangci-lint v2.x
+      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
       with:
-          version: v2.3.1
+          version: v1.61.0
           working-directory: prover
           args: --timeout=5m
     - name: generated files should not be modified

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -41,7 +41,7 @@ jobs:
       working-directory: prover
       run: if [[ -n $(gofmt -l .) ]]; then echo "please run gofmt"; exit 1; fi
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
+      uses: golangci/golangci-lint-action@v7 # update to v7 to support golangci-lint v2.x
       with:
           version: v2.3.1
           working-directory: prover

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -25,7 +25,7 @@ jobs:
     - name: install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
         cache-dependency-path: |
               prover/go.sum
     - uses: actions/cache@v4.2.0
@@ -43,7 +43,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
       with:
-          version: v1.61.0
+          version: v2.3.1
           working-directory: prover
           args: --timeout=5m
     - name: generated files should not be modified
@@ -57,7 +57,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
     # ~1 min saved vs large
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xl
     name: Prover testing

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -43,7 +43,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
       with:
-          version: v1.61.0
+          version: v1.64.3
           working-directory: prover
           args: --timeout=5m
     - name: generated files should not be modified

--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -6,7 +6,7 @@
 # G O + R U S T   B U I L D E R
 #
 ###############################
-FROM golang:1.23.0-alpine AS go-builder
+FROM golang:1.24.0-alpine AS go-builder
 
 RUN apk add --no-cache rust cargo bash make
 

--- a/prover/backend/execution/prove.go
+++ b/prover/backend/execution/prove.go
@@ -105,12 +105,12 @@ func mustProveAndPass(
 
 		srsProvider, err := circuits.NewSRSStore(cfg.PathForSRS())
 		if err != nil {
-			utils.Panic(err.Error())
+			utils.Panic("%s", err.Error())
 		}
 
 		setup, err := dummy.MakeUnsafeSetup(srsProvider, circuits.MockCircuitIDExecution, ecc.BLS12_377.ScalarField())
 		if err != nil {
-			utils.Panic(err.Error())
+			utils.Panic("%s", err.Error())
 		}
 
 		return dummy.MakeProof(&setup, w.FuncInp.SumAsField(), circuits.MockCircuitIDExecution), setup.VerifyingKeyDigest()

--- a/prover/backend/execution/prove.go
+++ b/prover/backend/execution/prove.go
@@ -110,7 +110,7 @@ func mustProveAndPass(
 
 		setup, err := dummy.MakeUnsafeSetup(srsProvider, circuits.MockCircuitIDExecution, ecc.BLS12_377.ScalarField())
 		if err != nil {
-			utils.Panic("%s", err.Error())
+			panic(err.Error())
 		}
 
 		return dummy.MakeProof(&setup, w.FuncInp.SumAsField(), circuits.MockCircuitIDExecution), setup.VerifyingKeyDigest()

--- a/prover/backend/execution/prove.go
+++ b/prover/backend/execution/prove.go
@@ -105,7 +105,7 @@ func mustProveAndPass(
 
 		srsProvider, err := circuits.NewSRSStore(cfg.PathForSRS())
 		if err != nil {
-			utils.Panic("%s", err.Error())
+			panic(err.Error())
 		}
 
 		setup, err := dummy.MakeUnsafeSetup(srsProvider, circuits.MockCircuitIDExecution, ecc.BLS12_377.ScalarField())

--- a/prover/go.mod
+++ b/prover/go.mod
@@ -1,8 +1,8 @@
 module github.com/consensys/linea-monorepo/prover
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.4
+toolchain go1.24.6
 
 require (
 	github.com/bits-and-blooms/bitset v1.20.0

--- a/prover/protocol/dedicated/byte32cmp/decompose.go
+++ b/prover/protocol/dedicated/byte32cmp/decompose.go
@@ -110,7 +110,7 @@ func Decompose(comp *wizard.CompiledIOP, col any, numLimbs int, bitPerLimbs int,
 		// Enforces the range over the limbs
 		comp.InsertRange(
 			round,
-			ifaces.QueryIDf("%s", ctxName("LIMB_"+strconv.Itoa(i))),
+			ifaces.QueryID(ctxName("LIMB_"+strconv.Itoa(i))),
 			limbs[i],
 			1<<bitPerLimbs,
 		)

--- a/prover/protocol/dedicated/byte32cmp/decompose.go
+++ b/prover/protocol/dedicated/byte32cmp/decompose.go
@@ -110,7 +110,7 @@ func Decompose(comp *wizard.CompiledIOP, col any, numLimbs int, bitPerLimbs int,
 		// Enforces the range over the limbs
 		comp.InsertRange(
 			round,
-			ifaces.QueryIDf("LIMB_DECOMPOSITION_%d_%s", len(comp.ListCommitments()), "LIMB_"+strconv.Itoa(i)),
+			ifaces.QueryIDf("%s", ctxName("LIMB_"+strconv.Itoa(i))),
 			limbs[i],
 			1<<bitPerLimbs,
 		)

--- a/prover/protocol/dedicated/byte32cmp/decompose.go
+++ b/prover/protocol/dedicated/byte32cmp/decompose.go
@@ -110,7 +110,7 @@ func Decompose(comp *wizard.CompiledIOP, col any, numLimbs int, bitPerLimbs int,
 		// Enforces the range over the limbs
 		comp.InsertRange(
 			round,
-			ifaces.QueryIDf(ctxName("LIMB_"+strconv.Itoa(i))),
+			ifaces.QueryIDf("LIMB_DECOMPOSITION_%d_%s", len(comp.ListCommitments()), "LIMB_"+strconv.Itoa(i)),
 			limbs[i],
 			1<<bitPerLimbs,
 		)

--- a/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
+++ b/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
@@ -100,9 +100,9 @@ func CmpMultiLimbs(comp *wizard.CompiledIOP, a, b LimbColumns) (isGreater, isEqu
 		numLimbs        = len(a.Limbs)
 		numBitsPerLimbs = a.LimbBitSize
 		ctx             = &MultiLimbCmp{
-			IsGreater:          comp.InsertCommit(round, ifaces.ColIDf(ctxName("IS_GREATER")), nRows),
-			IsLower:            comp.InsertCommit(round, ifaces.ColIDf(ctxName("IS_LOWER")), nRows),
-			NonNegativeSyndrom: comp.InsertCommit(round, ifaces.ColIDf(ctxName("MUST_BE_POSITIVE")), nRows),
+			IsGreater:          comp.InsertCommit(round, ifaces.ColIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "IS_GREATER"), nRows),
+			IsLower:            comp.InsertCommit(round, ifaces.ColIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "IS_LOWER"), nRows),
+			NonNegativeSyndrom: comp.InsertCommit(round, ifaces.ColIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "MUST_BE_POSITIVE"), nRows),
 		}
 
 		syndromExpression = sym.NewConstant(0)
@@ -145,7 +145,7 @@ func CmpMultiLimbs(comp *wizard.CompiledIOP, a, b LimbColumns) (isGreater, isEqu
 
 	comp.InsertGlobal(
 		round,
-		ifaces.QueryIDf(ctxName("FLAGS_MUTUALLY_EXCLUSIVE")),
+		ifaces.QueryIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "FLAGS_MUTUALLY_EXCLUSIVE"),
 		sym.Sub(1, ctx.IsGreater, isEqual, ctx.IsLower),
 	)
 

--- a/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
+++ b/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
@@ -100,9 +100,9 @@ func CmpMultiLimbs(comp *wizard.CompiledIOP, a, b LimbColumns) (isGreater, isEqu
 		numLimbs        = len(a.Limbs)
 		numBitsPerLimbs = a.LimbBitSize
 		ctx             = &MultiLimbCmp{
-			IsGreater:          comp.InsertCommit(round, ifaces.ColIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "IS_GREATER"), nRows),
-			IsLower:            comp.InsertCommit(round, ifaces.ColIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "IS_LOWER"), nRows),
-			NonNegativeSyndrom: comp.InsertCommit(round, ifaces.ColIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "MUST_BE_POSITIVE"), nRows),
+			IsGreater:          comp.InsertCommit(round, ifaces.ColIDf("%s", ctxName("IS_GREATER")), nRows),
+			IsLower:            comp.InsertCommit(round, ifaces.ColIDf("%s", ctxName("IS_LOWER")), nRows),
+			NonNegativeSyndrom: comp.InsertCommit(round, ifaces.ColIDf("%s", ctxName("MUST_BE_POSITIVE")), nRows),
 		}
 
 		syndromExpression = sym.NewConstant(0)
@@ -145,7 +145,7 @@ func CmpMultiLimbs(comp *wizard.CompiledIOP, a, b LimbColumns) (isGreater, isEqu
 
 	comp.InsertGlobal(
 		round,
-		ifaces.QueryIDf("CMP_MULTI_LIMB_%d_%s", len(comp.Columns.AllKeys()), "FLAGS_MUTUALLY_EXCLUSIVE"),
+		ifaces.QueryIDf("%s", ctxName("FLAGS_MUTUALLY_EXCLUSIVE")),
 		sym.Sub(1, ctx.IsGreater, isEqual, ctx.IsLower),
 	)
 

--- a/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
+++ b/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
@@ -145,7 +145,7 @@ func CmpMultiLimbs(comp *wizard.CompiledIOP, a, b LimbColumns) (isGreater, isEqu
 
 	comp.InsertGlobal(
 		round,
-		ifaces.QueryIDf("%s", ctxName("FLAGS_MUTUALLY_EXCLUSIVE")),
+		ifaces.QueryID(ctxName("FLAGS_MUTUALLY_EXCLUSIVE")),
 		sym.Sub(1, ctx.IsGreater, isEqual, ctx.IsLower),
 	)
 

--- a/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
+++ b/prover/protocol/dedicated/byte32cmp/multi_limb_cmp.go
@@ -100,9 +100,9 @@ func CmpMultiLimbs(comp *wizard.CompiledIOP, a, b LimbColumns) (isGreater, isEqu
 		numLimbs        = len(a.Limbs)
 		numBitsPerLimbs = a.LimbBitSize
 		ctx             = &MultiLimbCmp{
-			IsGreater:          comp.InsertCommit(round, ifaces.ColIDf("%s", ctxName("IS_GREATER")), nRows),
-			IsLower:            comp.InsertCommit(round, ifaces.ColIDf("%s", ctxName("IS_LOWER")), nRows),
-			NonNegativeSyndrom: comp.InsertCommit(round, ifaces.ColIDf("%s", ctxName("MUST_BE_POSITIVE")), nRows),
+			IsGreater:          comp.InsertCommit(round, ifaces.ColID(ctxName("IS_GREATER")), nRows),
+			IsLower:            comp.InsertCommit(round, ifaces.ColID(ctxName("IS_LOWER")), nRows),
+			NonNegativeSyndrom: comp.InsertCommit(round, ifaces.ColID(ctxName("MUST_BE_POSITIVE")), nRows),
 		}
 
 		syndromExpression = sym.NewConstant(0)

--- a/prover/protocol/dedicated/merkle/computemod.go
+++ b/prover/protocol/dedicated/merkle/computemod.go
@@ -445,7 +445,7 @@ func (cm *ComputeMod) qname(name string, args ...any) ifaces.QueryID {
 func (cm *ComputeMod) colZeroAtInactive(col ifaces.Column, name string) {
 	// col zero at inactive area, e.g., IsInactive[i]) * col[i] = 0
 	sug := cm.SugarVar
-	cm.Comp.InsertGlobal(cm.Round, cm.qname(name),
+	cm.Comp.InsertGlobal(cm.Round, cm.qname("%s", name),
 		symbolic.Mul(sug.IsInactive, col))
 }
 

--- a/prover/protocol/dedicated/merkle/computemod.go
+++ b/prover/protocol/dedicated/merkle/computemod.go
@@ -437,15 +437,15 @@ func (cm *ComputeMod) colname(name string, args ...any) ifaces.ColID {
 	return ifaces.ColIDf("%v_%v", cm.Name, cm.Comp.SelfRecursionCount) + "_" + ifaces.ColIDf(name, args...)
 }
 
-func (cm *ComputeMod) qname(name string, args ...any) ifaces.QueryID {
-	return ifaces.QueryIDf("%v_%v", cm.Name, cm.Comp.SelfRecursionCount) + "_" + ifaces.QueryIDf(name, args...)
+func (cm *ComputeMod) qname(name string) ifaces.QueryID {
+	return ifaces.QueryIDf("%s_%d", cm.Name, cm.Comp.SelfRecursionCount) + "_" + ifaces.QueryID(name)
 }
 
 // Function inserting a query that col is zero when IsActive is zero
 func (cm *ComputeMod) colZeroAtInactive(col ifaces.Column, name string) {
 	// col zero at inactive area, e.g., IsInactive[i]) * col[i] = 0
 	sug := cm.SugarVar
-	cm.Comp.InsertGlobal(cm.Round, cm.qname("%s", name),
+	cm.Comp.InsertGlobal(cm.Round, cm.qname(name),
 		symbolic.Mul(sug.IsInactive, col))
 }
 

--- a/prover/protocol/dedicated/merkle/merkle_test.go
+++ b/prover/protocol/dedicated/merkle/merkle_test.go
@@ -26,7 +26,6 @@ type merkleTestBuilder struct {
 	useNextMerkleProof []field.Element
 	isActive           []field.Element
 	counter            []field.Element
-	tree               smt.Tree
 }
 
 // newMerkleTestBuilder returns an empty builder

--- a/prover/protocol/dedicated/mimc/linear_hash.go
+++ b/prover/protocol/dedicated/mimc/linear_hash.go
@@ -193,7 +193,7 @@ func (ctx *linearHashCtx) HashingCols() {
 	//
 	ctx.Comp.InsertGlobal(
 		ctx.Round,
-		ifaces.QueryIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "CLEAN_NEW_STATE_%v", ctx.ToHash.GetColID())),
+		ifaces.QueryID(prefixWithLinearHash(ctx.Comp, ctx.Name, "CLEAN_NEW_STATE_%v", ctx.ToHash.GetColID())),
 		ctx.IsActiveVar().
 			Mul(ifaces.ColumnAsVariable(ctx.NewState)).
 			Sub(ifaces.ColumnAsVariable(ctx.NewStateClean)),
@@ -231,7 +231,7 @@ func (ctx *linearHashCtx) IsActiveExpected() ifaces.Column {
 		}
 
 		ctx.IsActiveRowExpected = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_EXPECTED_%v", ctx.ToHash.GetColID())),
+			ifaces.ColID(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_EXPECTED_%v", ctx.ToHash.GetColID())),
 			assignment,
 		)
 	}
@@ -248,7 +248,7 @@ func (ctx *linearHashCtx) IsActiveVar() *symbolic.Expression {
 	// Lazily registers the columns
 	if ctx.IsActiveLarge == nil {
 		ctx.IsActiveLarge = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_%v", ctx.ToHash.GetColID())),
+			ifaces.ColID(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_%v", ctx.ToHash.GetColID())),
 			smartvectors.RightZeroPadded(
 				vector.Repeat(field.One(), ctx.NumHash*ctx.Period),
 				ctx.ToHash.Size(),
@@ -276,7 +276,7 @@ func (ctx *linearHashCtx) IsEndOfHashVar() *symbolic.Expression {
 		}
 
 		ctx.IsEndOfHash = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_END_OF_HASH_%v", ctx.ToHash.GetColID())),
+			ifaces.ColID(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_END_OF_HASH_%v", ctx.ToHash.GetColID())),
 			smartvectors.RightZeroPadded(window, ctx.ToHash.Size()),
 		)
 	}

--- a/prover/protocol/dedicated/mimc/linear_hash.go
+++ b/prover/protocol/dedicated/mimc/linear_hash.go
@@ -160,7 +160,7 @@ func (ctx *linearHashCtx) HashingCols() {
 
 	ctx.NewStateClean = ctx.Comp.InsertCommit(
 		ctx.Round,
-		ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "NEW_STATE_CLEAN_%v", ctx.ToHash.GetColID())),
+		ifaces.ColID(prefixWithLinearHash(ctx.Comp, ctx.Name, "NEW_STATE_CLEAN_%v", ctx.ToHash.GetColID())),
 		ctx.ToHash.Size(),
 	)
 

--- a/prover/protocol/dedicated/mimc/linear_hash.go
+++ b/prover/protocol/dedicated/mimc/linear_hash.go
@@ -160,7 +160,7 @@ func (ctx *linearHashCtx) HashingCols() {
 
 	ctx.NewStateClean = ctx.Comp.InsertCommit(
 		ctx.Round,
-		ifaces.ColIDf("%s.LINEAR_HASH_%d_NEW_STATE_CLEAN_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
+		ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "NEW_STATE_CLEAN_%v", ctx.ToHash.GetColID())),
 		ctx.ToHash.Size(),
 	)
 
@@ -193,7 +193,7 @@ func (ctx *linearHashCtx) HashingCols() {
 	//
 	ctx.Comp.InsertGlobal(
 		ctx.Round,
-		ifaces.QueryIDf("%s.LINEAR_HASH_%d_CLEAN_NEW_STATE_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
+		ifaces.QueryIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "CLEAN_NEW_STATE_%v", ctx.ToHash.GetColID())),
 		ctx.IsActiveVar().
 			Mul(ifaces.ColumnAsVariable(ctx.NewState)).
 			Sub(ifaces.ColumnAsVariable(ctx.NewStateClean)),
@@ -231,7 +231,7 @@ func (ctx *linearHashCtx) IsActiveExpected() ifaces.Column {
 		}
 
 		ctx.IsActiveRowExpected = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf("%s.LINEAR_HASH_%d_IS_ACTIVE_EXPECTED_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
+			ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_EXPECTED_%v", ctx.ToHash.GetColID())),
 			assignment,
 		)
 	}
@@ -248,7 +248,7 @@ func (ctx *linearHashCtx) IsActiveVar() *symbolic.Expression {
 	// Lazily registers the columns
 	if ctx.IsActiveLarge == nil {
 		ctx.IsActiveLarge = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf("%s.LINEAR_HASH_%d_IS_ACTIVE_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
+			ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_%v", ctx.ToHash.GetColID())),
 			smartvectors.RightZeroPadded(
 				vector.Repeat(field.One(), ctx.NumHash*ctx.Period),
 				ctx.ToHash.Size(),
@@ -276,8 +276,7 @@ func (ctx *linearHashCtx) IsEndOfHashVar() *symbolic.Expression {
 		}
 
 		ctx.IsEndOfHash = ctx.Comp.InsertPrecomputed(
-			// ifaces.ColIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_END_OF_HASH_%v", ctx.ToHash.GetColID())),
-			ifaces.ColIDf("%s.LINEAR_HASH_%d_IS_END_OF_HASH_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
+			ifaces.ColIDf("%s", prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_END_OF_HASH_%v", ctx.ToHash.GetColID())),
 			smartvectors.RightZeroPadded(window, ctx.ToHash.Size()),
 		)
 	}

--- a/prover/protocol/dedicated/mimc/linear_hash.go
+++ b/prover/protocol/dedicated/mimc/linear_hash.go
@@ -160,7 +160,7 @@ func (ctx *linearHashCtx) HashingCols() {
 
 	ctx.NewStateClean = ctx.Comp.InsertCommit(
 		ctx.Round,
-		ifaces.ColIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "NEW_STATE_CLEAN_%v", ctx.ToHash.GetColID())),
+		ifaces.ColIDf("%s.LINEAR_HASH_%d_NEW_STATE_CLEAN_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
 		ctx.ToHash.Size(),
 	)
 
@@ -193,7 +193,7 @@ func (ctx *linearHashCtx) HashingCols() {
 	//
 	ctx.Comp.InsertGlobal(
 		ctx.Round,
-		ifaces.QueryIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "CLEAN_NEW_STATE_%v", ctx.ToHash.GetColID())),
+		ifaces.QueryIDf("%s.LINEAR_HASH_%d_CLEAN_NEW_STATE_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
 		ctx.IsActiveVar().
 			Mul(ifaces.ColumnAsVariable(ctx.NewState)).
 			Sub(ifaces.ColumnAsVariable(ctx.NewStateClean)),
@@ -231,7 +231,7 @@ func (ctx *linearHashCtx) IsActiveExpected() ifaces.Column {
 		}
 
 		ctx.IsActiveRowExpected = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_EXPECTED_%v", ctx.ToHash.GetColID())),
+			ifaces.ColIDf("%s.LINEAR_HASH_%d_IS_ACTIVE_EXPECTED_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
 			assignment,
 		)
 	}
@@ -248,7 +248,7 @@ func (ctx *linearHashCtx) IsActiveVar() *symbolic.Expression {
 	// Lazily registers the columns
 	if ctx.IsActiveLarge == nil {
 		ctx.IsActiveLarge = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_ACTIVE_%v", ctx.ToHash.GetColID())),
+			ifaces.ColIDf("%s.LINEAR_HASH_%d_IS_ACTIVE_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
 			smartvectors.RightZeroPadded(
 				vector.Repeat(field.One(), ctx.NumHash*ctx.Period),
 				ctx.ToHash.Size(),
@@ -276,7 +276,8 @@ func (ctx *linearHashCtx) IsEndOfHashVar() *symbolic.Expression {
 		}
 
 		ctx.IsEndOfHash = ctx.Comp.InsertPrecomputed(
-			ifaces.ColIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_END_OF_HASH_%v", ctx.ToHash.GetColID())),
+			// ifaces.ColIDf(prefixWithLinearHash(ctx.Comp, ctx.Name, "IS_END_OF_HASH_%v", ctx.ToHash.GetColID())),
+			ifaces.ColIDf("%s.LINEAR_HASH_%d_IS_END_OF_HASH_%s", ctx.Name, ctx.Comp.SelfRecursionCount, ctx.ToHash.GetColID()),
 			smartvectors.RightZeroPadded(window, ctx.ToHash.Size()),
 		)
 	}

--- a/prover/zkevm/arithmetization/definition.go
+++ b/prover/zkevm/arithmetization/definition.go
@@ -86,9 +86,6 @@ func (s *schemaScanner) scanColumns() {
 		}
 
 		// #nosec G115 -- this bound will not overflow
-		if size == 0 {
-			fmt.Printf("%s", name)
-		}
 		col := s.Comp.InsertCommit(0, ifaces.ColID(name), size)
 		pragmas.MarkLeftPadded(col)
 	}

--- a/prover/zkevm/arithmetization/definition.go
+++ b/prover/zkevm/arithmetization/definition.go
@@ -2,10 +2,11 @@ package arithmetization
 
 import (
 	"fmt"
-	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"math/big"
 	"reflect"
 	"strings"
+
+	"github.com/consensys/linea-monorepo/prover/maths/field"
 
 	"github.com/consensys/go-corset/pkg/air"
 	"github.com/consensys/go-corset/pkg/schema"
@@ -86,7 +87,7 @@ func (s *schemaScanner) scanColumns() {
 
 		// #nosec G115 -- this bound will not overflow
 		if size == 0 {
-			fmt.Printf(name)
+			fmt.Printf("%s", name)
 		}
 		col := s.Comp.InsertCommit(0, ifaces.ColID(name), size)
 		pragmas.MarkLeftPadded(col)

--- a/prover/zkevm/prover/hash/packing/block.go
+++ b/prover/zkevm/prover/hash/packing/block.go
@@ -53,7 +53,7 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 	b.IsBlockComplete, b.PA = dedicated.IsZero(comp, sym.Sub(b.AccNumLane, nbLanesPerBlock)).GetColumnAndProverAction()
 
 	// constraints over accNumLanes (accumulate backward)
-	comp.InsertLocal(0, ifaces.QueryIDf("%s", name+"_AccNumLane_Last"),
+	comp.InsertLocal(0, ifaces.QueryID(name+"_AccNumLane_Last"),
 		sym.Sub(column.Shift(b.AccNumLane, -1),
 			column.Shift(isLaneActive, -1)),
 	)

--- a/prover/zkevm/prover/hash/packing/block.go
+++ b/prover/zkevm/prover/hash/packing/block.go
@@ -70,7 +70,7 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 			b.AccNumLane,
 		)
 
-	comp.InsertGlobal(0, ifaces.QueryIDf("%s", name+"_AccNumLane_Glob"), expr)
+	comp.InsertGlobal(0, ifaces.QueryID(name+"_AccNumLane_Glob"), expr)
 
 	// isBlockComplete[0] = 1
 	// NB: this guarantees that the total sum of  nybtes ,given via imported.Nbytes,

--- a/prover/zkevm/prover/hash/packing/block.go
+++ b/prover/zkevm/prover/hash/packing/block.go
@@ -77,7 +77,7 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 	// indeed divides the blockSize.
 	// This fact can be used to guarantee that enough zeroes where padded during padding.
 	comp.InsertLocal(
-		0, ifaces.QueryIDf("%s", name+"_IsBlockComplete"),
+		0, ifaces.QueryID(name+"_IsBlockComplete"),
 		sym.Mul(
 			isLaneActive,
 			sym.Sub(1, b.IsBlockComplete),
@@ -85,7 +85,7 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 	)
 
 	// if isFirstLaneOfNewHash = 1 then isBlockComplete = 1.
-	comp.InsertGlobal(0, ifaces.QueryIDf("%s", name+"_EACH_HASH_HAS_COMPLETE_BLOCKS"),
+	comp.InsertGlobal(0, ifaces.QueryID(name+"_EACH_HASH_HAS_COMPLETE_BLOCKS"),
 		sym.Mul(
 			inp.Lanes.IsFirstLaneOfNewHash,
 			sym.Sub(1, b.IsBlockComplete),

--- a/prover/zkevm/prover/hash/packing/block.go
+++ b/prover/zkevm/prover/hash/packing/block.go
@@ -53,8 +53,7 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 	b.IsBlockComplete, b.PA = dedicated.IsZero(comp, sym.Sub(b.AccNumLane, nbLanesPerBlock)).GetColumnAndProverAction()
 
 	// constraints over accNumLanes (accumulate backward)
-	// accNumLane[last] =isLaneActive[last]
-	comp.InsertLocal(0, ifaces.QueryIDf(name+"_AccNumLane_Last"),
+	comp.InsertLocal(0, ifaces.QueryIDf("%s", name+"_AccNumLane_Last"),
 		sym.Sub(column.Shift(b.AccNumLane, -1),
 			column.Shift(isLaneActive, -1)),
 	)
@@ -71,14 +70,14 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 			b.AccNumLane,
 		)
 
-	comp.InsertGlobal(0, ifaces.QueryIDf(name+"_AccNumLane_Glob"), expr)
+	comp.InsertGlobal(0, ifaces.QueryIDf("%s", name+"_AccNumLane_Glob"), expr)
 
 	// isBlockComplete[0] = 1
 	// NB: this guarantees that the total sum of  nybtes ,given via imported.Nbytes,
 	// indeed divides the blockSize.
 	// This fact can be used to guarantee that enough zeroes where padded during padding.
 	comp.InsertLocal(
-		0, ifaces.QueryIDf(name+"_IsBlockComplete"),
+		0, ifaces.QueryIDf("%s", name+"_IsBlockComplete"),
 		sym.Mul(
 			isLaneActive,
 			sym.Sub(1, b.IsBlockComplete),
@@ -86,7 +85,7 @@ func newBlock(comp *wizard.CompiledIOP, inp blockInput) block {
 	)
 
 	// if isFirstLaneOfNewHash = 1 then isBlockComplete = 1.
-	comp.InsertGlobal(0, ifaces.QueryIDf(name+"_EACH_HASH_HAS_COMPLETE_BLOCKS"),
+	comp.InsertGlobal(0, ifaces.QueryIDf("%s", name+"_EACH_HASH_HAS_COMPLETE_BLOCKS"),
 		sym.Mul(
 			inp.Lanes.IsFirstLaneOfNewHash,
 			sym.Sub(1, b.IsBlockComplete),

--- a/prover/zkevm/prover/hash/packing/dedicated/accumulate_upto.go
+++ b/prover/zkevm/prover/hash/packing/dedicated/accumulate_upto.go
@@ -68,7 +68,7 @@ func AccumulateUpToMax(comp *wizard.CompiledIOP, maxValue int, colA, isActive if
 
 	// Constraints over the accumulator
 	// Accumulator[last] =ColA[last]
-	comp.InsertLocal(0, ifaces.QueryIDf("%s", "AccCLDLenSpaghetti_Loc_"+uniqueID),
+	comp.InsertLocal(0, ifaces.QueryID("AccCLDLenSpaghetti_Loc_"+uniqueID),
 		sym.Sub(
 			column.Shift(acc.Accumulator, -1), column.Shift(acc.Inputs.ColA, -1),
 		),
@@ -77,7 +77,7 @@ func AccumulateUpToMax(comp *wizard.CompiledIOP, maxValue int, colA, isActive if
 	// Accumulator[i] = Accumulator[i+1]*(1-acc.IsMax[i+1]) +ColA[i]; i standing for row-index.
 	res := sym.Sub(1, column.Shift(acc.IsMax, 1)) // 1-acc.IsMax[i+1]
 
-	comp.InsertGlobal(0, ifaces.QueryIDf("%s", "AccCLDLenSpaghetti_Glob_"+uniqueID),
+	comp.InsertGlobal(0, ifaces.QueryID("AccCLDLenSpaghetti_Glob_"+uniqueID),
 		sym.Sub(
 			sym.Add(
 				sym.Mul(

--- a/prover/zkevm/prover/hash/packing/dedicated/accumulate_upto.go
+++ b/prover/zkevm/prover/hash/packing/dedicated/accumulate_upto.go
@@ -68,7 +68,7 @@ func AccumulateUpToMax(comp *wizard.CompiledIOP, maxValue int, colA, isActive if
 
 	// Constraints over the accumulator
 	// Accumulator[last] =ColA[last]
-	comp.InsertLocal(0, ifaces.QueryIDf("AccCLDLenSpaghetti_Loc_"+uniqueID),
+	comp.InsertLocal(0, ifaces.QueryIDf("%s", "AccCLDLenSpaghetti_Loc_"+uniqueID),
 		sym.Sub(
 			column.Shift(acc.Accumulator, -1), column.Shift(acc.Inputs.ColA, -1),
 		),
@@ -77,7 +77,7 @@ func AccumulateUpToMax(comp *wizard.CompiledIOP, maxValue int, colA, isActive if
 	// Accumulator[i] = Accumulator[i+1]*(1-acc.IsMax[i+1]) +ColA[i]; i standing for row-index.
 	res := sym.Sub(1, column.Shift(acc.IsMax, 1)) // 1-acc.IsMax[i+1]
 
-	comp.InsertGlobal(0, ifaces.QueryIDf("AccCLDLenSpaghetti_Glob_"+uniqueID),
+	comp.InsertGlobal(0, ifaces.QueryIDf("%s", "AccCLDLenSpaghetti_Glob_"+uniqueID),
 		sym.Sub(
 			sym.Add(
 				sym.Mul(

--- a/prover/zkevm/prover/hash/packing/lane.go
+++ b/prover/zkevm/prover/hash/packing/lane.go
@@ -62,7 +62,7 @@ func newLane(comp *wizard.CompiledIOP, spaghetti spaghettiCtx, pckInp PackingInp
 		Lanes:                createCol("Lane"),
 		IsFirstLaneOfNewHash: createCol("IsFirstLaneOfNewHash"),
 		IsLaneActive:         createCol("IsLaneActive"),
-		Coeff:                comp.InsertCommit(0, ifaces.ColIDf("Coefficient_"+pckInp.Name), spaghettiSize),
+		Coeff:                comp.InsertCommit(0, ifaces.ColIDf("%s", "Coefficient_"+pckInp.Name), spaghettiSize),
 
 		PAAccUpToMax:   pa,
 		IsLaneComplete: pa.IsMax,
@@ -82,7 +82,7 @@ func newLane(comp *wizard.CompiledIOP, spaghetti spaghettiCtx, pckInp PackingInp
 
 	// constraints over isFirstLaneOfNewHash
 	// Project the isFirstLaneOfNewHash from isFirstSliceOfNewHash
-	comp.InsertProjection(ifaces.QueryIDf("Project_IsFirstLaneOfHash_"+pckInp.Name),
+	comp.InsertProjection(ifaces.QueryIDf("%s", "Project_IsFirstLaneOfHash_"+pckInp.Name),
 		query.ProjectionInput{ColumnA: []ifaces.Column{isFirstSliceOfNewHash},
 			ColumnB: []ifaces.Column{l.IsFirstLaneOfNewHash},
 			FilterA: l.IsLaneComplete,

--- a/prover/zkevm/prover/hash/packing/lane.go
+++ b/prover/zkevm/prover/hash/packing/lane.go
@@ -62,7 +62,7 @@ func newLane(comp *wizard.CompiledIOP, spaghetti spaghettiCtx, pckInp PackingInp
 		Lanes:                createCol("Lane"),
 		IsFirstLaneOfNewHash: createCol("IsFirstLaneOfNewHash"),
 		IsLaneActive:         createCol("IsLaneActive"),
-		Coeff:                comp.InsertCommit(0, ifaces.ColIDf("%s", "Coefficient_"+pckInp.Name), spaghettiSize),
+		Coeff:                comp.InsertCommit(0, ifaces.ColID("Coefficient_"+pckInp.Name), spaghettiSize),
 
 		PAAccUpToMax:   pa,
 		IsLaneComplete: pa.IsMax,
@@ -82,7 +82,7 @@ func newLane(comp *wizard.CompiledIOP, spaghetti spaghettiCtx, pckInp PackingInp
 
 	// constraints over isFirstLaneOfNewHash
 	// Project the isFirstLaneOfNewHash from isFirstSliceOfNewHash
-	comp.InsertProjection(ifaces.QueryIDf("%s", "Project_IsFirstLaneOfHash_"+pckInp.Name),
+	comp.InsertProjection(ifaces.QueryID("Project_IsFirstLaneOfHash_"+pckInp.Name),
 		query.ProjectionInput{ColumnA: []ifaces.Column{isFirstSliceOfNewHash},
 			ColumnB: []ifaces.Column{l.IsFirstLaneOfNewHash},
 			FilterA: l.IsLaneComplete,

--- a/prover/zkevm/prover/statemanager/accumulator/define.go
+++ b/prover/zkevm/prover/statemanager/accumulator/define.go
@@ -679,6 +679,6 @@ func (am *Module) qname(name string, args ...any) ifaces.QueryID {
 // Function inserting a query that col is zero when IsActive is zero
 func (am *Module) colZeroAtInactive(col ifaces.Column, name string) {
 	// col zero at inactive area, e.g., (1-IsActiveAccumulator[i]) * col[i] = 0
-	am.Comp.InsertGlobal(am.Round, am.qname(name),
+	am.Comp.InsertGlobal(am.Round, am.qname("%s", name),
 		symbolic.Mul(symbolic.Sub(1, am.Cols.IsActiveAccumulator), col))
 }

--- a/prover/zkevm/prover/statemanager/accumulator/define.go
+++ b/prover/zkevm/prover/statemanager/accumulator/define.go
@@ -672,13 +672,13 @@ func (am *Module) checkZeroInInactive() {
 }
 
 // Function returning a query name
-func (am *Module) qname(name string, args ...any) ifaces.QueryID {
-	return ifaces.QueryIDf("%v_%v", am.Name, am.Comp.SelfRecursionCount) + "_" + ifaces.QueryIDf(name, args...)
+func (am *Module) qname(name string) ifaces.QueryID {
+	return ifaces.QueryIDf("%s_%d", am.Name, am.Comp.SelfRecursionCount) + "_" + ifaces.QueryID(name)
 }
 
 // Function inserting a query that col is zero when IsActive is zero
 func (am *Module) colZeroAtInactive(col ifaces.Column, name string) {
 	// col zero at inactive area, e.g., (1-IsActiveAccumulator[i]) * col[i] = 0
-	am.Comp.InsertGlobal(am.Round, am.qname("%s", name),
+	am.Comp.InsertGlobal(am.Round, am.qname(name),
 		symbolic.Mul(symbolic.Sub(1, am.Cols.IsActiveAccumulator), col))
 }

--- a/prover/zkevm/prover/statemanager/mimccodehash/define.go
+++ b/prover/zkevm/prover/statemanager/mimccodehash/define.go
@@ -211,7 +211,7 @@ func (mh *Module) checkConsistency(comp *wizard.CompiledIOP) {
 
 // Function returning a query name
 func (mh *Module) qname(name string) ifaces.QueryID {
-	return ifaces.QueryIDf("%v", mh.Inputs.Name) + "_" + ifaces.QueryID(name)
+	return ifaces.QueryIDf("%s", mh.Inputs.Name) + "_" + ifaces.QueryID(name)
 }
 
 // Function inserting a query that col is zero when IsActive is zero

--- a/prover/zkevm/prover/statemanager/mimccodehash/define.go
+++ b/prover/zkevm/prover/statemanager/mimccodehash/define.go
@@ -210,13 +210,13 @@ func (mh *Module) checkConsistency(comp *wizard.CompiledIOP) {
 }
 
 // Function returning a query name
-func (mh *Module) qname(name string, args ...any) ifaces.QueryID {
-	return ifaces.QueryIDf("%v", mh.Inputs.Name) + "_" + ifaces.QueryIDf(name, args...)
+func (mh *Module) qname(name string) ifaces.QueryID {
+	return ifaces.QueryIDf("%v", mh.Inputs.Name) + "_" + ifaces.QueryID(name)
 }
 
 // Function inserting a query that col is zero when IsActive is zero
 func (mh *Module) colZeroAtInactive(comp *wizard.CompiledIOP, col ifaces.Column, name string) {
 	// col zero at inactive area, e.g., (1-IsActive[i]) * col[i] = 0
-	comp.InsertGlobal(mh.Inputs.Round, mh.qname("%s", name),
+	comp.InsertGlobal(mh.Inputs.Round, mh.qname(name),
 		sym.Mul(sym.Sub(1, mh.IsActive), col))
 }

--- a/prover/zkevm/prover/statemanager/mimccodehash/define.go
+++ b/prover/zkevm/prover/statemanager/mimccodehash/define.go
@@ -217,6 +217,6 @@ func (mh *Module) qname(name string, args ...any) ifaces.QueryID {
 // Function inserting a query that col is zero when IsActive is zero
 func (mh *Module) colZeroAtInactive(comp *wizard.CompiledIOP, col ifaces.Column, name string) {
 	// col zero at inactive area, e.g., (1-IsActive[i]) * col[i] = 0
-	comp.InsertGlobal(mh.Inputs.Round, mh.qname(name),
+	comp.InsertGlobal(mh.Inputs.Round, mh.qname("%s", name),
 		sym.Mul(sym.Sub(1, mh.IsActive), col))
 }


### PR DESCRIPTION
This PR bumps up go version to v1.24.0.

Ran a couple of proof requests and outer proof is successfully generated.

