### PR TITLE
Enable on conflation app to recreate Shanghai execution proofs

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -19,6 +19,7 @@ import linea.web3j.Web3jBlobExtended
 import linea.web3j.createWeb3jHttpClient
 import linea.web3j.createWeb3jHttpService
 import linea.web3j.ethapi.createEthApiClient
+import net.consensys.linea.async.toSafeFuture
 import net.consensys.linea.ethereum.gaspricing.BoundableFeeCalculator
 import net.consensys.linea.ethereum.gaspricing.FeesCalculator
 import net.consensys.linea.ethereum.gaspricing.FeesFetcher
@@ -672,14 +673,19 @@ class L1DependentApp(
   }
 
   override fun start(): CompletableFuture<Unit> {
-    return l1FinalizationMonitor.start()
-      .thenCompose { l1FinalizationHandlerForShomeiRpc.start() }
-      .thenCompose { blobSubmissionCoordinator.start() }
-      .thenCompose { aggregationFinalizationCoordinator.start() }
-      .thenCompose { messageAnchoringApp.start() }
-      .thenCompose { conflationApp.start() }
-      .thenCompose { l2NetworkGasPricingService?.start() ?: SafeFuture.completedFuture(Unit) }
-      .thenCompose { l1FeeHistoryCachingService.start() }
+    //return l1FinalizationMonitor.start()
+    //  .thenCompose { l1FinalizationHandlerForShomeiRpc.start() }
+    //  .thenCompose { blobSubmissionCoordinator.start() }
+    //  .thenCompose { aggregationFinalizationCoordinator.start() }
+    //  .thenCompose { messageAnchoringApp.start() }
+    //  .thenCompose { conflationApp.start() }
+    //  .thenCompose { l2NetworkGasPricingService?.start() ?: SafeFuture.completedFuture(Unit) }
+    //  .thenCompose { l1FeeHistoryCachingService.start() }
+    //  .thenPeek {
+    //    log.info("L1App started")
+    //  }
+
+    return conflationApp.start().toSafeFuture()
       .thenPeek {
         log.info("L1App started")
       }
@@ -688,13 +694,13 @@ class L1DependentApp(
   override fun stop(): CompletableFuture<Unit> {
     return SafeFuture.allOf(
       conflationApp.stop(),
-      l1FinalizationMonitor.stop(),
-      l1FinalizationHandlerForShomeiRpc.stop(),
-      blobSubmissionCoordinator.stop(),
-      aggregationFinalizationCoordinator.stop(),
-      messageAnchoringApp.stop(),
-      l2NetworkGasPricingService?.stop() ?: SafeFuture.completedFuture(Unit),
-      l1FeeHistoryCachingService.stop(),
+      //l1FinalizationMonitor.stop(),
+      //l1FinalizationHandlerForShomeiRpc.stop(),
+      //blobSubmissionCoordinator.stop(),
+      //aggregationFinalizationCoordinator.stop(),
+      //messageAnchoringApp.stop(),
+      //l2NetworkGasPricingService?.stop() ?: SafeFuture.completedFuture(Unit),
+      //l1FeeHistoryCachingService.stop(),
     )
       .thenApply { log.info("L1App Stopped") }
   }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -22,6 +22,7 @@ import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.traces.TracesCountersV2
 import net.consensys.zkevm.LongRunningService
+import net.consensys.zkevm.coordinator.app.DisabledLongRunningService
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.cleanupDbDataAfterBlockNumbers
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resumeAggregationFrom
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resumeConflationFrom
@@ -88,10 +89,14 @@ class ConflationApp(
 ) : LongRunningService {
   private val log = LogManager.getLogger("conflation.app")
 
-  private val lastProcessedBlockNumber = resumeConflationFrom(
-    aggregationsRepository,
-    lastFinalizedBlock,
-  ).get()
+  //private val lastProcessedBlockNumber = resumeConflationFrom(
+  //  aggregationsRepository,
+  //  lastFinalizedBlock,
+  //).get()
+
+  // First Shanghai block 8814442 on devnet
+  private val lastProcessedBlockNumber = 8814441uL
+
   private val lastConsecutiveAggregatedBlockNumber = resumeAggregationFrom(
     aggregationsRepository,
     lastFinalizedBlock,
@@ -424,17 +429,22 @@ class ConflationApp(
   }
 
   override fun start(): CompletableFuture<Unit> {
-    return cleanupDbDataAfterBlockNumbers(
-      lastProcessedBlockNumber = lastProcessedBlockNumber,
-      lastConsecutiveAggregatedBlockNumber = lastConsecutiveAggregatedBlockNumber,
-      batchesRepository = batchesRepository,
-      blobsRepository = blobsRepository,
-      aggregationsRepository = aggregationsRepository,
-    )
-      .thenCompose { proofAggregationCoordinatorService.start() }
-      .thenCompose { deadlineConflationCalculatorRunner?.start() ?: SafeFuture.completedFuture(Unit) }
-      .thenCompose { blockCreationMonitor.start() }
-      .thenCompose { blobCompressionProofCoordinator.start() }
+    //return cleanupDbDataAfterBlockNumbers(
+    //  lastProcessedBlockNumber = lastProcessedBlockNumber,
+    //  lastConsecutiveAggregatedBlockNumber = lastConsecutiveAggregatedBlockNumber,
+    //  batchesRepository = batchesRepository,
+    //  blobsRepository = blobsRepository,
+    //  aggregationsRepository = aggregationsRepository,
+    //)
+    //  .thenCompose { proofAggregationCoordinatorService.start() }
+    //  .thenCompose { deadlineConflationCalculatorRunner?.start() ?: SafeFuture.completedFuture(Unit) }
+    //  .thenCompose { blockCreationMonitor.start() }
+    //  .thenCompose { blobCompressionProofCoordinator.start() }
+    //  .thenPeek {
+    //    log.info("Conflation started")
+    //  }
+
+    return blockCreationMonitor.start()
       .thenPeek {
         log.info("Conflation started")
       }
@@ -442,10 +452,10 @@ class ConflationApp(
 
   override fun stop(): CompletableFuture<Unit> {
     return SafeFuture.allOf(
-      proofAggregationCoordinatorService.stop(),
+      //proofAggregationCoordinatorService.stop(),
       blockCreationMonitor.stop(),
-      deadlineConflationCalculatorRunner?.stop() ?: SafeFuture.completedFuture(Unit),
-      blobCompressionProofCoordinator.stop(),
+      //deadlineConflationCalculatorRunner?.stop() ?: SafeFuture.completedFuture(Unit),
+      //blobCompressionProofCoordinator.stop(),
     )
       .thenApply { log.info("Conflation Stopped") }
   }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run only the conflation/block creation flow starting from block `8814441`, disabling proof aggregation/blob compression and all L1 submission/finalization services.
> 
> - **Conflation**:
>   - Force starting point: set `lastProcessedBlockNumber` to `8814441uL` (pre-Shanghai) instead of `resumeConflationFrom(...)`.
>   - Startup/Shutdown: `start()` now only starts `blockCreationMonitor`; `stop()` only stops `blockCreationMonitor`.
>   - Disable surrounding flows: comment out DB cleanup, `proofAggregationCoordinatorService`, `deadlineConflationCalculatorRunner`, and `blobCompressionProofCoordinator`.
> - **L1 App**:
>   - Startup/Shutdown: `start()` now only starts `conflationApp` (via `toSafeFuture()`); `stop()` only stops `conflationApp`.
>   - Disable L1-related services by commenting out starts/stops for `l1FinalizationMonitor`, Shomei handler, blob submission, aggregation finalization, message anchoring, L2 gas pricing, and L1 fee history cache.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34f56dbeb5b51a025c2a20995ba397d9bab37927. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->