### PR TITLE
fix chain ID and remove cancun fork for mainnet

### DIFF
--- a/docker/linea-mainnet/genesis.json
+++ b/docker/linea-mainnet/genesis.json
@@ -13,7 +13,6 @@
     "londonBlock": 0,
     "terminalTotalDifficulty": 49492771,
     "shanghaiTime": 1761127200,
-    "cancunTime": 1761213600,
     "depositContractAddress": "0x94d4a7449B968b839dcbc64A61F195CA300986ae",
     "withdrawalRequestContractAddress": "0x66355689a9f067eeb9dc9d899E4192676988279C",
     "consolidationRequestContractAddress": "0xF0e003F0dE2d583Ae28FA8cBF66aa096CdAce3ff",

--- a/docker/linea-mainnet/maru/config/maru-config.toml
+++ b/docker/linea-mainnet/maru/config/maru-config.toml
@@ -8,11 +8,6 @@ ip-address = "0.0.0.0"
 static-peers = [] # Missing from mainnet
 reconnect-delay = "500ms"
 
-[p2p.discovery]
-port = 9000
-bootnodes = []
-refresh-interval = "3s"
-
 [payload-validator]
 # Besu node as execution layer client
 engine-api-endpoint = { endpoint = "http://linea-besu:8550" }  # Match Besu port

--- a/docker/linea-mainnet/maru/config/maru-genesis.json
+++ b/docker/linea-mainnet/maru/config/maru-genesis.json
@@ -1,5 +1,5 @@
 {
-  "chainId": 59141,
+  "chainId": 59144,
   "config": {
     "0": {
       "type": "difficultyAwareQbft",
@@ -13,14 +13,8 @@
     "1761127200": {
       "type": "qbft",
       "validatorSet": [],
-      "blockTimeSeconds": 2,
+      "blockTimeSeconds": 1,
       "elFork": "Shanghai"
-    },
-    "1761213600": {
-      "type": "qbft",
-      "validatorSet": [],
-      "blockTimeSeconds": 2,
-      "elFork": "Cancun"
     }
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update mainnet configs: change `chainId` to `59144`, remove Cancun fork/time, set Shanghai block time to 1s, and remove Maru P2P discovery settings.
> 
> - **Consensus/Genesis**
>   - `docker/linea-mainnet/maru/config/maru-genesis.json`:
>     - Set `chainId` to `59144`.
>     - Remove `1761213600` Cancun fork config.
>     - Change Shanghai (`1761127200`) `blockTimeSeconds` from `2` to `1`.
>   - `docker/linea-mainnet/genesis.json`:
>     - Remove `cancunTime` from `config`.
> - **Maru Node Config**
>   - `docker/linea-mainnet/maru/config/maru-config.toml`:
>     - Remove `[p2p.discovery]` section (ports/bootnodes/refresh).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5a0cc9f882b38b4641e25237346286d1534e3f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->