### PR TITLE
fix(bridge-ui): memory leak on token list fetch

### DIFF
--- a/bridge-ui/src/services/tokenService.ts
+++ b/bridge-ui/src/services/tokenService.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import log from "loglevel";
 import { Address } from "viem";
 import { config } from "@/config";
@@ -58,7 +59,9 @@ export async function fetchTokenPrices(
 
 export async function validateTokenURI(url: string): Promise<string> {
   try {
-    await fetch(url);
+    await fetch(url, {
+      next: { revalidate: 3600 }, // Cache 1h
+    });
     return url;
   } catch (error) {
     return `${process.env.NEXT_PUBLIC_BASE_PATH}/images/logo/noTokenLogo.svg`;
@@ -83,7 +86,7 @@ export async function formatToken(token: GithubTokenListToken): Promise<Token> {
   };
 }
 
-export async function getTokenConfig(): Promise<NetworkTokens> {
+export const getTokenConfig = cache(async (): Promise<NetworkTokens> => {
   if (config.e2eTestMode) {
     return {
       MAINNET: [
@@ -161,4 +164,4 @@ export async function getTokenConfig(): Promise<NetworkTokens> {
   updatedTokensConfig.SEPOLIA = sepolia;
 
   return updatedTokensConfig;
-}
+});


### PR DESCRIPTION
This PR implements issue(s) Consensys/zkevm-monorepo#4376

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps `getTokenConfig` with React `cache()` and adds 1h revalidation to `validateTokenURI` fetch.
> 
> - **bridge-ui/src/services/tokenService.ts**:
>   - Cache/memoization:
>     - Wrap `getTokenConfig` with React `cache()` to memoize computed token config.
>   - Networking/cache hints:
>     - Add `next: { revalidate: 3600 }` to `validateTokenURI` fetch to cache logo requests for 1 hour.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8d8e6e25413aff228458117ea50008b781f4bf2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->