### PR TITLE
Remove debug console.log from test file

### DIFF
--- a/postman/src/services/processors/__tests__/MessageClaimingPersister.test.ts
+++ b/postman/src/services/processors/__tests__/MessageClaimingPersister.test.ts
@@ -247,7 +247,6 @@ describe("TestMessageClaimingPersister ", () => {
         txReceipt,
         isRateLimitExceededError: false,
       });
-      console.log("boobies");
       await messageClaimingPersister.process();
 
       expect(l2QuerierGetReceiptSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Clean up leftover debug console.log statement in MessageClaimingPersister test that was polluting test output. This improves test output clarity and maintains code quality standards.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.