### PR TITLE
feat: update maru, linea-besu-package, and genesis files for prague fork

### DIFF
--- a/config/common/traces-limits-v2.toml
+++ b/config/common/traces-limits-v2.toml
@@ -24,7 +24,7 @@ OOB                 = 262144
 RLP_ADDR            = 4096
 RLP_TXN             = 131072
 RLP_TXN_RCPT        = 65536
-ROM                 = 8388608 # Note: set as 6291456 in production as workaround
+ROM                 = 8388608
 ROM_LEX             = 1024
 SHAKIRA_DATA        = 65536
 SHF                 = 262144
@@ -76,5 +76,5 @@ BLS                 = 0
 POINT_EVAL          = 0
 
 # Introduced from beta-v4.0-rc6-CANCUN and present on Cancun
-BLS_DATA                = 1073741824
+BLS_DATA                = 8192
 RLP_UTILS               = 131072

--- a/config/coordinator/coordinator-config-v2.toml
+++ b/config/coordinator/coordinator-config-v2.toml
@@ -78,7 +78,7 @@ fs-responses-directory = "/data/prover/v3/aggregation/responses"
 #fs-responses-directory = "/data/prover/v3/aggregation/responses"
 
 [traces]
-expected-traces-api-version = "beta-v4.0-rc11-debugging-e2e"
+expected-traces-api-version = "beta-v4.0-rc11"
 [traces.counters]
 endpoints = ["http://traces-node:8545/"]
 request-limit-per-endpoint = 1

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -13,7 +13,7 @@ services:
       - ../config/coordinator/coordinator-config-v2.toml:/coordinator/coordinator-config-v2.toml:ro
 
   maru:
-    image: consensys/maru:${MARU_TAG:-dbb6c73}
+    image: consensys/maru:${MARU_TAG:-54b73d9}
     hostname: maru
     container_name: maru
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
@@ -39,7 +39,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -117,7 +117,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -161,7 +161,7 @@ services:
   l2-node-besu-follower:
     hostname: l2-node-besu-follower
     container_name: l2-node-besu-follower
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -205,7 +205,7 @@ services:
   traces-node:
     hostname: traces-node
     container_name: traces-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -383,7 +383,7 @@ services:
       - l1network
 
   zkbesu-shomei:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     hostname: zkbesu-shomei
     container_name: zkbesu-shomei
     profiles: [ "l2", "l2-bc", "external-to-monorepo" ]
@@ -600,7 +600,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "external-to-monorepo", "staterecovery" ]

--- a/docker/compose-tracing-v2-fleet-ci-extension.yml
+++ b/docker/compose-tracing-v2-fleet-ci-extension.yml
@@ -26,7 +26,7 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: l2-node-besu
-    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json
@@ -44,7 +44,7 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: l2-node-besu-follower
-    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-debugging-e2e-20251002164638-c1b5c1e}
+    image: consensys/${BESU_PACKAGE_IMAGE_NAME:-linea-besu-package-with-fleet}:${BESU_PACKAGE_TAG:-beta-v4.0-rc11-20251004063519-a5c4c31}
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json

--- a/docker/config/l2-genesis-initialization/genesis-besu.json.template
+++ b/docker/config/l2-genesis-initialization/genesis-besu.json.template
@@ -15,6 +15,7 @@
     "terminalTotalDifficulty": 8,
     "shanghaiTime": %SHANGHAI_TIME%,
     "cancunTime": %CANCUN_TIME%,
+    "pragueTime": %PRAGUE_TIME%,
     "depositContractAddress": "0x3a69eD7FA6f6CA1dB2649327c4A2E666130823bE",
     "withdrawalRequestContractAddress": "0x3a69eD7FA6f6CA1dB2649327c4A2E666130823bE",
     "consolidationRequestContractAddress": "0x9AFC00F4CEaadb97A3822FCA2225FaD78839FBde",

--- a/docker/config/l2-genesis-initialization/genesis-maru.json.template
+++ b/docker/config/l2-genesis-initialization/genesis-maru.json.template
@@ -21,6 +21,12 @@
       "validatorSet": ["0x083e11f14b68d5ebeb4be3e3e0237ebbc5675ab5"],
       "blockTimeSeconds": 1,
       "elFork": "Cancun"
+    },
+     "%PRAGUE_TIME%": {
+      "type": "qbft",
+      "validatorSet": ["0x083e11f14b68d5ebeb4be3e3e0237ebbc5675ab5"],
+      "blockTimeSeconds": 1,
+      "elFork": "Prague"
     }
   }
 }

--- a/docker/config/l2-genesis-initialization/init.sh
+++ b/docker/config/l2-genesis-initialization/init.sh
@@ -28,4 +28,4 @@ shanghai_timestamp_ms=$((shanghai_timestamp * 1000))
 cancun_timestamp_ms=$((cancun_timestamp * 1000))
 prague_timestamp_ms=$((prague_timestamp * 1000))
 sed -i'' "s/^\(target-end-blocks[ ]*=[ ]*\).*/\1[4]/" coordinator-config-v2-hardforks.toml
-sed -i'' "s/^\(timestamp-based-hard-forks[ ]*=[ ]*\).*/\1[${shanghai_timestamp_ms}, ${cancun_timestamp_ms}]/" coordinator-config-v2-hardforks.toml
+sed -i'' "s/^\(timestamp-based-hard-forks[ ]*=[ ]*\).*/\1[${shanghai_timestamp_ms}, ${cancun_timestamp_ms}, ${prague_timestamp_ms}]/" coordinator-config-v2-hardforks.toml


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Prague fork timings to genesis, updates Besu/Maru images and expected traces API version, and tightens trace limits.
> 
> - **Hardfork/Genesis updates**:
>   - Add `pragueTime` to `docker/config/l2-genesis-initialization/genesis-besu.json.template`.
>   - Add `%PRAGUE_TIME%` (Prague) fork to `docker/config/l2-genesis-initialization/genesis-maru.json.template`.
>   - Update `docker/config/l2-genesis-initialization/init.sh` to generate Prague timestamps and include them in `timestamp-based-hard-forks`.
> - **Trace limits/config**:
>   - In `config/common/traces-limits-v2.toml`: set `ROM = 8388608`; reduce `BLS_DATA` from `1073741824` to `8192`.
>   - In `config/coordinator/coordinator-config-v2.toml`: set `expected-traces-api-version = "beta-v4.0-rc11"`.
> - **Docker images**:
>   - Bump `consensys/linea-besu-package` tags across L1/L2 services and tracing/fleet to `beta-v4.0-rc11-20251004063519-a5c4c31`.
>   - Bump `consensys/maru` default tag from `dbb6c73` to `54b73d9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ef23cd075460ad80b9d2cd6d695b202de3f44ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->