### PR TITLE
coordinator: optimize conflation to skip trace conflation and shomei …

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -29,7 +29,9 @@ import net.consensys.zkevm.coordinator.blockcreation.GethCliqueSafeBlockProvider
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.coordinator.clients.TracesGeneratorJsonRpcClientV2
 import net.consensys.zkevm.coordinator.clients.prover.ProverClientFactory
+import net.consensys.zkevm.domain.Batch
 import net.consensys.zkevm.domain.BlocksConflation
+import net.consensys.zkevm.domain.ProofIndex
 import net.consensys.zkevm.ethereum.coordination.HighestConflationTracker
 import net.consensys.zkevm.ethereum.coordination.HighestProvenBatchTracker
 import net.consensys.zkevm.ethereum.coordination.HighestProvenBlobTracker
@@ -345,6 +347,14 @@ class ConflationApp(
         ),
         batchProofHandler = batchProofHandler,
         vertx = vertx,
+        batchAlreadyProvenSupplier = { batch: Batch ->
+          executionProverClient.isProofAlreadyDone(
+            proofRequestId = ProofIndex(
+              batch.startBlockNumber,
+              batch.endBlockNumber,
+            ),
+          )
+        },
         config = ProofGeneratingConflationHandlerImpl.Config(5.seconds),
       )
 

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ABProverClientRouter.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ABProverClientRouter.kt
@@ -2,19 +2,27 @@ package net.consensys.zkevm.coordinator.clients.prover
 
 import linea.domain.BlockInterval
 import net.consensys.zkevm.coordinator.clients.ProverClient
