### PR TITLE
Removing LineaL1FinalizationTagUpdaterPlugin settings

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -63,9 +63,6 @@ services:
     command:
       - --config-file=/var/lib/besu/sequencer.config.toml
       - --node-private-key-file=/var/lib/besu/key
-      - --plugin-linea-l1-polling-interval=PT12S
-      - --plugin-linea-l1-smart-contract-address=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-      - --plugin-linea-l1-rpc-endpoint=http://l1-el-node:8545
       - --plugin-linea-rejected-tx-endpoint=http://transaction-exclusion-api:8080
       - --plugin-linea-node-type=SEQUENCER
     volumes:
@@ -140,9 +137,6 @@ services:
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json
-      - --plugin-linea-l1-polling-interval=PT12S
-      - --plugin-linea-l1-smart-contract-address=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-      - --plugin-linea-l1-rpc-endpoint=http://l1-el-node:8545
       - --plugin-linea-rejected-tx-endpoint=http://transaction-exclusion-api:8080
       - --plugin-linea-node-type=RPC
       - --bootnodes=enode://14408801a444dafc44afbccce2eb755f902aed3b5743fed787b3c790e021fef28b8c827ed896aa4e8fb46e22bd67c39f994a73768b4b382f8597b0d44370e15d@11.11.11.101:30303
@@ -184,9 +178,6 @@ services:
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json
-      - --plugin-linea-l1-polling-interval=PT12S
-      - --plugin-linea-l1-smart-contract-address=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-      - --plugin-linea-l1-rpc-endpoint=http://l1-el-node:8545
       - --plugin-linea-rejected-tx-endpoint=http://transaction-exclusion-api:8080
       - --plugin-linea-node-type=RPC
       - --bootnodes=enode://14408801a444dafc44afbccce2eb755f902aed3b5743fed787b3c790e021fef28b8c827ed896aa4e8fb46e22bd67c39f994a73768b4b382f8597b0d44370e15d@11.11.11.101:30303

--- a/docker/compose-tracing-v2-fleet-ci-extension.yml
+++ b/docker/compose-tracing-v2-fleet-ci-extension.yml
@@ -6,7 +6,7 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: web3signer
-  
+
   shomei-frontend:
     extends:
       file: compose-spec-l2-services.yml
@@ -30,14 +30,11 @@ services:
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json
-      - --plugin-linea-l1-polling-interval=PT12S
-      - --plugin-linea-l1-smart-contract-address=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-      - --plugin-linea-l1-rpc-endpoint=http://l1-el-node:8545
       - --plugin-linea-rejected-tx-endpoint=http://transaction-exclusion-api:8080
       - --plugin-linea-node-type=RPC
       - --bootnodes=enode://14408801a444dafc44afbccce2eb755f902aed3b5743fed787b3c790e021fef28b8c827ed896aa4e8fb46e22bd67c39f994a73768b4b382f8597b0d44370e15d@11.11.11.101:30303
       - --rpc-http-api=ADMIN,DEBUG,NET,ETH,WEB3,PLUGINS,LINEA,FLEET
-      - --plugins=LineaEstimateGasEndpointPlugin,LineaL1FinalizationTagUpdaterPlugin,LineaExtraDataPlugin,LineaTransactionPoolValidatorPlugin,LineaBundleEndpointsPlugin,ForwardBundlesPlugin,FleetPlugin
+      - --plugins=LineaEstimateGasEndpointPlugin,LineaExtraDataPlugin,LineaTransactionPoolValidatorPlugin,LineaBundleEndpointsPlugin,ForwardBundlesPlugin,FleetPlugin
       - --plugin-fleet-node-role=LEADER
 
   l2-node-besu-follower:
@@ -48,14 +45,11 @@ services:
     command:
       - --config-file=/var/lib/besu/l2-node-besu.config.toml
       - --genesis-file=/initialization/genesis-besu.json
-      - --plugin-linea-l1-polling-interval=PT12S
-      - --plugin-linea-l1-smart-contract-address=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-      - --plugin-linea-l1-rpc-endpoint=http://l1-el-node:8545
       - --plugin-linea-rejected-tx-endpoint=http://transaction-exclusion-api:8080
       - --plugin-linea-node-type=RPC
       - --bootnodes=enode://14408801a444dafc44afbccce2eb755f902aed3b5743fed787b3c790e021fef28b8c827ed896aa4e8fb46e22bd67c39f994a73768b4b382f8597b0d44370e15d@11.11.11.101:30303
       - --rpc-http-api=ADMIN,DEBUG,NET,ETH,WEB3,PLUGINS,LINEA,FLEET
