### PR TITLE
fix(bridge-ui): improve Fast Mode for CCTP USDC Bridge

### DIFF
--- a/bridge-ui/src/components/bridge/claiming/fees/with-fees/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/fees/with-fees/index.tsx
@@ -35,13 +35,7 @@ export default function WithFees({ iconPath }: Props) {
   return (
     <>
       {formattedCctpFees && (
-        <button
-          type="button"
-          className={styles["gas-fees"]}
-          onClick={() => {
-            setShowGasFeesModal(true);
-          }}
-        >
+        <button type="button" className={`${styles["gas-fees"]} ${styles["no-click"]}`}>
           <Image src={token.image} width={12} height={12} alt="usdc-fee-icon" />
           <p className={styles["estimate-crypto"]}>{formattedCctpFees} USDC</p>
         </button>
@@ -66,12 +60,7 @@ export default function WithFees({ iconPath }: Props) {
         </button>
       )}
       {showGasFeesModal && (
-        <GasFees
-          isModalOpen={showGasFeesModal}
-          onCloseModal={() => setShowGasFeesModal(false)}
-          fees={fees}
-          formattedCctpFees={formattedCctpFees}
-        />
+        <GasFees isModalOpen={showGasFeesModal} onCloseModal={() => setShowGasFeesModal(false)} fees={fees} />
       )}
     </>
   );

--- a/bridge-ui/src/components/bridge/claiming/fees/with-fees/with-fees.module.scss
+++ b/bridge-ui/src/components/bridge/claiming/fees/with-fees/with-fees.module.scss
@@ -24,3 +24,7 @@
     font-weight: 500;
   }
 }
+
+.no-click {
+  cursor: default;
+}

--- a/bridge-ui/src/components/bridge/claiming/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useAccount } from "wagmi";
 import BridgeTwoLogo from "@/components/bridge/bridge-two-logo";
@@ -7,7 +7,7 @@ import SettingIcon from "@/assets/icons/setting.svg";
 import Skeleton from "@/components/bridge/claiming/skeleton";
 import ReceivedAmount from "./received-amount";
 import Fees from "./fees";
-import { useFormStore, useChainStore } from "@/stores";
+import { useChainStore, useFormStore } from "@/stores";
 import BridgeMode from "./bridge-mode";
 import { BridgeProvider, CCTPMode, ChainLayer } from "@/types";
 import { isCctp } from "@/utils";
@@ -52,8 +52,7 @@ export default function Claiming() {
     if (fromChain.layer === ChainLayer.L2) return false;
     // No auto-claiming for USDC via CCTPV2
     if (isCctp(token)) return false;
-    if (loading) return false;
-    return true;
+    return !loading;
   }, [fromChain, token, loading]);
 
   if (!amount || amount <= 0n) return null;

--- a/bridge-ui/src/components/bridge/claiming/received-amount/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/received-amount/index.tsx
@@ -1,24 +1,32 @@
 import { formatUnits } from "viem";
 import styles from "./received-amount.module.scss";
 import { useTokenPrices } from "@/hooks";
-import { useConfigStore, useChainStore, useFormStore } from "@/stores";
-import { formatBalance } from "@/utils";
-import { ETH_SYMBOL } from "@/constants";
-import { ChainLayer } from "@/types";
+import { useChainStore, useConfigStore, useFormStore } from "@/stores";
+import { formatBalance, isCctp } from "@/utils";
+import { ChainLayer, Token } from "@/types";
 import { useMemo } from "react";
