### PR TITLE
Prover/perf opt serde

### DIFF
--- a/prover/protocol/serialization/cbor.go
+++ b/prover/protocol/serialization/cbor.go
@@ -1,8 +1,6 @@
 package serialization
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -14,16 +12,6 @@ var (
 	cborDecMode cbor.DecMode
 	encInitOnce sync.Once
 	decInitOnce sync.Once
-	bufferPool  = sync.Pool{
-		New: func() interface{} {
-			return new(bytes.Buffer)
-		},
-	}
-	readerPool = sync.Pool{
-		New: func() interface{} {
-			return new(bytes.Reader)
-		},
-	}
 )
 
 func initCBOREncMode() {
@@ -46,45 +34,14 @@ func initCBORDecMode() {
 	}
 }
 
-func SerializeAnyWithCborPkg(x any) (cbor.RawMessage, error) {
-	return encodeWithCBOR(x)
-}
-
-func DeserializeAnyWithCborPkg(data json.RawMessage, x any) error {
-	return decodeWithCBOR(data, x)
-}
-
-// encodeWithCBOR serializes an interface{} object into CBOR using a pooled buffer.
-// It will return an error on failure and is meant to be used on data and types that controlled
-// by the current package.
+// encodeWithCBOR: single-step Marshal, avoids buffer growth + extra copy
 func encodeWithCBOR(x any) (cbor.RawMessage, error) {
 	encInitOnce.Do(initCBOREncMode)
-
-	buf := bufferPool.Get().(*bytes.Buffer)
-	buf.Reset()
-	defer bufferPool.Put(buf)
-
-	enc := cborEncMode.NewEncoder(buf)
-	if err := enc.Encode(x); err != nil {
-		return nil, err
-	}
-	// Copy the bytes out before returning buffer to pool
-	out := make([]byte, buf.Len())
-	copy(out, buf.Bytes())
-	return out, nil
+	return cborEncMode.Marshal(x)
 }
 
