### PR TITLE
Adding Cancun and Prague upgrades

### DIFF
--- a/docs/getting-started/linea-mainnet/besu/besu-genesis.json
+++ b/docs/getting-started/linea-mainnet/besu/besu-genesis.json
@@ -13,6 +13,8 @@
     "londonBlock": 0,
     "terminalTotalDifficulty": 49575263,
     "shanghaiTime": 1761213600,
+    "cancunTime": 1761645600,
+    "pragueTime": 1761646200,
     "depositContractAddress": "0x94d4a7449B968b839dcbc64A61F195CA300986ae",
     "withdrawalRequestContractAddress": "0x66355689a9f067eeb9dc9d899E4192676988279C",
     "consolidationRequestContractAddress": "0xF0e003F0dE2d583Ae28FA8cBF66aa096CdAce3ff",
@@ -20,6 +22,23 @@
       "createemptyblocks": true,
       "blockperiodseconds": 1,
       "epochlength": 30000
+    },
+    "blobSchedule": {
+      "cancun": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "osaka": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
+      }
     }
   },
   "nonce": "0x0",

--- a/docs/getting-started/linea-mainnet/geth/geth-genesis.json
+++ b/docs/getting-started/linea-mainnet/geth/geth-genesis.json
@@ -13,6 +13,8 @@
     "londonBlock": 0,
     "terminalTotalDifficulty": 49575263,
     "shanghaiTime": 1761213600,
+    "cancunTime": 1761645600,
+    "pragueTime": 1761646200,
     "depositContractAddress": "0x94d4a7449B968b839dcbc64A61F195CA300986ae",
     "withdrawalRequestContractAddress": "0x66355689a9f067eeb9dc9d899E4192676988279C",
     "consolidationRequestContractAddress": "0xF0e003F0dE2d583Ae28FA8cBF66aa096CdAce3ff",
@@ -20,6 +22,23 @@
       "createemptyblocks": true,
       "period": 1,
       "epoch": 30000
+    },
+    "blobSchedule": {
+      "cancun": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "osaka": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
+      }
     }
   },
   "nonce": "0x0",

--- a/linea-besu-package/linea-besu/genesis/genesis.mainnet.json
+++ b/linea-besu-package/linea-besu/genesis/genesis.mainnet.json
@@ -13,6 +13,8 @@
     "londonBlock": 0,
     "terminalTotalDifficulty": 49575263,
     "shanghaiTime": 1761213600,
+    "cancunTime": 1761645600,
+    "pragueTime": 1761646200,
     "depositContractAddress": "0x94d4a7449B968b839dcbc64A61F195CA300986ae",
     "withdrawalRequestContractAddress": "0x66355689a9f067eeb9dc9d899E4192676988279C",
     "consolidationRequestContractAddress": "0xF0e003F0dE2d583Ae28FA8cBF66aa096CdAce3ff",
@@ -20,6 +22,23 @@
       "createemptyblocks": true,
       "blockperiodseconds": 1,
       "epochlength": 30000
+    },
+    "blobSchedule": {
+      "cancun": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
+      },
+      "osaka": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
+      }
     }
   },
   "nonce": "0x0",

--- a/linea-besu-package/linea-besu/genesis/genesis.sepolia.json
+++ b/linea-besu-package/linea-besu/genesis/genesis.sepolia.json
@@ -32,7 +32,12 @@
       "prague": {
         "target": 0,
         "max": 0,
-        "baseFeeUpdateFraction": 3338477
+        "baseFeeUpdateFraction": 5007716
+      },
+      "osaka": {
+        "target": 0,
+        "max": 0,
+        "baseFeeUpdateFraction": 5007716
       }
     }
   },


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Cancun/Prague fork times and a blobSchedule (incl. Osaka) to Linea mainnet genesis for Besu/Geth and updates Sepolia blob fee params.
> 
> - **Genesis configs (Linea mainnet)**:
>   - `docs/getting-started/linea-mainnet/besu/besu-genesis.json`, `docs/getting-started/linea-mainnet/geth/geth-genesis.json`, `linea-besu-package/linea-besu/genesis/genesis.mainnet.json`:
>     - Add `cancunTime` and `pragueTime`.
>     - Add `blobSchedule` with entries for `cancun` (baseFeeUpdateFraction `3338477`), `prague` and `osaka` (both `5007716`), all with `target: 0`, `max: 0`.
> - **Genesis config (Linea Sepolia)**:
>   - `linea-besu-package/linea-besu/genesis/genesis.sepolia.json`:
>     - Update `blobSchedule.prague.baseFeeUpdateFraction` to `5007716` and add `blobSchedule.osaka` with `target: 0`, `max: 0`, `baseFeeUpdateFraction: 5007716`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73e24b50ff7991588810a9e13c7d02aa589ce2ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->