+import { useCctpFee } from "@/hooks/transaction-args/cctp/useCctpUtilHooks";
+import { ETH_SYMBOL } from "@/constants";
 
 function formatReceivedAmount(
   amount: bigint,
-  tokenSymbol: string,
+  token: Token,
   bridgingFees: bigint,
   minimumFees: bigint,
   fromChainLayer: ChainLayer,
+  cctpFee: bigint | null,
 ) {
-  if (tokenSymbol !== ETH_SYMBOL) {
-    return amount;
-  }
+  if (isCctp(token)) {
+    return cctpFee ? amount - cctpFee : amount;
+  } else {
+    if (token.symbol !== ETH_SYMBOL) {
+      return amount;
+    }
 
-  return fromChainLayer === ChainLayer.L1 ? amount - bridgingFees : amount - minimumFees;
+    const feesToApply = fromChainLayer === ChainLayer.L1 ? bridgingFees : minimumFees;
+
+    return amount - feesToApply;
+  }
 }
 
 export default function ReceivedAmount() {
@@ -28,16 +36,17 @@ export default function ReceivedAmount() {
   const token = useFormStore((state) => state.token);
   const bridgingFees = useFormStore((state) => state.bridgingFees);
   const minimumFees = useFormStore((state) => state.minimumFees);
+  const cctpFee = useCctpFee(amount, token.decimals);
 
   const { data: tokenPrices } = useTokenPrices([token[fromChain.layer]], fromChain.id);
 
   const receivedAmount = useMemo(
     () =>
       formatUnits(
-        formatReceivedAmount(amount || 0n, token.symbol, bridgingFees, minimumFees, fromChain.layer),
+        formatReceivedAmount(amount || 0n, token, bridgingFees, minimumFees, fromChain.layer, cctpFee),
         token.decimals,
       ),
-    [amount, token.symbol, bridgingFees, minimumFees, fromChain.layer, token.decimals],
+    [amount, token, bridgingFees, minimumFees, fromChain.layer, cctpFee],
   );
 
   return (

--- a/bridge-ui/src/hooks/transaction-args/cctp/useCctpUtilHooks.ts
+++ b/bridge-ui/src/hooks/transaction-args/cctp/useCctpUtilHooks.ts
@@ -36,13 +36,7 @@ export const useCctpFee = (amount: bigint | null, tokenDecimals: number): bigint
 
     const THRESHOLD = cctpMode === CCTPMode.FAST ? CCTP_MAX_FINALITY_THRESHOLD : CCTP_MIN_FINALITY_THRESHOLD;
 
-    let finalityFee = data.find((fee) => fee.finalityThreshold === THRESHOLD)?.minimumFee;
-
-    // TODO: remove this once we have the correct fee for fast mode
-    // Temporary using 0.14% fee for fast mode
-    if (cctpMode === CCTPMode.FAST) {
-      finalityFee = 14;
-    }
+    const finalityFee = data.find((fee) => fee.finalityThreshold === THRESHOLD)?.minimumFee;
 
     if (isUndefined(finalityFee)) {
       return null;

--- a/bridge-ui/src/services/cctp.ts
+++ b/bridge-ui/src/services/cctp.ts
@@ -1,4 +1,4 @@
-import { CctpAttestationApiResponse, CctpV2ReattestationApiResponse, CctpFeeApiResponse } from "@/types/cctp";
+import { CctpAttestationApiResponse, CctpFeeApiResponse, CctpV2ReattestationApiResponse } from "@/types/cctp";
 
 export async function fetchCctpAttestationByTxHash(
   cctpDomain: number,
@@ -78,6 +78,7 @@ export async function getCctpFee(
   if (!response.ok) {
     throw new Error(`Error in getCctpFee: isTestnet=${isTestnet} srcDomain=${srcDomain} dstDomain=${dstDomain}`);
   }
+
   const data: CctpFeeApiResponse = await response.json();
   return data;
 }


### PR DESCRIPTION
This PR implements issue(s) #1495 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates CCTP USDC fee into received amount, makes the CCTP fee pill non-clickable, and uses API-derived fees for Fast mode.
> 
> - **Fees & Amounts**:
>   - Incorporate CCTP fee into `ReceivedAmount` by subtracting `useCctpFee` for USDC transfers; retain ETH fee logic for non-CCTP.
>   - Use API-provided `minimumFee` for Fast/Standard modes in `useCctpFee` (remove temporary 0.14% override).
> - **UI**:
>   - Make CCTP fee pill in `fees/with-fees/index.tsx` non-clickable (`no-click` class) and stop opening Gas Fees modal from it.
>   - Simplify `GasFees` usage by removing `formattedCctpFees` prop.
>   - Minor cleanup: simplify `showSettingIcon` logic; small import/order tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b2561bcbbbcb7267c698e1a06194d8efbe555b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->