### PR TITLE
feat: update coordinator and linea-besu-package image

### DIFF
--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc8-CANCUN-20250922065648-e5e1174}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -39,7 +39,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-bc1097d-tmp-20251002145501-bc1097d}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -117,7 +117,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-bc1097d-tmp-20251002145501-bc1097d}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -161,7 +161,7 @@ services:
   l2-node-besu-follower:
     hostname: l2-node-besu-follower
     container_name: l2-node-besu-follower
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-bc1097d-tmp-20251002145501-bc1097d}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -205,7 +205,7 @@ services:
   traces-node:
     hostname: traces-node
     container_name: traces-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-bc1097d-tmp-20251002145501-bc1097d}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -283,7 +283,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${COORDINATOR_TAG:-ec591cd-tmp}
+    image: consensys/linea-coordinator:${COORDINATOR_TAG:-c1b5c1e}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:
@@ -383,7 +383,7 @@ services:
       - l1network
 
   zkbesu-shomei:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-bc1097d-tmp-20251002145501-bc1097d}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     hostname: zkbesu-shomei
     container_name: zkbesu-shomei
     profiles: [ "l2", "l2-bc", "external-to-monorepo" ]
@@ -600,7 +600,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-bc1097d-tmp-20251002145501-bc1097d}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "external-to-monorepo", "staterecovery" ]

--- a/docker/compose-tracing-v2-fleet-ci-extension.yml
+++ b/docker/compose-tracing-v2-fleet-ci-extension.yml
@@ -26,7 +26,7 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: l2-node-besu
-    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc8-CANCUN-20250922065648-e5e1174}
+    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json
@@ -44,7 +44,7 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: l2-node-besu-follower
-    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc8-CANCUN-20250922065648-e5e1174}
+    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Docker image tags for `linea-besu-package` (to rc11-debugging-e2e) and `linea-coordinator` across L1/L2 compose files and fleet CI extension.
> 
> - **Docker Compose updates**:
>   - `docker/compose-spec-l1-services.yml`:
>     - `l1-el-node`: `linea-besu-package` -> `beta-v4.0-rc11-debugging-e2e-...c1b5c1e`.
>   - `docker/compose-spec-l2-services.yml`:
>     - `sequencer`, `l2-node-besu`, `l2-node-besu-follower`, `traces-node`, `zkbesu-shomei`, `zkbesu-shomei-sr`: `linea-besu-package` -> `beta-v4.0-rc11-debugging-e2e-...c1b5c1e`.
>     - `coordinator`: `linea-coordinator` -> tag `c1b5c1e`.
>   - `docker/compose-tracing-v2-fleet-ci-extension.yml`:
>     - `l2-node-besu`, `l2-node-besu-follower`: `linea-besu-package-with-fleet` -> `beta-v4.0-rc11-debugging-e2e-...c1b5c1e`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12ca48c7568b04a1896094a1032e0d032c8cbf91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->