+import net.consensys.zkevm.domain.ProofIndex
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
-class StartBlockNumberBasedSwitchPredicate<ProofRequest>(
+class StartBlockNumberBasedSwitchPredicate(
   private val switchStartBlockNumberInclusive: ULong,
-) where ProofRequest : BlockInterval {
-  fun invoke(proofRequest: ProofRequest): Boolean = proofRequest.startBlockNumber >= switchStartBlockNumberInclusive
+) {
+  fun invoke(proofRequest: BlockInterval): Boolean = proofRequest.startBlockNumber >= switchStartBlockNumberInclusive
 }
 
 class ABProverClientRouter<ProofRequest, ProofResponse>(
   private val proverA: ProverClient<ProofRequest, ProofResponse>,
   private val proverB: ProverClient<ProofRequest, ProofResponse>,
-  private val switchToProverBPredicate: (ProofRequest) -> Boolean,
-) : ProverClient<ProofRequest, ProofResponse> {
+  private val switchToProverBPredicate: (BlockInterval) -> Boolean,
+) : ProverClient<ProofRequest, ProofResponse> where ProofRequest : BlockInterval {
+  override fun findProofResponse(proofRequestId: ProofIndex): SafeFuture<ProofResponse?> {
+    return if (switchToProverBPredicate(proofRequestId)) {
+      proverB.findProofResponse(proofRequestId)
+    } else {
+      proverA.findProofResponse(proofRequestId)
+    }
+  }
 
   override fun requestProof(proofRequest: ProofRequest): SafeFuture<ProofResponse> {
     return if (switchToProverBPredicate(proofRequest)) {

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactory.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactory.kt
@@ -93,7 +93,7 @@ class ProverClientFactory(
   ): ProverClient<ProofRequest, ProofResponse>
     where ProofRequest : BlockInterval {
     return if (switchBlockNumberInclusive != null) {
-      val switchPredicate = StartBlockNumberBasedSwitchPredicate<ProofRequest>(switchBlockNumberInclusive)
+      val switchPredicate = StartBlockNumberBasedSwitchPredicate(switchBlockNumberInclusive)
       ABProverClientRouter(
         proverA = clientBuilder(proverAConfig),
         proverB = clientBuilder(proverBConfig!!),

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/ProverClient.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/ProverClient.kt
@@ -1,10 +1,18 @@
 package net.consensys.zkevm.coordinator.clients
 
+import net.consensys.zkevm.domain.ProofIndex
 import net.consensys.zkevm.domain.ProofToFinalize
 import net.consensys.zkevm.domain.ProofsToAggregate
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
-interface ProverClient<ProofRequest, ProofResponse> {
+interface ProverProofResponseChecker<ProofResponse> {
+  fun findProofResponse(proofRequestId: ProofIndex): SafeFuture<ProofResponse?>
+  fun isProofAlreadyDone(proofRequestId: ProofIndex): SafeFuture<Boolean> =
+    findProofResponse(proofRequestId).thenApply { it != null }
+}
+
+interface ProverClient<ProofRequest, ProofResponse> :
+  ProverProofResponseChecker<ProofResponse> {
   fun requestProof(proofRequest: ProofRequest): SafeFuture<ProofResponse>
 }
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -9,6 +9,7 @@ import com.github.michaelbull.result.runCatching
 import io.vertx.core.Vertx
 import linea.domain.Block
 import net.consensys.linea.async.AsyncRetryer
+import net.consensys.zkevm.domain.Batch
 import net.consensys.zkevm.domain.BlocksConflation
 import net.consensys.zkevm.ethereum.coordination.proofcreation.BatchProofHandler
 import net.consensys.zkevm.ethereum.coordination.proofcreation.ZkProofCreationCoordinator
@@ -21,6 +22,7 @@ class ProofGeneratingConflationHandlerImpl(
   private val tracesProductionCoordinator: TracesConflationCoordinator,
   private val zkProofProductionCoordinator: ZkProofCreationCoordinator,
   private val batchProofHandler: BatchProofHandler,
+  private val batchAlreadyProvenSupplier: (Batch) -> SafeFuture<Boolean>,
   private val vertx: Vertx,
   private val config: Config,
 ) : ConflationHandler {
@@ -68,35 +70,43 @@ class ProofGeneratingConflationHandlerImpl(
     val blockIntervalString = conflation.conflationResult.intervalString()
     return assertConsecutiveBlocksRange(conflation.blocks)
       .getOrThrow().let { blocksRange ->
-        tracesProductionCoordinator
-          .conflateExecutionTraces(blocksRange)
-          .whenException { th ->
-            log.debug(
-              "traces conflation failed: batch={} errorMessage={}",
-              conflation.conflationResult.intervalString(),
-              th.message,
-              th,
-            )
-          }
-          .thenCompose { blocksTracesConflated: BlocksTracesConflated ->
-            log.debug(
-              "requesting execution proof: batch={} tracesFile={}",
-              blockIntervalString,
-              blocksTracesConflated.tracesResponse.tracesFileName,
-            )
-            zkProofProductionCoordinator
-              .createZkProof(conflation, blocksTracesConflated)
-              .thenPeek {
-                log.info("execution proof generated: batch={}", blockIntervalString)
-              }
-              .whenException { th ->
-                log.debug(
-                  "execution proof failure: batch={} errorMessage={}",
-                  blockIntervalString,
-                  th.message,
-                  th,
-                )
-              }
+        val batch = Batch(conflation.startBlockNumber, conflation.endBlockNumber)
+        batchAlreadyProvenSupplier(batch)
+          .thenCompose { responseAlreadyDone ->
+            if (responseAlreadyDone) {
+              SafeFuture.completedFuture(batch)
+            } else {
+              tracesProductionCoordinator
+                .conflateExecutionTraces(blocksRange)
+                .whenException { th ->
+                  log.debug(
+                    "traces conflation failed: batch={} errorMessage={}",
+                    conflation.conflationResult.intervalString(),
+                    th.message,
+                    th,
+                  )
+                }
+                .thenCompose { blocksTracesConflated: BlocksTracesConflated ->
+                  log.debug(
+                    "requesting execution proof: batch={} tracesFile={}",
+                    blockIntervalString,
+                    blocksTracesConflated.tracesResponse.tracesFileName,
+                  )
+                  zkProofProductionCoordinator
+                    .createZkProof(conflation, blocksTracesConflated)
+                    .thenPeek {
+                      log.info("execution proof generated: batch={}", blockIntervalString)
+                    }
+                    .whenException { th ->
+                      log.debug(
+                        "execution proof failure: batch={} errorMessage={}",
+                        blockIntervalString,
+                        th.message,
+                        th,
+                      )
+                    }
+                }
+            }
           }
           .thenCompose { batchProofHandler.acceptNewBatch(it) }
       }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -74,6 +74,7 @@ class ProofGeneratingConflationHandlerImpl(
         batchAlreadyProvenSupplier(batch)
           .thenCompose { responseAlreadyDone ->
             if (responseAlreadyDone) {
+              log.info("skipping conflation and proof request: batch={} already proven", blockIntervalString)
               SafeFuture.completedFuture(batch)
             } else {
               tracesProductionCoordinator
@@ -108,7 +109,7 @@ class ProofGeneratingConflationHandlerImpl(
                 }
             }
           }
-          .thenCompose { batchProofHandler.acceptNewBatch(it) }
+          .thenCompose { batchProofHandler.acceptNewBatch(batch) }
       }
   }
 }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -82,7 +82,7 @@ class ProofGeneratingConflationHandlerImpl(
                 .whenException { th ->
                   log.debug(
                     "traces conflation failed: batch={} errorMessage={}",
-                    conflation.conflationResult.intervalString(),
+                    blockIntervalString,
                     th.message,
                     th,
                   )


### PR DESCRIPTION
# Description 
optimise conflation flow by to skipping 1) trace-api conflation and shomei when proof response already exists

Biggest inpact upon coordinator restart and conflation catch up.



### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.