### PR TITLE
Disabling p2p logs for mainnet in Maru's setup

### DIFF
--- a/docs/getting-started/linea-mainnet/maru/log4j.xml
+++ b/docs/getting-started/linea-mainnet/maru/log4j.xml
@@ -6,7 +6,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="maru.p2p" level="trace"/>
     <Root level="INFO" additivity="false">
       <appender-ref ref="console"/>
     </Root>


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `maru.p2p` trace logger from `docs/getting-started/linea-mainnet/maru/log4j.xml`, leaving only the root `INFO` logger.
> 
> - **Logging**:
>   - Remove `Logger name="maru.p2p" level="trace"` from `docs/getting-started/linea-mainnet/maru/log4j.xml`, reducing P2P logs in the mainnet setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95c5cfec699362c2051dc122b7fbc649b7aed8e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->