-      - --plugins=LineaEstimateGasEndpointPlugin,LineaL1FinalizationTagUpdaterPlugin,LineaExtraDataPlugin,LineaTransactionPoolValidatorPlugin,LineaBundleEndpointsPlugin,ForwardBundlesPlugin,FleetPlugin
+      - --plugins=LineaEstimateGasEndpointPlugin,LineaExtraDataPlugin,LineaTransactionPoolValidatorPlugin,LineaBundleEndpointsPlugin,ForwardBundlesPlugin,FleetPlugin
       - --plugin-fleet-node-role=FOLLOWER
       - --plugin-fleet-leader-http-host=l2-node-besu
       - --plugin-fleet-leader-http-port=8545

--- a/docker/config/l2-node-besu/l2-node-besu-config.toml
+++ b/docker/config/l2-node-besu/l2-node-besu-config.toml
@@ -37,7 +37,7 @@ metrics-port=9545
 data-storage-format="BONSAI"
 
 # plugins
-plugins=["LineaEstimateGasEndpointPlugin","LineaL1FinalizationTagUpdaterPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","ForwardBundlesPlugin"]
+plugins=["LineaEstimateGasEndpointPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","ForwardBundlesPlugin"]
 plugin-linea-module-limit-file-path="/var/lib/besu/traces-limits.toml"
 plugin-linea-deny-list-path="/var/lib/besu/deny-list.txt"
 plugin-linea-l1l2-bridge-contract="0xe537D669CA013d86EBeF1D64e40fC74CADC91987"

--- a/docker/config/linea-besu-sequencer/sequencer.config.toml
+++ b/docker/config/linea-besu-sequencer/sequencer.config.toml
@@ -49,7 +49,7 @@ cache-last-block-headers-preload-enabled=true
 cache-last-block-headers=50
 
 # plugins
-plugins=["LineaEstimateGasEndpointPlugin","LineaL1FinalizationTagUpdaterPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","LineaSetExtraDataEndpointPlugin","LineaTransactionSelectorPlugin"]
+plugins=["LineaEstimateGasEndpointPlugin","LineaExtraDataPlugin","LineaTransactionPoolValidatorPlugin","LineaBundleEndpointsPlugin","LineaSetExtraDataEndpointPlugin","LineaTransactionSelectorPlugin"]
 plugin-linea-module-limit-file-path="/var/lib/besu/traces-limits.toml"
 plugin-linea-deny-list-path="/var/lib/besu/deny-list.txt"
 plugin-linea-estimate-gas-compatibility-mode-enabled=false
@@ -72,7 +72,7 @@ plugin-linea-estimate-gas-min-margin="1.2"
 plugin-linea-limitless-enabled=false
 strict-tx-replay-protection-enabled=false
 
-# should uncomment only when the linea-sequencer plugin supports liveness 
+# should uncomment only when the linea-sequencer plugin supports liveness
 plugin-linea-liveness-enabled=true
 plugin-linea-liveness-max-block-age-seconds=8
 plugin-linea-liveness-bundle-max-timestamp-surplus-seconds=12

--- a/linea-besu-package/README.md
+++ b/linea-besu-package/README.md
@@ -1,7 +1,7 @@
 # Linea Besu Distribution
 
-This project uses Gradle to manage dependencies, build tasks, and create distributions for linea-besu with 
-all the necessary plugins to run a node for operators. The build process will also create a Docker image that can be 
+This project uses Gradle to manage dependencies, build tasks, and create distributions for linea-besu with
+all the necessary plugins to run a node for operators. The build process will also create a Docker image that can be
 used to run a node with a specific profile.
 
 ## Run with Docker
@@ -15,15 +15,6 @@ In the docker-compose.yaml file, update the --p2p-host command to include your p
 ```sh
 --p2p-host=103.10.10.10
 ```
