### PR TITLE
Fix: Avoid `ZkTracer` concurrency internal errors during block creation

### DIFF
--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/selectors/TraceLineLimitTransactionSelector.java
@@ -245,7 +245,10 @@ public class TraceLineLimitTransactionSelector
 
     @Override
     public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
-      delegate.traceEndBlock(blockHeader, blockBody);
+      // do not call the delegated since there is no need when building block
+      // this also avoid concurrency related exceptions, since ZkTracer is not thread safe,
+      // and during a block creation timeout there is the possibility of one thread still
+      // processing a tx while another is packing a block and call this method
       log.atDebug()
           .addMarker(BLOCK_LINE_COUNT_MARKER)
           .addKeyValue("blockNumber", blockHeader::getNumber)
@@ -287,7 +290,7 @@ public class TraceLineLimitTransactionSelector
 
     @Override
     public void traceEndConflation(final WorldView worldView) {
-      delegate.traceEndConflation(worldView);
+      // do not call the delegated since there is no need when building block
     }
 
     @Override


### PR DESCRIPTION
This PR fixes an internal error reported during tx selection during block creation, when a timeout occurs.

Since during a timeout there is a small period of time when 2 thread can concurrently call the `ZkTracer`, that is not thread safe, resulting in potential `ConcurrentModificationException`, as shown in the log below.

One thread is the one still processing the tx, that is being cancelled, and the other one is the thread that is responsible for the final phases of block creation, that specifically call `traceEndBlock`.

The fix is to just avoid calling `traceEndBlock` and `traceEndConflation` on the `ZkTracer` since their execution is not needed at all during block creation, because all it is needed is the result of `ZkTracer::getModulesLineCount` that is called before the 2 trace end call are made.

