### PR TITLE
Prover/fix mem reduce witness ser

### DIFF
--- a/prover/backend/execution/limitless/prove.go
+++ b/prover/backend/execution/limitless/prove.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"strconv"
 
 	"github.com/consensys/linea-monorepo/prover/backend/execution"
@@ -29,7 +28,7 @@ var (
 	// numConcurrentWitnessWritingGoroutines governs the goroutine serializing,
 	// compressing and writing the  witness. The writing part is also controlled
 	// by a semaphore on top of this.
-	numConcurrentWitnessWritingGoroutines = runtime.NumCPU()
+	numConcurrentWitnessWritingGoroutines = 20
 	// numConcurrentSubProverJobs governs the number of concurrent sub-prover
 	// jobs.
 	numConcurrentSubProverJobs = 4

--- a/prover/protocol/distributed/module_discovery_standard.go
+++ b/prover/protocol/distributed/module_discovery_standard.go
@@ -878,7 +878,7 @@ func (mod *QueryBasedModule) SegmentBoundaries(run *wizard.ProverRuntime, segmen
 
 	// In theory, the condition with the pragma is redundant based on the sanity
 	// check we are doing.
-	if stats.NbPragmaRightPadded > 0 || stats.NbAssignedRightPadded > 0 {
+	if stats.NbPragmaRightPadded > 0 || (stats.NbAssignedRightPadded > 0 && stats.NbPragmaLeftPadded == 0) {
 		start, stop := 0, totalSegmentedArea
 		mod.NbSegmentCacheMutex.Lock()
 		defer mod.NbSegmentCacheMutex.Unlock()
@@ -888,7 +888,7 @@ func (mod *QueryBasedModule) SegmentBoundaries(run *wizard.ProverRuntime, segmen
 
 	// In theory, the condition with the pragma is redundant based on the sanity
 	// check we are doing.
-	if stats.NbPragmaLeftPadded > 0 || stats.NbAssignedLeftPadded > 0 {
+	if stats.NbPragmaLeftPadded > 0 || (stats.NbAssignedLeftPadded > 0 && stats.NbPragmaRightPadded == 0) {
 		start, stop := stats.OriginalSize-totalSegmentedArea, stats.OriginalSize
 		mod.NbSegmentCacheMutex.Lock()
 		defer mod.NbSegmentCacheMutex.Unlock()


### PR DESCRIPTION
This PR implements issue(s) #

- Implements rate limitation by reducing the `numConcurrentWitnessWritingGoroutines` from `runtime.NumCPU()` to a fixed number `20`.