-// decodeWithCBOR deserializes CBOR data into an object using a pooled reader.
-func decodeWithCBOR(data json.RawMessage, x any) error {
+// decodeWithCBOR: single-step Unmarshal (no reader pool)
+func decodeWithCBOR(data []byte, x any) error {
 	decInitOnce.Do(initCBORDecMode)
-
-	r := readerPool.Get().(*bytes.Reader)
-	r.Reset(data)
-	defer readerPool.Put(r)
-
-	dec := cborDecMode.NewDecoder(r)
-	if err := dec.Decode(x); err != nil {
-		return fmt.Errorf("cbor.Unmarshal failed: %w", err)
-	}
-	return nil
+	return cborDecMode.Unmarshal(data, x)
 }

--- a/prover/protocol/serialization/distributed_wizard_test.go
+++ b/prover/protocol/serialization/distributed_wizard_test.go
@@ -174,7 +174,7 @@ func TestSerdeDWPerf(t *testing.T) {
 
 func BenchmarkSerdeDW(b *testing.B) {
 
-	// b.Skipf("the test is a development/debug/integration test. It is not needed for CI")
+	b.Skipf("the test is a development/debug/integration test. It is not needed for CI")
 
 	cfg, err := config.NewConfigFromFileUnchecked("/home/ubuntu/linea-monorepo/prover/config/config-sepolia-limitless.toml")
 	if err != nil {

--- a/prover/protocol/serialization/distributed_wizard_test.go
+++ b/prover/protocol/serialization/distributed_wizard_test.go
@@ -144,6 +144,66 @@ func TestSerdeDistWizard(t *testing.T) {
 	})
 }
 
+func TestSerdeDistWizardPerf(t *testing.T) {
+
+	// t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
+
+	dist := GetDistWizard()
+
+	t.Run("ModuleNames", func(t *testing.T) {
+		runSerdeTestPerf(t, dist.ModuleNames, "DistributedWizard.ModuleNames")
+	})
+
+	for i := range dist.GLs {
+		t.Run(fmt.Sprintf("GLModule-%d", i), func(t *testing.T) {
+			runSerdeTestPerf(t, dist.GLs[i], "DistributedWizard.GLs")
+		})
+	}
+
+	for i := range dist.LPPs {
+		t.Run(fmt.Sprintf("LPPModule-%d", i), func(t *testing.T) {
+			runSerdeTestPerf(t, dist.LPPs[i], "DistributedWizard.LPPs")
+		})
+	}
+
+	t.Run("DefaultModule", func(t *testing.T) {
+		runSerdeTestPerf(t, dist.DefaultModule, "DistributedWizard.DefaultModule")
+	})
+
+	t.Run("Bootstrapper", func(t *testing.T) {
+		runSerdeTestPerf(t, dist.Bootstrapper, "DistributedWizard.Bootstrapper")
+	})
+
+	t.Run("Discoverer", func(t *testing.T) {
+		runSerdeTestPerf(t, dist.Disc, "DistributedWizard.Discoverer")
+	})
+
+	t.Run("CompiledDefault", func(t *testing.T) {
+		runSerdeTestPerf(t, dist.CompiledDefault, "DistributedWizard.CompiledDefault")
+	})
+
+	for i := range dist.CompiledGLs {
+		t.Run(fmt.Sprintf("CompiledGL-%v", i), func(t *testing.T) {
+			runSerdeTestPerf(t, dist.CompiledGLs[i], fmt.Sprintf("DistributedWizard.CompiledGL-%v", i))
+		})
+	}
+
+	for i := range dist.CompiledLPPs {
+		t.Run(fmt.Sprintf("CompiledLPP-%v", i), func(t *testing.T) {
+			runSerdeTestPerf(t, dist.CompiledLPPs[i], fmt.Sprintf("DistributedWizard.CompiledLPP-%v", i))
+		})
+	}
+
+	// To save memory
+	cong := dist.CompiledConglomeration
+	dist = nil
+	runtime.GC()
+
+	t.Run("CompiledConglomeration", func(t *testing.T) {
+		runSerdeTestPerf(t, cong, "DistributedWizard.CompiledConglomeration")
+	})
+}
+
 func TestSerdeDWCong(t *testing.T) {
 
 	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")

--- a/prover/protocol/serialization/distributed_wizard_test.go
+++ b/prover/protocol/serialization/distributed_wizard_test.go
@@ -89,8 +89,7 @@ func GetBasicDW() *distributed.DistributedWizard {
 
 func TestSerdeDW(t *testing.T) {
 
-	// t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
-
+	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
 	cfg, err := config.NewConfigFromFileUnchecked("/home/ubuntu/linea-monorepo/prover/config/config-sepolia-limitless.toml")
 	if err != nil {
 		t.Fatalf("failed to read config file: %s", err)
@@ -155,7 +154,7 @@ func TestSerdeDW(t *testing.T) {
 // verified to be correct in the previous test (TestSerdeDW).
 func TestSerdeDWPerf(t *testing.T) {
 
-	// t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
+	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
 	cfg, err := config.NewConfigFromFileUnchecked("/home/ubuntu/linea-monorepo/prover/config/config-sepolia-limitless.toml")
 	if err != nil {
 		t.Fatalf("failed to read config file: %s", err)

--- a/prover/protocol/serialization/distributed_wizard_test.go
+++ b/prover/protocol/serialization/distributed_wizard_test.go
@@ -184,13 +184,13 @@ func TestSerdeDWPerf(t *testing.T) {
 
 	for i := range dw.GLs {
 		t.Run(fmt.Sprintf("GLModule-%d", i), func(t *testing.T) {
-			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.GLs[i], "DistributedWizard.GLs"))
+			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.GLs[i], fmt.Sprintf("DistributedWizard.GLModule-%v", i)))
 		})
 	}
 
 	for i := range dw.LPPs {
 		t.Run(fmt.Sprintf("LPPModule-%d", i), func(t *testing.T) {
-			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.LPPs[i], "DistributedWizard.LPPs"))
+			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.LPPs[i], fmt.Sprintf("LPPModule-%d", i)))
 		})
 	}
 

--- a/prover/protocol/serialization/distributed_wizard_test.go
+++ b/prover/protocol/serialization/distributed_wizard_test.go
@@ -112,46 +112,46 @@ func TestSerdeDW(t *testing.T) {
 	dist := GetDW()
 
 	t.Run("ModuleNames", func(t *testing.T) {
-		runSerdeTest(t, dist.ModuleNames, "DistributedWizard.ModuleNames", true, false)
+		runSerdeTest(t, dist.ModuleNames, "DW.ModuleNames", true, false)
 	})
 
 	for i := range dist.GLs {
 		t.Run(fmt.Sprintf("GLModule-%d", i), func(t *testing.T) {
-			runSerdeTest(t, dist.GLs[i], "DistributedWizard.GLs", true, false)
+			runSerdeTest(t, dist.GLs[i], "DW.GLs", true, false)
 		})
 	}
 
 	for i := range dist.LPPs {
 		t.Run(fmt.Sprintf("LPPModule-%d", i), func(t *testing.T) {
-			runSerdeTest(t, dist.LPPs[i], "DistributedWizard.LPPs", true, false)
+			runSerdeTest(t, dist.LPPs[i], "DW.LPPs", true, false)
 		})
 	}
 
 	t.Run("DefaultModule", func(t *testing.T) {
-		runSerdeTest(t, dist.DefaultModule, "DistributedWizard.DefaultModule", true, false)
+		runSerdeTest(t, dist.DefaultModule, "DW.DefaultModule", true, false)
 	})
 
 	t.Run("Bootstrapper", func(t *testing.T) {
-		runSerdeTest(t, dist.Bootstrapper, "DistributedWizard.Bootstrapper", true, false)
+		runSerdeTest(t, dist.Bootstrapper, "DW.Bootstrapper", true, false)
 	})
 
 	t.Run("Discoverer", func(t *testing.T) {
-		runSerdeTest(t, dist.Disc, "DistributedWizard.Discoverer", true, false)
+		runSerdeTest(t, dist.Disc, "DW.Discoverer", true, false)
 	})
 
 	t.Run("CompiledDefault", func(t *testing.T) {
-		runSerdeTest(t, dist.CompiledDefault, "DistributedWizard.CompiledDefault", true, false)
+		runSerdeTest(t, dist.CompiledDefault, "DW.CompiledDefault", true, false)
 	})
 
 	for i := range dist.CompiledGLs {
 		t.Run(fmt.Sprintf("CompiledGL-%v", i), func(t *testing.T) {
-			runSerdeTest(t, dist.CompiledGLs[i], fmt.Sprintf("DistributedWizard.CompiledGL-%v", i), true, false)
+			runSerdeTest(t, dist.CompiledGLs[i], fmt.Sprintf("DW.CompiledGL-%v", i), true, false)
 		})
 	}
 
 	for i := range dist.CompiledLPPs {
 		t.Run(fmt.Sprintf("CompiledLPP-%v", i), func(t *testing.T) {
-			runSerdeTest(t, dist.CompiledLPPs[i], fmt.Sprintf("DistributedWizard.CompiledLPP-%v", i), true, false)
+			runSerdeTest(t, dist.CompiledLPPs[i], fmt.Sprintf("DW.CompiledLPP-%v", i), true, false)
 		})
 	}
 
@@ -161,7 +161,7 @@ func TestSerdeDW(t *testing.T) {
 	runtime.GC()
 
 	t.Run("CompiledConglomeration", func(t *testing.T) {
-		runSerdeTest(t, cong, "DistributedWizard.CompiledConglomeration", true, false)
+		runSerdeTest(t, cong, "DW.CompiledConglomeration", true, false)
 	})
 }
 
@@ -179,46 +179,46 @@ func TestSerdeDWPerf(t *testing.T) {
 	dw := GetDWPerf(cfg)
 
 	t.Run("ModuleNames", func(t *testing.T) {
-		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.ModuleNames, "DistributedWizard.ModuleNames"))
+		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.ModuleNames, "DW.ModuleNames"))
 	})
 
 	for i := range dw.GLs {
 		t.Run(fmt.Sprintf("GLModule-%d", i), func(t *testing.T) {
-			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.GLs[i], fmt.Sprintf("DistributedWizard.GLModule-%v", i)))
+			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.GLs[i], fmt.Sprintf("DW.GLModule-%v", i)))
 		})
 	}
 
 	for i := range dw.LPPs {
 		t.Run(fmt.Sprintf("LPPModule-%d", i), func(t *testing.T) {
-			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.LPPs[i], fmt.Sprintf("LPPModule-%d", i)))
+			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.LPPs[i], fmt.Sprintf("DW.LPPModule-%d", i)))
 		})
 	}
 
 	t.Run("DefaultModule", func(t *testing.T) {
-		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.DefaultModule, "DistributedWizard.DefaultModule"))
+		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.DefaultModule, "DW.DefaultModule"))
 	})
 
 	t.Run("Bootstrapper", func(t *testing.T) {
-		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.Bootstrapper, "DistributedWizard.Bootstrapper"))
+		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.Bootstrapper, "DW.Bootstrapper"))
 	})
 
 	t.Run("Discoverer", func(t *testing.T) {
-		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.Disc, "DistributedWizard.Discoverer"))
+		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.Disc, "DW.Discoverer"))
 	})
 
 	t.Run("CompiledDefault", func(t *testing.T) {
-		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.CompiledDefault, "DistributedWizard.CompiledDefault"))
+		perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.CompiledDefault, "DW.CompiledDefault"))
 	})
 
 	for i := range dw.CompiledGLs {
 		t.Run(fmt.Sprintf("CompiledGL-%v", i), func(t *testing.T) {
-			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.CompiledGLs[i], fmt.Sprintf("DistributedWizard.CompiledGL-%v", i)))
+			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.CompiledGLs[i], fmt.Sprintf("DW.CompiledGL-%v", i)))
 		})
 	}
 
 	for i := range dw.CompiledLPPs {
 		t.Run(fmt.Sprintf("CompiledLPP-%v", i), func(t *testing.T) {
-			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.CompiledLPPs[i], fmt.Sprintf("DistributedWizard.CompiledLPP-%v", i)))
+			perfLogs = append(perfLogs, runSerdeTestPerf(t, dw.CompiledLPPs[i], fmt.Sprintf("DW.CompiledLPP-%v", i)))
 		})
 	}
 
