### PR TITLE
chore(bridge-ui): revert minimumReleaseAge exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,5 @@
 # 3 days
 minimumReleaseAge: 4320
-minimumReleaseAgeExclude:
-  - '@web3auth/modal'
-  - '@web3auth/no-modal'
 
 packages:
   - 'contracts/**'


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the minimumReleaseAge exclusions for '@web3auth/modal' and '@web3auth/no-modal' in `pnpm-workspace.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f3f33f10ff628d38699c4f69c7d436ea0a2d066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->