### PR TITLE
Fix: disable colors from Besu container output when running CI tests

### DIFF
--- a/.github/workflows/reuse-linea-besu-package-run-test.yml
+++ b/.github/workflows/reuse-linea-besu-package-run-test.yml
@@ -44,17 +44,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: linea-besu-package*
-      
+
       - name: Load Docker image
         run: |
           pwd && ls -la && echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" &&
           gunzip -c $GITHUB_WORKSPACE/linea-besu-package/linea-besu-package-image.tar.gz | docker load
         shell: bash
 
-      - name: Start container
+      - name: Start container # disabling color in the output
         run: |
           env
-          COMMAND="docker run -d --name ${{ env.CONTAINER_NAME }} -e BESU_PROFILE=${{ matrix.file }} ${{ env.DOCKER_IMAGE }}"
+          COMMAND="docker run -d --name ${{ env.CONTAINER_NAME }} -e BESU_PROFILE=${{ matrix.file }} ${{ env.DOCKER_IMAGE }} --color-enabled=false"
           echo $COMMAND
           eval $COMMAND
 


### PR DESCRIPTION
This PR implements issue(s) #

trying to fix https://github.com/Consensys/linea-monorepo/actions/runs/18468763386/job/52620585215


### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds --color-enabled=false to the docker run command to disable Besu container colorized output in the CI workflow.
> 
> - **CI Workflow** (`.github/workflows/reuse-linea-besu-package-run-test.yml`):
>   - **Start container**: Append `--color-enabled=false` to `docker run` command to disable Besu colorized output during tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f83e6b28b78637f13e63d85ba730cd9463add7ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->