```
2025-10-02 19:07:03.475+0000 | MinerExecutor-24072018 | DEBUG | BlockTransactionSelector | Transaction {sequence: 14281, addedAt: 1759426079538, isLocal=false, hasPriority=false, score=-128, 0xbab343342d0d08de886f57a99ec4fc09730618e07ecf92610b7c6b7480bc2953={MessageCall, 10, 0xacb17fc73cf202ebe532e107cec195d50dee61dd, FRONTIER, gp: 430.00 mwei, gl: 15942800, v: 0 wei, to: 0x0b2c83b6e39e32f694a86633b4d1fe69d13b63c5}} is processing for 1404ms, giving it 495ms grace time, before considering it taking too much time to execute

2025-10-02 19:07:03.476+0000 | MinerExecutor-24072018 | WARN  | BlockTransactionSelector | Interrupting the internal selection of transactions for block inclusion as it exceeds the allowed max duration of 1799ms

2025-10-02 19:07:03.477+0000 | MinerExecutor-24072018 | TRACE | BlockTransactionSelector | Transaction selection result cumulativeGasUsed=3823191, selectedTransactions=0xc50283074b6ed4ed182b9231e481576bff89dd957f09cd36f929f42ab6980f69, 0xbe7eb494a00afdba59c4e74e83af79f460cf7dbf70864b0c6e777f4ed82ff2cd, 0xabc6742c3f221417dbca68c6b59b2aea00c8e16defb69df5c1b24517f6b52b74, 0x40bb5d82baa739c352190e77ae4c09db063d447cf9f8000d08ece8c4a7e04faf, notSelectedTransactions=


2025-10-02 19:07:03.494+0000 | MinerExecutor-24072018 | TRACE | ZkTracer | Collected exception during transaction processing
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1095)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1049)
	at net.consensys.linea.zktracer.module.hub.defer.DeferRegistry.resolvePostBlock(DeferRegistry.java:163)
	at net.consensys.linea.zktracer.module.hub.Hub.traceEndBlock(Hub.java:577)
	at net.consensys.linea.zktracer.ZkTracer.traceEndBlock(ZkTracer.java:197)
	at net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelector$LineCountingTracerWithLog.traceEndBlock(TraceLineLimitTransactionSelector.java:248)
	at org.hyperledger.besu.services.TransactionSelectionServiceImpl$TracerAggregator.lambda$traceEndBlock$1(TransactionSelectionServiceImpl.java:165)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.hyperledger.besu.services.TransactionSelectionServiceImpl$TracerAggregator.traceEndBlock(TransactionSelectionServiceImpl.java:163)
	at org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator.createBlock(AbstractBlockCreator.java:337)
	at org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator.createBlock(AbstractBlockCreator.java:147)
	at org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator.createBlock(AbstractBlockCreator.java:129)
	at org.hyperledger.besu.ethereum.blockcreation.BlockMiner.mineBlock(BlockMiner.java:145)
	at org.hyperledger.besu.consensus.clique.blockcreation.CliqueBlockMiner.mineBlock(CliqueBlockMiner.java:76)
	at org.hyperledger.besu.ethereum.blockcreation.BlockMiner.run(BlockMiner.java:85)
	at org.hyperledger.besu.ethereum.blockcreation.AbstractMinerExecutor.lambda$startAsyncMining$1(AbstractMinerExecutor.java:79)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)


2025-10-02 19:07:03.700+0000 | EthScheduler-BlockCreation-35-24072018 | DEBUG | MainnetTransactionProcessor | Transaction 0xbab343342d0d08de886f57a99ec4fc09730618e07ecf92610b7c6b7480bc2953 reverted: 0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001d416464726573733a2063616c6c20746f206e6f6e2d636f6e7472616374000000

2025-10-02 19:07:03.701+0000 | EthScheduler-BlockCreation-35-24072018 | ERROR | BlockTransactionSelector | Unhandled exception evaluating transaction Hash=0xbab343342d0d08de886f57a99ec4fc09730618e07ecf92610b7c6b7480bc2953, nonce=10, sender=0xacb17fc73cf202ebe532e107cec195d50dee61dd, addedAt=1759426079538, sequence=14281, isLocal=false, hasPriority=false, score=-128}
net.consensys.linea.zktracer.exceptions.TracingExceptions: Exceptions triggered while tracing:
  - class java.util.ConcurrentModificationException: null

	at net.consensys.linea.zktracer.ZkTracer.maybeThrowTracingExceptions(ZkTracer.java:317)
	at net.consensys.linea.zktracer.ZkTracer.getModulesLineCount(ZkTracer.java:341)
	at net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelector$LineCountingTracerWithLog.getModulesLineCount(TraceLineLimitTransactionSelector.java:275)
	at net.consensys.linea.sequencer.txselection.selectors.TraceLineLimitTransactionSelector.evaluateTransactionPostProcessing(TraceLineLimitTransactionSelector.java:138)
	at net.consensys.linea.sequencer.txselection.selectors.LineaTransactionSelector.evaluateTransactionPostProcessing(LineaTransactionSelector.java:154)
	at org.hyperledger.besu.services.TransactionSelectionServiceImpl$AggregatedPluginTransactionSelector.lambda$evaluateTransactionPostProcessing$2(TransactionSelectionServiceImpl.java:116)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.tryAdvance(AbstractList.java:708)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findAny(ReferencePipeline.java:652)
	at org.hyperledger.besu.services.TransactionSelectionServiceImpl$AggregatedPluginTransactionSelector.evaluateTransactionPostProcessing(TransactionSelectionServiceImpl.java:118)
	at org.hyperledger.besu.ethereum.blockcreation.txselection.BlockTransactionSelector.evaluatePostProcessing(BlockTransactionSelector.java:615)
	at org.hyperledger.besu.ethereum.blockcreation.txselection.BlockTransactionSelector.evaluatePendingTransaction(BlockTransactionSelector.java:514)
	at org.hyperledger.besu.ethereum.blockcreation.txselection.BlockTransactionSelector.evaluateTransaction(BlockTransactionSelector.java:467)
	at org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredPendingTransactions.selectTransactions(LayeredPendingTransactions.java:336)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPool.selectTransactions(TransactionPool.java:605)
	at org.hyperledger.besu.ethereum.blockcreation.txselection.BlockTransactionSelector.lambda$internalTimeLimitedSelection$6(BlockTransactionSelector.java:257)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at org.hyperledger.besu.ethereum.eth.manager.EthScheduler.lambda$scheduleBlockCreationTask$11(EthScheduler.java:236)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)

2025-10-02 19:07:03.701+0000 | EthScheduler-BlockCreation-35-24072018 | TRACE | LayeredPendingTransactions | Selection result INTERNAL_ERROR for transaction {sequence: 14281, addedAt: 1759426079538, isLocal=false, hasPriority=false, score=-128, 0xbab343342d0d08de886f57a99ec4fc09730618e07ecf92610b7c6b7480bc2953={MessageCall, 10, 0xacb17fc73cf202ebe532e107cec195d50dee61dd, FRONTIER, gp: 430.00 mwei, gl: 15942800, v: 0 wei, to: 0x0b2c83b6e39e32f694a86633b4d1fe69d13b63c5}}

Invalid tx removed:{sequence: 14281, addedAt: 1759426079538, isLocal=false, hasPriority=false, score=-128, 0xbab343342d0d08de886f57a99ec4fc09730618e07ecf92610b7c6b7480bc2953={MessageCall, 10, 0xacb17fc73cf202ebe532e107cec195d50dee61dd, FRONTIER, gp: 430.00 mwei, gl: 15942800, v: 0 wei, to: 0x0b2c83b6e39e32f694a86633b4d1fe69d13b63c5}}, reason:INTERNAL_ERROR; RLP={0xf905ad0a8419a1478083f34490940b2c83b6e39e32f694a86633b4d1fe69d13b63c580b905447715ee750000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000007510000000000000000000000000000000000000000000000000000000000000006000000000000000000000000414a76e7150213a99795ff361b197c26f9374994000000000000000000000000ea4a8d08b7a51f9f5735c45f821a060a97521d870000000000000000000000007be690a799477a22e42b524550b242aeb40bcfb8000000000000000000000000c34b003257b5138972dd5393ebaf0c5d38c5a0e6000000000000000000000000cd51f9572dba19cf5ea22cba1ed1049ada48e27600000000000000000000000031e21bb44f6206c03a3969975b9d31a7dad5207f000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000024000000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000000360000000000000000000000000000000000000000000000000000000000000000400000000000000000000000093f4d0ab6a8b4271f4a28db399b5e30612d21116000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000e8a4c9b6a2b79fd844c9e3adbc8dc841eece557b0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000265b25e22bcd7f10a5bd6e6410f10537cc7567e8000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000e8a4c9b6a2b79fd844c9e3adbc8dc841eece557b0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000e8a4c9b6a2b79fd844c9e3adbc8dc841eece557b00000000000000000000000000000000000000000000000000000000000000030000000000000000000000004af15ec2a0bd43db75dd04e62faa3b8ef36b00d5000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000e8a4c9b6a2b79fd844c9e3adbc8dc841eece557b00000000000000000000000000000000000000000000000000000000000000040000000000000000000000005cc5e64ab764a0f1e97f23984e20fd4528356a6a000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000176211869ca2b568f2a7d4ee941e073a821ee1ff000000000000000000000000e8a4c9b6a2b79fd844c9e3adbc8dc841eece557b00000000000000000000000000000000000000000000000000000000000000030000000000000000000000004ea77a86d6e70ffe8bb947fc86d68a7f086f198a000000000000000000000000e5d7c2a44ffddf6b295a15c148167daaaf5cf34f000000000000000000000000e8a4c9b6a2b79fd844c9e3adbc8dc841eece557b8301ce33a0bc1e1c856938477869599a975323a70f1ca15605fe900a06af7cfdc8dcd787e7a0120abc428f4a83e71f9be0ae712b57fc28028eb0f87aef254985053bddfc1eb0}}
```

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop delegating `traceEndBlock` and `traceEndConflation` in `LineCountingTracerWithLog`; block line count logging remains.
> 
> - **Sequencer**
>   - **`TraceLineLimitTransactionSelector`**:
>     - In `LineCountingTracerWithLog`, stop delegating `traceEndBlock` and `traceEndConflation` to the underlying tracer.
>     - Preserve debug logging of block line counts in `traceEndBlock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2c6a4fe5fd5224b49e9b640e9d9c86e5008af2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->