### PR TITLE
Fixing jwt secret mount for Geth

### DIFF
--- a/docker/linea-mainnet/docker-compose.yml
+++ b/docker/linea-mainnet/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - --authrpc.addr=0.0.0.0
       - --authrpc.port=8550
       - --authrpc.vhosts=*
-      - --authrpc.jwtsecret=/root/.ethereum/jwt
+      - --authrpc.jwtsecret=/jwt
     ports:
       - 30303:30303
       - 30303:30303/udp
@@ -131,7 +131,7 @@ services:
       - 8550:8550
     volumes:
       - ./geth/geth-genesis.json:/genesis.json:ro
-      - ./engine-jwt:/root/.ethereum/jwt:ro
+      - ./engine-jwt:/jwt:ro
       - ./execution-layer-static-nodes.json:/root/.ethereum/static-nodes.json:ro # Loaded automatically by Geth if present
       - linea-mainnet-geth:/root/.ethereum
 

--- a/docker/linea-sepolia/docker-compose.yml
+++ b/docker/linea-sepolia/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - --authrpc.addr=0.0.0.0
       - --authrpc.port=8550
       - --authrpc.vhosts=*
-      - --authrpc.jwtsecret=/root/.ethereum/jwt
+      - --authrpc.jwtsecret=/jwt
     ports:
       - 30303:30303
       - 30303:30303/udp
@@ -129,7 +129,7 @@ services:
       - 8550:8550
     volumes:
       - ./geth/geth-genesis.json:/genesis.json:ro
-      - ./engine-jwt:/root/.ethereum/jwt:ro
+      - ./engine-jwt:/jwt:ro
       - ./execution-layer-static-nodes.json:/root/.ethereum/static-nodes.json:ro # Loaded automatically by Geth if present
       - linea-sepolia-geth:/root/.ethereum
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Geth JWT secret path and volume mount from /root/.ethereum/jwt to /jwt in both linea-mainnet and linea-sepolia docker-compose files.
> 
> - **Docker Compose**:
>   - **Geth JWT secret path**:
>     - `docker/linea-mainnet/docker-compose.yml`:
>       - Change `--authrpc.jwtsecret` from `/root/.ethereum/jwt` to `/jwt`.
>       - Update volume mount from `./engine-jwt:/root/.ethereum/jwt:ro` to `./engine-jwt:/jwt:ro`.
>     - `docker/linea-sepolia/docker-compose.yml`:
>       - Change `--authrpc.jwtsecret` from `/root/.ethereum/jwt` to `/jwt`.
>       - Update volume mount from `./engine-jwt:/root/.ethereum/jwt:ro` to `./engine-jwt:/jwt:ro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc7a8a9fdc25f3885b7d57ddc6d7ce3238f8beb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->