### PR TITLE
Chore: besu = "25.10.0-linea2" and arithmetization="beta-v4.0-rc16"

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/EngineAPIService.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/EngineAPIService.java
@@ -112,7 +112,7 @@ public class EngineAPIService {
     final ObjectNode blobsBundle;
     final ArrayNode executionRequests;
     final String newBlockHash;
-    final String parentBeaconBlockRoot;
+    final String parentBeaconBlockRoot = Hash.ZERO.toHexString();
     ArrayNode expectedBlobVersionedHashes = mapper.createArrayNode();
     try (final Response getPayloadResponse = getPayloadRequest.execute()) {
       assertThat(getPayloadResponse.code()).isEqualTo(200);
@@ -121,7 +121,6 @@ public class EngineAPIService {
       blobsBundle = (ObjectNode) result.get("blobsBundle");
       executionRequests = (ArrayNode) result.get("executionRequests");
       newBlockHash = executionPayload.get("blockHash").asText();
-      parentBeaconBlockRoot = executionPayload.remove("parentBeaconBlockRoot").asText();
       // Transform KZG commitments to versioned hashes
       for (JsonNode kzgCommitment : blobsBundle.get("commitments")) {
         Bytes kzgBytes = Bytes.fromHexString(kzgCommitment.asText());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,8 @@ wiremock = "3.13.0"
 logcaptor = "2.11.0"
 
 # Runtime
-arithmetization="beta-v4.0-rc14"
-besu = "25.10.0-linea1"
+arithmetization="beta-v4.0-rc16"
+besu = "25.10.0-linea2"
 blobCompressor = "2.1.0-rc1"
 blobShnarfCalculator = "1.2.0"
 bouncycastle = "1.79"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Besu and arithmetization versions and updates EngineAPIService to use ZERO parentBeaconBlockRoot instead of extracting/removing it from the payload.
> 
> - **Tests**:
>   - Update `besu-plugins/linea-sequencer/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/EngineAPIService.java` to set `parentBeaconBlockRoot` to `Hash.ZERO.toHexString()` and stop removing it from `executionPayload`.
> - **Dependencies**:
>   - Bump `arithmetization` to `beta-v4.0-rc16`.
>   - Bump `besu` to `25.10.0-linea2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e772e882f32826181325d4dd38df6d0edaa0418c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->