### PR TITLE
Geth downgrade until Shanghai

### DIFF
--- a/docker/linea-mainnet/docker-compose.yml
+++ b/docker/linea-mainnet/docker-compose.yml
@@ -13,12 +13,11 @@ volumes:
 
 # ─────────────────────────────────────────────
 # ⚠️ Execution Layer Clients Overview
-# Only `besu-node` is actively connected to the Maru Consensus Layer
-# and is referenced in the Maru config.toml file.
+# Only one execution client is actively connected to the Maru Consensus Layer at a time
+# and is referenced in the Maru config.toml file as el-client
 #
-# The other EL clients (Geth, Erigon, Nethermind) are included here
-# for reference or testing purposes only.
-# They are not connected to any Consensus Layer in this file.
+# The other EL clients are included here for reference or testing purposes only.
+# The user is free to choose any el client they want.
 # ─────────────────────────────────────────────
 services:
   # Besu node (Execution Layer for Maru)

--- a/docker/linea-sepolia/docker-compose.yml
+++ b/docker/linea-sepolia/docker-compose.yml
@@ -13,12 +13,11 @@ volumes:
 
 # ─────────────────────────────────────────────
 # ⚠️ Execution Layer Clients Overview
-# Only `besu-node` is actively connected to the Maru Consensus Layer
-# and is referenced in the Maru config.toml file.
+# Only one execution client is actively connected to the Maru Consensus Layer at a time
+# and is referenced in the Maru config.toml file as el-client
 #
-# The other EL clients (Geth, Erigon, Nethermind) are included here
-# for reference or testing purposes only.
-# They are not connected to any Consensus Layer in this file.
+# The other EL clients are included here for reference or testing purposes only.
+# The user is free to choose any el client they want.
 # ─────────────────────────────────────────────
 services:
   # Besu node (Execution Layer for Maru)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades Geth to v1.13.15 for linea-mainnet and clarifies EL client comments in both mainnet and sepolia compose files.
> 
> - **Docker Compose**:
>   - `docker/linea-mainnet/docker-compose.yml`:
>     - Downgrade Geth images (`geth-init`, `geth-node`) to `ethereum/client-go:v1.13.15`.
>     - Clarify EL client comments: only one EL client connects to Maru; others are for reference/testing; user may choose EL client.
>   - `docker/linea-sepolia/docker-compose.yml`:
>     - Update EL client comments with the same clarifications as above.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47399da9d8e684fec6b1c40f10621c6931cae6f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->