-
-Update plugin-linea-l1-rpc-endpoint config with your L1 RPC endpoint.
-You should replace YOUR_L1_RPC_ENDPOINT with your endpoint, like:
-```sh
---plugin-linea-l1-rpc-endpoint=https://mainnet.infura.io/v3/PROJECT_ID
-```
-
-This is required to enable RPC queries using "FINALIZED" block tag.
-Linea Finalization status is based on L1 RPC endpoint's response
 
 ### Step 2. Start the Besu node
 ```sh
@@ -41,7 +32,7 @@ docker run -e BESU_PROFILE=basic-mainnet consensys/linea-besu-package:2.1.0-2025
 ## Run with a binary distribution
 
 ### Step 1. Install Linea Besu from packaged binaries
-*  Download the [linea-besu-package-&lt;release&gt;.tar.gz](https://github.com/Consensys/linea-monorepo/releases?q=linea-besu-package&expanded=true) 
+*  Download the [linea-besu-package-&lt;release&gt;.tar.gz](https://github.com/Consensys/linea-monorepo/releases?q=linea-besu-package&expanded=true)
 from the assets.
 * Unpack the downloaded files and change directory into the `linea-besu/besu`
 directory.
@@ -53,12 +44,8 @@ bin/besu --help
 
 ### Step 2. Start the Besu client
 
-Note the YOUR_L1_RPC_ENDPOINT. You should replace this with your L1 RPC endpoint. 
-
-This is required to enable RPC queries using "FINALIZED" tag. 
-Linea Finalization status is based on L1 RPC endpoint's response
 ```sh
-bin/besu --profile=advanced-mainnet --plugin-linea-l1-rpc-endpoint=YOUR_L1_RPC_ENDPOINT
+bin/besu --profile=advanced-mainnet
 ```
 
 ## Build from source locally
@@ -69,9 +56,9 @@ bin/besu --profile=advanced-mainnet --plugin-linea-l1-rpc-endpoint=YOUR_L1_RPC_E
 
 3. Run `make clean && make build` (check the Makefile for build options)
 
-4. The docker image (i.e. default as `consensys/linea-besu-package:local`) should be created locally 
+4. The docker image (i.e. default as `consensys/linea-besu-package:local`) should be created locally
 
-### Note: 
+### Note:
 
 To build with specific platform (e.g. linux/amd64) and image tag (e.g. xxx), do the following:
 ```
@@ -119,7 +106,7 @@ plugin-linea-module-limit-file-path="config/trace-limits.mainnet.toml"
 
 Currently, the following profiles are available:
 
-| Profile Name                                                                                                              | Description                                                               | Network | 
+| Profile Name                                                                                                              | Description                                                               | Network |
 |---------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|---------|
 | [`basic-mainnet`](https://github.com/Consensys/linea-monorepo/blob/main/linea-besu-package/linea-besu/profiles/basic-mainnet.toml)       | Creates a basic Linea Node.                                               | Mainnet |
 | [`advanced-mainnet`](https://github.com/Consensys/linea-monorepo/blob/main/linea-besu-package/linea-besu/profiles/advanced-mainnet.toml) | Creates a Linea Node with `linea_estimateGas` and `finalized tag updater plugin`. | Mainnet |


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes LineaL1FinalizationTagUpdaterPlugin and all related L1 RPC flags from compose files/configs and cleans up README accordingly.
> 
> - **Docker Compose**:
>   - Remove `--plugin-linea-l1-polling-interval`, `--plugin-linea-l1-smart-contract-address`, and `--plugin-linea-l1-rpc-endpoint` from `sequencer`, `l2-node-besu`, and follower commands in `docker/compose-spec-l2-services.yml` and CI fleet extension.
>   - Update `--plugins` lists in fleet CI (`l2-node-besu` leader/follower) to exclude `LineaL1FinalizationTagUpdaterPlugin`.
> - **Configs**:
>   - Drop `LineaL1FinalizationTagUpdaterPlugin` from `plugins` arrays in `docker/config/l2-node-besu/l2-node-besu-config.toml` and `docker/config/linea-besu-sequencer/sequencer.config.toml`.
> - **Docs**:
>   - `linea-besu-package/README.md`: remove guidance and CLI example for `plugin-linea-l1-rpc-endpoint`; simplify startup instructions; minor formatting tidy-ups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de9d2a51128f1858a3c4064abac0b5de3e0ea35f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->