@@ -228,7 +228,7 @@ func TestSerdeDWPerf(t *testing.T) {
 	runtime.GC()
 
 	t.Run("CompiledConglomeration", func(t *testing.T) {
-		perfLogs = append(perfLogs, runSerdeTestPerf(t, cong, "DistributedWizard.CompiledConglomeration"))
+		perfLogs = append(perfLogs, runSerdeTestPerf(t, cong, "DW.CompiledConglomeration"))
 	})
 
 	// Write performance logs to CSV

--- a/prover/protocol/serialization/zkevm_test.go
+++ b/prover/protocol/serialization/zkevm_test.go
@@ -104,7 +104,6 @@ func runSerdeTestPerf(t *testing.T, input any, name string) *profiling.Performan
 	}()
 
 	func() {
-		// Measure deserialization time
 		logrus.Printf("Starting to deserialize:%s\n", name)
 		err = serialization.Deserialize(b, output)
 		if err != nil {

--- a/prover/protocol/serialization/zkevm_test.go
+++ b/prover/protocol/serialization/zkevm_test.go
@@ -119,6 +119,36 @@ func runSerdeTestPerf(t *testing.T, input any, name string) *profiling.Performan
 	return perfLog
 }
 
+func runSerdeBenchmark(t *testing.B, input any, name string) {
+	// In case the test panics, log the error but do not let the panic
+	// interrupt the test.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic during serialization/deserialization of %s: %v", name, r)
+			debug.PrintStack()
+		}
+	}()
+
+	if input == nil {
+		t.Error("test input is nil")
+		return
+	}
+
+	var output = reflect.New(reflect.TypeOf(input)).Interface()
+	var b []byte
+	var err error
+
+	b, err = serialization.Serialize(input)
+	if err != nil {
+		t.Fatalf("Error during serialization of %s: %v", name, err)
+	}
+
+	err = serialization.Deserialize(b, output)
+	if err != nil {
+		t.Fatalf("Error during deserialization of %s: %v", name, err)
+	}
+}
+
 func TestSerdeZkEVM(t *testing.T) {
 	runSerdeTest(t, z, "ZkEVM", true, false)
 }

