### PR TITLE
Refactor - Standardize tsconfig.json 'excludes' based on TypeScript documentation

### DIFF
--- a/bridge-ui/tsconfig.json
+++ b/bridge-ui/tsconfig.json
@@ -29,6 +29,6 @@
     }
   ],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["**/node_modules", "**/.*/"],
   "files": ["environment.d.ts"]
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -11,6 +11,5 @@
       "path": "../sdk/sdk-ethers"
     }
   ],
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"],
+  "include": ["**/*.ts"]
 }

--- a/operations/tsconfig.json
+++ b/operations/tsconfig.json
@@ -2,11 +2,9 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "module": "nodenext",
     "outDir": "dist",
     "rootDir": "src",
     "target": "es2022",
-    "moduleResolution": "nodenext"
   },
   "include": ["./src/**/*"],
 }

--- a/postman/README.md
+++ b/postman/README.md
@@ -171,7 +171,7 @@ Stop the postman docker container manually.
 
 Before the postman can be run and tested locally, we must build the monorepo projects linea-sdk and linea-native-libs
 ```bash
-NATIVE_LIBS_RELEASE_TAG=blob-libs-v1.2.0 pnpm run -F linea-native-libs build && pnpm run -F linea-sdk build
+NATIVE_LIBS_RELEASE_TAG=blob-libs-v1.2.0 pnpm run -F linea-native-libs build && pnpm run -F "./sdk/*" build
 ```
 
 From the postman folder run the following commands:

--- a/postman/src/application/postman/persistence/subscribers/MessageStatusSubscriber.ts
+++ b/postman/src/application/postman/persistence/subscribers/MessageStatusSubscriber.ts
@@ -8,8 +8,8 @@ import {
 } from "typeorm";
 import { Direction } from "@consensys/linea-sdk";
 import { MessageEntity } from "../entities/Message.entity";
-import { IMessageMetricsUpdater, MessagesMetricsAttributes } from "../../../../core/metrics";
-import { ILogger } from "../../../../core/utils/logging/ILogger";
+import { type IMessageMetricsUpdater, MessagesMetricsAttributes } from "../../../../core/metrics";
+import { type ILogger } from "../../../../core/utils/logging/ILogger";
 import { MessageStatus } from "../../../../core/enums";
 
 @EventSubscriber()

--- a/postman/tsconfig.build.json
+++ b/postman/tsconfig.build.json
@@ -9,6 +9,5 @@
     "rootDir": ".",
     "sourceMap": true
   },
-  "include": ["./src/**/*.ts", "scripts/**/runPostman.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["./src/**/*.ts", "scripts/**/runPostman.ts"]
 }

--- a/postman/tsconfig.build.json
+++ b/postman/tsconfig.build.json
@@ -9,5 +9,6 @@
     "rootDir": ".",
     "sourceMap": true
   },
-  "include": ["./src/**/*.ts", "scripts/**/runPostman.ts"]
+  "include": ["./src/**/*.ts", "scripts/**/runPostman.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/postman/tsconfig.json
+++ b/postman/tsconfig.json
@@ -13,6 +13,5 @@
     {
       "path": "../sdk/sdk-ethers"
     }
-  ],
-  "exclude": ["./dist", "**/node_modules"]
+  ]
 }

--- a/sdk/sdk-core/tsconfig.json
+++ b/sdk/sdk-core/tsconfig.json
@@ -8,6 +8,5 @@
     "isolatedModules": false,
     "strictPropertyInitialization": false,
     "exactOptionalPropertyTypes": false
-  },
-  "exclude": ["./dist", "**/node_modules"]
+  }
 }

--- a/sdk/sdk-ethers/tsconfig.json
+++ b/sdk/sdk-ethers/tsconfig.json
@@ -8,6 +8,5 @@
     "isolatedModules": false,
     "strictPropertyInitialization": false,
     "exactOptionalPropertyTypes": false
-  },
-  "exclude": ["./dist", "**/node_modules"]
+  }
 }

--- a/sdk/sdk-viem/tsconfig.json
+++ b/sdk/sdk-viem/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
     "lib": ["ES2022", "DOM"],
     "noEmit": false,
     "skipLibCheck": true,

--- a/ts-libs/linea-native-libs/tsconfig.json
+++ b/ts-libs/linea-native-libs/tsconfig.json
@@ -4,6 +4,5 @@
     "noUncheckedIndexedAccess": true,
     "composite": true,
     "removeComments": false
-  },
-  "exclude": ["./dist", "**/node_modules"]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "exactOptionalPropertyTypes": true,
     "noEmit": false
   },
-  "exclude": ["node_modules", "dist", "*.d.ts"]
+  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "exactOptionalPropertyTypes": true,
     "noEmit": false
   },
-  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/", "*.test.ts"]
+  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": ".",
-    "moduleResolution": "node",
-    "module": "commonjs",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
     "target": "es2022",
     "sourceMap": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "exactOptionalPropertyTypes": true,
     "noEmit": false
   },
-  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/"]
+  "exclude": ["**/node_modules", "**/dist", "*.d.ts", "**/.*/", "*.test.ts"]
 }


### PR DESCRIPTION
As per https://github.com/microsoft/Typescript/wiki/Performance#configuring-tsconfigjson-or-jsconfigjson

We should specify that we aren't including too many files in the TypeScript compilation

```json
{
    "compilerOptions": {
        // ...
    },
    "include": ["src"],
    "exclude": ["**/node_modules", "**/.*/"],
}
```



### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.