### PR TITLE
chore: update predeploy contracts mdx docs

### DIFF
--- a/contracts/docs/api/predeploy/UpgradeableBeaconChainDepositPredeploy.mdx
+++ b/contracts/docs/api/predeploy/UpgradeableBeaconChainDepositPredeploy.mdx
@@ -1,0 +1,34 @@
+# `UpgradeableBeaconChainDepositPredeploy`
+
+Implementation of Beacon Chain Deposit contract - https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/deposit-contract.md
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+### initialize
+
+```solidity
+function initialize() external
+```
+
+Initializes the contract state
+
+### fallback
+
+```solidity
+fallback() external payable
+```
+
+Fallback function - noop
+
+### receive
+
+```solidity
+receive() external payable
+```
+
+Receive function - noop
+

--- a/contracts/docs/api/predeploy/UpgradeableConsolidationQueuePredeploy.mdx
+++ b/contracts/docs/api/predeploy/UpgradeableConsolidationQueuePredeploy.mdx
@@ -1,0 +1,34 @@
+# `UpgradeableConsolidationQueuePredeploy`
+
+Implementation of EIP-7251 execution layer consolidation request contract
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+### initialize
+
+```solidity
+function initialize() external
+```
+
+Initializes the contract state
+
+### fallback
+
+```solidity
+fallback() external payable
+```
+
+Fallback function - noop
+
+### receive
+
+```solidity
+receive() external payable
+```
+
+Receive function - noop
+

--- a/contracts/docs/api/predeploy/UpgradeableWithdrawalQueuePredeploy.mdx
+++ b/contracts/docs/api/predeploy/UpgradeableWithdrawalQueuePredeploy.mdx
@@ -1,0 +1,34 @@
+# `UpgradeableWithdrawalQueuePredeploy`
+
+Implementation of EIP-7002 execution layer triggerable withdrawals
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+### initialize
+
+```solidity
+function initialize() external
+```
+
+Initializes the contract state
+
+### fallback
+
+```solidity
+fallback() external payable
+```
+
+Fallback function - noop
+
+### receive
+
+```solidity
+receive() external payable
+```
+
+Receive function - noop
+


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds MDX API docs for `UpgradeableBeaconChainDepositPredeploy`, `UpgradeableConsolidationQueuePredeploy`, and `UpgradeableWithdrawalQueuePredeploy`.
> 
> - **Docs**:
>   - **Predeploy API pages**:
>     - `contracts/docs/api/predeploy/UpgradeableBeaconChainDepositPredeploy.mdx`
>     - `contracts/docs/api/predeploy/UpgradeableConsolidationQueuePredeploy.mdx`
>     - `contracts/docs/api/predeploy/UpgradeableWithdrawalQueuePredeploy.mdx`
>   - Each documents `constructor`, `initialize`, `fallback`, and `receive` functions with brief descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 067795a3f2b26675bd229a24c7a9df834bd19857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->