### PR TITLE
code rearrange on web3j EthApi implementation

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/GethCliqueSafeBlockProvider.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/GethCliqueSafeBlockProvider.kt
@@ -3,7 +3,7 @@ package net.consensys.zkevm.coordinator.blockcreation
 import linea.domain.Block
 import linea.domain.BlockParameter.Companion.toBlockParameter
 import linea.web3j.domain.toWeb3j
-import linea.web3j.toDomain
+import linea.web3j.mappers.toDomain
 import net.consensys.linea.async.toSafeFuture
 import net.consensys.zkevm.ethereum.coordination.blockcreation.SafeBlockProvider
 import org.web3j.protocol.Web3j

--- a/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Block.kt
+++ b/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/Block.kt
@@ -28,7 +28,7 @@ data class BlockData<TxData>(
   val ommers: List<ByteArray> = emptyList(), // List of uncle block hashes
 ) {
   companion object {
-    // companion object  to allow static extension functions
+    // companion object to allow static extension functions
   }
 
   init {

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/ExtendedWeb3J.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/ExtendedWeb3J.kt
@@ -3,6 +3,7 @@ package linea.web3j
 import linea.domain.Block
 import linea.domain.BlockParameter
 import linea.web3j.domain.toWeb3j
+import linea.web3j.mappers.toDomain
 import net.consensys.linea.async.toSafeFuture
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.DefaultBlockParameter

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/ethapi/Web3jEthApiClient.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/ethapi/Web3jEthApiClient.kt
@@ -8,9 +8,9 @@ import linea.ethapi.EthApiClient
 import linea.kotlin.toULong
 import linea.web3j.domain.toDomain
 import linea.web3j.domain.toWeb3j
-import linea.web3j.mapToDomainWithTxHashes
+import linea.web3j.mappers.mapToDomainWithTxHashes
+import linea.web3j.mappers.toDomain
 import linea.web3j.requestAsync
-import linea.web3j.toDomain
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.methods.request.EthFilter
 import org.web3j.protocol.core.methods.response.Log

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/mappers/EthGetBlockToLineaBlockMappers.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/mappers/EthGetBlockToLineaBlockMappers.kt
@@ -1,17 +1,11 @@
-package linea.web3j
+package linea.web3j.mappers
 
-import linea.domain.AccessListEntry
 import linea.domain.Block
 import linea.domain.BlockData
 import linea.domain.BlockWithTxHashes
-import linea.domain.CodeDelegation
 import linea.domain.Transaction
-import linea.domain.TransactionType
 import linea.kotlin.decodeHex
-import linea.kotlin.toBigIntegerFromHex
-import linea.kotlin.toIntFromHex
 import linea.kotlin.toULong
-import linea.kotlin.toULongFromHex
 import org.web3j.protocol.core.methods.response.EthBlock
 
 fun EthBlock.Block.toDomain(): Block = mapToDomain(this)
@@ -70,61 +64,4 @@ fun <TxData> mapToDomain(web3jBlock: EthBlock.Block, txsMapper: (EthBlock.Block)
     transactions = txsMapper(web3jBlock), // List of transactions
   )
   return block
-}
-
-fun EthBlock.TransactionObject.toDomain(): Transaction {
-  val txType = mapType(this.type)
-  var gasPrice: ULong? = null
-  var maxFeePerGas: ULong? = null
-  var maxPriorityFeePerGas: ULong? = null
-
-  if (txType.supports1559FeeMarket()) {
-    maxFeePerGas = this.maxFeePerGas?.toULong()
-    maxPriorityFeePerGas = this.maxPriorityFeePerGas?.toULong()
-  } else {
-    gasPrice = this.gasPrice.toULong()
-  }
-  val accessList = this.accessList?.map { accessListEntry ->
-    AccessListEntry(
-      accessListEntry.address.decodeHex(),
-      accessListEntry.storageKeys.map { it.decodeHex() },
-    )
-  }
-  // TODO: Web3j doesn't support Type 4 / 7702 parsing transactions from the block
-  val codeDelegations = emptyList<CodeDelegation>()
-
-  val chainId = run {
-    this.chainId?.toULong()?.let {
-      when {
-        it == 0UL -> null // Web3j uses 0 for chainId when it's not present
-        else -> it
-      }
-    }
-  }
-
-  val domainTx = Transaction(
-    nonce = this.nonce.toULong(),
-    gasLimit = this.gas.toULong(),
-    to = this.to?.decodeHex(),
-    value = this.value,
-    input = this.input.decodeHex(),
-    r = this.r.toBigIntegerFromHex(),
-    s = this.s.toBigIntegerFromHex(),
-    v = this.v.toULong(),
-    yParity = this.getyParity()?.toULongFromHex(),
-    type = mapType(this.type), // Optional field for EIP-2718 typed transactions
-    chainId = chainId, // Optional field for EIP-155 transactions
-    gasPrice = gasPrice, // Optional field for EIP-1559 transactions
-    maxFeePerGas = maxFeePerGas, // Optional field for EIP-1559 transactions
-    maxPriorityFeePerGas = maxPriorityFeePerGas, // Optional field for EIP-1559 transactions,
-    accessList = accessList,
-    codeDelegations = codeDelegations,
-  )
-  return domainTx
-}
-
-fun mapType(type: String?): TransactionType {
-  return type
-    ?.let { TransactionType.fromEthApiSerializedValue(it.toIntFromHex()) }
-    ?: TransactionType.FRONTIER
 }

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/mappers/TransactionMapper.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/mappers/TransactionMapper.kt
@@ -1,0 +1,68 @@
+package linea.web3j.mappers
+
+import linea.domain.AccessListEntry
+import linea.domain.CodeDelegation
+import linea.domain.Transaction
+import linea.domain.TransactionType
+import linea.kotlin.decodeHex
+import linea.kotlin.toBigIntegerFromHex
+import linea.kotlin.toIntFromHex
+import linea.kotlin.toULong
+import linea.kotlin.toULongFromHex
+
+fun mapType(type: String?): TransactionType {
+  return type
+    ?.let { TransactionType.fromEthApiSerializedValue(it.toIntFromHex()) }
+    ?: TransactionType.FRONTIER
+}
+
+fun org.web3j.protocol.core.methods.response.Transaction.toDomain(): Transaction {
+  val txType = mapType(this.type)
+  var gasPrice: ULong? = null
+  var maxFeePerGas: ULong? = null
+  var maxPriorityFeePerGas: ULong? = null
+
+  if (txType.supports1559FeeMarket()) {
+    maxFeePerGas = this.maxFeePerGas?.toULong()
+    maxPriorityFeePerGas = this.maxPriorityFeePerGas?.toULong()
+  } else {
+    gasPrice = this.gasPrice.toULong()
+  }
+  val accessList = this.accessList?.map { accessListEntry ->
+    AccessListEntry(
+      accessListEntry.address.decodeHex(),
+      accessListEntry.storageKeys.map { it.decodeHex() },
+    )
+  }
+  // TODO: Web3j doesn't support Type 4 / 7702 parsing transactions from the block
+  val codeDelegations = emptyList<CodeDelegation>()
+
+  val chainId = run {
+    this.chainId?.toULong()?.let {
+      when {
+        it == 0UL -> null // Web3j uses 0 for chainId when it's not present
+        else -> it
+      }
+    }
+  }
+
+  val domainTx = Transaction(
+    nonce = this.nonce.toULong(),
+    gasLimit = this.gas.toULong(),
+    to = this.to?.decodeHex(),
+    value = this.value,
+    input = this.input.decodeHex(),
+    r = this.r.toBigIntegerFromHex(),
+    s = this.s.toBigIntegerFromHex(),
+    v = this.v.toULong(),
+    yParity = this.getyParity()?.toULongFromHex(),
+    type = mapType(this.type), // Optional field for EIP-2718 typed transactions
+    chainId = chainId, // Optional field for EIP-155 transactions
+    gasPrice = gasPrice, // Optional field for EIP-1559 transactions
+    maxFeePerGas = maxFeePerGas, // Optional field for EIP-1559 transactions
+    maxPriorityFeePerGas = maxPriorityFeePerGas, // Optional field for EIP-1559 transactions,
+    accessList = accessList,
+    codeDelegations = codeDelegations,
+  )
+  return domainTx
+}

--- a/jvm-libs/linea/web3j-extensions/src/test/kotlin/linea/web3j/mappers/EthGetBlockToLineaBlockMapperTest.kt
+++ b/jvm-libs/linea/web3j-extensions/src/test/kotlin/linea/web3j/mappers/EthGetBlockToLineaBlockMapperTest.kt
@@ -1,4 +1,4 @@
-package linea.web3j
+package linea.web3j.mappers
 
 import linea.domain.AccessListEntry
 import linea.domain.CodeDelegation
@@ -10,8 +10,7 @@ import linea.kotlin.toBigInteger
 import linea.kotlin.toBigIntegerFromHex
 import org.apache.tuweni.bytes.Bytes
 import org.apache.tuweni.bytes.Bytes32
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
+import org.assertj.core.api.Assertions
 import org.hyperledger.besu.datatypes.Address
 import org.hyperledger.besu.datatypes.Wei
 import org.junit.jupiter.api.Disabled
@@ -57,7 +56,7 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     val domainTx = txWeb3j.toDomain()
-    assertThat(domainTx).isEqualTo(
+    Assertions.assertThat(domainTx).isEqualTo(
       Transaction(
         nonce = 0x0UL,
         gasPrice = null,
@@ -79,23 +78,25 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     domainTx.toBesu().also { besuTx ->
-      assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.EIP1559)
-      assertThat(besuTx.nonce).isEqualTo(0x0L)
-      assertThat(besuTx.gasPrice.getOrNull()).isNull()
-      assertThat(besuTx.maxFeePerGas.getOrNull()).isEqualTo(Wei.of(0xeL))
-      assertThat(besuTx.maxPriorityFeePerGas.getOrNull()).isEqualTo(Wei.of(0x0L))
-      assertThat(besuTx.gasLimit).isEqualTo(0x29e2f7L)
-      assertThat(besuTx.to.getOrNull()).isNull()
-      assertThat(besuTx.value).isEqualTo(Wei.of(0x0L))
-      assertThat(besuTx.payload).isEqualTo(Bytes.fromHexString("0x60806040523480156200001157600080fd5b506200001c"))
-      assertThat(besuTx.signature.r).isEqualTo(
+      Assertions.assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.EIP1559)
+      Assertions.assertThat(besuTx.nonce).isEqualTo(0x0L)
+      Assertions.assertThat(besuTx.gasPrice.getOrNull()).isNull()
+      Assertions.assertThat(besuTx.maxFeePerGas.getOrNull()).isEqualTo(Wei.of(0xeL))
+      Assertions.assertThat(besuTx.maxPriorityFeePerGas.getOrNull()).isEqualTo(Wei.of(0x0L))
+      Assertions.assertThat(besuTx.gasLimit).isEqualTo(0x29e2f7L)
+      Assertions.assertThat(besuTx.to.getOrNull()).isNull()
+      Assertions.assertThat(besuTx.value).isEqualTo(Wei.of(0x0L))
+      Assertions.assertThat(
+        besuTx.payload,
+      ).isEqualTo(Bytes.fromHexString("0x60806040523480156200001157600080fd5b506200001c"))
+      Assertions.assertThat(besuTx.signature.r).isEqualTo(
         "0x1fa31b9272cc67174efb129c2fd2ec5afda122503745beb22bd26e48a42240bb".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.s).isEqualTo(
+      Assertions.assertThat(besuTx.signature.s).isEqualTo(
         "0x248c9cdf9352b4a379577c5b44bcb25a5350dc6722fd7b2aec40e193f670e4f4".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.recId).isEqualTo(0)
-      assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
+      Assertions.assertThat(besuTx.signature.recId).isEqualTo(0)
+      Assertions.assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
     }
   }
 
@@ -124,7 +125,7 @@ class EthGetBlockToLineaBlockMapperTest {
       """.trimIndent(),
     )
     val domainTx = txWeb3j.toDomain()
-    assertThat(domainTx).isEqualTo(
+    Assertions.assertThat(domainTx).isEqualTo(
       Transaction(
         nonce = 0x97411UL,
         gasPrice = 0xee2d984UL,
@@ -145,23 +146,25 @@ class EthGetBlockToLineaBlockMapperTest {
       ),
     )
     domainTx.toBesu().also { besuTx ->
-      assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.FRONTIER)
-      assertThat(besuTx.nonce).isEqualTo(0x97411L)
-      assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0xee2d984L))
-      assertThat(besuTx.gasLimit).isEqualTo(0x5208L)
-      assertThat(besuTx.to.getOrNull()).isEqualTo(Address.fromHexString("0x228466f2c715cbec05deabfac040ce3619d7cf0b"))
-      assertThat(besuTx.value).isEqualTo(Wei.of(0x186a0L))
-      assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
-      assertThat(besuTx.signature.r).isEqualTo(
+      Assertions.assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.FRONTIER)
+      Assertions.assertThat(besuTx.nonce).isEqualTo(0x97411L)
+      Assertions.assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0xee2d984L))
+      Assertions.assertThat(besuTx.gasLimit).isEqualTo(0x5208L)
+      Assertions.assertThat(
+        besuTx.to.getOrNull(),
+      ).isEqualTo(Address.fromHexString("0x228466f2c715cbec05deabfac040ce3619d7cf0b"))
+      Assertions.assertThat(besuTx.value).isEqualTo(Wei.of(0x186a0L))
+      Assertions.assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
+      Assertions.assertThat(besuTx.signature.r).isEqualTo(
         "0xdf28597129341d5d345c9043c7d0b0a22be82cac13988cfc1d8cbdaf3ab3f35b".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.s).isEqualTo(
+      Assertions.assertThat(besuTx.signature.s).isEqualTo(
         "0x3189b2ff80d8f728d6fb7503b46734ee77a60a42db01d0b09db10bdc9d5caa44".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.recId).isEqualTo(1)
-      assertThat(besuTx.chainId.getOrNull()).isEqualTo(0xe705L)
-      assertThat(besuTx.maxFeePerGas).isEmpty()
-      assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.signature.recId).isEqualTo(1)
+      Assertions.assertThat(besuTx.chainId.getOrNull()).isEqualTo(0xe705L)
+      Assertions.assertThat(besuTx.maxFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
     }
   }
 
@@ -201,7 +204,7 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     val domainTx = txWeb3j.toDomain()
-    assertThat(domainTx).isEqualTo(
+    Assertions.assertThat(domainTx).isEqualTo(
       Transaction(
         nonce = 0UL,
         gasPrice = 0x1017df87UL,
@@ -231,28 +234,30 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     domainTx.toBesu().also { besuTx ->
-      assertThat(besuTx.nonce).isEqualTo(0L)
-      assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
-      assertThat(besuTx.gasLimit).isEqualTo(0x30d40L)
-      assertThat(besuTx.to.getOrNull()).isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
-      assertThat(besuTx.value).isEqualTo(Wei.of(0x2386f26fc10000L))
-      assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
-      assertThat(besuTx.signature.r).isEqualTo(
+      Assertions.assertThat(besuTx.nonce).isEqualTo(0L)
+      Assertions.assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
+      Assertions.assertThat(besuTx.gasLimit).isEqualTo(0x30d40L)
+      Assertions.assertThat(
+        besuTx.to.getOrNull(),
+      ).isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
+      Assertions.assertThat(besuTx.value).isEqualTo(Wei.of(0x2386f26fc10000L))
+      Assertions.assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
+      Assertions.assertThat(besuTx.signature.r).isEqualTo(
         "0x4f24ed24207bec8591c8172584dc3b57cdf3ee96afbd5e63905a90a704ff33f0".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.s).isEqualTo(
+      Assertions.assertThat(besuTx.signature.s).isEqualTo(
         "0x6277bb9d2614843a4791ff2c192e70876438ec940c39d92deb504591b83dfeb3".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.recId).isEqualTo(1)
-      assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST)
-      assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
-      assertThat(besuTx.maxFeePerGas).isEmpty()
-      assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
-      val accessList = besuTx.accessList.getOrElse { fail("AccessList is empty") }
+      Assertions.assertThat(besuTx.signature.recId).isEqualTo(1)
+      Assertions.assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST)
+      Assertions.assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
+      Assertions.assertThat(besuTx.maxFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
+      val accessList = besuTx.accessList.getOrElse { Assertions.fail("AccessList is empty") }
 
-      assertThat(accessList.get(0).address)
+      Assertions.assertThat(accessList.get(0).address)
         .isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
-      assertThat(accessList.get(0).storageKeys)
+      Assertions.assertThat(accessList.get(0).storageKeys)
         .containsExactly(
           Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"),
           Bytes32.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000001"),
@@ -297,7 +302,7 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     val domainTx = txWeb3j.toDomain()
-    assertThat(domainTx).isEqualTo(
+    Assertions.assertThat(domainTx).isEqualTo(
       Transaction(
         nonce = 0UL,
         gasPrice = 0x1017df87UL,
@@ -328,38 +333,40 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     domainTx.toBesu().also { besuTx ->
-      assertThat(besuTx.nonce).isEqualTo(0L)
-      assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
-      assertThat(besuTx.gasLimit).isEqualTo(0x30d40L)
-      assertThat(besuTx.to.getOrNull()).isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
-      assertThat(besuTx.value).isEqualTo(Wei.of(0x2386f26fc10000L))
-      assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
-      assertThat(besuTx.signature.r).isEqualTo(
+      Assertions.assertThat(besuTx.nonce).isEqualTo(0L)
+      Assertions.assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
+      Assertions.assertThat(besuTx.gasLimit).isEqualTo(0x30d40L)
+      Assertions.assertThat(
+        besuTx.to.getOrNull(),
+      ).isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
+      Assertions.assertThat(besuTx.value).isEqualTo(Wei.of(0x2386f26fc10000L))
+      Assertions.assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
+      Assertions.assertThat(besuTx.signature.r).isEqualTo(
         "0x4f24ed24207bec8591c8172584dc3b57cdf3ee96afbd5e63905a90a704ff33f0".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.s).isEqualTo(
+      Assertions.assertThat(besuTx.signature.s).isEqualTo(
         "0x6277bb9d2614843a4791ff2c192e70876438ec940c39d92deb504591b83dfeb3".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.recId).isEqualTo(1)
-      assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST)
-      assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
-      assertThat(besuTx.maxFeePerGas).isEmpty()
-      assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
-      val codeDelegationList = besuTx.codeDelegationList.getOrElse { fail("CodeDelegationList is empty") }
+      Assertions.assertThat(besuTx.signature.recId).isEqualTo(1)
+      Assertions.assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST)
+      Assertions.assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
+      Assertions.assertThat(besuTx.maxFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
+      val codeDelegationList = besuTx.codeDelegationList.getOrElse { Assertions.fail("CodeDelegationList is empty") }
 
-      assertThat(codeDelegationList).hasSize(1)
+      Assertions.assertThat(codeDelegationList).hasSize(1)
       val codeDelegationListEntry = codeDelegationList[0]
-      assertThat(codeDelegationListEntry.address())
+      Assertions.assertThat(codeDelegationListEntry.address())
         .isEqualTo(Address.fromHexString("0x484be06b591d7bca761444e04e35acdf269a7873"))
-      assertThat(codeDelegationListEntry.chainId()).isEqualTo(1337.toBigInteger())
-      assertThat(codeDelegationListEntry.nonce()).isEqualTo(16L)
-      assertThat(codeDelegationListEntry.v()).isEqualTo(
+      Assertions.assertThat(codeDelegationListEntry.chainId()).isEqualTo(1337.toBigInteger())
+      Assertions.assertThat(codeDelegationListEntry.nonce()).isEqualTo(16L)
+      Assertions.assertThat(codeDelegationListEntry.v()).isEqualTo(
         1,
       )
-      assertThat(codeDelegationListEntry.r()).isEqualTo(
+      Assertions.assertThat(codeDelegationListEntry.r()).isEqualTo(
         "0x981f39bf086898f5a236f60dab3a4d56a14bc2b083ec52d3dec5238d2e8cc116".toBigIntegerFromHex(),
       )
-      assertThat(codeDelegationListEntry.s()).isEqualTo(
+      Assertions.assertThat(codeDelegationListEntry.s()).isEqualTo(
         "0x19b739390989da89acbd16d3eb937863dfe863744fe1101b95d37a412bd3a606".toBigIntegerFromHex(),
       )
     }
@@ -393,7 +400,7 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     val domainTx = txWeb3j.toDomain()
-    assertThat(domainTx).isEqualTo(
+    Assertions.assertThat(domainTx).isEqualTo(
       Transaction(
         nonce = 0UL,
         gasPrice = 0x1017df87UL,
@@ -415,25 +422,27 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     domainTx.toBesu().also { besuTx ->
-      assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST)
-      assertThat(besuTx.nonce).isEqualTo(0L)
-      assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
-      assertThat(besuTx.gasLimit).isEqualTo(0x5208L)
-      assertThat(besuTx.to.getOrNull()).isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
-      assertThat(besuTx.value).isEqualTo(Wei.of(0x2386f26fc10000L))
-      assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
-      assertThat(besuTx.signature.r).isEqualTo(
+      Assertions.assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST)
+      Assertions.assertThat(besuTx.nonce).isEqualTo(0L)
+      Assertions.assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
+      Assertions.assertThat(besuTx.gasLimit).isEqualTo(0x5208L)
+      Assertions.assertThat(
+        besuTx.to.getOrNull(),
+      ).isEqualTo(Address.fromHexString("0x8d97689c9818892b700e27f316cc3e41e17fbeb9"))
+      Assertions.assertThat(besuTx.value).isEqualTo(Wei.of(0x2386f26fc10000L))
+      Assertions.assertThat(besuTx.payload).isEqualTo(Bytes.EMPTY)
+      Assertions.assertThat(besuTx.signature.r).isEqualTo(
         "0xc57273f9ba15320937d5d9dfd1dc0b18d1e678b34bd3a4bfd29a63e11a856292".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.s).isEqualTo(
+      Assertions.assertThat(besuTx.signature.s).isEqualTo(
         "0x7aa875a64835ecc5f9ac1a9fe3ab38d2a62bb3643a2597ab585a5607641a0c57".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.recId).isEqualTo(1)
-      assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
-      assertThat(besuTx.maxFeePerGas).isEmpty()
-      assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.signature.recId).isEqualTo(1)
+      Assertions.assertThat(besuTx.chainId.getOrNull()).isEqualTo(0x539L)
+      Assertions.assertThat(besuTx.maxFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
       // it shall have an empty accessList
-      assertThat(besuTx.accessList.getOrNull()).isEmpty()
+      Assertions.assertThat(besuTx.accessList.getOrNull()).isEmpty()
     }
   }
 
@@ -471,7 +480,7 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     val txDomain = txWeb3j.toDomain()
-    assertThat(txDomain).isEqualTo(
+    Assertions.assertThat(txDomain).isEqualTo(
       Transaction(
         nonce = 0UL,
         // when type is EIP1559 gasPrice is null,
@@ -495,24 +504,26 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     txDomain.toBesu().also { txBesu ->
-      assertThat(txBesu.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.EIP1559)
-      assertThat(txBesu.nonce).isEqualTo(0L)
-      assertThat(txBesu.gasPrice.getOrNull()).isNull()
-      assertThat(txBesu.gasLimit).isEqualTo(0x5208L)
-      assertThat(txBesu.to.getOrNull()).isEqualTo(Address.fromHexString("0xe4392c8ecc46b304c83cdb5edaf742899b1bda93"))
-      assertThat(txBesu.value).isEqualTo(Wei.of(0x2386f26fc10000L))
-      assertThat(txBesu.payload).isEqualTo(Bytes.fromHexString(input))
-      assertThat(txBesu.signature.r).isEqualTo(
+      Assertions.assertThat(txBesu.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.EIP1559)
+      Assertions.assertThat(txBesu.nonce).isEqualTo(0L)
+      Assertions.assertThat(txBesu.gasPrice.getOrNull()).isNull()
+      Assertions.assertThat(txBesu.gasLimit).isEqualTo(0x5208L)
+      Assertions.assertThat(
+        txBesu.to.getOrNull(),
+      ).isEqualTo(Address.fromHexString("0xe4392c8ecc46b304c83cdb5edaf742899b1bda93"))
+      Assertions.assertThat(txBesu.value).isEqualTo(Wei.of(0x2386f26fc10000L))
+      Assertions.assertThat(txBesu.payload).isEqualTo(Bytes.fromHexString(input))
+      Assertions.assertThat(txBesu.signature.r).isEqualTo(
         "0xeb4f70991ea4f14d23efb32591da3621d551406fd32bdfdd78bb677dec13160a".toBigIntegerFromHex(),
       )
-      assertThat(txBesu.signature.s).isEqualTo(
+      Assertions.assertThat(txBesu.signature.s).isEqualTo(
         "0x783aaa89f73ef7535924da8fd5f12e15cae1a0811c4c4746d1c23abff1eacddf".toBigIntegerFromHex(),
       )
-      assertThat(txBesu.signature.recId).isEqualTo(1)
-      assertThat(txBesu.chainId.getOrNull()).isEqualTo(0x539L)
-      assertThat(txBesu.maxFeePerGas.getOrNull()).isEqualTo(Wei.of(0x1017dff7L))
-      assertThat(txBesu.maxPriorityFeePerGas.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
-      assertThat(txBesu.accessList.getOrNull()).isEmpty()
+      Assertions.assertThat(txBesu.signature.recId).isEqualTo(1)
+      Assertions.assertThat(txBesu.chainId.getOrNull()).isEqualTo(0x539L)
+      Assertions.assertThat(txBesu.maxFeePerGas.getOrNull()).isEqualTo(Wei.of(0x1017dff7L))
+      Assertions.assertThat(txBesu.maxPriorityFeePerGas.getOrNull()).isEqualTo(Wei.of(0x1017df87L))
+      Assertions.assertThat(txBesu.accessList.getOrNull()).isEmpty()
     }
   }
 
@@ -549,7 +560,7 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     val txDomain = txWeb3j.toDomain()
-    assertThat(txDomain).isEqualTo(
+    Assertions.assertThat(txDomain).isEqualTo(
       Transaction(
         nonce = 1UL,
         gasLimit = 0x83a3dUL,
@@ -571,24 +582,24 @@ class EthGetBlockToLineaBlockMapperTest {
     )
 
     txDomain.toBesu().let { txBesu ->
-      assertThat(txBesu.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.EIP1559)
-      assertThat(txBesu.nonce).isEqualTo(1L)
-      assertThat(txBesu.gasPrice.getOrNull()).isNull()
-      assertThat(txBesu.gasLimit).isEqualTo(0x83a3dL)
-      assertThat(txBesu.to.getOrNull()).isNull()
-      assertThat(txBesu.value).isEqualTo(Wei.ZERO)
-      assertThat(txBesu.payload).isEqualTo(Bytes.fromHexString(input))
-      assertThat(txBesu.signature.r).isEqualTo(
+      Assertions.assertThat(txBesu.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.EIP1559)
+      Assertions.assertThat(txBesu.nonce).isEqualTo(1L)
+      Assertions.assertThat(txBesu.gasPrice.getOrNull()).isNull()
+      Assertions.assertThat(txBesu.gasLimit).isEqualTo(0x83a3dL)
+      Assertions.assertThat(txBesu.to.getOrNull()).isNull()
+      Assertions.assertThat(txBesu.value).isEqualTo(Wei.ZERO)
+      Assertions.assertThat(txBesu.payload).isEqualTo(Bytes.fromHexString(input))
+      Assertions.assertThat(txBesu.signature.r).isEqualTo(
         "0xf7afccb560d0c52bea021ba522a27dbd6c3aba3512dd2d3b2f476ed8dd87d5f7".toBigIntegerFromHex(),
       )
-      assertThat(txBesu.signature.s).isEqualTo(
+      Assertions.assertThat(txBesu.signature.s).isEqualTo(
         "0x5f47f6ddcf1c216eb33eb69db553d682de34c78f5a5ab97905a428c2182f32e".toBigIntegerFromHex(),
       )
-      assertThat(txBesu.signature.recId).isEqualTo(1)
-      assertThat(txBesu.chainId.getOrNull()).isEqualTo(0x539L)
-      assertThat(txBesu.maxFeePerGas.getOrNull()).isEqualTo(Wei.of(0xeL))
-      assertThat(txBesu.maxPriorityFeePerGas.getOrNull()).isEqualTo(Wei.ZERO)
-      assertThat(txBesu.accessList.getOrNull()).isEmpty()
+      Assertions.assertThat(txBesu.signature.recId).isEqualTo(1)
+      Assertions.assertThat(txBesu.chainId.getOrNull()).isEqualTo(0x539L)
+      Assertions.assertThat(txBesu.maxFeePerGas.getOrNull()).isEqualTo(Wei.of(0xeL))
+      Assertions.assertThat(txBesu.maxPriorityFeePerGas.getOrNull()).isEqualTo(Wei.ZERO)
+      Assertions.assertThat(txBesu.accessList.getOrNull()).isEmpty()
     }
   }
 
@@ -618,12 +629,11 @@ class EthGetBlockToLineaBlockMapperTest {
       """.trimIndent(),
     )
     val domainTx = txWeb3j.toDomain()
-    assertThat(domainTx).isEqualTo(
+    Assertions.assertThat(domainTx).isEqualTo(
       Transaction(
         nonce = 0x1UL,
         gasPrice = 0x11e1a300UL,
         gasLimit = 0x1e8480UL,
-//        gasLimit = 0x2e8480UL,
         to = "0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67".decodeHex(),
         value = 0x0.toBigInteger(),
         input = input.decodeHex(),
@@ -640,23 +650,25 @@ class EthGetBlockToLineaBlockMapperTest {
       ),
     )
     domainTx.toBesu().also { besuTx ->
-      assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.FRONTIER)
-      assertThat(besuTx.nonce).isEqualTo(0x1L)
-      assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x11e1a300UL.toLong()))
-      assertThat(besuTx.gasLimit).isEqualTo(0x1e8480L)
-      assertThat(besuTx.to.getOrNull()).isEqualTo(Address.fromHexString("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67"))
-      assertThat(besuTx.value).isEqualTo(Wei.of(0x0))
-      assertThat(besuTx.payload).isEqualTo(Bytes.fromHexString(input))
-      assertThat(besuTx.signature.r).isEqualTo(
+      Assertions.assertThat(besuTx.type).isEqualTo(org.hyperledger.besu.datatypes.TransactionType.FRONTIER)
+      Assertions.assertThat(besuTx.nonce).isEqualTo(0x1L)
+      Assertions.assertThat(besuTx.gasPrice.getOrNull()).isEqualTo(Wei.of(0x11e1a300UL.toLong()))
+      Assertions.assertThat(besuTx.gasLimit).isEqualTo(0x1e8480L)
+      Assertions.assertThat(
+        besuTx.to.getOrNull(),
+      ).isEqualTo(Address.fromHexString("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67"))
+      Assertions.assertThat(besuTx.value).isEqualTo(Wei.of(0x0))
+      Assertions.assertThat(besuTx.payload).isEqualTo(Bytes.fromHexString(input))
+      Assertions.assertThat(besuTx.signature.r).isEqualTo(
         "0x98cf46978ebd95f2f61780c767b1ad392beaa11b68f0e310728f5be8296e752a".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.s).isEqualTo(
+      Assertions.assertThat(besuTx.signature.s).isEqualTo(
         "0x1c621c3046755e5600d73b83a0c28676b02a7dff6b89f76b02f5eddd7817854".toBigIntegerFromHex(),
       )
-      assertThat(besuTx.signature.recId).isEqualTo(0)
-      assertThat(besuTx.chainId.getOrNull()).isNull()
-      assertThat(besuTx.maxFeePerGas).isEmpty()
-      assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.signature.recId).isEqualTo(0)
+      Assertions.assertThat(besuTx.chainId.getOrNull()).isNull()
+      Assertions.assertThat(besuTx.maxFeePerGas).isEmpty()
+      Assertions.assertThat(besuTx.maxPriorityFeePerGas).isEmpty()
     }
   }
 }

--- a/transaction-decoder-tool/src/test/kotlin/linea/test/BlocksFetcher.kt
+++ b/transaction-decoder-tool/src/test/kotlin/linea/test/BlocksFetcher.kt
@@ -4,7 +4,7 @@ import io.vertx.core.Vertx
 import linea.domain.Block
 import linea.domain.BlockParameter.Companion.toBlockParameter
 import linea.web3j.domain.toWeb3j
-import linea.web3j.toDomain
+import linea.web3j.mappers.toDomain
 import net.consensys.linea.async.AsyncRetryer
 import net.consensys.linea.async.toSafeFuture
 import org.apache.logging.log4j.LogManager


### PR DESCRIPTION
This PR implements issue(s) #1577

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move Web3j block/transaction mapping into a new `linea.web3j.mappers` package and update clients/tests to use it.
> 
> - **Refactor mappers**:
>   - Move block mapping utilities to `linea.web3j.mappers` (`EthGetBlockToLineaBlockMappers.kt`), and extract transaction mapping into new `TransactionMapper.kt` (`org.web3j.protocol.core.methods.response.Transaction.toDomain`, `mapType`).
>   - Update usages to new package/imports in `GethCliqueSafeBlockProvider`, `ExtendedWeb3J`, `Web3jEthApiClient` (including `mapToDomainWithTxHashes`), and `transaction-decoder-tool/BlocksFetcher`.
> - **Tests**:
>   - Migrate test packages/imports to `linea.web3j.mappers` and switch assertions to `Assertions.assertThat(...)`/`Assertions.fail(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec79d95278c1c5db6eee210054ad5f37266e015e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->