--- a/prover/protocol/wizard/prover.go
+++ b/prover/protocol/wizard/prover.go
@@ -1,14 +1,10 @@
 package wizard
 
 import (
-	"encoding/csv"
 	"fmt"
-	"os"
 	"path"
 
-	"strconv"
 	"sync"
-	"time"
 
 	"github.com/consensys/linea-monorepo/prover/config"
 	"github.com/consensys/linea-monorepo/prover/crypto/fiatshamir"
@@ -187,7 +183,9 @@ func Prove(c *CompiledIOP, highLevelprover MainProverStep) Proof {
 
 	// Write the performance logs to the csv file is the performance monitor is active
 	if run.PerformanceMonitor.Active {
-		if err := run.writePerformanceLogsToCSV(); err != nil {
+		csvFilePath := path.Join(run.PerformanceMonitor.ProfileDir, "runtime_performance_logs.csv")
+		perfLogs := profiling.PerfLogs(run.PerformanceLogs)
+		if err := perfLogs.WritePerformanceLogsToCSV(csvFilePath); err != nil {
 			utils.Panic("error writing performance logs to CSV: %v", err.Error())
 		}
 	}
@@ -222,19 +220,6 @@ func RunProverUntilRound(c *CompiledIOP, highLevelProver MainProverStep, round i
 
 	return &runtime
 }
-
-// func RunProverUntilRound(c *CompiledIOP, highLevelprover MainProverStep, round int) *ProverRuntime {
-// 	runtime := c.createProver()
-// 	runtime.exec("high-level-prover", highLevelprover)
-// 	runtime.exec(fmt.Sprintf("prover-steps-round%d", runtime.currRound), runtime.runProverSteps)
-
-// 	for runtime.currRound+1 < round {
-// 		runtime.exec(fmt.Sprintf("next-after-round-%d", runtime.currRound), runtime.goNextRound)
-// 		runtime.exec(fmt.Sprintf("prover-steps-round-%d", runtime.currRound), runtime.runProverSteps)
-// 	}
-
-// 	return &runtime
-// }
 
 // ExtractProof extracts the proof from a [ProverRuntime]. If the runtime has
 // been obtained via a [RunProverUntilRound], then it may be the case that
@@ -1078,57 +1063,6 @@ func (runtime *ProverRuntime) profileAction(name string, action func()) {
 
 	// perfLog.PrintMetrics()
 	runtime.PerformanceLogs = append(runtime.PerformanceLogs, perfLog)
-}
-
-// writePerformanceLogsToCSV: Dumps all the performance logs inside prover runtime
-// to the csv file located at the specified path
-func (runtime *ProverRuntime) writePerformanceLogsToCSV() error {
-	csvFilePath := path.Join(runtime.PerformanceMonitor.ProfileDir, "runtime_performance_logs.csv")
-	file, err := os.Create(csvFilePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	writer := csv.NewWriter(file)
-	defer writer.Flush()
-
-	startTime := time.Now()
-	logrus.Infof("Writing the runtime performance logs to csv file located at path%s", csvFilePath)
-
-	// Define CSV headers
-	headers := []string{
-		"Description", "Runtime (s)",
-		"CPU_Usage_Min", "CPU_Usage_Avg", "CPU_Usage_Max",
-		"Mem_Allocated_Min (GiB)", "Mem_Allocated_Avg (GiB)", "Mem_Allocated_Max (GiB)",
-		"Mem_InUse_Min (GiB)", "Mem_InUse_Avg (GiB)", "Mem_InUse_Max (GiB)",
-		"Mem_GC_NotDeallocated_Min (GiB)", "Mem_GC_NotDeallocated_Avg (GiB)", "Mem_GC_NotDeallocated_Max (GiB)",
-	}
-	writer.Write(headers)
-
-	// Write performance logs to CSV
-	for _, log := range runtime.PerformanceLogs {
-		record := []string{
-			log.Description,
-			strconv.FormatFloat(log.StopTime.Sub(log.StartTime).Seconds(), 'f', -1, 64),
-			strconv.FormatFloat(log.CpuUsageStats[0], 'f', 2, 64),
-			strconv.FormatFloat(log.CpuUsageStats[1], 'f', 2, 64),
-			strconv.FormatFloat(log.CpuUsageStats[2], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryAllocatedStatsGiB[0], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryAllocatedStatsGiB[1], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryAllocatedStatsGiB[2], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryInUseStatsGiB[0], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryInUseStatsGiB[1], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryInUseStatsGiB[2], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryGCNotDeallocatedStatsGiB[0], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryGCNotDeallocatedStatsGiB[1], 'f', 2, 64),
-			strconv.FormatFloat(log.MemoryGCNotDeallocatedStatsGiB[2], 'f', 2, 64),
-		}
-		writer.Write(record)
-	}
-
-	logrus.Infof("Finished writing to the csv file. Took %s", time.Since(startTime).String())
-	return nil
 }
 
 // actionIsProverRound checks if the action is a plain function such as nextRound or runProverSteps


### PR DESCRIPTION
This PR implements issue(s) #

**Runtime and Memory Optimizations**
    * Skip the buffer and the extra copy in `cbor.go` by using EncMode.Marshal
    * Assign the packed payload directly and encode PackedObject only once rather than twice.
    * UnpackStructObject: use field by index (faster, avoids name lookup).  
   
**Refactoring**
  * Moved function to dump perf. logs to csv file from `wizard` pkg to `profiling` pkg
     
**Correctness**
   * Verified through `TestSerdeDW`.
   * Rerun setup for `execution-limitless` prover assets and successfully generated the proof for sepolia test data. Overall proof time ~38min. 

**Results**
Benchmarking (`benchstat`) results are as follows:

**Runtime (sec/op)**
The optimization reduced runtime across all 46 test cases, with an overall geometric mean improvement of 11.32%. Key highlights include:
* SerdeDW/CompiledGL-7: Reduced from 96.04 s to 29.69 s (-69.09%).
* SerdeDW/CompiledGL-2: Reduced from 52.45 s to 36.02 s (-31.33%).
* SerdeDW/CompiledConglomeration: Reduced from 165.0 s to 140.9 s (-14.61%).

**Memory Allocation (B/op)**
Memory allocation improved significantly, with a geometric mean reduction of 27.44% (from 16.47 GiB to 11.95 GiB). Notable reductions include:
* SerdeDW/CompiledGL-6: Reduced from 446.4 GiB to 281.7 GiB (-36.90%).
* SerdeDW/CompiledConglomeration: Reduced from 235.3 GiB to 153.4 GiB (-34.83%).
* SerdeDW/GLModule-2: Reduced from 50.11 GiB to 30.02 GiB (-40.08%).

Profiling data also indicates the overall runtime (serialization + deserialization time) reduction of ~18%. In some cases around 30%.

**Note**: Deployment will also require uploading new `prover-assets` for `execution-limitless` circuit to S3 and EFS.  The newly introduced  optimizations are not backward-compatible (existing serialized assets cannot be deserialized with this update).