### PR TITLE
chores(limitless): flat copy the content of f5a9367 into protocol/dis…

### DIFF
--- a/prover/protocol/distributed/conglomeration.go
+++ b/prover/protocol/distributed/conglomeration.go
@@ -1,993 +1,837 @@
 package distributed
 
-import (
-	"errors"
-	"fmt"
-	"slices"
-	"strings"
+// import (
+// 	"errors"
+// 	"fmt"
+// 	"slices"
+// 	"strings"
 
-	"github.com/consensys/gnark/frontend"
-	"github.com/consensys/linea-monorepo/prover/backend/files"
-	cmimc "github.com/consensys/linea-monorepo/prover/crypto/mimc"
-	"github.com/consensys/linea-monorepo/prover/crypto/ringsis"
-	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
-	"github.com/consensys/linea-monorepo/prover/maths/field"
-	"github.com/consensys/linea-monorepo/prover/protocol/accessors"
-	"github.com/consensys/linea-monorepo/prover/protocol/column/verifiercol"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/cleanup"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/logdata"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/mimc"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/plonkinwizard"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/recursion"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/selfrecursion"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/vortex"
-	"github.com/consensys/linea-monorepo/prover/protocol/ifaces"
-	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
-	"github.com/consensys/linea-monorepo/prover/symbolic"
-	"github.com/consensys/linea-monorepo/prover/utils"
-	"github.com/consensys/linea-monorepo/prover/utils/profiling"
-	"github.com/sirupsen/logrus"
-)
+// 	"github.com/consensys/gnark/frontend"
+// 	"github.com/consensys/linea-monorepo/prover/backend/files"
+// 	cmimc "github.com/consensys/linea-monorepo/prover/crypto/mimc"
+// 	"github.com/consensys/linea-monorepo/prover/crypto/ringsis"
+// 	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+// 	"github.com/consensys/linea-monorepo/prover/maths/field"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/accessors"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/column/verifiercol"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/cleanup"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/logdata"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/mimc"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/plonkinwizard"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/recursion"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/selfrecursion"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/vortex"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/ifaces"
+// 	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
+// 	"github.com/consensys/linea-monorepo/prover/symbolic"
+// 	"github.com/consensys/linea-monorepo/prover/utils"
+// 	"github.com/consensys/linea-monorepo/prover/utils/profiling"
+// 	"github.com/sirupsen/logrus"
+// )
 
-// The prerecursion prefix is a prefix to apply to the name of the public
-// inputs to be able to access them in the conglomerated wizard-IOP.
-const preRecursionPrefix = "wizard-recursion-0."
+// // The prerecursion prefix is a prefix to apply to the name of the public
+// // inputs to be able to access them in the conglomerated wizard-IOP.
+// const preRecursionPrefix = "wizard-recursion-0."
 
-// ConglomeratorCompilation hold the compilation context of the conglomeration
-// proof. It stores pointers to the type of proof it can conglomerate and
-// pointers of the resulting compiled IOP object.
-type ConglomeratorCompilation struct {
-	// MaxNbProofs is the maximum number of proofs that can be conglomerated
-	// by the conglomeration proof at once.
-	MaxNbProofs int
+// // ConglomeratorCompilation hold the compilation context of the conglomeration
+// // proof. It stores pointers to the type of proof it can conglomerate and
+// // pointers of the resulting compiled IOP object.
+// type ConglomeratorCompilation struct {
+// 	// MaxNbProofs is the maximum number of proofs that can be conglomerated
+// 	// by the conglomeration proof at once.
+// 	MaxNbProofs int
 
-	// ModuleProofs lists the wizard whose proof are supported by the current
-	// instance of the conglomerator.
-	ModuleGLIops  []*wizard.CompiledIOP `serde:"omit"`
-	ModuleLPPIops []*wizard.CompiledIOP `serde:"omit"`
+// 	// ModuleProofs lists the wizard whose proof are supported by the current
+// 	// instance of the conglomerator.
+// 	ModuleGLIops  []*wizard.CompiledIOP `serde:"omit"`
+// 	ModuleLPPIops []*wizard.CompiledIOP `serde:"omit"`
 
-	// DefaultIops is the wizard IOP used for filling
-	DefaultIops *RecursedSegmentCompilation
+// 	// DefaultIops is the wizard IOP used for filling
+// 	DefaultIops *RecursedSegmentCompilation
 
-	// DefaultWitness is the assignment of the default IOP.
-	DefaultWitness recursion.Witness
+// 	// DefaultWitness is the assignment of the default IOP.
+// 	DefaultWitness recursion.Witness
 
-	// Wiop is the compiled IOP of the conglomeration wizard.
-	Wiop *wizard.CompiledIOP
-	// Recursion is the recursion context used to compile the conglomeration
-	// proof.
-	Recursion *recursion.Recursion
+// 	// Wiop is the compiled IOP of the conglomeration wizard.
+// 	Wiop *wizard.CompiledIOP
+// 	// Recursion is the recursion context used to compile the conglomeration
+// 	// proof.
+// 	Recursion *recursion.Recursion
 
-	// HolisticLookupMappedLPPVK is a pair of column corresponding such that
-	// row "i" is equal to the LPP vk of the GL module of the i-th proof.
-	HolisticLookupMappedLPPVK [2]ifaces.Column
+// 	// HolisticLookupMappedLPPVK is a pair of column corresponding such that
+// 	// row "i" is equal to the LPP vk of the GL module of the i-th proof.
+// 	HolisticLookupMappedLPPVK [2]ifaces.Column
 
-	// HolisticLookupMappedLPPPostion is complementary to [HolisticLookupMappedLPPVK]
-	// and indicates for the corresponding GL verifying key, which column of the
-	// corresponding LPP module to look for when doing the LPP commitment consistency
-	// check. The column takes values in [0, lppGroupingArity) and is constrained by
-	// the same lookup as [HolisticLookupMappedLPPVK].
-	HolisticLookupMappedLPPPostion ifaces.Column
+// 	// HolisticLookupMappedLPPPostion is complementary to [HolisticLookupMappedLPPVK]
+// 	// and indicates for the corresponding GL verifying key, which column of the
+// 	// corresponding LPP module to look for when doing the LPP commitment consistency
+// 	// check. The column takes values in [0, lppGroupingArity) and is constrained by
+// 	// the same lookup as [HolisticLookupMappedLPPVK].
+// 	HolisticLookupMappedLPPPostion ifaces.Column
 
-	// PrecomputedLPPVks is a pair of precomputed column listing the whitelisted
-	// LPP columns.
-	PrecomputedLPPVks [2]ifaces.Column
+// 	// PrecomputedLPPVks is a pair of precomputed column listing the whitelisted
+// 	// LPP columns.
+// 	PrecomputedLPPVks [2]ifaces.Column
 
-	// PrecomputedGLVks is a pair of precomputed column listing the whitelisted
-	// GL columns. Each entry i corresponds to the GK vks that can be mapped to
-	// the i-th LPP module of the same row of [PrecomputedLPPVks].
-	PrecomputedGLVks [lppGroupingArity][2]ifaces.Column
+// 	// PrecomputedGLVks is a pair of precomputed column listing the whitelisted
+// 	// GL columns. Each entry i corresponds to the GK vks that can be mapped to
+// 	// the i-th LPP module of the same row of [PrecomputedLPPVks].
+// 	PrecomputedGLVks [lppGroupingArity][2]ifaces.Column
 
-	// IsGL is a column constructing by agglomerating accessors the IsGL public
-	// input of every segment.
-	IsGL ifaces.Column
+// 	// IsGL is a column constructing by agglomerating accessors the IsGL public
+// 	// input of every segment.
+// 	IsGL ifaces.Column
 
-	// VerifyingKeyColumns is a pair of column constructing by agglomerating the
-	// public inputs corresponding to the verifying key for every segment.
-	VerifyingKeyColumns [2]ifaces.Column
-}
+// 	// VerifyingKeyColumns is a pair of column constructing by agglomerating the
+// 	// public inputs corresponding to the verifying key for every segment.
+// 	VerifyingKeyColumns [2]ifaces.Column
+// }
 
-// ConglomerationHolisticCheck is a [wizard.VerifierAction] checking that all
-// the public inputs of the subproofs are the right ones.
-type ConglomerateHolisticCheck struct {
-	ConglomeratorCompilation
-}
+// // ConglomerationHolisticCheck is a [wizard.VerifierAction] checking that all
+// // the public inputs of the subproofs are the right ones.
+// type ConglomerateHolisticCheck struct {
+// 	ConglomeratorCompilation
+// }
 
-// ConglomerationAssignHolisticCheckColumn is a [wizard.ProverAction] responsible
-// for assigning the [HolisticLookupMappedLPPVK] columns.
-type ConglomerationAssignHolisticCheckColumn struct {
-	ConglomeratorCompilation
-}
+// // ConglomerationAssignHolisticCheckColumn is a [wizard.ProverAction] responsible
+// // for assigning the [HolisticLookupMappedLPPVK] columns.
+// type ConglomerationAssignHolisticCheckColumn struct {
+// 	ConglomeratorCompilation
+// }
 
-// conglomerate constructs and returns a new ConglomeratorCompilation object.
-// The Wiop of the returned object is compiled with iterative layers of
-// self-recursion.
-func conglomerate(maxNbProofs int, moduleGLs, moduleLpps []*RecursedSegmentCompilation, moduleDefault *RecursedSegmentCompilation) *ConglomeratorCompilation {
+// // conglomerate constructs and returns a new ConglomeratorCompilation object.
+// // The Wiop of the returned object is compiled with iterative layers of
+// // self-recursion.
+// func conglomerate(maxNbProofs int, moduleGLs, moduleLpps []*RecursedSegmentCompilation, moduleDefault *RecursedSegmentCompilation) *ConglomeratorCompilation {
 
-	cong := &ConglomeratorCompilation{
-		MaxNbProofs: maxNbProofs,
-		DefaultIops: moduleDefault,
-	}
+// 	cong := &ConglomeratorCompilation{
+// 		MaxNbProofs: maxNbProofs,
+// 		DefaultIops: moduleDefault,
+// 	}
 
-	for i := range moduleGLs {
-		cong.ModuleGLIops = append(cong.ModuleGLIops, moduleGLs[i].RecursionComp)
-	}
+// 	for i := range moduleGLs {
+// 		cong.ModuleGLIops = append(cong.ModuleGLIops, moduleGLs[i].RecursionComp)
+// 	}
 
-	for i := range moduleLpps {
-		cong.ModuleLPPIops = append(cong.ModuleLPPIops, moduleLpps[i].RecursionComp)
-	}
+// 	for i := range moduleLpps {
+// 		cong.ModuleLPPIops = append(cong.ModuleLPPIops, moduleLpps[i].RecursionComp)
+// 	}
 
-	sisInstance := ringsis.Params{LogTwoBound: 16, LogTwoDegree: 6}
+// 	sisInstance := ringsis.Params{LogTwoBound: 16, LogTwoDegree: 6}
 
-	cong.Wiop = wizard.Compile(
-		func(build *wizard.Builder) {
-			cong.Compile(build.CompiledIOP)
-		},
-		mimc.CompileMiMC,
-		plonkinwizard.Compile,
-		compiler.Arcane(
-			compiler.WithTargetColSize(1<<17),
-		),
-		logdata.Log("before first vortex"),
-		vortex.Compile(
-			2,
-			vortex.ForceNumOpenedColumns(256),
-			vortex.WithSISParams(&sisInstance),
-			vortex.WithOptionalSISHashingThreshold(64),
-		),
-		selfrecursion.SelfRecurse,
-		cleanup.CleanUp,
-		mimc.CompileMiMC,
-		compiler.Arcane(
-			compiler.WithTargetColSize(1<<15),
-		),
-		vortex.Compile(
-			8,
-			vortex.ForceNumOpenedColumns(32),
-			vortex.WithSISParams(&sisInstance),
-			vortex.WithOptionalSISHashingThreshold(64),
-		),
-		selfrecursion.SelfRecurse,
-		cleanup.CleanUp,
-		mimc.CompileMiMC,
-		compiler.Arcane(
-			compiler.WithTargetColSize(1<<13),
-		),
-		vortex.Compile(
-			8,
-			vortex.ForceNumOpenedColumns(32),
-			vortex.WithOptionalSISHashingThreshold(1<<20),
-		),
-	)
+// 	cong.Wiop = wizard.Compile(
+// 		func(build *wizard.Builder) {
+// 			cong.Compile(build.CompiledIOP)
+// 		},
+// 		mimc.CompileMiMC,
+// 		plonkinwizard.Compile,
+// 		compiler.Arcane(
+// 			compiler.WithTargetColSize(1<<17),
+// 		),
+// 		logdata.Log("before first vortex"),
+// 		vortex.Compile(
+// 			2,
+// 			vortex.ForceNumOpenedColumns(256),
+// 			vortex.WithSISParams(&sisInstance),
+// 			vortex.WithOptionalSISHashingThreshold(64),
+// 		),
+// 		selfrecursion.SelfRecurse,
+// 		cleanup.CleanUp,
+// 		mimc.CompileMiMC,
+// 		compiler.Arcane(
+// 			compiler.WithTargetColSize(1<<15),
+// 		),
+// 		vortex.Compile(
+// 			8,
+// 			vortex.ForceNumOpenedColumns(32),
+// 			vortex.WithSISParams(&sisInstance),
+// 			vortex.WithOptionalSISHashingThreshold(64),
+// 		),
+// 		selfrecursion.SelfRecurse,
+// 		cleanup.CleanUp,
+// 		mimc.CompileMiMC,
+// 		compiler.Arcane(
+// 			compiler.WithTargetColSize(1<<13),
+// 		),
+// 		vortex.Compile(
+// 			8,
+// 			vortex.ForceNumOpenedColumns(32),
+// 			vortex.WithOptionalSISHashingThreshold(1<<20),
+// 		),
+// 	)
 
-	return cong
-}
+// 	return cong
+// }
 
 // Compile compiles the conglomeration proof. The function first checks if the public
 // inputs are compatible and then compiles the conglomeration proof.
-func (c *ConglomeratorCompilation) Compile(comp *wizard.CompiledIOP) {
-
-	var (
-		wiops = slices.Concat(c.ModuleGLIops, c.ModuleLPPIops, []*wizard.CompiledIOP{c.DefaultIops.RecursionComp})
-		w0    = wiops[0]
-	)
-
-	for i := 1; i < len(wiops); i++ {
-		diff1, diff2 := cmpWizardIOP(w0, wiops[i])
-		if len(diff1) > 0 || len(diff2) > 0 {
-
-			for i, modIOP := range wiops {
-				dumpWizardIOP(modIOP, fmt.Sprintf("conglomeration-debug/iop-%d.csv", i))
-			}
-
-			utils.Panic("incompatible IOPs i=%v\n\t+++=%v\n\t---=%v", i, diff1, diff2)
-		}
-	}
-
-	defaultRun := c.DefaultIops.ProveSegment(nil)
-	c.DefaultWitness = recursion.ExtractWitness(defaultRun)
-
-	c.Recursion = recursion.DefineRecursionOf(comp, w0, recursion.Parameters{
-		Name:                   "conglomeration",
-		WithoutGkr:             true,
-		MaxNumProof:            c.MaxNbProofs,
-		WithExternalHasherOpts: true,
-	})
-
-	c.Wiop = comp
-	c.PrecomputedLPPVks, c.PrecomputedGLVks = c.precomputeToTheWhiteListVKeys()
-	c.declareLookups()
-
-	comp.RegisterVerifierAction(0, &ConglomerateHolisticCheck{ConglomeratorCompilation: *c})
-	comp.RegisterProverAction(0, &ConglomerationAssignHolisticCheckColumn{ConglomeratorCompilation: *c})
-}
-
-// Run implements the [wizard.VerifierAction] interface.
-func (c *ConglomerateHolisticCheck) Run(run wizard.Runtime) error {
-
-	var (
-		allGrandProduct           = field.NewElement(1)
-		allLogDerivativeSum       = field.Element{}
-		allHornerSum              = field.Element{}
-		prevGlobalSent            = field.Element{}
-		prevHornerN1Hash          = field.Element{}
-		usedSharedRandomness      = field.Element{}
-		usedSharedRandomnessFound bool
-		collectedLPPCommitments   = make([]field.Element, 0)
-		mainErr                   error
-	)
-
-	type proofPublicInput struct {
-		LPPCommitment    field.Element
-		SharedRandomness field.Element
-		VerifyingKey     field.Element
-		VerifyingKey2    field.Element
-		LogDerivativeSum field.Element
-		GrandProduct     field.Element
-		HornerSum        field.Element
-		HornerN0Hash     field.Element
-		HornerN1Hash     field.Element
-		GlobalReceived   field.Element
-		GlobalSent       field.Element
-		IsFirst          bool
-		IsLast           bool
-		IsLPP            bool
-		IsGL             bool
-		SameVkAsPrev     bool
-		SameVkAsNext     bool
-	}
-
-	allPis := []proofPublicInput{}
-
-	for i := 0; i < c.MaxNbProofs; i++ {
-
-		pi := proofPublicInput{
-			LPPCommitment:    c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, 0), i),
-			SharedRandomness: c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+InitialRandomnessPublicInput, i),
-			VerifyingKey:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+verifyingKeyPublicInput, i),
-			VerifyingKey2:    c.Recursion.GetPublicInputOfInstance(run, verifyingKey2PublicInput, i),
-			LogDerivativeSum: c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+LogDerivativeSumPublicInput, i),
-			GrandProduct:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+GrandProductPublicInput, i),
-			HornerSum:        c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+HornerPublicInput, i),
-			HornerN0Hash:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+HornerN0HashPublicInput, i),
-			HornerN1Hash:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+HornerN1HashPublicInput, i),
-			GlobalReceived:   c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+GlobalReceiverPublicInput, i),
-			GlobalSent:       c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+GlobalSenderPublicInput, i),
-			IsFirst:          c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsFirstPublicInput, i) == field.One(),
-			IsLast:           c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsLastPublicInput, i) == field.One(),
-			IsLPP:            c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsLppPublicInput, i) == field.One(),
-			IsGL:             c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsGlPublicInput, i) == field.One(),
-		}
-
-		allPis = append(allPis, pi)
-
-		var (
-			sameVerifyingKeyAsPrev, sameVerifyingKeyAsNext bool
-		)
-
-		if i > 0 {
-			prevVerifyingKey := c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+verifyingKeyPublicInput, i-1)
-			prevVerifyingKey2 := c.Recursion.GetPublicInputOfInstance(run, verifyingKey2PublicInput, i-1)
-			sameVerifyingKeyAsPrev = pi.VerifyingKey == prevVerifyingKey && pi.VerifyingKey2 == prevVerifyingKey2
-		}
-
-		if i < c.MaxNbProofs-1 {
-			nextVerifyingKey := c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+verifyingKeyPublicInput, i+1)
-			nextVerifyingKey2 := c.Recursion.GetPublicInputOfInstance(run, verifyingKey2PublicInput, i+1)
-			sameVerifyingKeyAsNext = pi.VerifyingKey == nextVerifyingKey && pi.VerifyingKey2 == nextVerifyingKey2
-		}
-
-		if pi.IsLPP && sameVerifyingKeyAsPrev && pi.HornerN0Hash != prevHornerN1Hash {
-			mainErr = errors.Join(mainErr, errors.New("horner-n0-hash mismatch"))
-		}
-
-		if pi.IsGL && !sameVerifyingKeyAsPrev != pi.IsFirst {
-			mainErr = errors.Join(mainErr, errors.New("isFirst is inconsistent with the verifying keys"))
-		}
-
-		if pi.IsGL && !sameVerifyingKeyAsNext != pi.IsLast {
-			mainErr = errors.Join(mainErr, errors.New("isLast is inconsistent with the verifying keys"))
-		}
-
-		if pi.IsGL && sameVerifyingKeyAsPrev && pi.GlobalReceived != prevGlobalSent {
-			mainErr = errors.Join(mainErr, errors.New("global sent and receive don't match"))
-		}
-
-		if pi.IsLPP && !usedSharedRandomnessFound {
-			usedSharedRandomness = pi.SharedRandomness
-			usedSharedRandomnessFound = true
-		}
-
-		if pi.IsGL && usedSharedRandomnessFound {
-			if usedSharedRandomness != pi.SharedRandomness {
-				mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch between different LPP segments: %v and %v", usedSharedRandomness.String(), pi.SharedRandomness.String()))
-			}
-		}
-
-		if pi.IsGL {
-			collectedLPPCommitments = append(collectedLPPCommitments, pi.LPPCommitment)
-		}
-
-		prevHornerN1Hash = pi.HornerN1Hash
-		prevGlobalSent = pi.GlobalSent
-
-		if pi.IsLPP {
-			allGrandProduct.Mul(&allGrandProduct, &pi.GrandProduct)
-			allHornerSum.Add(&allHornerSum, &pi.HornerSum)
-			allLogDerivativeSum.Add(&allLogDerivativeSum, &pi.LogDerivativeSum)
-		}
-	}
-
-	computedSharedRandomness := GetSharedRandomness(collectedLPPCommitments)
-	if computedSharedRandomness != usedSharedRandomness {
-		mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch, between the one used in LPP and the hash of the LPP commitments computed by the GL: %v and %v", usedSharedRandomness.String(), computedSharedRandomness.String()))
-	}
-
-	if !allGrandProduct.IsOne() {
-		mainErr = errors.Join(mainErr, fmt.Errorf("grand product is not one: %v", allGrandProduct.String()))
-	}
-
-	if !allHornerSum.IsZero() {
-		mainErr = errors.Join(mainErr, fmt.Errorf("horner sum is not zero: %v", allHornerSum.String()))
-	}
-
-	if !allLogDerivativeSum.IsZero() {
-		mainErr = errors.Join(mainErr, fmt.Errorf("log derivative sum is not zero: %v", allLogDerivativeSum.String()))
-	}
-
-	if mainErr != nil {
-		fmt.Printf("conglomeration failed: err=%v pis=%++v\n", mainErr, allPis)
-	}
-
-	return mainErr
-}
-
-// RunGnark is as [Run] but in a gnark circuit
-func (c *ConglomeratorCompilation) RunGnark(api frontend.API, run wizard.GnarkRuntime) {
-
-	var (
-		allGrandProduct           = frontend.Variable(1)
-		allLogDerivativeSum       = frontend.Variable(0)
-		allHornerSum              = frontend.Variable(0)
-		prevGlobalSent            = frontend.Variable(0)
-		prevHornerN1Hash          = frontend.Variable(0)
-		usedSharedRandomness      = frontend.Variable(0)
-		usedSharedRandomnessFound = frontend.Variable(0)
-		accumulativeLppHash       = frontend.Variable(0)
-	)
-
-	for i := 0; i < c.MaxNbProofs; i++ {
-
-		var (
-			lppCommitment    = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, 0), i)
-			sharedRandomness = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+InitialRandomnessPublicInput, i)
-			verifyingKey     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+verifyingKeyPublicInput, i)
-			verifyingKey2    = c.Recursion.GetPublicInputOfInstanceGnark(api, run, verifyingKey2PublicInput, i)
-			logDerivativeSum = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+LogDerivativeSumPublicInput, i)
-			grandProduct     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+GrandProductPublicInput, i)
-			hornerSum        = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+HornerPublicInput, i)
-			hornerN0Hash     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+HornerN0HashPublicInput, i)
-			hornerN1Hash     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+HornerN1HashPublicInput, i)
-			globalReceived   = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+GlobalReceiverPublicInput, i)
-			globalSent       = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+GlobalSenderPublicInput, i)
-			isFirst          = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsFirstPublicInput, i)
-			isLast           = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsLastPublicInput, i)
-			isLPP            = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsLppPublicInput, i)
-			isGL             = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsGlPublicInput, i)
-
-			sameVerifyingKeyAsPrev, sameVerifyingKeyAsNext = frontend.Variable(0), frontend.Variable(0)
-		)
-
-		if i > 0 {
-			prevVerifyingKey := c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+verifyingKeyPublicInput, i-1)
-			prevVerifyingKey2 := c.Recursion.GetPublicInputOfInstanceGnark(api, run, verifyingKey2PublicInput, i-1)
-
-			sameVerifyingKeyAsPrev = api.Mul(
-				api.IsZero(api.Sub(prevVerifyingKey, verifyingKey)),
-				api.IsZero(api.Sub(prevVerifyingKey2, verifyingKey2)),
-			)
-		}
-
-		if i < c.MaxNbProofs-1 {
-			nextVerifyingKey := c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+verifyingKeyPublicInput, i+1)
-			nextVerifyingKey2 := c.Recursion.GetPublicInputOfInstanceGnark(api, run, verifyingKey2PublicInput, i+1)
-
-			sameVerifyingKeyAsNext = api.Mul(
-				api.IsZero(api.Sub(nextVerifyingKey, verifyingKey)),
-				api.IsZero(api.Sub(nextVerifyingKey2, verifyingKey2)),
-			)
-		}
-
-		// This emulates the following check:
-		//
-		// if isLPP.IsOne() && sameVerifyingKeyAsPrev && hornerN0Hash != prevHornerN1Hash {
-		// 	mainErr = errors.Join(mainErr, errors.New("horner-n0-hash mismatch"))
-		// }
-		api.AssertIsEqual(0,
-			api.Mul(
-				isLPP,
-				sameVerifyingKeyAsPrev,
-				api.Sub(hornerN0Hash, prevHornerN1Hash),
-			),
-		)
-
-		// This emulates the following check:
-		//
-		// if isGL.IsOne() && !sameVerifyingKeyAsPrev != isFirst.IsOne() {
-		// 	mainErr = errors.Join(mainErr, errors.New("isFirst is inconsistent with the verifying keys"))
-		// }
-		api.AssertIsEqual(0,
-			api.Mul(
-				isGL,
-				// these are already ensured to be boolean, that's why the check
-				// works. sameVerifyingKeyAsPrev is boolean as the product of two booleans
-				// and isFirst is enforced to be boolean thanks to being a public input
-				// of a whitelisted circuit which enforces it to be a boolean.
-				api.Sub(1, sameVerifyingKeyAsPrev, isFirst),
-			),
-		)
-
-		// This emulates the following check:
-		//
-		// if isGL.IsOne() && !sameVerifyingKeyAsNext != isLast.IsOne() {
-		// 	mainErr = errors.Join(mainErr, errors.New("isLast is inconsistent with the verifying keys"))
-		// }
-		api.AssertIsEqual(0,
-			api.Mul(
-				isGL,
-				// these are already ensured to be boolean, that's why the check
-				// works. sameVerifyingKeyAsNext is boolean as the product of two booleans
-				// and isLast is enforced to be boolean thanks to being a public input
-				// of a whitelisted circuit which enforces it to be a boolean.
-				api.Sub(1, sameVerifyingKeyAsNext, isLast),
-			),
-		)
-
-		// This emulates the following check:
-		//
-		// if isGL.IsOne() && sameVerifyingKeyAsPrev && globalReceived != prevGlobalSent {
-		// 	mainErr = errors.Join(mainErr, errors.New("global sent and receive don't match"))
-		// }
-		api.AssertIsEqual(0,
-			api.Mul(
-				isGL,
-				sameVerifyingKeyAsPrev,
-				api.Sub(globalReceived, prevGlobalSent),
-			),
-		)
-
-		// This emulates the following conditional updates:
-		//
-		// if isLPP.IsOne() && !usedSharedRandomnessFound {
-		// 	usedSharedRandomness = sharedRandomness
-		// 	usedSharedRandomnessFound = true
-		// }
-		isFirstUseOfRandomness := api.Mul(isLPP, api.Sub(1, usedSharedRandomnessFound))
-		usedSharedRandomness = api.Select(isFirstUseOfRandomness, sharedRandomness, usedSharedRandomness)
-		usedSharedRandomnessFound = api.Add(usedSharedRandomnessFound, isFirstUseOfRandomness)
-
-		// This emulates the following check:
-		//
-		// if isLPP.IsOne() && usedSharedRandomnessFound {
-		// 	if usedSharedRandomness != sharedRandomness {
-		// 		mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch between different LPP segments: %v and %v", usedSharedRandomness.String(), sharedRandomness.String()))
-		// 	}
-		// }
-		api.AssertIsEqual(0,
-			api.Mul(
-				isLPP,
-				usedSharedRandomnessFound,
-				api.Sub(usedSharedRandomness, sharedRandomness),
-			),
-		)
-
-		// This emulates the following conditional append. As in a gnark circuit it is
-		// complicated to do a conditional append, we instead do a conditional hasher
-		// update.
-		//
-		// if isGL.IsOne() {
-		// 	collectedLPPCommitments = append(collectedLPPCommitments, lppCommitment)
-		// }
-		newAccIfUpdateNeeded := cmimc.GnarkBlockCompression(api, accumulativeLppHash, lppCommitment)
-		accumulativeLppHash = api.Select(isGL, newAccIfUpdateNeeded, accumulativeLppHash)
-
-		prevHornerN1Hash = hornerN1Hash
-		prevGlobalSent = globalSent
-
-		// Note: although the native version of the update conditions the update to
-		// be done only if we are scanning through an LPP instance, the other circuits
-		// are guaranteed to give the neutral element for the update. So, we can simplify
-		// the circuit a little bit.
-		allGrandProduct = api.Mul(allGrandProduct, grandProduct)
-		allHornerSum = api.Add(allHornerSum, hornerSum)
-		allLogDerivativeSum = api.Add(allLogDerivativeSum, logDerivativeSum)
-	}
-
-	api.AssertIsEqual(accumulativeLppHash, usedSharedRandomness)
-	api.AssertIsEqual(allGrandProduct, 1)
-	api.AssertIsEqual(allHornerSum, 0)
-	api.AssertIsEqual(allLogDerivativeSum, 0)
-}
-
-// BubbleUpPublicInput bubbles up the public inputs of a given name.
-func (c *ConglomeratorCompilation) BubbleUpPublicInput(name string) wizard.PublicInput {
-
-	pubInputSum := symbolic.NewConstant(0)
-	for i := 0; i < c.MaxNbProofs; i++ {
-		subPubInput := c.Recursion.GetPublicInputAccessorOfInstance(c.Wiop, preRecursionPrefix+name, i)
-		isFirst := c.Recursion.GetPublicInputAccessorOfInstance(c.Wiop, preRecursionPrefix+IsFirstPublicInput, i)
-		pubInputSum = symbolic.Add(pubInputSum, symbolic.Mul(isFirst, subPubInput))
-	}
-
-	return c.Wiop.InsertPublicInput(name, accessors.NewFromExpression(pubInputSum, name+"_SUMMATION_ACCESSOR"))
-}
-
-// Prove is the main entry point for the prover. It takes a compiled IOP and
-// returns a proof.
-func (c *ConglomeratorCompilation) Prove(moduleGlProofs, moduleLppProofs []recursion.Witness) wizard.Proof {
-
-	var proof wizard.Proof
-	recursionTime := profiling.TimeIt(func() {
-		proof = wizard.Prove(
-			c.Wiop,
-			c.Recursion.GetMainProverStep(slices.Concat(moduleGlProofs, moduleLppProofs), &c.DefaultWitness),
-		)
-	})
-
-	logrus.
-		WithField("time", recursionTime).
-		WithField("nb_lpp_proofs", len(moduleLppProofs)).
-		WithField("nb_gl_proofs", len(moduleGlProofs)).
-		Info("recursion done")
-
-	return proof
-}
-
-// Run implements the [wizard.ProverAction] interface.
-func (cong *ConglomerationAssignHolisticCheckColumn) Run(run *wizard.ProverRuntime) {
-
-	var (
-		vkMapping          = map[[2]field.Element][2]field.Element{}
-		lppPositionMapping = map[[2]field.Element]int{}
-		assignment         = [2][]field.Element{}
-		isGL               = cong.IsGL.GetColAssignment(run).IntoRegVecSaveAlloc()
-		verifyingKey       = [2][]field.Element{
-			cong.VerifyingKeyColumns[0].GetColAssignment(run).IntoRegVecSaveAlloc(),
-			cong.VerifyingKeyColumns[1].GetColAssignment(run).IntoRegVecSaveAlloc(),
-		}
-		numPrecomputedRow = cong.PrecomputedGLVks[0][0].Size()
-	)
-
-	for i := 0; i < numPrecomputedRow; i++ {
-
-		vk0LPP := cong.PrecomputedLPPVks[0].GetColAssignmentAt(run, i)
-		vk1LPP := cong.PrecomputedLPPVks[1].GetColAssignmentAt(run, i)
-
-		for j := 0; j < lppGroupingArity; j++ {
-
-			vk0GL := cong.PrecomputedGLVks[j][0].GetColAssignmentAt(run, i)
-			vk1GL := cong.PrecomputedGLVks[j][1].GetColAssignmentAt(run, i)
-			vkMapping[[2]field.Element{vk0GL, vk1GL}] = [2]field.Element{vk0LPP, vk1LPP}
-			lppPositionMapping[[2]field.Element{vk0GL, vk1GL}] = j
-		}
-	}
-
-	assignment[0] = make([]field.Element, len(verifyingKey[0]))
-	assignment[1] = make([]field.Element, len(verifyingKey[1]))
-	lppColumnIndex := make([]field.Element, len(verifyingKey[0]))
-
-	for i := 0; i < len(verifyingKey[0]); i++ {
-
-		if !isGL[i].IsOne() {
-			continue
-		}
-
-		var (
-			glKey            = [2]field.Element{verifyingKey[0][i], verifyingKey[1][i]}
-			mappedLPP, found = vkMapping[glKey]
-			mappedPosition   = lppPositionMapping[glKey]
-		)
-
-		if !found {
-
-			// Before panicking we unfold the list of the available vkeys from
-			// the mapping to try to make it easier to debug.
-
-			var (
-				glKeysFmtted = []string{}
-				glKeys       = utils.SortedKeysOf(vkMapping, func(a, b [2]field.Element) bool {
-					if a[0].Cmp(&b[0]) != 0 {
-						return a[0].Cmp(&b[0]) < 0
-					}
-					return a[1].Cmp(&b[1]) < 0
-				})
-			)
-
-			for i := range glKeys {
-				glKeysFmtted = append(glKeysFmtted, fmt.Sprintf("[%v %v]", glKeys[i][0].Text(16), glKeys[i][1].Text(16)))
-			}
-
-			utils.Panic("verifying key not found missing=[%v %v], row=%v availble-keys=%v",
-				verifyingKey[0][i].Text(16), verifyingKey[1][i].Text(16),
-				i,
-				glKeysFmtted,
-			)
-		}
-
-		assignment[0][i] = mappedLPP[0]
-		assignment[1][i] = mappedLPP[1]
-		lppColumnIndex[i] = field.NewElement(uint64(mappedPosition))
-
-		continue
-	}
-
-	colToAssign := cong.HolisticLookupMappedLPPVK
-	posToAssign := cong.HolisticLookupMappedLPPPostion
-
-	run.AssignColumn(colToAssign[0].GetColID(), smartvectors.RightZeroPadded(assignment[0], colToAssign[0].Size()))
-	run.AssignColumn(colToAssign[1].GetColID(), smartvectors.RightZeroPadded(assignment[1], colToAssign[1].Size()))
-	run.AssignColumn(posToAssign.GetColID(), smartvectors.RightZeroPadded(lppColumnIndex, posToAssign.Size()))
-}
-
-// cmpWizardIOP compares two compiled IOPs. The function is here to help ensuring
-// that all the conglomerated wizard IOPs have the same structure and help
-// figuring out inconsistencies if there are.
-func cmpWizardIOP(c1, c2 *wizard.CompiledIOP) (diff1, diff2 []string) {
-
-	var (
-		stringB1 = &strings.Builder{}
-		stringB2 = &strings.Builder{}
-	)
-
-	logdata.GenCSV(stringB1, logdata.IncludeAllFilter)(c1)
-	logdata.GenCSV(stringB2, logdata.IncludeAllFilter)(c2)
-
-	var (
-		c1Formatted = strings.Split(stringB1.String(), "\n")
-		c2Formatted = strings.Split(stringB2.String(), "\n")
-	)
-
-	diff1, diff2 = utils.SetDiff(c1Formatted, c2Formatted)
-	lessFunc := func(a, b string) int {
-		if a < b {
-			return -1
-		} else if a > b {
-			return 1
-		} else {
-			return 0
-		}
-	}
-
-	slices.SortFunc(diff1, lessFunc)
-	slices.SortFunc(diff2, lessFunc)
-
-	return diff1, diff2
-}
-
-// dumpWizardIOP dumps a compiled IOP to a file.
-func dumpWizardIOP(c *wizard.CompiledIOP, name string) {
-	logdata.GenCSV(files.MustOverwrite(name), logdata.IncludeAllFilter)(c)
-}
-
-// precomputeToTheWhiteListVKeys declares the precomputed columns needed to
-// perform the white-list-check of the verifying keys.
-func (cong *ConglomeratorCompilation) precomputeToTheWhiteListVKeys() ([2]ifaces.Column, [lppGroupingArity][2]ifaces.Column) {
-
-	var (
-		comp = cong.Wiop
-
-		// vkMappingWhiteList is a list of pairs representing the correspondance
-		// table between the VKs for the GL and the LPP modules. Namely, it
-		// represents the list of the GL modules that can be linked to an LPP
-		// module.
-		vkMappingPaddedSize   = utils.NextPowerOfTwo(len(cong.ModuleLPPIops))
-		vkMappingWhiteListLPP = [2][]field.Element{}
-		vkMappingWhiteListGL  = [lppGroupingArity][2][]field.Element{}
-
-		// The columns for the vkMapping
-		vkMappingColumnsLPP = [2]ifaces.Column{}
-		vkMappingColumnsGL  = [lppGroupingArity][2]ifaces.Column{}
-	)
-
-	//
-	// Collect the content of the lookup tables
-	//
-
-	for i := range cong.ModuleLPPIops {
-
-		vk0, vk1 := getVerifyingKeyPair(cong.ModuleLPPIops[i])
-		vkMappingWhiteListLPP[0] = append(vkMappingWhiteListLPP[0], vk0)
-		vkMappingWhiteListLPP[1] = append(vkMappingWhiteListLPP[1], vk1)
-
-		for j := 0; j < lppGroupingArity; j++ {
-
-			vk0, vk1 := field.Zero(), field.Zero()
-			if i*lppGroupingArity+j < len(cong.ModuleGLIops) {
-				vk0, vk1 = getVerifyingKeyPair(cong.ModuleGLIops[i*lppGroupingArity+j])
-			}
-
-			vkMappingWhiteListGL[j][0] = append(vkMappingWhiteListGL[j][0], vk0)
-			vkMappingWhiteListGL[j][1] = append(vkMappingWhiteListGL[j][1], vk1)
-		}
-	}
-
-	//
-	// Declare the whiteListed VKs as precomputed columns representing the correspondance
-	// table between the VKs for the GL and the LPP modules.
-	//
-
-	vkMappingColumnsLPP[0] = comp.InsertPrecomputed(
-		"CONG_VK_LPP_0",
-		smartvectors.RightPadded(vkMappingWhiteListLPP[0], vkMappingWhiteListLPP[0][0], vkMappingPaddedSize),
-	)
-
-	vkMappingColumnsLPP[1] = comp.InsertPrecomputed(
-		"CONG_VK_LPP_1",
-		smartvectors.RightPadded(vkMappingWhiteListLPP[1], vkMappingWhiteListLPP[1][0], vkMappingPaddedSize),
-	)
-
-	for j := 0; j < lppGroupingArity; j++ {
-
-		vkMappingColumnsGL[j][0] = comp.InsertPrecomputed(
-			ifaces.ColIDf("CONG_VK_GL_%d_0", j),
-			smartvectors.RightPadded(vkMappingWhiteListGL[j][0], vkMappingWhiteListGL[j][0][0], vkMappingPaddedSize),
-		)
-
-		vkMappingColumnsGL[j][1] = comp.InsertPrecomputed(
-			ifaces.ColIDf("CONG_VK_GL_%d_1", j),
-			smartvectors.RightPadded(vkMappingWhiteListGL[j][1], vkMappingWhiteListGL[j][1][0], vkMappingPaddedSize),
-		)
-	}
-
-	return vkMappingColumnsLPP, vkMappingColumnsGL
-}
-
-// declareLookups declares the lookup constraints needed to complete the
-// holistic checks. The role of these lookups is to:
-//
-// 1. Ensures that the LPP commitments are correctly passed from GL to LPP
-// 2. Ensures that all the verifying keys are whitelisted.
-func (cong *ConglomeratorCompilation) declareLookups() {
-
-	var (
-		comp = cong.Wiop
-
-		// The effective assignments of the VKs and the LPP columns
-		effectiveColumnSize   = utils.NextPowerOfTwo(cong.MaxNbProofs)
-		effectiveVksAccessors = [2][]ifaces.Accessor{}
-		isGLAccessors         = []ifaces.Accessor{}
-		isLPPAccessors        = []ifaces.Accessor{}
-		lppColumnsAccessors   = [lppGroupingArity][]ifaces.Accessor{}
-	)
-
-	cong.HolisticLookupMappedLPPVK = [2]ifaces.Column{
-		comp.InsertCommit(0, "CONG_MAPPED_LPP_VK_0", effectiveColumnSize),
-		comp.InsertCommit(0, "CONG_MAPPED_LPP_VK_1", effectiveColumnSize),
-	}
-
-	cong.HolisticLookupMappedLPPPostion = comp.InsertCommit(0, "CONG_MAPPED_LPP_POSITION", effectiveColumnSize)
-
-	//
-	// Collect the accessors of the public inputs
-	//
-
-	for i := 0; i < cong.MaxNbProofs; i++ {
-
-		var (
-			verifyingKey  = cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+verifyingKeyPublicInput, i)
-			verifyingKey2 = cong.Recursion.GetPublicInputAccessorOfInstance(comp, verifyingKey2PublicInput, i)
-			isLPP         = cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+IsLppPublicInput, i)
-			isGL          = cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+IsGlPublicInput, i)
-		)
-
-		effectiveVksAccessors[0] = append(effectiveVksAccessors[0], verifyingKey)
-		effectiveVksAccessors[1] = append(effectiveVksAccessors[1], verifyingKey2)
-		isGLAccessors = append(isGLAccessors, isGL)
-		isLPPAccessors = append(isLPPAccessors, isLPP)
-
-		for j := 0; j < lppGroupingArity; j++ {
-			pubInputName := fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, j)
-			lppColumnsAccessors[j] = append(
-				lppColumnsAccessors[j],
-				cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+pubInputName, i),
-			)
-		}
-	}
-
-	//
-	// Declare columns for the collected accessors
-	//
-
-	var (
-		vkColums = [2]ifaces.Column{
-			verifiercol.NewFromAccessors(effectiveVksAccessors[0], field.Zero(), effectiveColumnSize),
-			verifiercol.NewFromAccessors(effectiveVksAccessors[1], field.Zero(), effectiveColumnSize),
-		}
-
-		isGLCol  = verifiercol.NewFromAccessors(isGLAccessors, field.Zero(), effectiveColumnSize)
-		isLPPCol = verifiercol.NewFromAccessors(isLPPAccessors, field.Zero(), effectiveColumnSize)
-	)
-
-	cong.IsGL = isGLCol
-	cong.VerifyingKeyColumns = vkColums
-
-	//
-	// This constraints checks the validity of the mapped VK and LPP columns
-	//
-
-	var (
-		includingLppLookup       = [][]ifaces.Column{}
-		includingFilterLppLookup = []ifaces.Column{}
-		includingVKeyMatching    = [][]ifaces.Column{}
-	)
-
-	for j := 0; j < lppGroupingArity; j++ {
-
-		includingVKeyMatching = append(includingVKeyMatching, []ifaces.Column{
-			cong.PrecomputedLPPVks[0],
-			cong.PrecomputedLPPVks[1],
-			cong.PrecomputedGLVks[j][0],
-			cong.PrecomputedGLVks[j][1],
-		})
-
-		includingLppLookup = append(includingLppLookup, []ifaces.Column{
-			verifiercol.NewConstantCol(field.NewElement(uint64(j)), effectiveColumnSize, ""),
-			verifiercol.NewFromAccessors(lppColumnsAccessors[j], field.Zero(), effectiveColumnSize),
-			vkColums[0],
-			vkColums[1],
-		})
-
-		includingFilterLppLookup = append(includingFilterLppLookup, isLPPCol)
-	}
-
-	comp.GenericFragmentedConditionalInclusion(
-		0,
-		ifaces.QueryID("CONG_LPP_CONSISTENCY"),
-		includingLppLookup,
-		[]ifaces.Column{
-			cong.HolisticLookupMappedLPPPostion,
-			verifiercol.NewFromAccessors(lppColumnsAccessors[0], field.Zero(), effectiveColumnSize),
-			cong.HolisticLookupMappedLPPVK[0],
-			cong.HolisticLookupMappedLPPVK[1],
-		},
-		includingFilterLppLookup,
-		isGLCol,
-	)
-
-	comp.GenericFragmentedConditionalInclusion(
-		0,
-		ifaces.QueryID("CONG_VK_CONSISTENCY"),
-		includingVKeyMatching,
-		[]ifaces.Column{
-			cong.HolisticLookupMappedLPPVK[0],
-			cong.HolisticLookupMappedLPPVK[1],
-			vkColums[0],
-			vkColums[1],
-		},
-		nil,
-		isGLCol,
-	)
-}
-
-// getVerifyingKeyPair extracts the verifyingKeys from the compiled IOP.
-func getVerifyingKeyPair(wiop *wizard.CompiledIOP) (vkGL, vkLPP field.Element) {
-	return wiop.ExtraData[verifyingKeyPublicInput].(field.Element),
-		wiop.ExtraData[verifyingKey2PublicInput].(field.Element)
-}
-
-// SanityCheckPublicInputsForConglo checks that a list of runtime is compatible
-// with each other. The function will perform the same checks that the
-// conglomerator but can be used on debugging-circuits.
-func SanityCheckPublicInputsForConglo(runtimes []*wizard.ProverRuntime) error {
-
-	var (
-		allGrandProduct           = field.NewElement(1)
-		allLogDerivativeSum       = field.Element{}
-		allHornerSum              = field.Element{}
-		prevGlobalSent            = field.Element{}
-		usedSharedRandomness      = field.Element{}
-		usedSharedRandomnessFound bool
-		mainErr                   error
-	)
-
-	type proofPublicInput struct {
-		LPPCommitment    field.Element
-		SharedRandomness field.Element
-		LogDerivativeSum field.Element
-		GrandProduct     field.Element
-		HornerSum        field.Element
-		HornerN0Hash     field.Element
-		HornerN1Hash     field.Element
-		GlobalReceived   field.Element
-		GlobalSent       field.Element
-		IsFirst          bool
-		IsLast           bool
-		IsLPP            bool
-		IsGL             bool
-		SameVkAsPrev     bool
-		SameVkAsNext     bool
-	}
-
-	allPis := []proofPublicInput{}
-
-	for _, run := range runtimes {
-
-		pi := proofPublicInput{
-			LogDerivativeSum: run.GetPublicInput(LogDerivativeSumPublicInput),
-			GrandProduct:     run.GetPublicInput(GrandProductPublicInput),
-			HornerSum:        run.GetPublicInput(HornerPublicInput),
-			HornerN0Hash:     run.GetPublicInput(HornerN0HashPublicInput),
-			HornerN1Hash:     run.GetPublicInput(HornerN1HashPublicInput),
-			GlobalReceived:   run.GetPublicInput(GlobalReceiverPublicInput),
-			GlobalSent:       run.GetPublicInput(GlobalSenderPublicInput),
-			IsFirst:          run.GetPublicInput(IsFirstPublicInput) == field.One(),
-			IsLast:           run.GetPublicInput(IsLastPublicInput) == field.One(),
-			IsLPP:            run.GetPublicInput(IsLppPublicInput) == field.One(),
-			IsGL:             run.GetPublicInput(IsGlPublicInput) == field.One(),
-		}
-
-		allPis = append(allPis, pi)
-
-		var (
-			sameVerifyingKeyAsPrev = !pi.IsFirst
-			sameVerifyingKeyAsNext = !pi.IsLast
-		)
-
-		// @alex: actually IsFirst and IsLast are not set for LPP segments so
-		// this check is moot.
-		// if pi.IsLPP && sameVerifyingKeyAsPrev && pi.HornerN0Hash != prevHornerN1Hash {
-		// 	mainErr = errors.Join(mainErr, fmt.Errorf("horner-n0-hash mismatch: %v != %v; i=%v isFirst: %v; isLast: %v", i, pi.IsFirst, pi.IsLast, pi.HornerN0Hash.String(), prevHornerN1Hash.String()))
-		// }
-
-		if pi.IsGL && !sameVerifyingKeyAsPrev != pi.IsFirst {
-			mainErr = errors.Join(mainErr, errors.New("isFirst is inconsistent with the verifying keys"))
-		}
-
-		if pi.IsGL && !sameVerifyingKeyAsNext != pi.IsLast {
-			mainErr = errors.Join(mainErr, errors.New("isLast is inconsistent with the verifying keys"))
-		}
-
-		if pi.IsGL && sameVerifyingKeyAsPrev && pi.GlobalReceived != prevGlobalSent {
-			mainErr = errors.Join(mainErr, errors.New("global sent and receive don't match"))
-		}
-
-		if pi.IsLPP && !usedSharedRandomnessFound {
-			usedSharedRandomness = pi.SharedRandomness
-			usedSharedRandomnessFound = true
-		}
-
-		if pi.IsGL && usedSharedRandomnessFound {
-			if usedSharedRandomness != pi.SharedRandomness {
-				mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch between different LPP segments: %v and %v", usedSharedRandomness.String(), pi.SharedRandomness.String()))
-			}
-		}
-
-		prevGlobalSent = pi.GlobalSent
-
-		if pi.IsLPP {
-			allGrandProduct.Mul(&allGrandProduct, &pi.GrandProduct)
-			allHornerSum.Add(&allHornerSum, &pi.HornerSum)
-			allLogDerivativeSum.Add(&allLogDerivativeSum, &pi.LogDerivativeSum)
-		}
-	}
-
-	if !allGrandProduct.IsOne() {
-		mainErr = errors.Join(mainErr, fmt.Errorf("grand product is not one: %v", allGrandProduct.String()))
-	}
-
-	if !allHornerSum.IsZero() {
-		mainErr = errors.Join(mainErr, fmt.Errorf("horner sum is not zero: %v", allHornerSum.String()))
-	}
-
-	if !allLogDerivativeSum.IsZero() {
-		mainErr = errors.Join(mainErr, fmt.Errorf("log derivative sum is not zero: %v", allLogDerivativeSum.String()))
-	}
-
-	if mainErr != nil {
-		fmt.Printf("conglomeration failed: err=%v pis=%++v\n", mainErr, allPis)
-	}
-
-	return mainErr
-
-}
+// func (c *ConglomeratorCompilation) Compile(comp *wizard.CompiledIOP) {
+
+// 	var (
+// 		wiops = slices.Concat(c.ModuleGLIops, c.ModuleLPPIops, []*wizard.CompiledIOP{c.DefaultIops.RecursionComp})
+// 		w0    = wiops[0]
+// 	)
+
+// 	for i := 1; i < len(wiops); i++ {
+// 		diff1, diff2 := cmpWizardIOP(w0, wiops[i])
+// 		if len(diff1) > 0 || len(diff2) > 0 {
+
+// 			for i, modIOP := range wiops {
+// 				dumpWizardIOP(modIOP, fmt.Sprintf("conglomeration-debug/iop-%d.csv", i))
+// 			}
+
+// 			utils.Panic("incompatible IOPs i=%v\n\t+++=%v\n\t---=%v", i, diff1, diff2)
+// 		}
+// 	}
+
+// 	defaultRun := c.DefaultIops.ProveSegment(nil)
+// 	c.DefaultWitness = recursion.ExtractWitness(defaultRun)
+
+// 	c.Recursion = recursion.DefineRecursionOf(comp, w0, recursion.Parameters{
+// 		Name:                   "conglomeration",
+// 		WithoutGkr:             true,
+// 		MaxNumProof:            c.MaxNbProofs,
+// 		WithExternalHasherOpts: true,
+// 	})
+
+// 	c.Wiop = comp
+// 	c.PrecomputedLPPVks, c.PrecomputedGLVks = c.precomputeToTheWhiteListVKeys()
+// 	c.declareLookups()
+
+// 	comp.RegisterVerifierAction(0, &ConglomerateHolisticCheck{ConglomeratorCompilation: *c})
+// 	comp.RegisterProverAction(0, &ConglomerationAssignHolisticCheckColumn{ConglomeratorCompilation: *c})
+// }
+
+// // Run implements the [wizard.VerifierAction] interface.
+// func (c *ConglomerateHolisticCheck) Run(run wizard.Runtime) error {
+
+// 	var (
+// 		allGrandProduct           = field.NewElement(1)
+// 		allLogDerivativeSum       = field.Element{}
+// 		allHornerSum              = field.Element{}
+// 		prevGlobalSent            = field.Element{}
+// 		prevHornerN1Hash          = field.Element{}
+// 		usedSharedRandomness      = field.Element{}
+// 		usedSharedRandomnessFound bool
+// 		collectedLPPCommitments   = make([]field.Element, 0)
+// 		mainErr                   error
+// 	)
+
+// 	type proofPublicInput struct {
+// 		LPPCommitment    field.Element
+// 		SharedRandomness field.Element
+// 		VerifyingKey     field.Element
+// 		VerifyingKey2    field.Element
+// 		LogDerivativeSum field.Element
+// 		GrandProduct     field.Element
+// 		HornerSum        field.Element
+// 		HornerN0Hash     field.Element
+// 		HornerN1Hash     field.Element
+// 		GlobalReceived   field.Element
+// 		GlobalSent       field.Element
+// 		IsFirst          bool
+// 		IsLast           bool
+// 		IsLPP            bool
+// 		IsGL             bool
+// 		SameVkAsPrev     bool
+// 		SameVkAsNext     bool
+// 	}
+
+// 	allPis := []proofPublicInput{}
+
+// 	for i := 0; i < c.MaxNbProofs; i++ {
+
+// 		pi := proofPublicInput{
+// 			LPPCommitment:    c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, 0), i),
+// 			SharedRandomness: c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+InitialRandomnessPublicInput, i),
+// 			VerifyingKey:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+verifyingKeyPublicInput, i),
+// 			VerifyingKey2:    c.Recursion.GetPublicInputOfInstance(run, verifyingKey2PublicInput, i),
+// 			LogDerivativeSum: c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+LogDerivativeSumPublicInput, i),
+// 			GrandProduct:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+GrandProductPublicInput, i),
+// 			HornerSum:        c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+HornerPublicInput, i),
+// 			HornerN0Hash:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+HornerN0HashPublicInput, i),
+// 			HornerN1Hash:     c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+HornerN1HashPublicInput, i),
+// 			GlobalReceived:   c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+GlobalReceiverPublicInput, i),
+// 			GlobalSent:       c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+GlobalSenderPublicInput, i),
+// 			IsFirst:          c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsFirstPublicInput, i) == field.One(),
+// 			IsLast:           c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsLastPublicInput, i) == field.One(),
+// 			IsLPP:            c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsLppPublicInput, i) == field.One(),
+// 			IsGL:             c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+IsGlPublicInput, i) == field.One(),
+// 		}
+
+// 		allPis = append(allPis, pi)
+
+// 		var (
+// 			sameVerifyingKeyAsPrev, sameVerifyingKeyAsNext bool
+// 		)
+
+// 		if i > 0 {
+// 			prevVerifyingKey := c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+verifyingKeyPublicInput, i-1)
+// 			prevVerifyingKey2 := c.Recursion.GetPublicInputOfInstance(run, verifyingKey2PublicInput, i-1)
+// 			sameVerifyingKeyAsPrev = pi.VerifyingKey == prevVerifyingKey && pi.VerifyingKey2 == prevVerifyingKey2
+// 		}
+
+// 		if i < c.MaxNbProofs-1 {
+// 			nextVerifyingKey := c.Recursion.GetPublicInputOfInstance(run, preRecursionPrefix+verifyingKeyPublicInput, i+1)
+// 			nextVerifyingKey2 := c.Recursion.GetPublicInputOfInstance(run, verifyingKey2PublicInput, i+1)
+// 			sameVerifyingKeyAsNext = pi.VerifyingKey == nextVerifyingKey && pi.VerifyingKey2 == nextVerifyingKey2
+// 		}
+
+// 		if pi.IsLPP && sameVerifyingKeyAsPrev && pi.HornerN0Hash != prevHornerN1Hash {
+// 			mainErr = errors.Join(mainErr, errors.New("horner-n0-hash mismatch"))
+// 		}
+
+// 		if pi.IsGL && !sameVerifyingKeyAsPrev != pi.IsFirst {
+// 			mainErr = errors.Join(mainErr, errors.New("isFirst is inconsistent with the verifying keys"))
+// 		}
+
+// 		if pi.IsGL && !sameVerifyingKeyAsNext != pi.IsLast {
+// 			mainErr = errors.Join(mainErr, errors.New("isLast is inconsistent with the verifying keys"))
+// 		}
+
+// 		if pi.IsGL && sameVerifyingKeyAsPrev && pi.GlobalReceived != prevGlobalSent {
+// 			mainErr = errors.Join(mainErr, errors.New("global sent and receive don't match"))
+// 		}
+
+// 		if pi.IsLPP && !usedSharedRandomnessFound {
+// 			usedSharedRandomness = pi.SharedRandomness
+// 			usedSharedRandomnessFound = true
+// 		}
+
+// 		if pi.IsGL && usedSharedRandomnessFound {
+// 			if usedSharedRandomness != pi.SharedRandomness {
+// 				mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch between different LPP segments: %v and %v", usedSharedRandomness.String(), pi.SharedRandomness.String()))
+// 			}
+// 		}
+
+// 		if pi.IsGL {
+// 			collectedLPPCommitments = append(collectedLPPCommitments, pi.LPPCommitment)
+// 		}
+
+// 		prevHornerN1Hash = pi.HornerN1Hash
+// 		prevGlobalSent = pi.GlobalSent
+
+// 		if pi.IsLPP {
+// 			allGrandProduct.Mul(&allGrandProduct, &pi.GrandProduct)
+// 			allHornerSum.Add(&allHornerSum, &pi.HornerSum)
+// 			allLogDerivativeSum.Add(&allLogDerivativeSum, &pi.LogDerivativeSum)
+// 		}
+// 	}
+
+// 	computedSharedRandomness := GetSharedRandomness(collectedLPPCommitments)
+// 	if computedSharedRandomness != usedSharedRandomness {
+// 		mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch, between the one used in LPP and the hash of the LPP commitments computed by the GL: %v and %v", usedSharedRandomness.String(), computedSharedRandomness.String()))
+// 	}
+
+// 	if !allGrandProduct.IsOne() {
+// 		mainErr = errors.Join(mainErr, fmt.Errorf("grand product is not one: %v", allGrandProduct.String()))
+// 	}
+
+// 	if !allHornerSum.IsZero() {
+// 		mainErr = errors.Join(mainErr, fmt.Errorf("horner sum is not zero: %v", allHornerSum.String()))
+// 	}
+
+// 	if !allLogDerivativeSum.IsZero() {
+// 		mainErr = errors.Join(mainErr, fmt.Errorf("log derivative sum is not zero: %v", allLogDerivativeSum.String()))
+// 	}
+
+// 	if mainErr != nil {
+// 		fmt.Printf("conglomeration failed: err=%v pis=%++v\n", mainErr, allPis)
+// 	}
+
+// 	return mainErr
+// }
+
+// // RunGnark is as [Run] but in a gnark circuit
+// func (c *ConglomeratorCompilation) RunGnark(api frontend.API, run wizard.GnarkRuntime) {
+
+// 	var (
+// 		allGrandProduct           = frontend.Variable(1)
+// 		allLogDerivativeSum       = frontend.Variable(0)
+// 		allHornerSum              = frontend.Variable(0)
+// 		prevGlobalSent            = frontend.Variable(0)
+// 		prevHornerN1Hash          = frontend.Variable(0)
+// 		usedSharedRandomness      = frontend.Variable(0)
+// 		usedSharedRandomnessFound = frontend.Variable(0)
+// 		accumulativeLppHash       = frontend.Variable(0)
+// 	)
+
+// 	for i := 0; i < c.MaxNbProofs; i++ {
+
+// 		var (
+// 			lppCommitment    = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, 0), i)
+// 			sharedRandomness = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+InitialRandomnessPublicInput, i)
+// 			verifyingKey     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+verifyingKeyPublicInput, i)
+// 			verifyingKey2    = c.Recursion.GetPublicInputOfInstanceGnark(api, run, verifyingKey2PublicInput, i)
+// 			logDerivativeSum = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+LogDerivativeSumPublicInput, i)
+// 			grandProduct     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+GrandProductPublicInput, i)
+// 			hornerSum        = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+HornerPublicInput, i)
+// 			hornerN0Hash     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+HornerN0HashPublicInput, i)
+// 			hornerN1Hash     = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+HornerN1HashPublicInput, i)
+// 			globalReceived   = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+GlobalReceiverPublicInput, i)
+// 			globalSent       = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+GlobalSenderPublicInput, i)
+// 			isFirst          = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsFirstPublicInput, i)
+// 			isLast           = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsLastPublicInput, i)
+// 			isLPP            = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsLppPublicInput, i)
+// 			isGL             = c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+IsGlPublicInput, i)
+
+// 			sameVerifyingKeyAsPrev, sameVerifyingKeyAsNext = frontend.Variable(0), frontend.Variable(0)
+// 		)
+
+// 		if i > 0 {
+// 			prevVerifyingKey := c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+verifyingKeyPublicInput, i-1)
+// 			prevVerifyingKey2 := c.Recursion.GetPublicInputOfInstanceGnark(api, run, verifyingKey2PublicInput, i-1)
+
+// 			sameVerifyingKeyAsPrev = api.Mul(
+// 				api.IsZero(api.Sub(prevVerifyingKey, verifyingKey)),
+// 				api.IsZero(api.Sub(prevVerifyingKey2, verifyingKey2)),
+// 			)
+// 		}
+
+// 		if i < c.MaxNbProofs-1 {
+// 			nextVerifyingKey := c.Recursion.GetPublicInputOfInstanceGnark(api, run, preRecursionPrefix+verifyingKeyPublicInput, i+1)
+// 			nextVerifyingKey2 := c.Recursion.GetPublicInputOfInstanceGnark(api, run, verifyingKey2PublicInput, i+1)
+
+// 			sameVerifyingKeyAsNext = api.Mul(
+// 				api.IsZero(api.Sub(nextVerifyingKey, verifyingKey)),
+// 				api.IsZero(api.Sub(nextVerifyingKey2, verifyingKey2)),
+// 			)
+// 		}
+
+// 		// This emulates the following check:
+// 		//
+// 		// if isLPP.IsOne() && sameVerifyingKeyAsPrev && hornerN0Hash != prevHornerN1Hash {
+// 		// 	mainErr = errors.Join(mainErr, errors.New("horner-n0-hash mismatch"))
+// 		// }
+// 		api.AssertIsEqual(0,
+// 			api.Mul(
+// 				isLPP,
+// 				sameVerifyingKeyAsPrev,
+// 				api.Sub(hornerN0Hash, prevHornerN1Hash),
+// 			),
+// 		)
+
+// 		// This emulates the following check:
+// 		//
+// 		// if isGL.IsOne() && !sameVerifyingKeyAsPrev != isFirst.IsOne() {
+// 		// 	mainErr = errors.Join(mainErr, errors.New("isFirst is inconsistent with the verifying keys"))
+// 		// }
+// 		api.AssertIsEqual(0,
+// 			api.Mul(
+// 				isGL,
+// 				// these are already ensured to be boolean, that's why the check
+// 				// works. sameVerifyingKeyAsPrev is boolean as the product of two booleans
+// 				// and isFirst is enforced to be boolean thanks to being a public input
+// 				// of a whitelisted circuit which enforces it to be a boolean.
+// 				api.Sub(1, sameVerifyingKeyAsPrev, isFirst),
+// 			),
+// 		)
+
+// 		// This emulates the following check:
+// 		//
+// 		// if isGL.IsOne() && !sameVerifyingKeyAsNext != isLast.IsOne() {
+// 		// 	mainErr = errors.Join(mainErr, errors.New("isLast is inconsistent with the verifying keys"))
+// 		// }
+// 		api.AssertIsEqual(0,
+// 			api.Mul(
+// 				isGL,
+// 				// these are already ensured to be boolean, that's why the check
+// 				// works. sameVerifyingKeyAsNext is boolean as the product of two booleans
+// 				// and isLast is enforced to be boolean thanks to being a public input
+// 				// of a whitelisted circuit which enforces it to be a boolean.
+// 				api.Sub(1, sameVerifyingKeyAsNext, isLast),
+// 			),
+// 		)
+
+// 		// This emulates the following check:
+// 		//
+// 		// if isGL.IsOne() && sameVerifyingKeyAsPrev && globalReceived != prevGlobalSent {
+// 		// 	mainErr = errors.Join(mainErr, errors.New("global sent and receive don't match"))
+// 		// }
+// 		api.AssertIsEqual(0,
+// 			api.Mul(
+// 				isGL,
+// 				sameVerifyingKeyAsPrev,
+// 				api.Sub(globalReceived, prevGlobalSent),
+// 			),
+// 		)
+
+// 		// This emulates the following conditional updates:
+// 		//
+// 		// if isLPP.IsOne() && !usedSharedRandomnessFound {
+// 		// 	usedSharedRandomness = sharedRandomness
+// 		// 	usedSharedRandomnessFound = true
+// 		// }
+// 		isFirstUseOfRandomness := api.Mul(isLPP, api.Sub(1, usedSharedRandomnessFound))
+// 		usedSharedRandomness = api.Select(isFirstUseOfRandomness, sharedRandomness, usedSharedRandomness)
+// 		usedSharedRandomnessFound = api.Add(usedSharedRandomnessFound, isFirstUseOfRandomness)
+
+// 		// This emulates the following check:
+// 		//
+// 		// if isLPP.IsOne() && usedSharedRandomnessFound {
+// 		// 	if usedSharedRandomness != sharedRandomness {
+// 		// 		mainErr = errors.Join(mainErr, fmt.Errorf("shared randomness mismatch between different LPP segments: %v and %v", usedSharedRandomness.String(), sharedRandomness.String()))
+// 		// 	}
+// 		// }
+// 		api.AssertIsEqual(0,
+// 			api.Mul(
+// 				isLPP,
+// 				usedSharedRandomnessFound,
+// 				api.Sub(usedSharedRandomness, sharedRandomness),
+// 			),
+// 		)
+
+// 		// This emulates the following conditional append. As in a gnark circuit it is
+// 		// complicated to do a conditional append, we instead do a conditional hasher
+// 		// update.
+// 		//
+// 		// if isGL.IsOne() {
+// 		// 	collectedLPPCommitments = append(collectedLPPCommitments, lppCommitment)
+// 		// }
+// 		newAccIfUpdateNeeded := cmimc.GnarkBlockCompression(api, accumulativeLppHash, lppCommitment)
+// 		accumulativeLppHash = api.Select(isGL, newAccIfUpdateNeeded, accumulativeLppHash)
+
+// 		prevHornerN1Hash = hornerN1Hash
+// 		prevGlobalSent = globalSent
+
+// 		// Note: although the native version of the update conditions the update to
+// 		// be done only if we are scanning through an LPP instance, the other circuits
+// 		// are guaranteed to give the neutral element for the update. So, we can simplify
+// 		// the circuit a little bit.
+// 		allGrandProduct = api.Mul(allGrandProduct, grandProduct)
+// 		allHornerSum = api.Add(allHornerSum, hornerSum)
+// 		allLogDerivativeSum = api.Add(allLogDerivativeSum, logDerivativeSum)
+// 	}
+
+// 	api.AssertIsEqual(accumulativeLppHash, usedSharedRandomness)
+// 	api.AssertIsEqual(allGrandProduct, 1)
+// 	api.AssertIsEqual(allHornerSum, 0)
+// 	api.AssertIsEqual(allLogDerivativeSum, 0)
+// }
+
+// // BubbleUpPublicInput bubbles up the public inputs of a given name.
+// func (c *ConglomeratorCompilation) BubbleUpPublicInput(name string) wizard.PublicInput {
+
+// 	pubInputSum := symbolic.NewConstant(0)
+// 	for i := 0; i < c.MaxNbProofs; i++ {
+// 		subPubInput := c.Recursion.GetPublicInputAccessorOfInstance(c.Wiop, preRecursionPrefix+name, i)
+// 		isFirst := c.Recursion.GetPublicInputAccessorOfInstance(c.Wiop, preRecursionPrefix+IsFirstPublicInput, i)
+// 		pubInputSum = symbolic.Add(pubInputSum, symbolic.Mul(isFirst, subPubInput))
+// 	}
+
+// 	return c.Wiop.InsertPublicInput(name, accessors.NewFromExpression(pubInputSum, name+"_SUMMATION_ACCESSOR"))
+// }
+
+// // Prove is the main entry point for the prover. It takes a compiled IOP and
+// // returns a proof.
+// func (c *ConglomeratorCompilation) Prove(moduleGlProofs, moduleLppProofs []recursion.Witness) wizard.Proof {
+
+// 	var proof wizard.Proof
+// 	recursionTime := profiling.TimeIt(func() {
+// 		proof = wizard.Prove(
+// 			c.Wiop,
+// 			c.Recursion.GetMainProverStep(slices.Concat(moduleGlProofs, moduleLppProofs), &c.DefaultWitness),
+// 		)
+// 	})
+
+// 	logrus.
+// 		WithField("time", recursionTime).
+// 		WithField("nb_lpp_proofs", len(moduleLppProofs)).
+// 		WithField("nb_gl_proofs", len(moduleGlProofs)).
+// 		Info("recursion done")
+
+// 	return proof
+// }
+
+// // Run implements the [wizard.ProverAction] interface.
+// func (cong *ConglomerationAssignHolisticCheckColumn) Run(run *wizard.ProverRuntime) {
+
+// 	var (
+// 		vkMapping          = map[[2]field.Element][2]field.Element{}
+// 		lppPositionMapping = map[[2]field.Element]int{}
+// 		assignment         = [2][]field.Element{}
+// 		isGL               = cong.IsGL.GetColAssignment(run).IntoRegVecSaveAlloc()
+// 		verifyingKey       = [2][]field.Element{
+// 			cong.VerifyingKeyColumns[0].GetColAssignment(run).IntoRegVecSaveAlloc(),
+// 			cong.VerifyingKeyColumns[1].GetColAssignment(run).IntoRegVecSaveAlloc(),
+// 		}
+// 		numPrecomputedRow = cong.PrecomputedGLVks[0][0].Size()
+// 	)
+
+// 	for i := 0; i < numPrecomputedRow; i++ {
+
+// 		vk0LPP := cong.PrecomputedLPPVks[0].GetColAssignmentAt(run, i)
+// 		vk1LPP := cong.PrecomputedLPPVks[1].GetColAssignmentAt(run, i)
+
+// 		for j := 0; j < lppGroupingArity; j++ {
+
+// 			vk0GL := cong.PrecomputedGLVks[j][0].GetColAssignmentAt(run, i)
+// 			vk1GL := cong.PrecomputedGLVks[j][1].GetColAssignmentAt(run, i)
+// 			vkMapping[[2]field.Element{vk0GL, vk1GL}] = [2]field.Element{vk0LPP, vk1LPP}
+// 			lppPositionMapping[[2]field.Element{vk0GL, vk1GL}] = j
+// 		}
+// 	}
+
+// 	assignment[0] = make([]field.Element, len(verifyingKey[0]))
+// 	assignment[1] = make([]field.Element, len(verifyingKey[1]))
+// 	lppColumnIndex := make([]field.Element, len(verifyingKey[0]))
+
+// 	for i := 0; i < len(verifyingKey[0]); i++ {
+
+// 		if !isGL[i].IsOne() {
+// 			continue
+// 		}
+
+// 		var (
+// 			glKey            = [2]field.Element{verifyingKey[0][i], verifyingKey[1][i]}
+// 			mappedLPP, found = vkMapping[glKey]
+// 			mappedPosition   = lppPositionMapping[glKey]
+// 		)
+
+// 		if !found {
+
+// 			// Before panicking we unfold the list of the available vkeys from
+// 			// the mapping to try to make it easier to debug.
+
+// 			var (
+// 				glKeysFmtted = []string{}
+// 				glKeys       = utils.SortedKeysOf(vkMapping, func(a, b [2]field.Element) bool {
+// 					if a[0].Cmp(&b[0]) != 0 {
+// 						return a[0].Cmp(&b[0]) < 0
+// 					}
+// 					return a[1].Cmp(&b[1]) < 0
+// 				})
+// 			)
+
+// 			for i := range glKeys {
+// 				glKeysFmtted = append(glKeysFmtted, fmt.Sprintf("[%v %v]", glKeys[i][0].Text(16), glKeys[i][1].Text(16)))
+// 			}
+
+// 			utils.Panic("verifying key not found missing=[%v %v], row=%v availble-keys=%v",
+// 				verifyingKey[0][i].Text(16), verifyingKey[1][i].Text(16),
+// 				i,
+// 				glKeysFmtted,
+// 			)
+// 		}
+
+// 		assignment[0][i] = mappedLPP[0]
+// 		assignment[1][i] = mappedLPP[1]
+// 		lppColumnIndex[i] = field.NewElement(uint64(mappedPosition))
+
+// 		continue
+// 	}
+
+// 	colToAssign := cong.HolisticLookupMappedLPPVK
+// 	posToAssign := cong.HolisticLookupMappedLPPPostion
+
+// 	run.AssignColumn(colToAssign[0].GetColID(), smartvectors.RightZeroPadded(assignment[0], colToAssign[0].Size()))
+// 	run.AssignColumn(colToAssign[1].GetColID(), smartvectors.RightZeroPadded(assignment[1], colToAssign[1].Size()))
+// 	run.AssignColumn(posToAssign.GetColID(), smartvectors.RightZeroPadded(lppColumnIndex, posToAssign.Size()))
+// }
+
+// // precomputeToTheWhiteListVKeys declares the precomputed columns needed to
+// // perform the white-list-check of the verifying keys.
+// func (cong *ConglomeratorCompilation) precomputeToTheWhiteListVKeys() ([2]ifaces.Column, [lppGroupingArity][2]ifaces.Column) {
+
+// 	var (
+// 		comp = cong.Wiop
+
+// 		// vkMappingWhiteList is a list of pairs representing the correspondance
+// 		// table between the VKs for the GL and the LPP modules. Namely, it
+// 		// represents the list of the GL modules that can be linked to an LPP
+// 		// module.
+// 		vkMappingPaddedSize   = utils.NextPowerOfTwo(len(cong.ModuleLPPIops))
+// 		vkMappingWhiteListLPP = [2][]field.Element{}
+// 		vkMappingWhiteListGL  = [lppGroupingArity][2][]field.Element{}
+
+// 		// The columns for the vkMapping
+// 		vkMappingColumnsLPP = [2]ifaces.Column{}
+// 		vkMappingColumnsGL  = [lppGroupingArity][2]ifaces.Column{}
+// 	)
+
+// 	//
+// 	// Collect the content of the lookup tables
+// 	//
+
+// 	for i := range cong.ModuleLPPIops {
+
+// 		vk0, vk1 := getVerifyingKeyPair(cong.ModuleLPPIops[i])
+// 		vkMappingWhiteListLPP[0] = append(vkMappingWhiteListLPP[0], vk0)
+// 		vkMappingWhiteListLPP[1] = append(vkMappingWhiteListLPP[1], vk1)
+
+// 		for j := 0; j < lppGroupingArity; j++ {
+
+// 			vk0, vk1 := field.Zero(), field.Zero()
+// 			if i*lppGroupingArity+j < len(cong.ModuleGLIops) {
+// 				vk0, vk1 = getVerifyingKeyPair(cong.ModuleGLIops[i*lppGroupingArity+j])
+// 			}
+
+// 			vkMappingWhiteListGL[j][0] = append(vkMappingWhiteListGL[j][0], vk0)
+// 			vkMappingWhiteListGL[j][1] = append(vkMappingWhiteListGL[j][1], vk1)
+// 		}
+// 	}
+
+// 	//
+// 	// Declare the whiteListed VKs as precomputed columns representing the correspondance
+// 	// table between the VKs for the GL and the LPP modules.
+// 	//
+
+// 	vkMappingColumnsLPP[0] = comp.InsertPrecomputed(
+// 		"CONG_VK_LPP_0",
+// 		smartvectors.RightPadded(vkMappingWhiteListLPP[0], vkMappingWhiteListLPP[0][0], vkMappingPaddedSize),
+// 	)
+
+// 	vkMappingColumnsLPP[1] = comp.InsertPrecomputed(
+// 		"CONG_VK_LPP_1",
+// 		smartvectors.RightPadded(vkMappingWhiteListLPP[1], vkMappingWhiteListLPP[1][0], vkMappingPaddedSize),
+// 	)
+
+// 	for j := 0; j < lppGroupingArity; j++ {
+
+// 		vkMappingColumnsGL[j][0] = comp.InsertPrecomputed(
+// 			ifaces.ColIDf("CONG_VK_GL_%d_0", j),
+// 			smartvectors.RightPadded(vkMappingWhiteListGL[j][0], vkMappingWhiteListGL[j][0][0], vkMappingPaddedSize),
+// 		)
+
+// 		vkMappingColumnsGL[j][1] = comp.InsertPrecomputed(
+// 			ifaces.ColIDf("CONG_VK_GL_%d_1", j),
+// 			smartvectors.RightPadded(vkMappingWhiteListGL[j][1], vkMappingWhiteListGL[j][1][0], vkMappingPaddedSize),
+// 		)
+// 	}
+
+// 	return vkMappingColumnsLPP, vkMappingColumnsGL
+// }
+
+// // declareLookups declares the lookup constraints needed to complete the
+// // holistic checks. The role of these lookups is to:
+// //
+// // 1. Ensures that the LPP commitments are correctly passed from GL to LPP
+// // 2. Ensures that all the verifying keys are whitelisted.
+// func (cong *ConglomeratorCompilation) declareLookups() {
+
+// 	var (
+// 		comp = cong.Wiop
+
+// 		// The effective assignments of the VKs and the LPP columns
+// 		effectiveColumnSize   = utils.NextPowerOfTwo(cong.MaxNbProofs)
+// 		effectiveVksAccessors = [2][]ifaces.Accessor{}
+// 		isGLAccessors         = []ifaces.Accessor{}
+// 		isLPPAccessors        = []ifaces.Accessor{}
+// 		lppColumnsAccessors   = [lppGroupingArity][]ifaces.Accessor{}
+// 	)
+
+// 	cong.HolisticLookupMappedLPPVK = [2]ifaces.Column{
+// 		comp.InsertCommit(0, "CONG_MAPPED_LPP_VK_0", effectiveColumnSize),
+// 		comp.InsertCommit(0, "CONG_MAPPED_LPP_VK_1", effectiveColumnSize),
+// 	}
+
+// 	cong.HolisticLookupMappedLPPPostion = comp.InsertCommit(0, "CONG_MAPPED_LPP_POSITION", effectiveColumnSize)
+
+// 	//
+// 	// Collect the accessors of the public inputs
+// 	//
+
+// 	for i := 0; i < cong.MaxNbProofs; i++ {
+
+// 		var (
+// 			verifyingKey  = cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+verifyingKeyPublicInput, i)
+// 			verifyingKey2 = cong.Recursion.GetPublicInputAccessorOfInstance(comp, verifyingKey2PublicInput, i)
+// 			isLPP         = cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+IsLppPublicInput, i)
+// 			isGL          = cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+IsGlPublicInput, i)
+// 		)
+
+// 		effectiveVksAccessors[0] = append(effectiveVksAccessors[0], verifyingKey)
+// 		effectiveVksAccessors[1] = append(effectiveVksAccessors[1], verifyingKey2)
+// 		isGLAccessors = append(isGLAccessors, isGL)
+// 		isLPPAccessors = append(isLPPAccessors, isLPP)
+
+// 		for j := 0; j < lppGroupingArity; j++ {
+// 			pubInputName := fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, j)
+// 			lppColumnsAccessors[j] = append(
+// 				lppColumnsAccessors[j],
+// 				cong.Recursion.GetPublicInputAccessorOfInstance(comp, preRecursionPrefix+pubInputName, i),
+// 			)
+// 		}
+// 	}
+
+// 	//
+// 	// Declare columns for the collected accessors
+// 	//
+
+// 	var (
+// 		vkColums = [2]ifaces.Column{
+// 			verifiercol.NewFromAccessors(effectiveVksAccessors[0], field.Zero(), effectiveColumnSize),
+// 			verifiercol.NewFromAccessors(effectiveVksAccessors[1], field.Zero(), effectiveColumnSize),
+// 		}
+
+// 		isGLCol  = verifiercol.NewFromAccessors(isGLAccessors, field.Zero(), effectiveColumnSize)
+// 		isLPPCol = verifiercol.NewFromAccessors(isLPPAccessors, field.Zero(), effectiveColumnSize)
+// 	)
+
+// 	cong.IsGL = isGLCol
+// 	cong.VerifyingKeyColumns = vkColums
+
+// 	//
+// 	// This constraints checks the validity of the mapped VK and LPP columns
+// 	//
+
+// 	var (
+// 		includingLppLookup       = [][]ifaces.Column{}
+// 		includingFilterLppLookup = []ifaces.Column{}
+// 		includingVKeyMatching    = [][]ifaces.Column{}
+// 	)
+
+// 	for j := 0; j < lppGroupingArity; j++ {
+
+// 		includingVKeyMatching = append(includingVKeyMatching, []ifaces.Column{
+// 			cong.PrecomputedLPPVks[0],
+// 			cong.PrecomputedLPPVks[1],
+// 			cong.PrecomputedGLVks[j][0],
+// 			cong.PrecomputedGLVks[j][1],
+// 		})
+
+// 		includingLppLookup = append(includingLppLookup, []ifaces.Column{
+// 			verifiercol.NewConstantCol(field.NewElement(uint64(j)), effectiveColumnSize, ""),
+// 			verifiercol.NewFromAccessors(lppColumnsAccessors[j], field.Zero(), effectiveColumnSize),
+// 			vkColums[0],
+// 			vkColums[1],
+// 		})
+
+// 		includingFilterLppLookup = append(includingFilterLppLookup, isLPPCol)
+// 	}
+
+// 	comp.GenericFragmentedConditionalInclusion(
+// 		0,
+// 		ifaces.QueryID("CONG_LPP_CONSISTENCY"),
+// 		includingLppLookup,
+// 		[]ifaces.Column{
+// 			cong.HolisticLookupMappedLPPPostion,
+// 			verifiercol.NewFromAccessors(lppColumnsAccessors[0], field.Zero(), effectiveColumnSize),
+// 			cong.HolisticLookupMappedLPPVK[0],
+// 			cong.HolisticLookupMappedLPPVK[1],
+// 		},
+// 		includingFilterLppLookup,
+// 		isGLCol,
+// 	)
+
+// 	comp.GenericFragmentedConditionalInclusion(
+// 		0,
+// 		ifaces.QueryID("CONG_VK_CONSISTENCY"),
+// 		includingVKeyMatching,
+// 		[]ifaces.Column{
+// 			cong.HolisticLookupMappedLPPVK[0],
+// 			cong.HolisticLookupMappedLPPVK[1],
+// 			vkColums[0],
+// 			vkColums[1],
+// 		},
+// 		nil,
+// 		isGLCol,
+// 	)
+// }
+
+// // getVerifyingKeyPair extracts the verifyingKeys from the compiled IOP.
+// func getVerifyingKeyPair(wiop *wizard.CompiledIOP) (vkGL, vkLPP field.Element) {
+// 	return wiop.ExtraData[verifyingKeyPublicInput].(field.Element),
+// 		wiop.ExtraData[verifyingKey2PublicInput].(field.Element)
+// }

--- a/prover/protocol/distributed/conglomeration_hierarchical.go
+++ b/prover/protocol/distributed/conglomeration_hierarchical.go
@@ -1,0 +1,1200 @@
+package distributed
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/consensys/gnark/frontend"
+	gmimc "github.com/consensys/gnark/std/hash/mimc"
+	"github.com/consensys/linea-monorepo/prover/backend/files"
+	"github.com/consensys/linea-monorepo/prover/crypto/mimc"
+	"github.com/consensys/linea-monorepo/prover/crypto/state-management/hashtypes"
+	"github.com/consensys/linea-monorepo/prover/crypto/state-management/smt"
+	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
+	"github.com/consensys/linea-monorepo/prover/maths/field"
+	"github.com/consensys/linea-monorepo/prover/protocol/accessors"
+	"github.com/consensys/linea-monorepo/prover/protocol/compiler/logdata"
+	"github.com/consensys/linea-monorepo/prover/protocol/compiler/recursion"
+	"github.com/consensys/linea-monorepo/prover/protocol/ifaces"
+	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
+	"github.com/consensys/linea-monorepo/prover/utils"
+	"github.com/consensys/linea-monorepo/prover/utils/types"
+)
+
+type ProofType int
+
+const (
+
+	// types enum for the proof types
+	proofTypeLPP ProofType = iota
+	proofTypeGL
+	proofTypeConglo
+
+	// aggregationArity is the arity of the aggregation circuit
+	aggregationArity = 2
+
+	// name of the public inputs
+	TargetNbSegmentPublicInputBase          = "TARGET_NB_SEGMENTS"
+	SegmentCountLPPPublicInputBase          = "GL_SEGMENT_COUNT"
+	SegmentCountGLPublicInputBase           = "LPP_SEGMENT_COUNT"
+	GeneralMultiSetPublicInputBase          = "GENERAL_MULTI_SET"
+	SharedRandomnessMultiSetPublicInputBase = "SHARED_RANDOMNESS_MULTI_SET"
+	VkMerkleProofBase                       = "VK_MERKLE_PROOF"
+	InitialRandomnessPublicInput            = "INITIAL_RANDOMNESS_PUBLIC_INPUT"
+	LogDerivativeSumPublicInput             = "LOG_DERIVATE_SUM_PUBLIC_INPUT"
+	GrandProductPublicInput                 = "GRAND_PRODUCT_PUBLIC_INPUT"
+	HornerPublicInput                       = "HORNER_FINAL_RES_PUBLIC_INPUT"
+	globalHashSentPublicInput               = "GLOBAL_HASH_SENT"
+	globalHashReceivedPublicInput           = "GLOBAL_HASH_RECEIVED"
+	VerifyingKeyPublicInput                 = "VERIFYING_KEY"
+	VerifyingKey2PublicInput                = "VERIFYING_KEY_2"
+	VerifyingKeyMerkleRootPublicInput       = "VK_MERKLE_ROOT"
+	lppMerkleRootPublicInput                = "LPP_COLUMNS_MERKLE_ROOTS"
+)
+
+// ConglomerationCompilation holds the compilation context of the hierarchical
+// conglomeration.
+type ModuleConglo struct {
+	// ModuleNumber gives the number of modules of the distributed prover
+	ModuleNumber int
+	// Wiop is the compiled IOP of the conglomeration wizard.
+	Wiop *wizard.CompiledIOP
+	// Recursion is the recursion context used to compile the conglomeration
+	// proof.
+	Recursion *recursion.Recursion
+	// PublicInputs stores the public inputs of the conglomeration proof.
+	PublicInputs LimitlessPublicInput[wizard.PublicInput]
+	// VerificationKeyMerkleProofs is the list of the verification keys proving
+	// the membership of the verifying keys of the instances inside the
+	// VerificationKeyMerkleTree. Each merkle proof is structured as a list of
+	// D columns if size 1 where D is the depth of the merkle tree.
+	VerificationKeyMerkleProofs [][]ifaces.Column
+}
+
+// ModuleWitnessConglo collects the witness elements of the conglomeration
+// compiler
+type ModuleWitnessConglo struct {
+	SegmentProofs             []SegmentProof
+	VerificationKeyMerkleTree VerificationKeyMerkleTree
+}
+
+// VerificationKeyMerkleTree is a Merkle tree storing a list of verification keys
+// and it is meant to store the verification keys of all the moduleGL/LPP and
+// and of the ConglomerationHierarchical circuit.
+type VerificationKeyMerkleTree struct {
+	Tree             *smt.Tree
+	VerificationKeys [][2]field.Element
+}
+
+// ConglomerationHierarchicalVerifierAction implements the [wizard.VerifierAction]
+// interface for the conglomeration proof. It checks the consistency of the
+// public inputs with the children instance's public inputs.
+type ConglomerationHierarchicalVerifierAction struct {
+	ModuleConglo
+}
+
+// LimitlessPublicInput stores the columns totalling the
+// public inputs of a conglomeration node.
+type LimitlessPublicInput[T any] struct {
+	Functionals                  []T
+	TargetNbSegments             []T
+	SegmentCountGL               []T
+	SegmentCountLPP              []T
+	GeneralMultiSetHash          []T
+	SharedRandomnessMultiSetHash []T
+	VKeyMerkleRoot               T
+	VerifyingKey                 [2]T
+	LogDerivativeSum             T
+	HornerSum                    T
+	GrandProduct                 T
+	SharedRandomness             T
+}
+
+// buildVerificationKeyMerkleTree builds the verification key merkle tree.
+func buildVerificationKeyMerkleTree(moduleGL, moduleLPP []*RecursedSegmentCompilation, hierAgg *RecursedSegmentCompilation) VerificationKeyMerkleTree {
+
+	var (
+		leaves           = make([]types.Bytes32, 0, len(moduleGL)+len(moduleLPP)+1)
+		verificationKeys = make([][2]field.Element, 0, len(moduleGL)+len(moduleLPP)+1)
+		vkList           = ""
+	)
+
+	appendLeaf := func(comp *wizard.CompiledIOP) {
+		var (
+			vk0, vk1 = getVerifyingKeyPair(comp)
+			leafF    = mimc.HashVec([]field.Element{vk0, vk1})
+			leaf     types.Bytes32
+		)
+
+		leaf.SetField(leafF)
+		leaves = append(leaves, leaf)
+		verificationKeys = append(verificationKeys, [2]field.Element{vk0, vk1})
+
+		vkList += fmt.Sprintf("\t%v %v\n", vk0.String(), vk1.String())
+	}
+
+	for _, module := range moduleGL {
+		appendLeaf(module.RecursionComp)
+	}
+
+	for _, module := range moduleLPP {
+		appendLeaf(module.RecursionComp)
+	}
+
+	appendLeaf(hierAgg.RecursionComp)
+
+	// padding with zeroes so that the leaves number if a power-of-two
+	paddedSize := utils.NextPowerOfTwo(len(leaves))
+	for i := len(leaves); i < paddedSize; i++ {
+		leaves = append(leaves, types.Bytes32{})
+	}
+
+	return VerificationKeyMerkleTree{
+		Tree:             smt.BuildComplete(leaves, hashtypes.MiMC),
+		VerificationKeys: verificationKeys,
+	}
+}
+
+// GetVkMerkleProof return the merkle proof of a verification key
+func (vmt VerificationKeyMerkleTree) GetVkMerkleProof(segProof SegmentProof) []field.Element {
+
+	var (
+		leafPosition = -1
+		numModule    = utils.DivExact(len(vmt.VerificationKeys)-1, 2)
+		moduleIndex  = segProof.ModuleIndex
+	)
+
+	switch segProof.ProofType {
+	// the instance is a conglomeration proof
+	case proofTypeConglo:
+		leafPosition = 2 * numModule
+	case proofTypeLPP:
+		leafPosition = moduleIndex + numModule
+	case proofTypeGL:
+		leafPosition = moduleIndex
+	default:
+		panic("unexpected proof type")
+	}
+
+	proof := vmt.Tree.MustProve(leafPosition)
+	res := make([]field.Element, len(proof.Siblings))
+	for i, sibling := range proof.Siblings {
+		res[i].SetBytes(sibling[:])
+	}
+
+	fmt.Printf(
+		"[getMerkleProof] leaf position: %v, root: %v, leaf: %v, vk: %v\n",
+		leafPosition, vmt.Tree.Root.Hex(), vmt.Tree.OccupiedLeaves[leafPosition].Hex(),
+		vector.Prettify(vmt.VerificationKeys[leafPosition][:]))
+
+	return res
+}
+
+// GetRoot returns the root of the verification key merkle tree encoded as a
+// field element.
+func (vmt VerificationKeyMerkleTree) GetRoot() field.Element {
+	root := vmt.Tree.Root
+	var rootF field.Element
+	rootF.SetBytes(root[:])
+	return rootF
+}
+
+// CheckMembership checks if a verification key is in the merkle tree.
+func checkVkMembership(t ProofType, numModule int, moduleIndex int, vk [2]field.Element, rootF field.Element, proofF []field.Element) error {
+
+	var leafPosition = -1
+
+	switch t {
+	// the instance is a conglomeration proof
+	case proofTypeConglo:
+		leafPosition = 2 * numModule
+	case proofTypeLPP:
+		leafPosition = moduleIndex + numModule
+	case proofTypeGL:
+		leafPosition = moduleIndex
+	default:
+		panic("unexpected proof type")
+	}
+
+	// This part of the loop checks the membership of the VK as a member of
+	// the tree using the leafPosition from above.
+
+	var (
+		merkleDepth = utils.Log2Ceil(2*numModule + 1)
+		root        types.Bytes32
+		mProof      = smt.Proof{
+			Path:     leafPosition,
+			Siblings: make([]types.Bytes32, merkleDepth),
+		}
+		smtCfg = &smt.Config{HashFunc: hashtypes.MiMC, Depth: merkleDepth}
+		leafF  = mimc.HashVec(vk[:])
+		leaf   = types.Bytes32{}
+	)
+
+	if merkleDepth != len(proofF) {
+		panic("merkleDepth != len(proofF)")
+	}
+
+	leaf.SetField(leafF)
+
+	for lvl := 0; lvl < merkleDepth; lvl++ {
+		mProof.Siblings[lvl].SetField(proofF[lvl])
+	}
+
+	root.SetField(rootF)
+
+	fmt.Printf("verified VK merkle proof: %v, moduleIndex: %v, proofType: %v, leaf: %v, root: %v", leafPosition, moduleIndex, t, leaf.Hex(), root.Hex())
+
+	if !mProof.Verify(smtCfg, leaf, root) {
+		return fmt.Errorf("VK is not a member of the tree: pos: %v, moduleIndex: %v, proofType: %v, leaf: %v, root: %v", leafPosition, moduleIndex, t, leaf.Hex(), root.Hex())
+	}
+
+	return nil
+}
+
+// CheckMembershipGnark checks if a verification key is in the merkle tree.
+func checkVkMembershipGnark(
+	api frontend.API,
+	leafPosition frontend.Variable,
+	numModule int,
+	vk [2]frontend.Variable,
+	root frontend.Variable,
+	proofF []frontend.Variable,
+) {
+
+	// This part of the loop checks the membership of the VK as a member of
+	// the tree using the leafPosition from above.
+
+	var (
+		merkleDepth = utils.Log2Ceil(2*numModule + 1)
+		mProof      = smt.GnarkProof{
+			Path:     leafPosition,
+			Siblings: proofF,
+		}
+		leaf = mimc.GnarkHashVec(api, vk[:])
+	)
+
+	if merkleDepth != len(proofF) {
+		panic("merkleDepth != len(proofF)")
+	}
+
+	h, err := gmimc.NewMiMC(api)
+	if err != nil {
+		panic(err)
+	}
+
+	smt.GnarkVerifyMerkleProof(api, mProof, leaf, root, &h)
+}
+
+// Conglomerate runs the conglomeration compiler and returns a pointer to the
+// receiver of the method.
+func (d *DistributedWizard) Conglomerate(params CompilationParams) *DistributedWizard {
+
+	conglo := &ModuleConglo{
+		ModuleNumber: len(d.CompiledGLs),
+	}
+
+	comp := wizard.NewCompiledIOP()
+	conglo.Compile(comp, d.CompiledGLs[0].RecursionComp)
+	d.CompiledConglomeration = CompileSegment(conglo, params)
+	assertCompatibleIOPs(d)
+
+	d.VerificationKeyMerkleTree = buildVerificationKeyMerkleTree(
+		d.CompiledGLs,
+		d.CompiledLPPs,
+		d.CompiledConglomeration,
+	)
+
+	return d
+}
+
+// Compile compiles the conglomeration proof. The function first checks if the
+// public inputs are compatible and then compiles the conglomeration proof.
+func (c *ModuleConglo) Compile(comp *wizard.CompiledIOP, moduleMod *wizard.CompiledIOP) {
+
+	c.Recursion = recursion.DefineRecursionOf(comp, moduleMod, recursion.Parameters{
+		Name:                   "conglomeration",
+		WithoutGkr:             true,
+		MaxNumProof:            2,
+		WithExternalHasherOpts: true,
+	})
+
+	c.Wiop = comp
+
+	for _, pi := range scanFunctionalInputs(moduleMod) {
+		c.PublicInputs.Functionals = append(c.PublicInputs.Functionals, declarePiColumn(c.Wiop, pi.Name))
+	}
+
+	c.PublicInputs.TargetNbSegments = declareListOfPiColumns(c.Wiop, 0, TargetNbSegmentPublicInputBase, c.ModuleNumber)
+	c.PublicInputs.SegmentCountGL = declareListOfPiColumns(c.Wiop, 0, SegmentCountGLPublicInputBase, c.ModuleNumber)
+	c.PublicInputs.SegmentCountLPP = declareListOfPiColumns(c.Wiop, 0, SegmentCountLPPPublicInputBase, c.ModuleNumber)
+	c.PublicInputs.GeneralMultiSetHash = declareListOfPiColumns(c.Wiop, 0, GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+	c.PublicInputs.SharedRandomnessMultiSetHash = declareListOfPiColumns(c.Wiop, 0, SharedRandomnessMultiSetPublicInputBase, mimc.MSetHashSize)
+	c.PublicInputs.LogDerivativeSum = declarePiColumn(c.Wiop, LogDerivativeSumPublicInput)
+	c.PublicInputs.HornerSum = declarePiColumn(c.Wiop, HornerPublicInput)
+	c.PublicInputs.GrandProduct = declarePiColumn(c.Wiop, GrandProductPublicInput)
+	c.PublicInputs.SharedRandomness = declarePiColumn(c.Wiop, InitialRandomnessPublicInput)
+	c.PublicInputs.VKeyMerkleRoot = declarePiColumn(c.Wiop, VerifyingKeyMerkleRootPublicInput)
+
+	// vkMerkleTreeDepth is the depth of the verification key merkle tree
+	vkMerkleTreeDepth := c.VKeyMTreeDepth()
+	c.VerificationKeyMerkleProofs = make([][]ifaces.Column, c.ModuleNumber)
+	for i := 0; i < aggregationArity; i++ {
+		for j := 0; j < vkMerkleTreeDepth; j++ {
+			col := comp.InsertProof(0, ifaces.ColID(fmt.Sprintf("vkMerkleProof_%d_%d", i, j)), 1)
+			c.VerificationKeyMerkleProofs[i] = append(c.VerificationKeyMerkleProofs[i], col)
+		}
+	}
+
+	comp.RegisterVerifierAction(0, &ConglomerationHierarchicalVerifierAction{ModuleConglo: *c})
+}
+
+// GetMainProverStep returns a [wizard.ProverStep] running [Assign] passing
+// the provided [ModuleWitness] argument.
+func (c *ModuleConglo) GetMainProverStep(witness *ModuleWitnessConglo) wizard.MainProverStep {
+	return func(run *wizard.ProverRuntime) {
+		c.Assign(&witness.VerificationKeyMerkleTree, run, witness.SegmentProofs)
+	}
+}
+
+// Assign assigns the public inputs for the conglomeration proof
+func (c *ModuleConglo) Assign(
+	mt *VerificationKeyMerkleTree,
+	run *wizard.ProverRuntime,
+	proofs []SegmentProof,
+) {
+
+	recursionWitnesses := []recursion.Witness{}
+
+	// This assigns the Merkle proofs in the verification key merkle tree
+	for i := range proofs {
+		mProof := mt.GetVkMerkleProof(proofs[i])
+		recursionWitnesses = append(recursionWitnesses, proofs[i].Witness)
+		for j := range mProof {
+			run.AssignColumn(
+				c.VerificationKeyMerkleProofs[i][j].GetColID(),
+				smartvectors.NewConstant(mProof[j], 1),
+			)
+		}
+	}
+
+	// This runs the recursion system. Expectedly, the filling input is never
+	// used because this is pairwise aggregation and we always pass exactly pass
+	// exactly 2 inputs.
+	c.Recursion.Assign(run, recursionWitnesses, &recursionWitnesses[0])
+
+	// Now, it remains to assign the public inputs for the conglomeration proof.
+	var (
+		collectedPIs                = [aggregationArity]LimitlessPublicInput[field.Element]{}
+		sumCountGLs                 = []field.Element{}
+		sumCountLPPs                = []field.Element{}
+		mSetSharedRand              = mimc.MSetHash{}
+		mSetGeneral                 = mimc.MSetHash{}
+		sumLogDerivative, sumHorner field.Element
+		prodGrandProduct            = field.One()
+	)
+
+	for instance := 0; instance < aggregationArity; instance++ {
+
+		collectedPIs[instance] = c.collectAllPublicInputsOfInstance(run, instance)
+
+		// This combines the query results
+		sumHorner.Add(&sumHorner, &collectedPIs[instance].HornerSum)
+		sumLogDerivative.Add(&sumLogDerivative, &collectedPIs[instance].LogDerivativeSum)
+		prodGrandProduct.Mul(&prodGrandProduct, &collectedPIs[instance].GrandProduct)
+
+		// This combines the multiset hashes
+		subMSetGeneral := mimc.MSetHash(collectedPIs[instance].GeneralMultiSetHash)
+		subMSetSharedRand := mimc.MSetHash(collectedPIs[instance].SharedRandomnessMultiSetHash)
+		mSetGeneral.Add(subMSetGeneral)
+		mSetSharedRand.Add(subMSetSharedRand)
+	}
+
+	// This assigns the functional public input by summing them
+	for f := range c.PublicInputs.Functionals {
+		var sumValue field.Element
+		for instance := 0; instance < aggregationArity; instance++ {
+			sumValue.Add(&sumValue, &collectedPIs[instance].Functionals[f])
+		}
+		pi := c.PublicInputs.Functionals[f]
+		assignPiColumn(run, pi.Name, sumValue)
+	}
+
+	assignListOfPiColumns(run, GeneralMultiSetPublicInputBase, mSetGeneral[:])
+	assignListOfPiColumns(run, SharedRandomnessMultiSetPublicInputBase, mSetSharedRand[:])
+
+	assignPiColumn(run, LogDerivativeSumPublicInput, sumLogDerivative)
+	assignPiColumn(run, HornerPublicInput, sumHorner)
+	assignPiColumn(run, GrandProductPublicInput, prodGrandProduct)
+
+	var sharedRandomness field.Element
+	for i := 0; i < aggregationArity; i++ {
+		r := collectedPIs[i].SharedRandomness
+		if !r.IsZero() {
+			sharedRandomness = r
+			break
+		}
+	}
+
+	assignPiColumn(run, InitialRandomnessPublicInput, sharedRandomness)
+	assignPiColumn(run, VerifyingKeyMerkleRootPublicInput, collectedPIs[0].VKeyMerkleRoot)
+
+	for k := 0; k < c.ModuleNumber; k++ {
+
+		var sumCountGL, sumCountLPP field.Element
+
+		for instance := 0; instance < aggregationArity; instance++ {
+			// This agglomerates the segment count for the GL and the LPPs modules. There
+			// is one GL and one LPP counter for each module that's why we do them in the
+			sumCountGL.Add(&sumCountGL, &collectedPIs[instance].SegmentCountGL[k])
+			sumCountLPP.Add(&sumCountLPP, &collectedPIs[instance].SegmentCountLPP[k])
+		}
+
+		sumCountGLs = append(sumCountGLs, sumCountGL)
+		sumCountLPPs = append(sumCountLPPs, sumCountLPP)
+	}
+
+	assignListOfPiColumns(run, TargetNbSegmentPublicInputBase, collectedPIs[0].TargetNbSegments)
+	assignListOfPiColumns(run, SegmentCountGLPublicInputBase, sumCountGLs)
+	assignListOfPiColumns(run, SegmentCountLPPPublicInputBase, sumCountLPPs)
+}
+
+// Run implements the [wizard.VerifierAction] for the
+// ConglomerationHierarchicalVerifierAction.
+func (c *ConglomerationHierarchicalVerifierAction) Run(run wizard.Runtime) error {
+
+	var (
+		err          error
+		collectedPIs = [aggregationArity]LimitlessPublicInput[field.Element]{}
+		topPIs       = collectAllPublicInputs(run)
+	)
+
+	for instance := 0; instance < aggregationArity; instance++ {
+		collectedPIs[instance] = c.collectAllPublicInputsOfInstance(run, instance)
+	}
+
+	// This checks that the functional public inputs are correctly conglomerated
+	// across all instances.
+	for k := range topPIs.Functionals {
+
+		summedUpValue := field.Element{}
+
+		for instance := 0; instance < aggregationArity; instance++ {
+			funcPI := collectedPIs[instance].Functionals[k]
+			summedUpValue.Add(&summedUpValue, &funcPI)
+		}
+
+		if summedUpValue != topPIs.Functionals[k] {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for Functionals at index %d, name=%v", k, c.PublicInputs.Functionals[k].Name))
+		}
+	}
+
+	for k := 0; k < c.ModuleNumber; k++ {
+
+		var (
+			sumCountGL  = field.Element{}
+			sumCountLPP = field.Element{}
+		)
+
+		for instance := 0; instance < aggregationArity; instance++ {
+
+			// This checks that the TargetNbSegments public inputs are the same for all
+			// the children instances and the current node.
+			if collectedPIs[instance].TargetNbSegments[k] != topPIs.TargetNbSegments[k] {
+				err = errors.Join(err, fmt.Errorf("public input mismatch for TargetNbSegments at instance %d", instance))
+			}
+
+			// This agglomerates the segment count for the GL and the LPPs modules. There
+			// is one GL and one LPP counter for each module that's why we do them in the
+			sumCountGL.Add(&sumCountGL, &collectedPIs[instance].SegmentCountGL[k])
+			sumCountLPP.Add(&sumCountLPP, &collectedPIs[instance].SegmentCountLPP[k])
+		}
+
+		if sumCountGL != topPIs.SegmentCountGL[k] {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for SegmentCountGL for module %d", k))
+		}
+
+		if sumCountLPP != topPIs.SegmentCountLPP[k] {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for SegmentCountLPP for module %d", k))
+		}
+	}
+
+	// This agglomerates the multiset hashes
+	for k := 0; k < mimc.MSetHashSize; k++ {
+
+		var (
+			generalSum = field.Element{}
+			sharedSum  = field.Element{}
+		)
+
+		for instance := 0; instance < aggregationArity; instance++ {
+			generalSum.Add(&generalSum, &collectedPIs[instance].GeneralMultiSetHash[k])
+			sharedSum.Add(&sharedSum, &collectedPIs[instance].SharedRandomnessMultiSetHash[k])
+		}
+
+		if generalSum != topPIs.GeneralMultiSetHash[k] {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for generalMultiSetHash for index %d", k))
+		}
+
+		if sharedSum != topPIs.SharedRandomnessMultiSetHash[k] {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for sharedRandomness for index %d", k))
+		}
+	}
+
+	// The loop below "aggregate" the public inputs: log-derivative-sum, gd-product,
+	// and horner sum of the sub-instances. The aggregation is done by multiplying/summing
+	// the values. The results are then compared the top-level public inputs.
+	var (
+		accGrandProduct = field.One()
+		accLogDeriv     = field.Zero()
+		accHornerSum    = field.Zero()
+	)
+
+	for instance := 0; instance < aggregationArity; instance++ {
+
+		// This agglomerates the horner N0 hash checker, the grand product, the
+		// log derivative sum and the horner sum.
+		accGrandProduct.Mul(&accGrandProduct, &collectedPIs[instance].GrandProduct)
+		accLogDeriv.Add(&accLogDeriv, &collectedPIs[instance].LogDerivativeSum)
+		accHornerSum.Add(&accHornerSum, &collectedPIs[instance].HornerSum)
+
+		if !collectedPIs[instance].SharedRandomness.IsZero() && collectedPIs[instance].SharedRandomness != topPIs.SharedRandomness {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for SharedRandomness for instance %d", instance))
+		}
+
+		if collectedPIs[instance].VKeyMerkleRoot != topPIs.VKeyMerkleRoot {
+			err = errors.Join(err, fmt.Errorf("public input mismatch for VKeyMerkleRoot for instance %d, sub-value=%v, top-value=%v",
+				instance, collectedPIs[instance].VKeyMerkleRoot.String(), topPIs.VKeyMerkleRoot.String(),
+			))
+		}
+	}
+
+	if accGrandProduct != topPIs.GrandProduct {
+		err = errors.Join(err, fmt.Errorf("public input mismatch for GrandProduct, %v != %v", accGrandProduct.String(), topPIs.GrandProduct.String()))
+	}
+
+	if accLogDeriv != topPIs.LogDerivativeSum {
+		err = errors.Join(err, fmt.Errorf("public input mismatch for LogDerivativeSum, %v != %v", accLogDeriv.String(), topPIs.LogDerivativeSum.String()))
+	}
+
+	if accHornerSum != topPIs.HornerSum {
+		err = errors.Join(err, fmt.Errorf("public input mismatch for HornerSum, %v != %v", accHornerSum.String(), topPIs.HornerSum.String()))
+	}
+
+	// This loop checks the VK membership in the tree. The merkle leaf position
+	// is deduced from the segment count public inputs in the following way;
+	//
+	// 	- If segment-count-sum of the GL position is one and LPP is zero, then
+	//  	the position is the position of the "count=1" GL input.
+	//
+	//  - If the segment segment-count-sum of the LPP positions is one and GL is
+	// 		zero, then the position is the position of the "count=1" LPP input +
+	// 		nb-module
+	//
+	// 	- Otherwise (the total sum is larger than 1), the position is 2*nb-module
+
+	for instance := 0; instance < aggregationArity; instance++ {
+
+		proofType, moduleIndex := findProofTypeAndModule(collectedPIs[instance])
+
+		mProof := make([]field.Element, c.ModuleConglo.VKeyMTreeDepth())
+		for i := range mProof {
+			mProof[i] = c.VerificationKeyMerkleProofs[instance][i].GetColAssignmentAt(run, 0)
+		}
+
+		vkErr := checkVkMembership(
+			proofType,
+			c.ModuleNumber,
+			moduleIndex,
+			collectedPIs[instance].VerifyingKey,
+			collectedPIs[instance].VKeyMerkleRoot,
+			mProof,
+		)
+
+		if vkErr != nil {
+			err = errors.Join(err, vkErr)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunGnark implements the [wizard.VerifierAction] interface.
+func (c *ConglomerationHierarchicalVerifierAction) RunGnark(api frontend.API, run wizard.GnarkRuntime) {
+
+	var (
+		collectedPIs = [aggregationArity]LimitlessPublicInput[frontend.Variable]{}
+		topPIs       = c.collectAllPublicInputsGnark(api, run)
+		hasher       = run.GetHasherFactory().NewHasher()
+	)
+
+	for instance := 0; instance < aggregationArity; instance++ {
+		collectedPIs[instance] = c.collectAllPublicInputsOfInstanceGnark(api, run, instance)
+	}
+
+	// This checks that the functional public inputs are correctly conglomerated
+	// across all instances.
+	for k := range topPIs.Functionals {
+		summedUpValue := frontend.Variable(0)
+		for instance := 0; instance < aggregationArity; instance++ {
+			funcPI := collectedPIs[instance].Functionals[k]
+			summedUpValue = api.Add(summedUpValue, funcPI)
+		}
+		api.AssertIsEqual(summedUpValue, topPIs.Functionals[k])
+	}
+
+	for k := 0; k < c.ModuleNumber; k++ {
+
+		var (
+			sumCountGL  = frontend.Variable(0)
+			sumCountLPP = frontend.Variable(0)
+		)
+
+		for instance := 0; instance < aggregationArity; instance++ {
+
+			// This checks that the TargetNbSegments public inputs are the same for all
+			// the children instances and the current node.
+			api.AssertIsEqual(collectedPIs[instance].TargetNbSegments[k], topPIs.TargetNbSegments[k])
+
+			// This agglomerates the segment count for the GL and the LPPs modules. There
+			// is one GL and one LPP counter for each module that's why we do them in the
+			sumCountGL = api.Add(sumCountGL, collectedPIs[instance].SegmentCountGL[k])
+			sumCountLPP = api.Add(sumCountLPP, collectedPIs[instance].SegmentCountLPP[k])
+		}
+
+		api.AssertIsEqual(sumCountGL, topPIs.SegmentCountGL[k])
+		api.AssertIsEqual(sumCountLPP, topPIs.SegmentCountLPP[k])
+	}
+
+	// This agglomerates the multiset hashes
+	var (
+		generalSum = mimc.EmptyMSetHashGnark(hasher)
+		sharedSum  = mimc.EmptyMSetHashGnark(hasher)
+	)
+
+	for instance := 0; instance < aggregationArity; instance++ {
+		generalSum.AddRaw(api, collectedPIs[instance].GeneralMultiSetHash)
+		sharedSum.AddRaw(api, collectedPIs[instance].SharedRandomnessMultiSetHash)
+	}
+
+	sharedSum.AssertEqualRaw(api, topPIs.SharedRandomnessMultiSetHash)
+	generalSum.AssertEqualRaw(api, topPIs.GeneralMultiSetHash)
+
+	// The loop below "aggregate" the public inputs: log-derivative-sum, gd-product,
+	// and horner sum of the sub-instances. The aggregation is done by multiplying/summing
+	// the values. The results are then compared the top-level public inputs.
+	var (
+		accGrandProduct = frontend.Variable(1)
+		accLogDeriv     = frontend.Variable(0)
+		accHornerSum    = frontend.Variable(0)
+	)
+
+	for instance := 0; instance < aggregationArity; instance++ {
+
+		// This agglomerates the horner N0 hash checker, the grand product, the
+		// log derivative sum and the horner sum.
+		accGrandProduct = api.Mul(accGrandProduct, collectedPIs[instance].GrandProduct)
+		accLogDeriv = api.Add(accLogDeriv, collectedPIs[instance].LogDerivativeSum)
+		accHornerSum = api.Add(accHornerSum, collectedPIs[instance].HornerSum)
+
+		api.AssertIsEqual(
+			api.Mul(
+				api.Sub(1, api.IsZero(collectedPIs[instance].SharedRandomness)),
+				api.Sub(collectedPIs[instance].SharedRandomness, topPIs.SharedRandomness),
+			),
+			0,
+		)
+
+		api.AssertIsEqual(collectedPIs[instance].VKeyMerkleRoot, topPIs.VKeyMerkleRoot)
+	}
+
+	api.AssertIsEqual(accGrandProduct, topPIs.GrandProduct)
+	api.AssertIsEqual(accLogDeriv, topPIs.LogDerivativeSum)
+	api.AssertIsEqual(accHornerSum, topPIs.HornerSum)
+
+	// This loop checks the VK membership in the tree. The merkle leaf position
+	// is deduced from the segment count public inputs in the following way;
+	//
+	// 	- If segment-count-sum of the GL position is one and LPP is zero, then
+	//  	the position is the position of the "count=1" GL input.
+	//
+	//  - If the segment segment-count-sum of the LPP positions is one and GL is
+	// 		zero, then the position is the position of the "count=1" LPP input +
+	// 		nb-module
+	//
+	// 	- Otherwise (the total sum is larger than 1), the position is 2*nb-module
+
+	for instance := 0; instance < aggregationArity; instance++ {
+
+		leafPosition := findVkPositionGnark(api, collectedPIs[instance])
+		mProof := make([]frontend.Variable, c.ModuleConglo.VKeyMTreeDepth())
+		for i := range mProof {
+			mProof[i] = c.VerificationKeyMerkleProofs[instance][i].GetColAssignmentGnarkAt(run, 0)
+		}
+
+		checkVkMembershipGnark(
+			api,
+			leafPosition,
+			c.ModuleNumber,
+			collectedPIs[instance].VerifyingKey,
+			collectedPIs[instance].VKeyMerkleRoot,
+			mProof,
+		)
+	}
+}
+
+// declarePi declares a column with the requested name as proof column and length
+// one and also declare a public input from that column with the same provided
+// name.
+func declarePiColumn(comp *wizard.CompiledIOP, name string) wizard.PublicInput {
+	return declarePiColumnAtRound(comp, 0, name)
+}
+
+// declarePiColumn at round declares a column at the requested round to generate
+// a public input with the requested name.
+func declarePiColumnAtRound(comp *wizard.CompiledIOP, round int, name string) wizard.PublicInput {
+	col := comp.InsertProof(round, ifaces.ColID(name+"_PI_COLUMN"), 1)
+	return comp.InsertPublicInput(name, accessors.NewFromPublicColumn(col, 0))
+}
+
+// assignPiColumn assigns the column of a public input with the requested name
+// to the provided column.
+func assignPiColumn(run *wizard.ProverRuntime, name string, val field.Element) {
+	run.AssignColumn(
+		ifaces.ColID(name+"_PI_COLUMN"),
+		smartvectors.NewConstant(val, 1),
+	)
+}
+
+// declareListOfPiColumns declares a list of columns with the requested name as
+// proof columns and length provided.
+func declareListOfPiColumns(comp *wizard.CompiledIOP, round int, name string, length int) []wizard.PublicInput {
+	var cols []wizard.PublicInput
+	for i := 0; i < length; i++ {
+		cols = append(cols, declarePiColumnAtRound(comp, round, name+"_"+strconv.Itoa(i)))
+	}
+	return cols
+}
+
+// declareListOfConstantPi declares a list of public inputs as constant values.
+// This is useful to create dummy public inputs making the aggregation process
+// simpler.
+func declareListOfConstantPi(comp *wizard.CompiledIOP, name string, values []field.Element) []wizard.PublicInput {
+	res := make([]wizard.PublicInput, len(values))
+	for i, val := range values {
+		name := name + "_" + strconv.Itoa(i)
+		pub := comp.InsertPublicInput(name, accessors.NewConstant(val))
+		res = append(res, pub)
+	}
+	return res
+}
+
+// assignListOfPiColumns assigns a list of columns with the requested name using
+// the provided list of values.
+func assignListOfPiColumns(run *wizard.ProverRuntime, name string, values []field.Element) {
+	for i, val := range values {
+		name := name + "_" + strconv.Itoa(i)
+		assignPiColumn(run, name, val)
+	}
+}
+
+// GetPublicInputList returns a list of public input of the provided name for the
+// current WIOP (e.g. not the for the children instance).
+//
+// @alex: would be interesting to make that a utility function in the wizard
+// package because it helps whenever we want to encode stuffs as public inputs.
+func GetPublicInputList(run wizard.Runtime, name string, nb int) []field.Element {
+	var res []field.Element
+	for i := 0; i < nb; i++ {
+		name := name + "_" + strconv.Itoa(i)
+		res = append(res, run.GetPublicInput(name))
+	}
+	return res
+}
+
+// getPublicInputListOfInstance returns a list of public inputs of the provided
+// name and instance.
+func getPublicInputListOfInstance(rec *recursion.Recursion, run wizard.Runtime, name string, instance int, nb int) []field.Element {
+	var res []field.Element
+	for i := 0; i < nb; i++ {
+		name := name + "_" + strconv.Itoa(i)
+		res = append(res, rec.GetPublicInputOfInstance(run, name, instance))
+	}
+	return res
+}
+
+// GetPublicInputListGnark is as [getPublicInputList] but for gnark.
+func GetPublicInputListGnark(api frontend.API, run wizard.GnarkRuntime, name string, nb int) []frontend.Variable {
+	var res []frontend.Variable
+	for i := 0; i < nb; i++ {
+		name := name + "_" + strconv.Itoa(i)
+		res = append(res, run.GetPublicInput(api, name))
+	}
+	return res
+}
+
+// getPublicInputListOfInstance returns a list of public inputs of the provided
+// name and instance.
+func getPublicInputListOfInstanceGnark(rec *recursion.Recursion, api frontend.API, run wizard.GnarkRuntime, name string, instance int, nb int) []frontend.Variable {
+	var res []frontend.Variable
+	for i := 0; i < nb; i++ {
+		name := name + "_" + strconv.Itoa(i)
+		res = append(res, rec.GetPublicInputOfInstanceGnark(api, run, name, instance))
+	}
+	return res
+}
+
+// collectAllPublicInputsOfInstance returns a structured object representing
+// the public inputs of the given instance.
+func (c ModuleConglo) collectAllPublicInputsOfInstance(run wizard.Runtime, instance int) LimitlessPublicInput[field.Element] {
+
+	res := LimitlessPublicInput[field.Element]{
+		TargetNbSegments:             getPublicInputListOfInstance(c.Recursion, run, TargetNbSegmentPublicInputBase, instance, c.ModuleNumber),
+		SegmentCountGL:               getPublicInputListOfInstance(c.Recursion, run, SegmentCountGLPublicInputBase, instance, c.ModuleNumber),
+		SegmentCountLPP:              getPublicInputListOfInstance(c.Recursion, run, SegmentCountLPPPublicInputBase, instance, c.ModuleNumber),
+		GeneralMultiSetHash:          getPublicInputListOfInstance(c.Recursion, run, GeneralMultiSetPublicInputBase, instance, mimc.MSetHashSize),
+		SharedRandomnessMultiSetHash: getPublicInputListOfInstance(c.Recursion, run, SharedRandomnessMultiSetPublicInputBase, instance, mimc.MSetHashSize),
+		LogDerivativeSum:             c.Recursion.GetPublicInputOfInstance(run, LogDerivativeSumPublicInput, instance),
+		HornerSum:                    c.Recursion.GetPublicInputOfInstance(run, HornerPublicInput, instance),
+		GrandProduct:                 c.Recursion.GetPublicInputOfInstance(run, GrandProductPublicInput, instance),
+		SharedRandomness:             c.Recursion.GetPublicInputOfInstance(run, InitialRandomnessPublicInput, instance),
+		VKeyMerkleRoot:               c.Recursion.GetPublicInputOfInstance(run, VerifyingKeyMerkleRootPublicInput, instance),
+		VerifyingKey: [2]field.Element{
+			c.Recursion.GetPublicInputOfInstance(run, VerifyingKeyPublicInput, instance),
+			c.Recursion.GetPublicInputOfInstance(run, VerifyingKey2PublicInput, instance),
+		},
+	}
+
+	for _, pi := range c.PublicInputs.Functionals {
+		res.Functionals = append(res.Functionals, c.Recursion.GetPublicInputOfInstance(run, pi.Name, instance))
+	}
+
+	return res
+}
+
+// collectAllPublicInputs returns a structured object representing the public
+// inputs of all the instances.
+func collectAllPublicInputs(run wizard.Runtime) LimitlessPublicInput[field.Element] {
+
+	// This function auto-detects the number of module. It counts the number of
+	// public inputs with the [targetNbSegmentPublicInputBase] prefix in their
+	// name.
+	var (
+		moduleNumber int
+		pubs         = run.GetSpec().PublicInputs
+	)
+
+	for _, pub := range pubs {
+		if strings.Contains(pub.Name, TargetNbSegmentPublicInputBase) && !strings.Contains(pub.Name, "conglomeration") {
+			moduleNumber++
+		}
+	}
+
+	res := LimitlessPublicInput[field.Element]{
+		TargetNbSegments:             GetPublicInputList(run, TargetNbSegmentPublicInputBase, moduleNumber),
+		SegmentCountGL:               GetPublicInputList(run, SegmentCountGLPublicInputBase, moduleNumber),
+		SegmentCountLPP:              GetPublicInputList(run, SegmentCountLPPPublicInputBase, moduleNumber),
+		GeneralMultiSetHash:          GetPublicInputList(run, GeneralMultiSetPublicInputBase, mimc.MSetHashSize),
+		SharedRandomnessMultiSetHash: GetPublicInputList(run, SharedRandomnessMultiSetPublicInputBase, mimc.MSetHashSize),
+		LogDerivativeSum:             run.GetPublicInput(LogDerivativeSumPublicInput),
+		HornerSum:                    run.GetPublicInput(HornerPublicInput),
+		GrandProduct:                 run.GetPublicInput(GrandProductPublicInput),
+		SharedRandomness:             run.GetPublicInput(InitialRandomnessPublicInput),
+		VKeyMerkleRoot:               run.GetPublicInput(VerifyingKeyMerkleRootPublicInput),
+	}
+
+	for _, pi := range scanFunctionalInputs(run.GetSpec()) {
+		res.Functionals = append(res.Functionals, run.GetPublicInput(pi.Name))
+	}
+
+	return res
+}
+
+// collectAllPublicInputsOfInstanceGnark returns a structured object representing
+// the public inputs of the given instance.
+func (c ModuleConglo) collectAllPublicInputsOfInstanceGnark(api frontend.API, run wizard.GnarkRuntime, instance int) LimitlessPublicInput[frontend.Variable] {
+
+	res := LimitlessPublicInput[frontend.Variable]{
+		TargetNbSegments:             getPublicInputListOfInstanceGnark(c.Recursion, api, run, TargetNbSegmentPublicInputBase, instance, c.ModuleNumber),
+		SegmentCountGL:               getPublicInputListOfInstanceGnark(c.Recursion, api, run, SegmentCountGLPublicInputBase, instance, c.ModuleNumber),
+		SegmentCountLPP:              getPublicInputListOfInstanceGnark(c.Recursion, api, run, SegmentCountLPPPublicInputBase, instance, c.ModuleNumber),
+		GeneralMultiSetHash:          getPublicInputListOfInstanceGnark(c.Recursion, api, run, GeneralMultiSetPublicInputBase, instance, mimc.MSetHashSize),
+		SharedRandomnessMultiSetHash: getPublicInputListOfInstanceGnark(c.Recursion, api, run, SharedRandomnessMultiSetPublicInputBase, instance, mimc.MSetHashSize),
+		LogDerivativeSum:             c.Recursion.GetPublicInputOfInstanceGnark(api, run, LogDerivativeSumPublicInput, instance),
+		HornerSum:                    c.Recursion.GetPublicInputOfInstanceGnark(api, run, HornerPublicInput, instance),
+		GrandProduct:                 c.Recursion.GetPublicInputOfInstanceGnark(api, run, GrandProductPublicInput, instance),
+		SharedRandomness:             c.Recursion.GetPublicInputOfInstanceGnark(api, run, InitialRandomnessPublicInput, instance),
+		VKeyMerkleRoot:               c.Recursion.GetPublicInputOfInstanceGnark(api, run, VerifyingKeyMerkleRootPublicInput, instance),
+		VerifyingKey: [2]frontend.Variable{
+			c.Recursion.GetPublicInputOfInstanceGnark(api, run, VerifyingKeyPublicInput, instance),
+			c.Recursion.GetPublicInputOfInstanceGnark(api, run, VerifyingKey2PublicInput, instance),
+		},
+	}
+
+	for _, pi := range c.PublicInputs.Functionals {
+		res.Functionals = append(res.Functionals, c.Recursion.GetPublicInputOfInstanceGnark(api, run, pi.Name, instance))
+	}
+
+	return res
+}
+
+// collectAllPublicInputsGnark returns a structured object representing the public
+// inputs of all the instances.
+//
+// In the returned object, the verifying key public inputs are not populated.
+func (c ModuleConglo) collectAllPublicInputsGnark(api frontend.API, run wizard.GnarkRuntime) LimitlessPublicInput[frontend.Variable] {
+
+	res := LimitlessPublicInput[frontend.Variable]{
+		TargetNbSegments:             GetPublicInputListGnark(api, run, TargetNbSegmentPublicInputBase, c.ModuleNumber),
+		SegmentCountGL:               GetPublicInputListGnark(api, run, SegmentCountGLPublicInputBase, c.ModuleNumber),
+		SegmentCountLPP:              GetPublicInputListGnark(api, run, SegmentCountLPPPublicInputBase, c.ModuleNumber),
+		GeneralMultiSetHash:          GetPublicInputListGnark(api, run, GeneralMultiSetPublicInputBase, mimc.MSetHashSize),
+		SharedRandomnessMultiSetHash: GetPublicInputListGnark(api, run, SharedRandomnessMultiSetPublicInputBase, mimc.MSetHashSize),
+		LogDerivativeSum:             run.GetPublicInput(api, LogDerivativeSumPublicInput),
+		HornerSum:                    run.GetPublicInput(api, HornerPublicInput),
+		GrandProduct:                 run.GetPublicInput(api, GrandProductPublicInput),
+		SharedRandomness:             run.GetPublicInput(api, InitialRandomnessPublicInput),
+		VKeyMerkleRoot:               run.GetPublicInput(api, VerifyingKeyMerkleRootPublicInput),
+	}
+
+	for _, pi := range scanFunctionalInputs(c.Recursion.InputCompiledIOP) {
+		res.Functionals = append(res.Functionals, run.GetPublicInput(api, pi.Name))
+	}
+
+	return res
+}
+
+// VKeyMTreeDepth returns the depth of the verification key merkle tree.
+func (c ModuleConglo) VKeyMTreeDepth() int {
+	return utils.Log2Ceil(2*c.ModuleNumber + 1)
+}
+
+// findProofTypeAndModule returns the proofType and the module index of the
+// provided instance given collected public inputs of the instances.
+func findProofTypeAndModule(instance LimitlessPublicInput[field.Element]) (ProofType, int) {
+
+	var (
+		sumGL, sumLPP = 0, 0
+		moduleIndex   = -1 // can't be -1 at the end of the "mod" loop.
+		moduleNumber  = len(instance.SegmentCountGL)
+	)
+
+	for mod := 0; mod < moduleNumber; mod++ {
+
+		var (
+			segmentCountGL  = instance.SegmentCountGL[mod]
+			segmentCountLPP = instance.SegmentCountLPP[mod]
+		)
+
+		sumGL += int(segmentCountGL.Uint64())
+		sumLPP += int(segmentCountLPP.Uint64())
+
+		if !segmentCountGL.IsZero() || !segmentCountLPP.IsZero() {
+			moduleIndex = mod
+		}
+	}
+
+	switch {
+	case sumGL+sumLPP > 1:
+		return proofTypeConglo, 0
+	case sumGL == 1:
+		return proofTypeGL, moduleIndex
+	case sumLPP == 1:
+		return proofTypeLPP, moduleIndex
+	}
+
+	panic("unreachable")
+}
+
+func findVkPositionGnark(api frontend.API, instance LimitlessPublicInput[frontend.Variable]) frontend.Variable {
+
+	var (
+		sumGL, sumLPP = frontend.Variable(0), frontend.Variable(0)
+		moduleIndex   = frontend.Variable(-1) // can't be -1 at the end of the "mod" loop.
+		moduleNumber  = len(instance.SegmentCountGL)
+	)
+
+	for mod := 0; mod < moduleNumber; mod++ {
+
+		var (
+			segmentCountGL  = instance.SegmentCountGL[mod]
+			segmentCountLPP = instance.SegmentCountLPP[mod]
+		)
+
+		sumGL = api.Add(sumGL, segmentCountGL)
+		sumLPP = api.Add(sumLPP, segmentCountLPP)
+		moduleIndex = api.Select(
+			api.IsZero(api.Add(segmentCountGL, segmentCountLPP)),
+			moduleIndex,
+			frontend.Variable(mod),
+		)
+	}
+
+	var (
+		hasNothing = api.IsZero(
+			api.Add(sumGL, sumLPP),
+		)
+
+		isGL = api.Mul(
+			api.IsZero(sumLPP),
+			api.IsZero(api.Sub(sumGL, 1)),
+		)
+
+		isLPP = api.Mul(
+			api.IsZero(sumGL),
+			api.IsZero(api.Sub(sumLPP, 1)),
+		)
+	)
+
+	api.AssertIsEqual(hasNothing, 0)
+
+	return api.Select(isGL, moduleIndex, // when isGL
+		api.Select(isLPP, api.Add(moduleNumber, moduleIndex), // when isLPP
+			2*moduleNumber, // when conglomeration
+		),
+	)
+}
+
+// getVerifyingKeyPair extracts the verifyingKeys from the compiled IOP.
+func getVerifyingKeyPair(wiop *wizard.CompiledIOP) (vkGL, vkLPP field.Element) {
+	return wiop.ExtraData[VerifyingKeyPublicInput].(field.Element),
+		wiop.ExtraData[VerifyingKey2PublicInput].(field.Element)
+}
+
+// scanFunctionalInputs returns a list of public inputs corresponding to
+// functional inputs. The function works by looking up the public inputs whose
+// name starts by the string "functional".
+func scanFunctionalInputs(comp *wizard.CompiledIOP) []wizard.PublicInput {
+	var res []wizard.PublicInput
+	for _, pub := range comp.PublicInputs {
+		if strings.HasPrefix(pub.Name, "functional.") {
+			res = append(res, pub)
+		}
+	}
+	return res
+}
+
+// assertCompatibleIOPs checks that all the compiled IOPs are compatible and
+// can be aggregated within the same conglomeration.
+func assertCompatibleIOPs(d *DistributedWizard) {
+
+	w0 := d.CompiledConglomeration.RecursionComp
+
+	for i := range d.CompiledGLs {
+		diff1, diff2 := cmpWizardIOP(w0, d.CompiledGLs[i].RecursionComp)
+		if len(diff1) > 0 || len(diff2) > 0 {
+			dumpWizardIOP(w0, "conglomeration-debug/iop-conglo.csv")
+			dumpWizardIOP(d.CompiledGLs[i].RecursionComp, fmt.Sprintf("conglomeration-debug/iop-gl-%d.csv", i))
+			utils.Panic("incompatible IOPs i=%v\n\t+++=%v\n\t---=%v", i, diff1, diff2)
+		}
+	}
+
+	for i := range d.CompiledLPPs {
+		diff1, diff2 := cmpWizardIOP(w0, d.CompiledLPPs[i].RecursionComp)
+		if len(diff1) > 0 || len(diff2) > 0 {
+			dumpWizardIOP(w0, "conglomeration-debug/iop-conglomeration.csv")
+			dumpWizardIOP(d.CompiledLPPs[i].RecursionComp, fmt.Sprintf("conglomeration-debug/iop-lpp-%d.csv", i))
+			utils.Panic("incompatible IOPs i=%v\n\t+++=%v\n\t---=%v", i, diff1, diff2)
+		}
+	}
+}
+
+// cmpWizardIOP compares two compiled IOPs. The function is here to help ensuring
+// that all the conglomerated wizard IOPs have the same structure and help
+// figuring out inconsistencies if there are.
+func cmpWizardIOP(c1, c2 *wizard.CompiledIOP) (diff1, diff2 []string) {
+
+	var (
+		stringB1 = &strings.Builder{}
+		stringB2 = &strings.Builder{}
+	)
+
+	logdata.GenCSV(stringB1, logdata.IncludeAllFilter)(c1)
+	logdata.GenCSV(stringB2, logdata.IncludeAllFilter)(c2)
+
+	var (
+		c1Formatted = strings.Split(stringB1.String(), "\n")
+		c2Formatted = strings.Split(stringB2.String(), "\n")
+	)
+
+	diff1, diff2 = utils.SetDiff(c1Formatted, c2Formatted)
+	lessFunc := func(a, b string) int {
+		if a < b {
+			return -1
+		} else if a > b {
+			return 1
+		} else {
+			return 0
+		}
+	}
+
+	slices.SortFunc(diff1, lessFunc)
+	slices.SortFunc(diff2, lessFunc)
+
+	return diff1, diff2
+}
+
+// dumpWizardIOP dumps a compiled IOP to a file.
+func dumpWizardIOP(c *wizard.CompiledIOP, name string) {
+	logdata.GenCSV(files.MustOverwrite(name), logdata.IncludeAllFilter)(c)
+}
+
+// SanityCheckPublicInputsForConglo checks that a list of runtime is compatible
+// with each other. The function will perform the same checks that the
+// conglomerator but can be used on debugging-circuits.
+func SanityCheckPublicInputsForConglo(wiop *wizard.CompiledIOP, proofs SegmentProof) error {
+
+	var (
+		mainErr error
+		run, _  = wizard.VerifyWithRuntime(wiop, proofs.Witness.Proof)
+		pi      = collectAllPublicInputs(run)
+	)
+
+	if !pi.GrandProduct.IsOne() {
+		mainErr = errors.Join(mainErr, errors.New("grand product is not 1"))
+	}
+
+	if !pi.LogDerivativeSum.IsZero() {
+		mainErr = errors.Join(mainErr, errors.New("log derivative sum is not 0"))
+	}
+
+	if !pi.HornerSum.IsZero() {
+		mainErr = errors.Join(mainErr, errors.New("horner sum is not 0"))
+	}
+
+	for i := range pi.GeneralMultiSetHash {
+		if !pi.GeneralMultiSetHash[i].IsZero() {
+			mainErr = errors.Join(mainErr, errors.New("general multi set hash is not 0"))
+			break
+		}
+	}
+
+	for i := range pi.TargetNbSegments {
+		if !pi.TargetNbSegments[i].Equal(&pi.SegmentCountGL[i]) {
+			mainErr = errors.Join(mainErr, errors.New("target nb segments is not equal to segment count gl"))
+		}
+
+		if !pi.TargetNbSegments[i].Equal(&pi.SegmentCountLPP[i]) {
+			mainErr = errors.Join(mainErr, errors.New("target nb segments is not equal to segment count lpp"))
+		}
+	}
+
+	sharedRandSum := mimc.HashVec(pi.SharedRandomnessMultiSetHash)
+	if sharedRandSum != pi.SharedRandomness {
+		mainErr = errors.Join(mainErr, errors.New("shared randomness sum is not equal to shared randomness multi set hash"))
+	}
+
+	if mainErr != nil {
+		fmt.Printf("conglomeration failed: err=%v\n", mainErr)
+	}
+
+	return mainErr
+}

--- a/prover/protocol/distributed/conglomeration_test.go
+++ b/prover/protocol/distributed/conglomeration_test.go
@@ -8,18 +8,15 @@ import (
 	"github.com/consensys/linea-monorepo/prover/backend/execution"
 	"github.com/consensys/linea-monorepo/prover/backend/files"
 	"github.com/consensys/linea-monorepo/prover/config"
-	"github.com/consensys/linea-monorepo/prover/maths/field"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/recursion"
 	"github.com/consensys/linea-monorepo/prover/protocol/distributed"
 	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
 	"github.com/consensys/linea-monorepo/prover/utils/test_utils"
 	"github.com/consensys/linea-monorepo/prover/zkevm"
+	"github.com/sirupsen/logrus"
 )
 
 // TestConglomerationBasic generates a conglomeration proof and checks if it is valid
 func TestConglomerationBasic(t *testing.T) {
-
-	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
 
 	var (
 		numRow = 1 << 10
@@ -34,8 +31,8 @@ func TestConglomerationBasic(t *testing.T) {
 
 		// This tests the compilation of the compiled-IOP
 		distWizard = distributed.DistributeWizard(comp, disc).
-				CompileSegments().
-				Conglomerate(20)
+				CompileSegments(zkevm.LimitlessCompilationParams).
+				Conglomerate(zkevm.LimitlessCompilationParams)
 
 		runtimeBoot             = wizard.RunProver(distWizard.Bootstrapper, tc.Assign)
 		witnessGLs, witnessLPPs = distributed.SegmentRuntime(
@@ -43,53 +40,58 @@ func TestConglomerationBasic(t *testing.T) {
 			distWizard.Disc,
 			distWizard.BlueprintGLs,
 			distWizard.BlueprintLPPs,
+			distWizard.VerificationKeyMerkleTree.GetRoot(),
 		)
-		runGLs = runProverGLs(t, distWizard, witnessGLs)
-	)
-
-	for i := range runGLs {
-		t.Logf("sanity-checking runGLs[%d]\n", i)
-		sanityCheckConglomeration(t, distWizard.CompiledConglomeration, runGLs[i])
-	}
-
-	var (
-		sharedRandomness = getSharedRandomness(runGLs)
+		glProofs         = runProverGLs(t, distWizard, witnessGLs)
+		sharedRandomness = distributed.GetSharedRandomnessFromSegmentProofs(glProofs)
 		runLPPs          = runProverLPPs(t, distWizard, sharedRandomness, witnessLPPs)
 	)
 
-	for i := range runLPPs {
-		t.Logf("sanity-checking runLPPs[%d]\n", i)
-		sanityCheckConglomeration(t, distWizard.CompiledConglomeration, runLPPs[i])
+	runConglomerationProver(
+		&distWizard.VerificationKeyMerkleTree,
+		distWizard.CompiledConglomeration,
+		glProofs,
+		runLPPs,
+	)
+}
+
+// TestConglomerationProverDebug
+func TestConglomerationProverDebug(t *testing.T) {
+
+	var (
+		reqFile        = files.MustRead("/home/ubuntu/mainnet-beta-v2-5.1.3/prover-execution/requests/20106872-20106937-etv0.2.0-stv2.3.0-getZkProof.json")
+		cfgFilePath    = "/home/ubuntu/zkevm-monorepo/prover/config/config-mainnet-limitless.toml"
+		req            = &execution.Request{}
+		reqDecodeErr   = json.NewDecoder(reqFile).Decode(req)
+		cfg, cfgErr    = config.NewConfigFromFileUnchecked(cfgFilePath)
+		limitlessZkEVM = zkevm.NewLimitlessDebugZkEVM(cfg)
+		_, witness     = test_utils.GetZkevmWitness(req, cfg)
+	)
+
+	if reqDecodeErr != nil {
+		t.Fatalf("could not read the request file: %v", reqDecodeErr)
 	}
 
-	runConglomerationProver(t, distWizard.CompiledConglomeration, runGLs, runLPPs)
+	if cfgErr != nil {
+		t.Fatalf("could not read the config file: err=%v, cfg=%++v", cfgErr, cfg)
+	}
+
+	limitlessZkEVM.RunDebug(cfg, witness)
+
 }
 
 // TestConglomeration generates a conglomeration proof and checks if it is valid
-func TestConglomeration(t *testing.T) {
-
-	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
+func TestConglomerationProverFile(t *testing.T) {
 
 	var (
-		z    = zkevm.GetTestZkEVM()
-		disc = &distributed.StandardModuleDiscoverer{
-			TargetWeight: 1 << 28,
-			Affinities:   zkevm.GetAffinities(z),
-			Predivision:  1,
-		}
-
-		// This tests the compilation of the compiled-IOP
-		distWizard = distributed.DistributeWizard(z.WizardIOP, disc).
-				CompileSegments().
-				Conglomerate(20)
-	)
-
-	var (
-		reqFile      = files.MustRead("/home/ubuntu/beta-v2-rc11/10556002-10556002-etv0.2.0-stv2.2.2-getZkProof.json")
-		cfgFilePath  = "/home/ubuntu/zkevm-monorepo/prover/config/config-sepolia-full.toml"
-		req          = &execution.Request{}
-		reqDecodeErr = json.NewDecoder(reqFile).Decode(req)
-		cfg, cfgErr  = config.NewConfigFromFileUnchecked(cfgFilePath)
+		reqFile        = files.MustRead("/home/ubuntu/mainnet-beta-v2-5.1.3/prover-execution/requests/20106872-20106937-etv0.2.0-stv2.3.0-getZkProof.json")
+		cfgFilePath    = "/home/ubuntu/zkevm-monorepo/prover/config/config-mainnet-limitless.toml"
+		req            = &execution.Request{}
+		reqDecodeErr   = json.NewDecoder(reqFile).Decode(req)
+		cfg, cfgErr    = config.NewConfigFromFileUnchecked(cfgFilePath)
+		limitlessZkEVM = zkevm.NewLimitlessZkEVM(cfg)
+		z              = limitlessZkEVM.Zkevm
+		distWizard     = limitlessZkEVM.DistWizard
 	)
 
 	if reqDecodeErr != nil {
@@ -117,84 +119,81 @@ func TestConglomeration(t *testing.T) {
 			distWizard.Disc,
 			distWizard.BlueprintGLs,
 			distWizard.BlueprintLPPs,
+			distWizard.VerificationKeyMerkleTree.GetRoot(),
 		)
-		runGLs = runProverGLs(t, distWizard, witnessGLs)
-	)
-
-	for i := range runGLs {
-		t.Logf("sanity-checking runGLs[%d]\n", i)
-		sanityCheckConglomeration(t, distWizard.CompiledConglomeration, runGLs[i])
-	}
-
-	var (
-		sharedRandomness = getSharedRandomness(runGLs)
+		glProofs         = runProverGLs(t, distWizard, witnessGLs)
+		sharedRandomness = distributed.GetSharedRandomnessFromSegmentProofs(glProofs)
 		runLPPs          = runProverLPPs(t, distWizard, sharedRandomness, witnessLPPs)
 	)
 
-	for i := range runLPPs {
-		t.Logf("sanity-checking runLPPs[%d]\n", i)
-		sanityCheckConglomeration(t, distWizard.CompiledConglomeration, runLPPs[i])
-	}
-
-	runConglomerationProver(t, distWizard.CompiledConglomeration, runGLs, runLPPs)
+	runConglomerationProver(
+		&distWizard.VerificationKeyMerkleTree,
+		distWizard.CompiledConglomeration,
+		glProofs,
+		runLPPs,
+	)
 }
 
-// getSharedRandomness computes the shared randomnesses from the runtime
-func getSharedRandomness(runs []*wizard.ProverRuntime) field.Element {
-	witnesses := make([]recursion.Witness, len(runs))
-	for i := range runs {
-		witnesses[i] = recursion.ExtractWitness(runs[i])
-	}
+// This function runs a prover for a conglomerator compilation. It takes in a
+// ConglomeratorCompilation object and two slices of ProverRuntime objects,
+// runGLs and runLPPs. It extracts witnesses from these runtimes, then uses the
+// ConglomeratorCompilation object to prove the conglomerator, logging the start
+// and end times of the proof process.
+func runConglomerationProver(
+	mt *distributed.VerificationKeyMerkleTree,
+	cong *distributed.RecursedSegmentCompilation,
+	runGLs, runLPPs []distributed.SegmentProof,
+) distributed.SegmentProof {
 
-	comps := make([]*wizard.CompiledIOP, len(runs))
-	for i := range runs {
-		comps[i] = runs[i].Spec
-	}
-
-	return distributed.GetSharedRandomnessFromWitnesses(comps, witnesses)
-}
-
-// Sanity-check for conglomeration compilation.
-func sanityCheckConglomeration(t *testing.T, cong *distributed.ConglomeratorCompilation, run *wizard.ProverRuntime) {
-
-	t.Logf("sanity-check for conglomeration")
-	stopRound := recursion.VortexQueryRound(cong.ModuleGLIops[0])
-	err := wizard.VerifyUntilRound(cong.ModuleGLIops[0], run.ExtractProof(), stopRound+1)
-
-	if err != nil {
-		t.Fatalf("could not verify proof: %v", err)
-	}
-}
-
-// This function runs a prover for a conglomerator compilation. It takes in a ConglomeratorCompilation
-// object and two slices of ProverRuntime objects, runGLs and runLPPs. It extracts witnesses from
-// these runtimes, then uses the ConglomeratorCompilation object to prove the conglomerator,
-// logging the start and end times of the proof process.
-func runConglomerationProver(t *testing.T, cong *distributed.ConglomeratorCompilation, runGLs, runLPPs []*wizard.ProverRuntime) {
-
+	// The channel is used as a FIFO queue to store the remaining proofs to be
+	// aggregated.
 	var (
-		witLPPs = make([]recursion.Witness, len(runLPPs))
-		witGLs  = make([]recursion.Witness, len(runGLs))
+		remainingProofs = make(chan distributed.SegmentProof, len(runGLs)+len(runLPPs))
 	)
 
-	for i := range runLPPs {
-		witLPPs[i] = recursion.ExtractWitness(runLPPs[i])
-	}
-
+	// This populates the queue
 	for i := range runGLs {
-		witGLs[i] = recursion.ExtractWitness(runGLs[i])
+		remainingProofs <- runGLs[i]
 	}
 
-	t.Logf("[%v] Starting to prove conglomerator\n", time.Now())
-	proof := cong.Prove(witGLs, witLPPs)
-	t.Logf("[%v] Finished proving conglomerator\n", time.Now())
-
-	t.Logf("[%v] start sanity-checking proof\n", time.Now())
-
-	err := wizard.Verify(cong.Wiop, proof)
-	if err != nil {
-		t.Fatalf("could not verify proof: %v", err)
+	for i := range runLPPs {
+		remainingProofs <- runLPPs[i]
 	}
 
-	t.Logf("[%v] done sanity-checking proof\n", time.Now())
+	// TryPopQueue attempts to consume a proof from the queue or return false
+	// if the queue is empty.
+	tryPopQueue := func() (distributed.SegmentProof, bool) {
+		select {
+		case proof := <-remainingProofs:
+			return proof, true
+		default:
+			return distributed.SegmentProof{}, false
+		}
+	}
+
+	// This is the actual proof aggregation loop.
+	for {
+		a, ok := tryPopQueue()
+		if !ok {
+			panic("the queue cannot be empty here")
+		}
+
+		// If b cannot be found, it means that the queue contained only a single
+		// proof to aggregate which means it was the result of the function.
+		b, ok := tryPopQueue()
+		if !ok {
+			return a
+		}
+
+		logrus.Infof("AGGREGATING PROOF, remaining %v\n", len(remainingProofs))
+
+		new := cong.ProveSegment(&distributed.ModuleWitnessConglo{
+			SegmentProofs:             []distributed.SegmentProof{a, b},
+			VerificationKeyMerkleTree: *mt,
+		})
+
+		logrus.Infof("AGGREGATED PROOFS\n")
+
+		remainingProofs <- new
+	}
 }

--- a/prover/protocol/distributed/distribute.go
+++ b/prover/protocol/distributed/distribute.go
@@ -12,7 +12,6 @@ import (
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/logderivativesum"
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/mimc"
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/permutation"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/recursion"
 	"github.com/consensys/linea-monorepo/prover/protocol/ifaces"
 	"github.com/consensys/linea-monorepo/prover/protocol/query"
 	"github.com/consensys/linea-monorepo/prover/protocol/serialization"
@@ -20,11 +19,6 @@ import (
 	"github.com/consensys/linea-monorepo/prover/utils"
 	"github.com/sirupsen/logrus"
 )
-
-// lppGroupingArity indicates how many GL modules an LPP module relates to. The
-// value is fixed to 1 not for efficiency concern but putting it to a higher
-// value creates edge-cases for the FS security that are not fully-addressed yet.
-const lppGroupingArity = 1
 
 // DistributedWizard represents a wizard protocol that has undergone a
 // distributed compilation process.
@@ -54,11 +48,6 @@ type DistributedWizard struct {
 	// BlueprintLPPs is the list of the blueprints for each LPP module
 	BlueprintLPPs []ModuleSegmentationBlueprint
 
-	// DefaultModule is the module used for filling when the number of
-	// effective segment is smaller than the maximum number of segment to
-	// conglomerate.
-	DefaultModule *DefaultModule
-
 	// Bootstrapper is the original compiledIOP precompiled with a few
 	// preparation steps.
 	Bootstrapper *wizard.CompiledIOP
@@ -66,10 +55,6 @@ type DistributedWizard struct {
 	// Disc is the [*StandardModuleDiscoverer] used to delimitate the scope for
 	// each module.
 	Disc *StandardModuleDiscoverer
-
-	// CompiledDefault stores the compiled default module and is set by calling
-	// [DistributedWizard.Compile]
-	CompiledDefault *RecursedSegmentCompilation
 
 	// CompiledGLs stores the compiled GL modules and is set by calling
 	// [DistributedWizard.Compile]
@@ -81,7 +66,10 @@ type DistributedWizard struct {
 
 	// CompiledConglomeration stores the compilation context of the
 	// conglomeration wizard.
-	CompiledConglomeration *ConglomeratorCompilation
+	CompiledConglomeration *RecursedSegmentCompilation
+
+	// VerificationKeyMerkleTree
+	VerificationKeyMerkleTree VerificationKeyMerkleTree
 }
 
 func init() {
@@ -95,8 +83,7 @@ func init() {
 	serialization.RegisterImplementation(ModuleGLAssignSendReceiveGlobal{})
 	serialization.RegisterImplementation(ModuleGLCheckSendReceiveGlobal{})
 	serialization.RegisterImplementation(LPPSegmentBoundaryCalculator{})
-	serialization.RegisterImplementation(ConglomerateHolisticCheck{})
-	serialization.RegisterImplementation(ConglomerationAssignHolisticCheckColumn{})
+	serialization.RegisterImplementation(ConglomerationHierarchicalVerifierAction{})
 }
 
 // DistributeWizard returns a [DistributedWizard] from a [wizard.CompiledIOP]. It
@@ -128,8 +115,6 @@ func DistributeWizard(comp *wizard.CompiledIOP, disc *StandardModuleDiscoverer) 
 		filteredModuleInputs := moduleFilter.FilterCompiledIOP(
 			distributedWizard.Bootstrapper,
 		)
-
-		logrus.Infof("Compiling GL module %v", moduleName)
 
 		var (
 			moduleGL         = BuildModuleGL(&filteredModuleInputs)
@@ -168,22 +153,18 @@ func DistributeWizard(comp *wizard.CompiledIOP, disc *StandardModuleDiscoverer) 
 		nbLPP = len(distributedWizard.ModuleNames)
 	)
 
-	for i := 0; i < nbLPP; i += lppGroupingArity {
-
-		stop := min(len(distributedWizard.ModuleNames), i+lppGroupingArity)
-
-		logrus.Infof("Compiling LPP modules [%d .. %d]", i, stop)
+	for i := 0; i < nbLPP; i++ {
 
 		var (
-			moduleLPP         = BuildModuleLPP(allFilteredModuleInputs[i:stop])
-			moduleLPPForDebug = BuildModuleLPP(allFilteredModuleInputs[i:stop])
+			moduleLPP         = BuildModuleLPP(allFilteredModuleInputs[i])
+			moduleLPPForDebug = BuildModuleLPP(allFilteredModuleInputs[i])
 		)
 
 		// This add sanity-checking the module initial assignment. Without
 		// this compilation, the module would not check anything.
 		wizard.ContinueCompilation(
 			moduleLPPForDebug.Wiop,
-			dummy.CompileAtProverLvl(dummy.WithMsg(fmt.Sprintf("LPP module (debug) [%d .. %d]", i, stop))),
+			dummy.CompileAtProverLvl(dummy.WithMsg(fmt.Sprintf("LPP module (debug) %d", i))),
 		)
 
 		distributedWizard.DebugLPPs = append(
@@ -202,60 +183,37 @@ func DistributeWizard(comp *wizard.CompiledIOP, disc *StandardModuleDiscoverer) 
 		)
 	}
 
-	distributedWizard.DefaultModule = BuildDefaultModule(&allFilteredModuleInputs[0])
-
 	return distributedWizard
 }
 
 // CompileModules applies the compilation steps to each modules identically.
-func (dist *DistributedWizard) CompileSegments() *DistributedWizard {
+func (dist *DistributedWizard) CompileSegments(params CompilationParams) *DistributedWizard {
 	logrus.Infoln("Compiling distributed wizard default module")
-	dist.CompiledDefault = CompileSegment(dist.DefaultModule)
 
 	logrus.Infof("Number of GL modules to compile:%d\n", len(dist.GLs))
 	dist.CompiledGLs = make([]*RecursedSegmentCompilation, len(dist.GLs))
 	for i := range dist.GLs {
+
 		logrus.
 			WithField("module-name", dist.GLs[i].DefinitionInput.ModuleName).
 			WithField("module-type", "GL").
 			Info("compiling module")
 
-		dist.CompiledGLs[i] = CompileSegment(dist.GLs[i])
+		dist.CompiledGLs[i] = CompileSegment(dist.GLs[i], params)
 	}
 
 	logrus.Infof("Number of LPP modules to compile:%d\n", len(dist.LPPs))
 	dist.CompiledLPPs = make([]*RecursedSegmentCompilation, len(dist.LPPs))
 	for i := range dist.LPPs {
 		logrus.
-			WithField("module-name", dist.LPPs[i].ModuleNames()).
+			WithField("module-name", dist.LPPs[i].ModuleName()).
 			WithField("module-type", "LPP").
 			Info("compiling module")
 
-		dist.CompiledLPPs[i] = CompileSegment(dist.LPPs[i])
+		dist.CompiledLPPs[i] = CompileSegment(dist.LPPs[i], params)
 	}
 
 	return dist
-}
-
-// Conglomerate registers the conglomeration wizard and compiles it.
-func (dist *DistributedWizard) Conglomerate(maxNumSegment int) *DistributedWizard {
-	dist.CompiledConglomeration = conglomerate(
-		maxNumSegment,
-		dist.CompiledGLs,
-		dist.CompiledLPPs,
-		dist.CompiledDefault,
-	)
-	return dist
-}
-
-// GetSharedRandomness returns the shared randomness used by the protocol
-// to generate the LPP proofs. The LPP commitments are supposed to be the
-// one extractable from the [recursion.Witness] of the LPPs.
-//
-// The result of this function is to be used as the shared randomness for
-// the LPP provers.
-func GetSharedRandomness(lppCommitments []field.Element) field.Element {
-	return cmimc.HashVec(lppCommitments)
 }
 
 // GetSharedRandomnessFromRuntime returns the shared randomness used by the protocol
@@ -264,20 +222,28 @@ func GetSharedRandomness(lppCommitments []field.Element) field.Element {
 //
 // The result of this function is to be used as the shared randomness for
 // the LPP provers.
-func GetSharedRandomnessFromWitnesses(comp []*wizard.CompiledIOP, gLWitnesses []recursion.Witness) field.Element {
-	lppCommitments := []field.Element{}
+func GetSharedRandomnessFromSegmentProofs(gLWitnesses []SegmentProof) field.Element {
+
+	mset := cmimc.MSetHash{}
+
 	for i := range gLWitnesses {
-		name := fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, 0)
-		lpp := gLWitnesses[i].Proof.GetPublicInput(comp[i], preRecursionPrefix+name)
-		lppCommitments = append(lppCommitments, lpp)
+
+		var (
+			moduleIndex, _  = new(field.Element).SetInterface(gLWitnesses[i].ModuleIndex)
+			segmentIndex, _ = new(field.Element).SetInterface(gLWitnesses[i].SegmentIndex)
+			lppCommitment   = gLWitnesses[i].LppCommitment
+		)
+
+		mset.Insert(*moduleIndex, *segmentIndex, lppCommitment)
 	}
-	return GetSharedRandomness(lppCommitments)
+
+	return cmimc.HashVec(mset[:])
 }
 
-// GetLppCommitmentFromRuntime returns the LPP commitment from the runtime
-func GetLppCommitmentFromRuntime(runtime *wizard.ProverRuntime) field.Element {
+// getLppCommitmentFromRuntime returns the LPP commitment from the runtime
+func getLppCommitmentFromRuntime(runtime *wizard.ProverRuntime) field.Element {
 	name := fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, 0)
-	return runtime.GetPublicInput(preRecursionPrefix + name)
+	return runtime.GetPublicInput(name)
 }
 
 // PrecompileInitialWizard pre-compiles the initial wizard protocol by applying all the
@@ -285,18 +251,19 @@ func GetLppCommitmentFromRuntime(runtime *wizard.ProverRuntime) field.Element {
 // ensure that all of the queries that cannot be processed by the splitting phase
 // are removed from the compiled IOP.
 func PrecompileInitialWizard(comp *wizard.CompiledIOP, disc *StandardModuleDiscoverer) *wizard.CompiledIOP {
-	mimc.CompileMiMC(comp)
-	// specialqueries.RangeProof(comp)
-	// specialqueries.CompileFixedPermutations(comp)
-	logderivativesum.LookupIntoLogDerivativeSumWithSegmenter(
-		&LPPSegmentBoundaryCalculator{
-			Disc:     disc,
-			LPPArity: lppGroupingArity,
-		},
-	)(comp)
-	permutation.CompileIntoGdProduct(comp)
-	horner.ProjectionToHorner(comp)
-	return comp
+
+	return wizard.ContinueCompilation(
+		comp,
+		mimc.CompileMiMC,
+		logderivativesum.LookupIntoLogDerivativeSumWithSegmenter(
+			&LPPSegmentBoundaryCalculator{
+				Disc: disc,
+			},
+		),
+		permutation.CompileIntoGdProduct,
+		horner.ProjectionToHorner,
+		tagFunctionalInputs,
+	)
 }
 
 // auditInitialWizard scans the initial compiled-IOP and checks if the provided
@@ -364,4 +331,12 @@ func auditInitialWizard(comp *wizard.CompiledIOP) error {
 	}
 
 	return err
+}
+
+// tagFunctionalInputs takes the public inputs of the original wizard and
+// changes their name to "functional". This is meant to help us recognize them
+func tagFunctionalInputs(comp *wizard.CompiledIOP) {
+	for i := range comp.PublicInputs {
+		comp.PublicInputs[i].Name = "functional." + comp.PublicInputs[i].Name
+	}
 }

--- a/prover/protocol/distributed/distribute_test.go
+++ b/prover/protocol/distributed/distribute_test.go
@@ -1,88 +1,39 @@
 package distributed_test
 
 import (
-	"encoding/json"
-	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/consensys/linea-monorepo/prover/backend/execution"
-	"github.com/consensys/linea-monorepo/prover/backend/files"
-	"github.com/consensys/linea-monorepo/prover/config"
+	"github.com/consensys/linea-monorepo/prover/crypto/mimc"
 	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/dummy"
-	"github.com/consensys/linea-monorepo/prover/protocol/compiler/logdata"
 	"github.com/consensys/linea-monorepo/prover/protocol/distributed"
 	"github.com/consensys/linea-monorepo/prover/protocol/ifaces"
 	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
 	"github.com/consensys/linea-monorepo/prover/symbolic"
-	"github.com/consensys/linea-monorepo/prover/utils/test_utils"
 	"github.com/consensys/linea-monorepo/prover/zkevm"
 )
 
-// TestDistributedWizard attempts to compiler the wizard distribution.
-func TestDistributedWizard(t *testing.T) {
-
-	t.SkipNow()
+// TestDistributedWizardBasic attempts to compiler the wizard distribution.
+func TestDistributedWizardBasic(t *testing.T) {
 
 	var (
-		z          = zkevm.GetTestZkEVM()
-		affinities = zkevm.GetAffinities(z)
-		discoverer = &distributed.StandardModuleDiscoverer{
-			TargetWeight: 1 << 28,
-			Affinities:   affinities,
-			Predivision:  1,
-		}
-	)
-
-	// This dumps a CSV with the list of all the columns in the original wizard
-	logdata.GenCSV(
-		files.MustOverwrite("./base-data/main.csv"),
-		logdata.IncludeAllFilter,
-	)(z.WizardIOP)
-
-	distributed := distributed.DistributeWizard(z.WizardIOP, discoverer)
-
-	for i, modGL := range distributed.GLs {
-
-		logdata.GenCSV(
-			files.MustOverwrite(fmt.Sprintf("./module-data/module-%v-gl.csv", i)),
-			logdata.IncludeAllFilter,
-		)(modGL.Wiop)
-	}
-
-	for i, modLPP := range distributed.LPPs {
-
-		logdata.GenCSV(
-			files.MustOverwrite(fmt.Sprintf("./module-data/module-%v-lpp.csv", i)),
-			logdata.IncludeAllFilter,
-		)(modLPP.Wiop)
-	}
-}
-
-// TestDistributeWizard attempts to run and compile the distributed protocol in
-// dummy mode. Meaning without actual compilation.
-func TestDistributedWizardLogic(t *testing.T) {
-
-	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
-
-	var (
-		// #nosec G404 --we don't need a cryptographic RNG for testing purpose
-		// rng              = rand.New(utils.NewRandSource(0))
-		// sharedRandomness = field.PseudoRand(rng)
-		z    = zkevm.GetTestZkEVM()
-		disc = &distributed.StandardModuleDiscoverer{
-			TargetWeight: 1 << 28,
-			Affinities:   zkevm.GetAffinities(z),
+		z       = DistributeTestCase{numRow: 1 << 20}
+		defFunc = func(build *wizard.Builder) { z.Define(build.CompiledIOP) }
+		wiop    = wizard.Compile(defFunc)
+		disc    = &distributed.StandardModuleDiscoverer{
+			TargetWeight: 1 << 20,
 			Predivision:  1,
 		}
 
 		// This tests the compilation of the compiled-IOP
-		distWizard = distributed.DistributeWizard(z.WizardIOP, disc)
+		distWizard = distributed.DistributeWizard(wiop, disc).CompileSegments(zkevm.LimitlessCompilationParams)
 	)
+
+	// This compilation step is needed for sanity-checking the bootstrapper
+	dummy.Compile(distWizard.Bootstrapper)
 
 	// This applies the dummy.Compiler to all parts of the distributed wizard.
 	for i := range distWizard.GLs {
@@ -94,31 +45,10 @@ func TestDistributedWizardLogic(t *testing.T) {
 	}
 
 	var (
-		reqFile      = files.MustRead("/home/ubuntu/beta-v2-rc11/10556002-10556002-etv0.2.0-stv2.2.2-getZkProof.json")
-		cfgFilePath  = "/home/ubuntu/zkevm-monorepo/prover/config/config-sepolia-full.toml"
-		req          = &execution.Request{}
-		reqDecodeErr = json.NewDecoder(reqFile).Decode(req)
-		cfg, cfgErr  = config.NewConfigFromFileUnchecked(cfgFilePath)
-	)
-
-	if reqDecodeErr != nil {
-		t.Fatalf("could not read the request file: %v", reqDecodeErr)
-	}
-
-	if cfgErr != nil {
-		t.Fatalf("could not read the config file: err=%v, cfg=%++v", cfgErr, cfg)
-	}
-
-	t.Logf("loaded config: %++v", cfg)
-
-	t.Logf("Checking the initial bootstrapper - wizard")
-	var (
-		_, witness  = test_utils.GetZkevmWitness(req, cfg)
-		runtimeBoot = wizard.RunProver(distWizard.Bootstrapper, z.GetMainProverStep(witness))
+		runtimeBoot = wizard.RunProver(distWizard.Bootstrapper, z.Assign)
 		proof       = runtimeBoot.ExtractProof()
 		verBootErr  = wizard.Verify(distWizard.Bootstrapper, proof)
 	)
-	t.Logf("Checking the initial bootstrapper - wizard")
 
 	if verBootErr != nil {
 		t.Fatalf("Bootstrapper failed because: %v", verBootErr)
@@ -128,8 +58,7 @@ func TestDistributedWizardLogic(t *testing.T) {
 		allGrandProduct     = field.NewElement(1)
 		allLogDerivativeSum = field.Element{}
 		allHornerSum        = field.Element{}
-		prevGlobalSent      = field.Element{}
-		prevHornerN1Hash    = field.Element{}
+		generalMSet         = mimc.MSetHash{}
 	)
 
 	witnessGLs, witnessLPPs := distributed.SegmentRuntime(
@@ -137,15 +66,16 @@ func TestDistributedWizardLogic(t *testing.T) {
 		distWizard.Disc,
 		distWizard.BlueprintGLs,
 		distWizard.BlueprintLPPs,
+		distWizard.VerificationKeyMerkleTree.GetRoot(),
 	)
 
 	for i := range witnessGLs {
 
 		var (
-			witnessGL   = witnessGLs[i]
-			moduleIndex = witnessGLs[i].ModuleIndex
-			moduleName  = witnessGLs[i].ModuleName
-			moduleGL    *distributed.ModuleGL
+			witnessGL = witnessGLs[i]
+			// moduleIndex = witnessGLs[i].ModuleIndex
+			// moduleName  = witnessGLs[i].ModuleName
+			moduleGL *distributed.ModuleGL
 		)
 
 		t.Logf("segment(total)=%v module=%v segment.index=%v", i, witnessGL.ModuleName, witnessGL.ModuleIndex)
@@ -164,38 +94,18 @@ func TestDistributedWizardLogic(t *testing.T) {
 		}
 
 		var (
-			proverRunGL        = wizard.RunProver(moduleGL.Wiop, moduleGL.GetMainProverStep(witnessGLs[i]))
-			proofGL            = proverRunGL.ExtractProof()
-			verGLRun, verGLErr = wizard.VerifyWithRuntime(moduleGL.Wiop, proofGL)
+			proverRunGL         = wizard.RunProver(moduleGL.Wiop, moduleGL.GetMainProverStep(witnessGLs[i]))
+			proofGL             = proverRunGL.ExtractProof()
+			verRun, verGLErr    = wizard.VerifyWithRuntime(moduleGL.Wiop, proofGL)
+			generalMSetFromGLFr = distributed.GetPublicInputList(verRun, distributed.GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+			generalMSetFromGL   = mimc.MSetHash(generalMSetFromGLFr)
 		)
 
 		if verGLErr != nil {
 			t.Errorf("verifier failed for segment %v, reason=%v", i, verGLErr)
 		}
 
-		var (
-			errMsg         = fmt.Sprintf("segment=%v, moduleName=%v, segment-index=%v", i, moduleName, moduleIndex)
-			globalReceived = verGLRun.GetPublicInput(distributed.GlobalReceiverPublicInput)
-			globalSent     = verGLRun.GetPublicInput(distributed.GlobalSenderPublicInput)
-			isFirst        = verGLRun.GetPublicInput(distributed.IsFirstPublicInput)
-			isLast         = verGLRun.GetPublicInput(distributed.IsLastPublicInput)
-			shouldBeFirst  = i == 0 || witnessGLs[i].ModuleName != witnessGLs[i-1].ModuleName
-			shouldBeLast   = i == len(witnessGLs)-1 || witnessGLs[i].ModuleName != witnessGLs[i+1].ModuleName
-		)
-
-		if isFirst.IsOne() != shouldBeFirst {
-			t.Error("isFirst has unexpected values: " + errMsg)
-		}
-
-		if isLast.IsOne() != shouldBeLast {
-			t.Error("isLast has unexpected values: " + errMsg)
-		}
-
-		if !shouldBeFirst && globalReceived != prevGlobalSent {
-			t.Error("global-received does not match: " + errMsg)
-		}
-
-		prevGlobalSent = globalSent
+		generalMSet.Add(generalMSetFromGL)
 	}
 
 	for i := range witnessLPPs {
@@ -203,54 +113,35 @@ func TestDistributedWizardLogic(t *testing.T) {
 		var (
 			witnessLPP  = witnessLPPs[i]
 			moduleIndex = witnessLPPs[i].ModuleIndex
-			moduleNames = witnessLPPs[i].ModuleName
-			moduleLPP   *distributed.ModuleLPP
+			moduleLPP   = distWizard.LPPs[moduleIndex]
 		)
 
 		witnessLPP.InitialFiatShamirState = field.NewFromString("6861409415040334196327676756394403519979367936044773323994693747743991500772")
 
 		t.Logf("segment(total)=%v module=%v segment.index=%v", i, witnessLPP.ModuleName, witnessLPP.ModuleIndex)
 
-		for k := range distWizard.LPPs {
-			if !reflect.DeepEqual(distWizard.LPPs[k].ModuleNames(), moduleNames) {
-				continue
-			}
-
-			moduleLPP = distWizard.LPPs[k]
-			break
-		}
-
-		if moduleLPP == nil {
-			t.Fatalf("module does not exists")
-		}
-
 		var (
 			proverRunLPP         = wizard.RunProver(moduleLPP.Wiop, moduleLPP.GetMainProverStep(witnessLPP))
 			proofLPP             = proverRunLPP.ExtractProof()
-			verLPPRun, verLPPErr = wizard.VerifyWithRuntime(moduleLPP.Wiop, proofLPP)
+			verRun, verLPPErr    = wizard.VerifyWithRuntime(moduleLPP.Wiop, proofLPP)
+			generalMSetFromLPPFr = distributed.GetPublicInputList(verRun, distributed.GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+			generalMSetFromLPP   = mimc.MSetHash(generalMSetFromLPPFr)
 		)
 
 		if verLPPErr != nil {
 			t.Errorf("verifier failed for segment %v, reason=%v", i, verLPPErr)
 		}
 
-		var (
-			errMsg           = fmt.Sprintf("segment=%v, moduleName=%v, segment-index=%v", i, moduleNames, moduleIndex)
-			logDerivativeSum = verLPPRun.GetPublicInput(distributed.LogDerivativeSumPublicInput)
-			grandProduct     = verLPPRun.GetPublicInput(distributed.GrandProductPublicInput)
-			hornerSum        = verLPPRun.GetPublicInput(distributed.HornerPublicInput)
-			hornerN0Hash     = verLPPRun.GetPublicInput(distributed.HornerN0HashPublicInput)
-			hornerN1Hash     = verLPPRun.GetPublicInput(distributed.HornerN1HashPublicInput)
-			shouldBeFirst    = i == 0 || !reflect.DeepEqual(witnessLPPs[i].ModuleName, witnessLPPs[i-1].ModuleName)
-		)
+		generalMSet.Add(generalMSetFromLPP)
 
-		if !shouldBeFirst && hornerN0Hash != prevHornerN1Hash {
-			t.Error("horner-n0-hash mismatch: " + errMsg)
-		}
+		var (
+			logDerivativeSum = verRun.GetPublicInput(distributed.LogDerivativeSumPublicInput)
+			grandProduct     = verRun.GetPublicInput(distributed.GrandProductPublicInput)
+			hornerSum        = verRun.GetPublicInput(distributed.HornerPublicInput)
+		)
 
 		t.Logf("log-derivative-sum=%v grand-product=%v horner-sum=%v", logDerivativeSum.String(), grandProduct.String(), hornerSum.String())
 
-		prevHornerN1Hash = hornerN1Hash
 		allGrandProduct.Mul(&allGrandProduct, &grandProduct)
 		allHornerSum.Add(&allHornerSum, &hornerSum)
 		allLogDerivativeSum.Add(&allLogDerivativeSum, &logDerivativeSum)
@@ -267,63 +158,12 @@ func TestDistributedWizardLogic(t *testing.T) {
 	if !allLogDerivativeSum.IsZero() {
 		t.Errorf("log-derivative-sum does not cancel. Has %v", allLogDerivativeSum.String())
 	}
-}
 
-// TestBenchDistributedWizard runs the distributed wizard will all the compilations
-func TestBenchDistributedWizard(t *testing.T) {
-
-	t.Skipf("the test is a development/debug/integration test. It is not needed for CI")
-
-	var (
-		z    = zkevm.GetTestZkEVM()
-		disc = &distributed.StandardModuleDiscoverer{
-			TargetWeight: 1 << 28,
-			Affinities:   zkevm.GetAffinities(z),
-			Predivision:  1,
+	for i := 0; i < len(generalMSet); i++ {
+		if !generalMSet.IsEmpty() {
+			t.Errorf("generalMSet does not cancel: ")
 		}
-
-		// This tests the compilation of the compiled-IOP
-		distWizard = distributed.DistributeWizard(z.WizardIOP, disc).CompileSegments()
-	)
-
-	var (
-		reqFile      = files.MustRead("/home/ubuntu/beta-v2-rc11/10556002-10556002-etv0.2.0-stv2.2.2-getZkProof.json")
-		cfgFilePath  = "/home/ubuntu/zkevm-monorepo/prover/config/config-sepolia-full.toml"
-		req          = &execution.Request{}
-		reqDecodeErr = json.NewDecoder(reqFile).Decode(req)
-		cfg, cfgErr  = config.NewConfigFromFileUnchecked(cfgFilePath)
-	)
-
-	if reqDecodeErr != nil {
-		t.Fatalf("could not read the request file: %v", reqDecodeErr)
 	}
-
-	if cfgErr != nil {
-		t.Fatalf("could not read the config file: err=%v, cfg=%++v", cfgErr, cfg)
-	}
-
-	t.Logf("loaded config: %++v", cfg)
-
-	t.Logf("[%v] running the bootstrapper\n", time.Now())
-
-	var (
-		_, witness  = test_utils.GetZkevmWitness(req, cfg)
-		runtimeBoot = wizard.RunProver(distWizard.Bootstrapper, z.GetMainProverStep(witness))
-	)
-
-	t.Logf("[%v] done running the bootstrapper\n", time.Now())
-
-	var (
-		witnessGLs, witnessLPPs = distributed.SegmentRuntime(
-			runtimeBoot,
-			distWizard.Disc,
-			distWizard.BlueprintGLs,
-			distWizard.BlueprintLPPs,
-		)
-		runGLs           = runProverGLs(t, distWizard, witnessGLs)
-		sharedRandomness = getSharedRandomness(runGLs)
-		_                = runProverLPPs(t, distWizard, sharedRandomness, witnessLPPs)
-	)
 }
 
 // DistributeTestCase is an implementation of the testcase interface. The
@@ -386,12 +226,13 @@ func runProverGLs(
 	t *testing.T,
 	distWizard *distributed.DistributedWizard,
 	witnessGLs []*distributed.ModuleWitnessGL,
-) []*wizard.ProverRuntime {
+) (proofs []distributed.SegmentProof) {
 
 	var (
 		compiledGLs = distWizard.CompiledGLs
-		runs        = make([]*wizard.ProverRuntime, len(witnessGLs))
 	)
+
+	proofs = make([]distributed.SegmentProof, len(witnessGLs))
 
 	for i := range witnessGLs {
 
@@ -400,7 +241,7 @@ func runProverGLs(
 			moduleGL  *distributed.RecursedSegmentCompilation
 		)
 
-		t.Logf("segment(total)=%v module=%v segment.index=%v", i, witnessGL.ModuleName, witnessGL.ModuleIndex)
+		t.Logf("segment(total)=%v module=%v module.index=%v segment.index=%v", i, witnessGL.ModuleName, witnessGL.ModuleIndex, witnessGL.SegmentModuleIndex)
 		for k := range distWizard.ModuleNames {
 			if distWizard.ModuleNames[k] != witnessGLs[i].ModuleName {
 				continue
@@ -413,11 +254,12 @@ func runProverGLs(
 		}
 
 		t.Logf("RUNNING THE GL PROVER: %v", time.Now())
-		runs[i] = moduleGL.ProveSegment(witnessGL)
+		proofs[i] = moduleGL.ProveSegment(witnessGL)
 		t.Logf("RUNNING THE GL PROVER - DONE: %v", time.Now())
+
 	}
 
-	return runs
+	return proofs
 }
 
 // runProverLPPs runs a prover for a LPP segment. It takes in a DistributedWizard
@@ -430,49 +272,27 @@ func runProverLPPs(
 	distWizard *distributed.DistributedWizard,
 	sharedRandomness field.Element,
 	witnessLPPs []*distributed.ModuleWitnessLPP,
-) []*wizard.ProverRuntime {
+) []distributed.SegmentProof {
 
 	var (
-		runs         = make([]*wizard.ProverRuntime, len(witnessLPPs))
-		compiledLPPs = distWizard.CompiledLPPs
+		proofs = make([]distributed.SegmentProof, len(witnessLPPs))
 	)
 
 	for i := range witnessLPPs {
 
 		var (
-			witnessLPP      = witnessLPPs[i]
-			moduleLPP       *distributed.RecursedSegmentCompilation
-			distModuleNames = [][]distributed.ModuleName{}
+			witnessLPP  = witnessLPPs[i]
+			moduleIndex = witnessLPP.ModuleIndex
+			moduleLPP   = distWizard.CompiledLPPs[moduleIndex]
 		)
 
 		witnessLPP.InitialFiatShamirState = sharedRandomness
 
-		t.Logf("segment(total)=%v module=%v segment.index=%v", i, witnessLPP.ModuleName, witnessLPP.ModuleIndex)
-
-	ModuleLoop:
-		for k := range distWizard.LPPs {
-
-			moduleList := distWizard.LPPs[k].ModuleNames()
-			distModuleNames = append(distModuleNames, moduleList)
-
-			for l, m := range moduleList {
-				if m != witnessLPP.ModuleName[l] {
-					continue ModuleLoop
-				}
-			}
-
-			moduleLPP = compiledLPPs[k]
-			break
-		}
-
-		if moduleLPP == nil {
-			t.Fatalf("module does not exists, moduleName=%v distModuleNames=%v", witnessLPP.ModuleName, distModuleNames)
-		}
-
+		t.Logf("segment(total)=%v module=%v module.index=%v segment.index=%v", i, witnessLPP.ModuleName, witnessLPP.ModuleIndex, witnessLPP.SegmentModuleIndex)
 		t.Logf("RUNNING THE LPP PROVER: %v", time.Now())
-		runs[i] = moduleLPP.ProveSegment(witnessLPP)
+		proofs[i] = moduleLPP.ProveSegment(witnessLPP)
 		t.Logf("RUNNING THE LPP PROVER - DONE: %v", time.Now())
 	}
 
-	return runs
+	return proofs
 }

--- a/prover/protocol/distributed/hierarchical-doc.md
+++ b/prover/protocol/distributed/hierarchical-doc.md
@@ -1,0 +1,64 @@
+# Hierarchical aggregation
+
+This short document describes the hierarchical aggregation scheme. The scheme
+allows aggregating the segment subproofs 2-by-2 in any order to reduce the 
+latency as much as possible.
+
+Crucially, the scheme relies on an LtHash, an order-independant hash function. 
+The proofs are recursively verified as we do with the all-at-once conglomeration
+, but the main change is that the scheme allow recursively aggregating the 
+conglomeration proofs. The list of the "acceptable" verification keys of the 
+aggregated proofs can no longer be fixed when defining the hierarchical 
+conglomeration circuit and must be defined as public input which is ultimately
+enforced by the verifier.
+
+A second aspect of the hierarchical conglomeration is how the public inputs are
+managed during the aggregation. Crucially, the conglomeration must guarantee the
+following properties.
+
+- All the segment proofs are from a list of whitelisted circuits
+- At the end of the process, all the segments have been verified
+    - This is done by a check on the public inputs by the outer-circuit
+- All the segments have the same view of the randomness generation and the
+    randomness has been correctly generated.
+- The logderivative sum, grand product etc.. are holistically valid
+- The "from-prev-to-next-segments" checks (HornerN0Hash and GlobalSendReceive) 
+    are verified
+- The LPP commitments are consistent between GL and LPP of the same segments and 
+    the pair should have verification keys for the same module
+- The functional inputs are propagated up through the aggregation steps
+
+
+## Making it possible to detect that all the segments have been aggregated
+
+For each of the type of proofs (GL/LPP/AGG), we introduce the following public
+inputs.
+
+- SegmentCountGL: A list of inputs containing the count of all the proofs that have been aggregated so far by module (only for the LPP)
+- SegmentCountLPP: A list of inputs containing the count of all the proofs that have been aggregated so far by module (only for the GL)
+- TargetCount: A list of inputs containing the count of all the segments that are to be aggregated by module.
+
+When aggregating two proofs, we sum the "SegmentCountXXX" public input for the two sub-proofs and we also check that the two subproofs have the same "TargetCount" counts and we just propagate the same value upward.
+
+We know that a subproof has aggregated all the segments if the TargetCount is reached for both SegmentCountGL and SegmentCountLPP.
+
+## Proving the unicity of the segments
+
+This is not really needed. Each segment is taking part in a succession of N0Hash
+and GlobalSent/ReceiveHash. Having a valid sequence is OK and sufficient for us.
+
+## Proving the segments are from a list of whitelisted circuits
+
+Each segment comes with a pair of field element to represent the verifying key.
+The aggregation circuit checks if the segment has the right verifying key by
+comparing it with the entries of a Merkle tree.
+
+## Actions
+- [] Adding the segment counting public inputs
+    - [] GL
+    - [] LPP
+    - [] Hierarchical
+- [] Adding the segment target propagation
+    - [] GL
+    - [] LPP
+    - [] Hierarchicals

--- a/prover/protocol/distributed/module_discovery.go
+++ b/prover/protocol/distributed/module_discovery.go
@@ -101,9 +101,6 @@ func ModuleOfColumn(disc *StandardModuleDiscoverer, col ifaces.Column) ModuleNam
 	case verifiercol.FromAccessors:
 		return ModuleOfList(disc, c.Accessors...)
 
-	case verifiercol.ExpandedVerifCol:
-		return ModuleOfColumn(disc, c.Verifiercol)
-
 	default:
 		utils.Panic("unexpected type of column: %T", col)
 	}

--- a/prover/protocol/distributed/module_discovery_standard.go
+++ b/prover/protocol/distributed/module_discovery_standard.go
@@ -302,7 +302,7 @@ func (disc *StandardModuleDiscoverer) analyzeBasic(comp *wizard.CompiledIOP) {
 			continue
 		}
 
-		if distNext > distPrev {
+		if distNext > distPrev && currWeightSum > 0 {
 			groups = append(groups, []*QueryBasedModule{})
 			currWeightSum = 0
 		}
@@ -358,6 +358,10 @@ func (disc *StandardModuleDiscoverer) analyzeBasic(comp *wizard.CompiledIOP) {
 					panic("the 'reduction' is bounded by the min number of rows so it should not be smaller than 1")
 				}
 				currWeight += groups[i][j].Weight(comp, numRow)
+			}
+
+			if currWeight == 0 {
+				utils.Panic("currWeight == 0, for module %v, index %d", disc.Modules[i].ModuleName, i)
 			}
 
 			currDist := utils.Abs(currWeight - disc.TargetWeight)
@@ -1310,9 +1314,8 @@ func weightOfGroupOfQBModules(comp *wizard.CompiledIOP, group []*QueryBasedModul
 // inclusion compiler understanding which parts of the S columns to use
 // to compute the M columns.
 type LPPSegmentBoundaryCalculator struct {
-	Disc     *StandardModuleDiscoverer
-	LPPArity int
-	Cached   map[*wizard.ProverRuntime]map[ifaces.ColID][2]int
+	Disc   *StandardModuleDiscoverer
+	Cached map[*wizard.ProverRuntime]map[ifaces.ColID][2]int
 }
 
 func (ls *LPPSegmentBoundaryCalculator) SegmentBoundaryOf(run *wizard.ProverRuntime, col column.Natural) (int, int) {
@@ -1331,13 +1334,7 @@ func (ls *LPPSegmentBoundaryCalculator) SegmentBoundaryOf(run *wizard.ProverRunt
 			continue
 		}
 
-		var (
-			lppModuleID = i / ls.LPPArity
-			s0          = lppModuleID * ls.LPPArity
-			s1          = min(len(moduleNames), s0+ls.LPPArity)
-		)
-
-		nbSegment = NbSegmentOfModule(run, ls.Disc, moduleNames[s0:s1])
+		nbSegment = NbSegmentOfModule(run, ls.Disc, moduleNames[i])
 	}
 
 	// NewLen correspond to the sum of the size of all the segments that will be
@@ -1394,4 +1391,14 @@ func (ls *LPPSegmentBoundaryCalculator) SegmentBoundaryOf(run *wizard.ProverRunt
 
 	utils.Panic("start=%v, stop=%v, nbSegment=%v, newSize=%v, newLen=%v, col=%v", start, stop, nbSegment, sizeOfSegment, newLen, col.ID)
 	return -1, -1 // Unreachable
+}
+
+// IndexOf returns the module index for a given module name
+func (disc *StandardModuleDiscoverer) IndexOf(moduleName ModuleName) int {
+	for i := range disc.Modules {
+		if disc.Modules[i].ModuleName == moduleName {
+			return i
+		}
+	}
+	panic("module not found")
 }

--- a/prover/protocol/distributed/module_discovery_test.go
+++ b/prover/protocol/distributed/module_discovery_test.go
@@ -17,7 +17,7 @@ func TestStandardDiscoveryOnZkEVM(t *testing.T) {
 		z    = zkevm.GetTestZkEVM()
 		disc = &distributed.StandardModuleDiscoverer{
 			TargetWeight: 1 << 28,
-			Affinities:   zkevm.GetAffinities(z),
+			Advices:      zkevm.DiscoveryAdvices,
 			Predivision:  16,
 		}
 	)
@@ -26,8 +26,6 @@ func TestStandardDiscoveryOnZkEVM(t *testing.T) {
 
 	// The test is to make sure that this function returns
 	disc.Analyze(z.WizardIOP)
-
-	fmt.Printf("%++v\n", disc)
 
 	allCols := z.WizardIOP.Columns.AllKeys()
 	for _, colName := range allCols {

--- a/prover/protocol/distributed/module_filtering.go
+++ b/prover/protocol/distributed/module_filtering.go
@@ -18,6 +18,9 @@ import (
 // CompiledIOP and not the distributed ones.
 type FilteredModuleInputs struct {
 
+	// ModuleIndex is the integer index of the module
+	ModuleIndex int
+
 	// ModuleName is the name of the current module.
 	ModuleName ModuleName
 
@@ -118,6 +121,14 @@ func (mf moduleFilter) FilterCompiledIOP(comp *wizard.CompiledIOP) FilteredModul
 		queryParamsName   = comp.QueriesParams.AllUnignoredKeys()
 		queryNoParamsName = comp.QueriesNoParams.AllUnignoredKeys()
 	)
+
+	// This sets the correct module index
+	for i, name := range mf.Disc.ModuleList() {
+		if name == mf.Module {
+			fmi.ModuleIndex = i
+			break
+		}
+	}
 
 	for _, columnName := range columnNames {
 

--- a/prover/protocol/distributed/module_gl.go
+++ b/prover/protocol/distributed/module_gl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/linea-monorepo/prover/crypto/mimc"
 	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/accessors"
 	"github.com/consensys/linea-monorepo/prover/protocol/coin"
@@ -18,15 +19,6 @@ import (
 	"github.com/consensys/linea-monorepo/prover/protocol/wizardutils"
 	sym "github.com/consensys/linea-monorepo/prover/symbolic"
 	"github.com/consensys/linea-monorepo/prover/utils"
-)
-
-const (
-	ModuleGLReceiveGlobalKey  = "RECEIVE_GLOBAL"
-	ModuleGLSendGlobalKey     = "SEND_GLOBAL"
-	GlobalSenderPublicInput   = "GLOBAL_PROVIDER"
-	GlobalReceiverPublicInput = "GLOBAL_RECEIVER"
-	IsFirstPublicInput        = "IS_FIRST"
-	IsLastPublicInput         = "IS_LAST"
 )
 
 // ModuleGL is a compilation structure holding the central informations
@@ -41,6 +33,11 @@ type ModuleGL struct {
 	// DefinitionInput stores the [FilteredModuleInputs] that was used
 	// to generate the module.
 	DefinitionInput *FilteredModuleInputs
+
+	// SegmentModuleIndex is the index of the module in the segment. The value
+	// is used to assign a column and check that "isFirst" and "isLast" are
+	// right-fully computed.
+	SegmentModuleIndex ifaces.Column
 
 	// IsFirst is a column of length one storing a binary value indicating
 	// if the current (vertical) instance of the module is the first one.
@@ -94,6 +91,9 @@ type ModuleGL struct {
 	// to check if a value has already been added to [SentValuesGlobal]. The
 	// key string are formatted as "<column-name>/<position>".
 	ReceivedValuesGlobalMap map[string]int
+
+	// PublicInputs contains the public inputs of the module.
+	PublicInputs LimitlessPublicInput[wizard.PublicInput]
 }
 
 // ModuleGLAssignSendReceiveGlobal is an implementation of the [wizard.ProverRuntime]
@@ -148,8 +148,6 @@ func NewModuleGL(builder *wizard.Builder, moduleInput *FilteredModuleInputs) *Mo
 			Disc: moduleInput.Disc,
 		},
 		DefinitionInput:         moduleInput,
-		IsFirst:                 builder.InsertProof(0, "GL_IS_FIRST", 1),
-		IsLast:                  builder.InsertProof(0, "GL_IS_LAST", 1),
 		SentValuesGlobalMap:     map[string]int{},
 		ReceivedValuesGlobalMap: map[string]int{},
 	}
@@ -184,6 +182,9 @@ func NewModuleGL(builder *wizard.Builder, moduleInput *FilteredModuleInputs) *Mo
 	// the columns and the queries but not for the coins.
 	_ = moduleGL.Wiop.InsertCoin(1, "DUMMY_GL_COIN", coin.Field)
 
+	moduleGL.IsFirst = moduleGL.Wiop.InsertProof(0, "IS_FIRST", 1)
+	moduleGL.IsLast = moduleGL.Wiop.InsertProof(0, "IS_LAST", 1)
+
 	for _, globalCs := range moduleInput.GlobalConstraints {
 		moduleGL.InsertGlobal(*globalCs)
 	}
@@ -216,45 +217,7 @@ func NewModuleGL(builder *wizard.Builder, moduleInput *FilteredModuleInputs) *Mo
 		moduleGL.CompleteGlobalCs(newGlobalCs)
 	}
 
-	for i := range moduleInput.PublicInputs {
-
-		pubInputAcc := accessors.NewConstant(field.Zero())
-
-		if moduleInput.PublicInputs[i].Acc != nil {
-			pubInputAcc = moduleGL.TranslateAccessor(moduleInput.PublicInputs[i].Acc)
-		}
-
-		moduleGL.Wiop.InsertPublicInput(
-			moduleInput.PublicInputs[i].Name,
-			pubInputAcc,
-		)
-	}
-
-	moduleGL.Wiop.InsertPublicInput(InitialRandomnessPublicInput, accessors.NewConstant(field.Zero()))
-	moduleGL.Wiop.InsertPublicInput(IsFirstPublicInput, accessors.NewFromPublicColumn(moduleGL.IsFirst, 0))
-	moduleGL.Wiop.InsertPublicInput(IsLastPublicInput, accessors.NewFromPublicColumn(moduleGL.IsLast, 0))
-
-	if len(moduleGL.ReceivedValuesGlobalMap) > 0 {
-		moduleGL.Wiop.InsertPublicInput(GlobalSenderPublicInput, accessors.NewFromPublicColumn(moduleGL.SentValuesGlobalHash, 0))
-		moduleGL.Wiop.InsertPublicInput(GlobalReceiverPublicInput, accessors.NewFromPublicColumn(moduleGL.ReceivedValuesGlobalHash, 0))
-	} else {
-		moduleGL.Wiop.InsertPublicInput(GlobalSenderPublicInput, accessors.NewConstant(field.Zero()))
-		moduleGL.Wiop.InsertPublicInput(GlobalReceiverPublicInput, accessors.NewConstant(field.Zero()))
-	}
-
-	// These public-inputs are the "dummy" ones and are only here so that the
-	// LPP and GL modules have exactly the same set of public inputs. The
-	// public-inputs are reordered a posteriori to ensure that the order
-	// match between GL and LPP.
-	moduleGL.Wiop.InsertPublicInput(LogDerivativeSumPublicInput, accessors.NewConstant(field.Zero()))
-	moduleGL.Wiop.InsertPublicInput(GrandProductPublicInput, accessors.NewConstant(field.One()))
-	moduleGL.Wiop.InsertPublicInput(HornerPublicInput, accessors.NewConstant(field.Zero()))
-	moduleGL.Wiop.InsertPublicInput(HornerN0HashPublicInput, accessors.NewConstant(field.Zero()))
-	moduleGL.Wiop.InsertPublicInput(HornerN1HashPublicInput, accessors.NewConstant(field.Zero()))
-
-	moduleGL.Wiop.InsertPublicInput(IsGlPublicInput, accessors.NewConstant(field.One()))
-	moduleGL.Wiop.InsertPublicInput(IsLppPublicInput, accessors.NewConstant(field.Zero()))
-	moduleGL.Wiop.InsertPublicInput(NbActualLppPublicInput, accessors.NewConstant(field.Zero()))
+	moduleGL.declarePublicInput()
 
 	moduleGL.Wiop.RegisterProverAction(1, &ModuleGLAssignGL{ModuleGL: moduleGL})
 	moduleGL.Wiop.RegisterProverAction(1, &ModuleGLAssignSendReceiveGlobal{ModuleGL: moduleGL})
@@ -262,15 +225,6 @@ func NewModuleGL(builder *wizard.Builder, moduleInput *FilteredModuleInputs) *Mo
 
 	return moduleGL
 }
-
-// func (m *ModuleGL) GetModuleTranslator() moduleTranslator {
-// 	return m.moduleTranslator
-// }
-
-// func (m *ModuleGL) SetModuleTranslator(comp *wizard.CompiledIOP, disc *StandardModuleDiscoverer) {
-// 	m.moduleTranslator.Wiop = comp
-// 	m.moduleTranslator.Disc = disc
-// }
 
 // GetMainProverStep returns a [wizard.ProverStep] running [Assign] passing
 // the provided [ModuleWitness] argument.
@@ -332,16 +286,18 @@ func (m *ModuleGL) Assign(run *wizard.ProverRuntime, witness *ModuleWitnessGL) {
 
 	isFirst, isLast := field.Element{}, field.Element{}
 
-	if witness.IsFirst {
+	if witness.SegmentModuleIndex == 0 {
 		isFirst = field.One()
 	}
 
-	if witness.IsLast {
+	if witness.SegmentModuleIndex == witness.TotalSegmentCount[witness.ModuleIndex]-1 {
 		isLast = field.One()
 	}
 
 	run.AssignColumn(m.IsFirst.GetColID(), smartvectors.NewConstant(isFirst, 1))
 	run.AssignColumn(m.IsLast.GetColID(), smartvectors.NewConstant(isLast, 1))
+
+	m.assignPublicInput(run, witness)
 }
 
 // InsertGlobal inserts a global constraint in the target compiled IOP and
@@ -501,6 +457,8 @@ func (m *ModuleGL) CompleteGlobalCs(newGlobal query.GlobalConstraint) {
 			},
 		)
 
+		// TODO @alex: we actually need a cancellator criterion for the local
+		// constraints.
 		localExpr = sym.Mul(localExpr, sym.Sub(1, accessors.NewFromPublicColumn(m.IsFirst, 0)))
 		m.Wiop.InsertLocal(
 			newExprRound,
@@ -612,46 +570,47 @@ func (m *ModuleGL) processSendAndReceiveGlobal() {
 // The function also assigns the [SentValueGlobal] local openings.
 func (a *ModuleGLAssignSendReceiveGlobal) Run(run *wizard.ProverRuntime) {
 
-	if len(a.ReceivedValuesGlobalMap) == 0 {
-		return
+	if len(a.ReceivedValuesGlobalMap) > 0 {
+
+		hashSend := field.Element{}
+
+		for i := range a.SentValuesGlobal {
+			lo := a.SentValuesGlobal[i]
+			v := lo.Pol.GetColAssignmentAt(run, 0)
+			run.AssignLocalPoint(lo.ID, v)
+			hashSend = mimc.BlockCompression(hashSend, v)
+		}
+
+		run.AssignColumn(
+			a.SentValuesGlobalHash.GetColID(),
+			smartvectors.NewConstant(hashSend, 1),
+		)
+
+		witness := run.State.MustGet(moduleWitnessKey).(*ModuleWitnessGL)
+		rcvData := witness.ReceivedValuesGlobal
+
+		if len(rcvData) != len(a.ReceivedValuesGlobalAccs) {
+			utils.Panic("len(rcvData: %v) != len(a.ReceivedValuesGlobalAccs: %v)", len(rcvData), len(a.ReceivedValuesGlobalAccs))
+		}
+
+		run.AssignColumn(
+			a.ReceivedValuesGlobal.GetColID(),
+			smartvectors.RightZeroPadded(rcvData, a.ReceivedValuesGlobal.Size()),
+		)
+
+		hashRcv := field.Element{}
+		for i := range rcvData {
+			v := rcvData[i]
+			hashRcv = mimc.BlockCompression(hashRcv, v)
+		}
+
+		run.AssignColumn(
+			a.ReceivedValuesGlobalHash.GetColID(),
+			smartvectors.NewConstant(hashRcv, 1),
+		)
 	}
 
-	hashSend := field.Element{}
-
-	for i := range a.SentValuesGlobal {
-		lo := a.SentValuesGlobal[i]
-		v := lo.Pol.GetColAssignmentAt(run, 0)
-		run.AssignLocalPoint(lo.ID, v) //TODO@yao:fix, v=field.Oct
-		hashSend = mimc.BlockCompression(hashSend, v)
-	}
-
-	run.AssignColumn(
-		a.SentValuesGlobalHash.GetColID(),
-		smartvectors.NewConstant(hashSend, 1),
-	)
-
-	witness := run.State.MustGet(moduleWitnessKey).(*ModuleWitnessGL)
-	rcvData := witness.ReceivedValuesGlobal
-
-	if len(rcvData) != len(a.ReceivedValuesGlobalAccs) {
-		utils.Panic("len(rcvData: %v) != len(a.ReceivedValuesGlobalAccs: %v)", len(rcvData), len(a.ReceivedValuesGlobalAccs))
-	}
-
-	run.AssignColumn(
-		a.ReceivedValuesGlobal.GetColID(),
-		smartvectors.RightZeroPadded(rcvData, a.ReceivedValuesGlobal.Size()),
-	)
-
-	hashRcv := field.Element{}
-	for i := range rcvData {
-		v := rcvData[i]
-		hashRcv = mimc.BlockCompression(hashRcv, v)
-	}
-
-	run.AssignColumn(
-		a.ReceivedValuesGlobalHash.GetColID(),
-		smartvectors.NewConstant(hashRcv, 1),
-	)
+	a.ModuleGL.assignMultiSetHash(run)
 }
 
 // Run implements the [wizard.VerifierAction] interface and recomputes and
@@ -709,6 +668,8 @@ func (a *ModuleGLCheckSendReceiveGlobal) Run(run wizard.Runtime) error {
 		)
 	}
 
+	a.ModuleGL.checkMultiSetHash(run)
+
 	return nil
 }
 
@@ -748,6 +709,8 @@ func (a *ModuleGLCheckSendReceiveGlobal) RunGnark(api frontend.API, run wizard.G
 	}
 
 	api.AssertIsEqual(hsh.Sum(), rcvGlobalHash)
+
+	a.ModuleGL.checkGnarkMultiSetHash(api, run)
 }
 
 func (a *ModuleGLCheckSendReceiveGlobal) Skip() {
@@ -804,4 +767,273 @@ func (a *ModuleGLAssignGL) Run(run *wizard.ProverRuntime) {
 		y := newLo.Pol.GetColAssignmentAt(run, 0)
 		run.AssignLocalPoint(a.DefinitionInput.LocalOpenings[i].ID, y)
 	}
+}
+
+func (modGl *ModuleGL) declarePublicInput() {
+
+	var (
+		nbModules = len(modGl.DefinitionInput.Disc.Modules)
+		// segmenCountGL is an array of zero with a one at the position
+		// corresponding to the current module.
+		segmentCountGl = make([]field.Element, nbModules)
+		// segmentCountLpp is an array of zero.
+		segmentCountLpp = make([]field.Element, nbModules)
+		defInp          = modGl.DefinitionInput
+	)
+
+	modGl.SegmentModuleIndex = modGl.Wiop.InsertProof(0, "SEGMENT_MODULE_INDEX", 1)
+
+	segmentCountGl[modGl.Disc.IndexOf(modGl.DefinitionInput.ModuleName)] = field.One()
+
+	modGl.PublicInputs = LimitlessPublicInput[wizard.PublicInput]{
+		VKeyMerkleRoot:               declarePiColumn(modGl.Wiop, VerifyingKeyMerkleRootPublicInput),
+		TargetNbSegments:             declareListOfPiColumns(modGl.Wiop, 0, TargetNbSegmentPublicInputBase, nbModules),
+		SegmentCountGL:               declareListOfConstantPi(modGl.Wiop, SegmentCountGLPublicInputBase, segmentCountGl),
+		SegmentCountLPP:              declareListOfConstantPi(modGl.Wiop, SegmentCountLPPPublicInputBase, segmentCountLpp),
+		GeneralMultiSetHash:          declareListOfPiColumns(modGl.Wiop, 1, GeneralMultiSetPublicInputBase, mimc.MSetHashSize),
+		SharedRandomnessMultiSetHash: declareListOfPiColumns(modGl.Wiop, 1, SharedRandomnessMultiSetPublicInputBase, mimc.MSetHashSize),
+		SharedRandomness:             modGl.Wiop.InsertPublicInput(InitialRandomnessPublicInput, accessors.NewConstant(field.Zero())),
+	}
+
+	// This adds the functional inputs by multiplying them with the value of
+	// isFirst.
+	for i := range defInp.PublicInputs {
+
+		pubInputAcc := accessors.NewConstant(field.Zero())
+
+		if defInp.PublicInputs[i].Acc != nil {
+			pubInputAcc = modGl.TranslateAccessor(defInp.PublicInputs[i].Acc)
+			pubInputAcc = accessors.NewFromExpression(sym.Mul(
+				pubInputAcc,
+				accessors.NewFromPublicColumn(modGl.IsFirst, 0),
+			), "IS_FIRST_MULT_"+defInp.PublicInputs[i].Name)
+		}
+
+		modGl.Wiop.InsertPublicInput(
+			defInp.PublicInputs[i].Name,
+			pubInputAcc,
+		)
+	}
+
+	// This section adds the dummy public inputs for the log-derivative, grand-product
+	// horner-sum.
+
+	modGl.PublicInputs.HornerSum = modGl.Wiop.InsertPublicInput(
+		HornerPublicInput,
+		accessors.NewConstant(field.Zero()),
+	)
+
+	modGl.PublicInputs.LogDerivativeSum = modGl.Wiop.InsertPublicInput(
+		LogDerivativeSumPublicInput,
+		accessors.NewConstant(field.Zero()),
+	)
+
+	modGl.PublicInputs.GrandProduct = modGl.Wiop.InsertPublicInput(
+		GrandProductPublicInput,
+		accessors.NewConstant(field.One()),
+	)
+
+}
+
+func (modGL *ModuleGL) assignPublicInput(run *wizard.ProverRuntime, witness *ModuleWitnessGL) {
+
+	// This assigns the segment module index proof column
+	run.AssignColumn(
+		modGL.SegmentModuleIndex.GetColID(),
+		smartvectors.NewConstant(field.NewElement(uint64(witness.SegmentModuleIndex)), 1),
+	)
+
+	// This assigns the VKeyMerkleRoot
+	assignPiColumn(run, modGL.PublicInputs.VKeyMerkleRoot.Name, witness.VkMerkleRoot)
+
+	// This assigns the columns corresponding to the public input indicating
+	// the number of segments
+	assignListOfPiColumns(run, TargetNbSegmentPublicInputBase, vector.ForTest(witness.TotalSegmentCount...))
+}
+
+// assignLPPCommitmentMSetGL assigns the LPP commitment MSet. It is meant to be
+// run as part of a prover action. It also adds the "sent" and "received" values
+// to the MSet.
+func (modGL *ModuleGL) assignMultiSetHash(run *wizard.ProverRuntime) {
+
+	var lppCommitments field.Element
+	if run.HasPublicInput(lppMerkleRootPublicInput + "_0") {
+		lppCommitments = run.GetPublicInput(lppMerkleRootPublicInput + "_0")
+	}
+
+	var (
+		segmentIndex             = modGL.SegmentModuleIndex.GetColAssignmentAt(run, 0)
+		typeOfProof              = field.NewElement(uint64(proofTypeGL))
+		hasSentOrReceive         = len(modGL.ReceivedValuesGlobalMap) > 0
+		multiSetGeneral          = mimc.MSetHash{}
+		multiSetSharedRandomness = mimc.MSetHash{}
+		defInp                   = modGL.DefinitionInput
+		moduleIndex              = field.NewElement(uint64(defInp.ModuleIndex))
+		segmentIndexInt          = segmentIndex.Uint64()
+		numSegmentModule         = modGL.PublicInputs.TargetNbSegments[defInp.ModuleIndex].Acc.GetVal(run)
+	)
+
+	multiSetSharedRandomness.Insert(moduleIndex, segmentIndex, lppCommitments)
+	multiSetGeneral.Add(multiSetSharedRandomness)
+
+	// If the segment is not the last one of its module we add the "sent" value
+	// in the multiset.
+	if hasSentOrReceive && segmentIndexInt < numSegmentModule.Uint64()-1 {
+		globalSentHash := modGL.SentValuesGlobalHash.GetColAssignmentAt(run, 0)
+		multiSetGeneral.Insert(moduleIndex, segmentIndex, typeOfProof, globalSentHash)
+	}
+
+	// If the segment is not the first one of its module, we add the received
+	// value in the multiset
+	if hasSentOrReceive && !segmentIndex.IsZero() {
+
+		var (
+			prevSegmentIndex field.Element
+			one              = field.One()
+			globalRcvdHash   = modGL.ReceivedValuesGlobalHash.GetColAssignmentAt(run, 0)
+		)
+
+		prevSegmentIndex.Sub(&segmentIndex, &one)
+		multiSetGeneral.Remove(moduleIndex, prevSegmentIndex, typeOfProof, globalRcvdHash)
+	}
+
+	assignListOfPiColumns(run, GeneralMultiSetPublicInputBase, multiSetGeneral[:])
+	assignListOfPiColumns(run, SharedRandomnessMultiSetPublicInputBase, multiSetSharedRandomness[:])
+}
+
+// checkMultiSetHash checks that the LPP commitment MSet is correctly
+// assigned. It is meant to be run as part of a verifier action. The function
+// also checks that isFirst and isLast are correctly assigned.
+func (modGL *ModuleGL) checkMultiSetHash(run wizard.Runtime) error {
+
+	var (
+		targetMSetGeneral          = GetPublicInputList(run, GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+		targetMSetSharedRandomness = GetPublicInputList(run, SharedRandomnessMultiSetPublicInputBase, mimc.MSetHashSize)
+		lppCommitments             = run.GetPublicInput(lppMerkleRootPublicInput + "_0")
+		segmentIndex               = modGL.SegmentModuleIndex.GetColAssignmentAt(run, 0)
+		typeOfProof                = field.NewElement(uint64(proofTypeGL))
+		hasSentOrReceive           = len(modGL.ReceivedValuesGlobalMap) > 0
+		multiSetGeneral            = mimc.MSetHash{}
+		multiSetSharedRandomness   = mimc.MSetHash{}
+		defInp                     = modGL.DefinitionInput
+		moduleIndex                = field.NewElement(uint64(defInp.ModuleIndex))
+		segmentIndexInt            = segmentIndex.Uint64()
+		numSegmentOfCurrModule     = modGL.PublicInputs.TargetNbSegments[segmentIndexInt].Acc.GetVal(run)
+		isFirst                    = modGL.IsFirst.GetColAssignmentAt(run, 0)
+		isLast                     = modGL.IsLast.GetColAssignmentAt(run, 0)
+	)
+
+	multiSetSharedRandomness.Insert(moduleIndex, segmentIndex, lppCommitments)
+	multiSetGeneral.Add(multiSetSharedRandomness)
+
+	if !isFirst.IsZero() && !isFirst.IsOne() {
+		return fmt.Errorf("isFirst is not 0 or 1")
+	}
+
+	if !isLast.IsZero() && !isLast.IsOne() {
+		return fmt.Errorf("isLast is not 0 or 1")
+	}
+
+	// This checks that isFirst and isLast are well assigned wrt to the segment
+	// index
+	if (segmentIndexInt == 0) != isFirst.IsOne() {
+		return fmt.Errorf("isFirst does not match the segment index")
+	}
+
+	if (segmentIndexInt == numSegmentOfCurrModule.Uint64()-1) != isLast.IsOne() {
+		return fmt.Errorf("isLast does not match the segment index")
+	}
+
+	// If the segment is not the last one of its module we add the "sent" value
+	// in the multiset.
+	if hasSentOrReceive && segmentIndexInt < numSegmentOfCurrModule.Uint64()-1 {
+		globalSentHash := modGL.SentValuesGlobalHash.GetColAssignmentAt(run, 0)
+		// This is a local module
+		multiSetGeneral.Insert(moduleIndex, segmentIndex, typeOfProof, globalSentHash)
+	}
+
+	// If the segment is not the first one of its module, we add the received
+	// value in the multiset
+	if hasSentOrReceive && !segmentIndex.IsZero() {
+
+		var (
+			prevSegmentIndex field.Element
+			one              = field.One()
+			globalRcvdHash   = modGL.ReceivedValuesGlobalHash.GetColAssignmentAt(run, 0)
+		)
+
+		prevSegmentIndex.Sub(&segmentIndex, &one)
+		multiSetGeneral.Remove(moduleIndex, prevSegmentIndex, typeOfProof, globalRcvdHash)
+	}
+
+	if !vector.Equal(targetMSetGeneral, multiSetGeneral[:]) {
+		return fmt.Errorf("LPP commitment MSet mismatch, expected: %v, got: %v", targetMSetGeneral, multiSetGeneral[:])
+	}
+
+	if !vector.Equal(targetMSetSharedRandomness, multiSetSharedRandomness[:]) {
+		return fmt.Errorf("shared randomness MSet mismatch, expected: %v, got: %v", targetMSetSharedRandomness, multiSetSharedRandomness[:])
+	}
+
+	return nil
+}
+
+// checkGnarkMultiSetHash checks that the LPP commitment MSet is correctly
+// assigned. It is meant to be run as part of a verifier action.
+func (modGL *ModuleGL) checkGnarkMultiSetHash(api frontend.API, run wizard.GnarkRuntime) error {
+
+	var (
+		targetMSetGeneral          = GetPublicInputListGnark(api, run, GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+		targetMSetSharedRandomness = GetPublicInputListGnark(api, run, SharedRandomnessMultiSetPublicInputBase, mimc.MSetHashSize)
+		lppCommitments             = run.GetPublicInput(api, lppMerkleRootPublicInput+"_0")
+		segmentIndex               = modGL.SegmentModuleIndex.GetColAssignmentGnarkAt(run, 0)
+		typeOfProof                = field.NewElement(uint64(proofTypeGL))
+		hasSentOrReceive           = len(modGL.ReceivedValuesGlobalMap) > 0
+		hasher                     = run.GetHasherFactory().NewHasher()
+		multiSetGeneral            = mimc.EmptyMSetHashGnark(hasher)
+		multiSetSharedRandomness   = mimc.EmptyMSetHashGnark(hasher)
+		defInp                     = modGL.DefinitionInput
+		moduleIndex                = frontend.Variable(defInp.ModuleIndex)
+		numSegmentOfCurrModule     = modGL.PublicInputs.TargetNbSegments[defInp.ModuleIndex].Acc.GetFrontendVariable(api, run)
+		isFirst                    = modGL.IsFirst.GetColAssignmentGnarkAt(run, 0)
+		isLast                     = modGL.IsLast.GetColAssignmentGnarkAt(run, 0)
+	)
+
+	multiSetSharedRandomness.Insert(api, moduleIndex, segmentIndex, lppCommitments)
+	multiSetGeneral.Add(api, multiSetSharedRandomness)
+
+	api.AssertIsBoolean(isFirst)
+	api.AssertIsBoolean(isLast)
+
+	// This checks that isFirst and isLast are well assigned wrt to the segment
+	// index
+	api.AssertIsEqual(isFirst, api.IsZero(segmentIndex))
+	api.AssertIsEqual(isLast, api.IsZero(api.Sub(numSegmentOfCurrModule, segmentIndex, 1)))
+
+	// If the segment is not the last one of its module we add the "sent" value
+	// in the multiset.
+	if hasSentOrReceive {
+		globalSentHash := modGL.SentValuesGlobalHash.GetColAssignmentGnarkAt(run, 0)
+		mSetOfSentGlobal := mimc.MsetOfSingletonGnark(api, hasher, moduleIndex, segmentIndex, typeOfProof, globalSentHash)
+		for i := range mSetOfSentGlobal.Inner {
+			mSetOfSentGlobal.Inner[i] = api.Mul(mSetOfSentGlobal.Inner[i], api.Sub(1, isLast))
+			multiSetGeneral.Inner[i] = api.Add(multiSetGeneral.Inner[i], mSetOfSentGlobal.Inner[i])
+		}
+
+		// If the segment is not the first one of its module, we add the received
+		// value in the multiset. If the segment index is zero, the singleton hash
+		// will be zero-ed out by the "1 - isFirst" term
+		globalRcvdHash := modGL.ReceivedValuesGlobalHash.GetColAssignmentGnarkAt(run, 0)
+		mSetOfReceivedGlobal := mimc.MsetOfSingletonGnark(api, hasher, moduleIndex, api.Sub(segmentIndex, 1), typeOfProof, globalRcvdHash)
+		for i := range mSetOfReceivedGlobal.Inner {
+			mSetOfReceivedGlobal.Inner[i] = api.Mul(mSetOfReceivedGlobal.Inner[i], api.Sub(1, isFirst))
+			multiSetGeneral.Inner[i] = api.Sub(multiSetGeneral.Inner[i], mSetOfReceivedGlobal.Inner[i])
+		}
+	}
+
+	for i := range multiSetGeneral.Inner {
+		api.AssertIsEqual(multiSetGeneral.Inner[i], targetMSetGeneral[i])
+		api.AssertIsEqual(multiSetSharedRandomness.Inner[i], targetMSetSharedRandomness[i])
+	}
+
+	return nil
 }

--- a/prover/protocol/distributed/module_lpp.go
+++ b/prover/protocol/distributed/module_lpp.go
@@ -6,6 +6,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/linea-monorepo/prover/crypto/mimc"
 	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/accessors"
 	"github.com/consensys/linea-monorepo/prover/protocol/coin"
@@ -14,18 +15,6 @@ import (
 	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
 	"github.com/consensys/linea-monorepo/prover/symbolic"
 	"github.com/consensys/linea-monorepo/prover/utils"
-)
-
-var (
-	LogDerivativeSumPublicInput  = "LOG_DERIVATE_SUM_PUBLIC_INPUT"
-	GrandProductPublicInput      = "GRAND_PRODUCT_PUBLIC_INPUT"
-	HornerPublicInput            = "HORNER_FINAL_RES_PUBLIC_INPUT"
-	HornerN0HashPublicInput      = "HORNER_N0_HASH_PUBLIC_INPUT"
-	HornerN1HashPublicInput      = "HORNER_N1_HASH_PUBLIC_INPUT"
-	IsLppPublicInput             = "IS_LPP"
-	IsGlPublicInput              = "IS_GL"
-	NbActualLppPublicInput       = "NB_ACTUAL_LPP"
-	InitialRandomnessPublicInput = "INITIAL_RANDOMNESS_PUBLIC_INPUT"
 )
 
 // ModuleLPP is a compilation structure holding the central informations
@@ -37,9 +26,14 @@ type ModuleLPP struct {
 	// this module.
 	ModuleTranslator
 
-	// DefinitionInputs stores the [FilteredModuleInputs] that was used
+	// DefinitionInput stores the [FilteredModuleInputs] that was used
 	// to generate the module.
-	DefinitionInputs []FilteredModuleInputs
+	DefinitionInput FilteredModuleInputs
+
+	// SegmentModuleIndex is the index of the module in the segment. The value
+	// is used to assign a column and check that "isFirst" and "isLast" are
+	// right-fully computed.
+	SegmentModuleIndex ifaces.Column
 
 	// InitialFiatShamirState is the state at which to start the FiatShamir
 	// computation
@@ -52,13 +46,17 @@ type ModuleLPP struct {
 	N1Hash ifaces.Column
 
 	// LogDerivativeSum is the translated log-derivative query in the module
-	LogDerivativeSum query.LogDerivativeSum
+	LogDerivativeSum *query.LogDerivativeSum
 
 	// GrandProduct is the translated grand-product query in the module
-	GrandProduct query.GrandProduct
+	GrandProduct *query.GrandProduct
 
 	// Horner is the translated horner query in the module
-	Horner query.Horner
+	Horner *query.Horner
+
+	// PublicInput contains the list of the public inputs for the current LPP
+	// module.
+	PublicInputs LimitlessPublicInput[wizard.PublicInput]
 }
 
 // SetInitialFSHash sets the initial FiatShamir state
@@ -90,7 +88,7 @@ type LppWitnessAssignment struct {
 // BuildModuleLPP builds a [ModuleLPP] from scratch from a [FilteredModuleInputs].
 // The function works by creating a define function that will call [NewModuleLPP]
 // / and then it calls [wizard.Compile] without passing compilers.
-func BuildModuleLPP(moduleInput []FilteredModuleInputs) *ModuleLPP {
+func BuildModuleLPP(moduleInput FilteredModuleInputs) *ModuleLPP {
 
 	var (
 		moduleLPP  *ModuleLPP
@@ -109,186 +107,85 @@ func BuildModuleLPP(moduleInput []FilteredModuleInputs) *ModuleLPP {
 // and a [FilteredModuleInput]. The function performs all the necessary
 // declarations to build the LPP part of the module and returns the constructed
 // module.
-func NewModuleLPP(builder *wizard.Builder, moduleInputs []FilteredModuleInputs) *ModuleLPP {
+func NewModuleLPP(builder *wizard.Builder, moduleInput FilteredModuleInputs) *ModuleLPP {
 
 	moduleLPP := &ModuleLPP{
 		ModuleTranslator: ModuleTranslator{
 			Wiop: builder.CompiledIOP,
-			Disc: moduleInputs[0].Disc,
+			Disc: moduleInput.Disc,
 		},
-		DefinitionInputs:       moduleInputs,
+		DefinitionInput:        moduleInput,
 		InitialFiatShamirState: builder.InsertProof(0, "INITIAL_FIATSHAMIR_STATE", 1),
 	}
 
-	// The starting round is the round where we can add data other than the LPP
-	// columns.
-	var startingRound = len(moduleInputs)
+	for _, col := range moduleInput.Columns {
 
-	// These are the "dummy" public inputs that are only here so that the
-	// moduleGL and moduleLPP have identical set of public inputs. The order
-	// of declaration is also important. Namely, these needs to be declared before
-	// the non-dummy ones.
-	for _, pi := range moduleInputs[0].PublicInputs {
-		moduleLPP.Wiop.InsertPublicInput(pi.Name, accessors.NewConstant(field.Zero()))
-	}
-
-	moduleLPP.Wiop.InsertPublicInput(InitialRandomnessPublicInput, accessors.NewFromPublicColumn(moduleLPP.InitialFiatShamirState, 0))
-	moduleLPP.Wiop.InsertPublicInput(IsFirstPublicInput, accessors.NewConstant(field.Zero()))
-	moduleLPP.Wiop.InsertPublicInput(IsLastPublicInput, accessors.NewConstant(field.Zero()))
-	moduleLPP.Wiop.InsertPublicInput(GlobalSenderPublicInput, accessors.NewConstant(field.Zero()))
-	moduleLPP.Wiop.InsertPublicInput(GlobalReceiverPublicInput, accessors.NewConstant(field.Zero()))
-
-	for round, moduleInput := range moduleInputs {
-		for _, col := range moduleInput.Columns {
-
-			if col.Round() != 0 {
-				utils.Panic("cannot translate a column with non-zero round %v", col.Round())
-			}
-
-			_, isLPP := moduleInput.ColumnsLPPSet[col.GetColID()]
-
-			if !isLPP {
-				continue
-			}
-
-			if data, isPrecomp := moduleInput.ColumnsPrecomputed[col.GetColID()]; isPrecomp {
-				moduleLPP.InsertPrecomputed(*col, data)
-				continue
-			}
-
-			moduleLPP.InsertColumn(*col, round)
+		if col.Round() != 0 {
+			utils.Panic("cannot translate a column with non-zero round %v", col.Round())
 		}
+
+		_, isLPP := moduleInput.ColumnsLPPSet[col.GetColID()]
+
+		if !isLPP {
+			continue
+		}
+
+		if data, isPrecomp := moduleInput.ColumnsPrecomputed[col.GetColID()]; isPrecomp {
+			moduleLPP.InsertPrecomputed(*col, data)
+			continue
+		}
+
+		moduleLPP.InsertColumn(*col, 0)
 	}
 
-	logDerivativeArgs, grandProductArgs, hornerArgs := getQueryArgs(moduleInputs)
-
-	if len(logDerivativeArgs) > 0 {
-
-		moduleLPP.LogDerivativeSum = moduleLPP.InsertLogDerivative(
-			startingRound,
+	if len(moduleInput.LogDerivativeArgs) > 0 {
+		q := moduleLPP.InsertLogDerivative(
+			1,
 			ifaces.QueryID("MAIN_LOGDERIVATIVE"),
-			logDerivativeArgs,
+			moduleInput.LogDerivativeArgs,
 		)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			LogDerivativeSumPublicInput,
-			accessors.NewLogDerivSumAccessor(moduleLPP.LogDerivativeSum),
-		)
-
-	} else {
-
-		moduleLPP.Wiop.InsertPublicInput(
-			LogDerivativeSumPublicInput,
-			accessors.NewConstant(field.Zero()),
-		)
+		moduleLPP.LogDerivativeSum = &q
 	}
 
-	if len(grandProductArgs) > 0 {
-
-		moduleLPP.GrandProduct = moduleLPP.InsertGrandProduct(
-			startingRound,
+	if len(moduleInput.GrandProductArgs) > 0 {
+		q := moduleLPP.InsertGrandProduct(
+			1,
 			ifaces.QueryID("MAIN_GRANDPRODUCT"),
-			grandProductArgs,
+			moduleInput.GrandProductArgs,
 		)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			GrandProductPublicInput,
-			accessors.NewGrandProductAccessor(moduleLPP.GrandProduct),
-		)
-
-	} else {
-
-		moduleLPP.Wiop.InsertPublicInput(
-			GrandProductPublicInput,
-			accessors.NewConstant(field.One()),
-		)
+		moduleLPP.GrandProduct = &q
 	}
 
-	if len(hornerArgs) > 0 {
-
-		moduleLPP.Horner = moduleLPP.InsertHorner(
-			startingRound,
+	if len(moduleInput.HornerArgs) > 0 {
+		q := moduleLPP.InsertHorner(
+			1,
 			ifaces.QueryID("MAIN_HORNER"),
-			hornerArgs,
+			moduleInput.HornerArgs,
 		)
+		moduleLPP.Horner = &q
 
-		moduleLPP.N0Hash = builder.InsertProof(startingRound, "LPP_N0_HASH", 1)
-		moduleLPP.N1Hash = builder.InsertProof(startingRound, "LPP_N1_HASH", 1)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			HornerPublicInput,
-			accessors.NewFromHornerAccessorFinalValue(&moduleLPP.Horner),
-		)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			HornerN0HashPublicInput,
-			accessors.NewFromPublicColumn(moduleLPP.N0Hash, 0),
-		)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			HornerN1HashPublicInput,
-			accessors.NewFromPublicColumn(moduleLPP.N1Hash, 0),
-		)
-
-		moduleLPP.Wiop.RegisterVerifierAction(startingRound, &CheckNxHash{ModuleLPP: *moduleLPP})
-
-	} else {
-
-		moduleLPP.Wiop.InsertPublicInput(
-			HornerPublicInput,
-			accessors.NewConstant(field.Zero()),
-		)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			HornerN0HashPublicInput,
-			accessors.NewConstant(field.Zero()),
-		)
-
-		moduleLPP.Wiop.InsertPublicInput(
-			HornerN1HashPublicInput,
-			accessors.NewConstant(field.Zero()),
-		)
+		moduleLPP.N0Hash = moduleLPP.Wiop.InsertProof(1, "N0_HASH", 1)
+		moduleLPP.N1Hash = moduleLPP.Wiop.InsertProof(1, "N1_HASH", 1)
 	}
-
-	moduleLPP.Wiop.InsertPublicInput(IsGlPublicInput, accessors.NewConstant(field.Zero()))
-	moduleLPP.Wiop.InsertPublicInput(IsLppPublicInput, accessors.NewConstant(field.One()))
-	moduleLPP.Wiop.InsertPublicInput(NbActualLppPublicInput, accessors.NewConstant(field.NewElement(uint64(len(moduleInputs)))))
 
 	// In case the LPP part is empty, we have a scenario where the sub-proof to
 	// build has no registered coin. This creates errors in the compilation
 	// due to sanity-check firing up. We add a coin to remediate.
-	for i := 0; i < len(moduleInputs); i++ {
-		moduleLPP.InsertCoin(coin.Namef("LPP_DUMMY_COIN_%v", i+1), i+1)
-	}
+	moduleLPP.InsertCoin(coin.Namef("LPP_DUMMY_COIN_%v", 1), 1)
 
-	for round := 1; round < len(moduleInputs); round++ {
-		moduleLPP.Wiop.RegisterProverAction(round, LppWitnessAssignment{ModuleLPP: *moduleLPP, Round: round})
-	}
+	moduleLPP.declarePublicInput()
 
-	moduleLPP.Wiop.RegisterProverAction(startingRound, &AssignLPPQueries{*moduleLPP})
+	moduleLPP.Wiop.RegisterProverAction(1, &AssignLPPQueries{*moduleLPP})
+	moduleLPP.Wiop.RegisterVerifierAction(1, &CheckNxHash{ModuleLPP: *moduleLPP})
 	moduleLPP.Wiop.FiatShamirHooksPreSampling.AppendToInner(1, &SetInitialFSHash{ModuleLPP: *moduleLPP})
 
 	return moduleLPP
 }
 
-// ModuleNames returns the list of the module names of the [ModuleLPP].
-func (m *ModuleLPP) ModuleNames() []ModuleName {
-	res := make([]ModuleName, 0)
-	for _, definitionInput := range m.DefinitionInputs {
-		res = append(res, definitionInput.ModuleName)
-	}
-	return res
+// ModuleName returns the module name of the [ModuleLPP].
+func (m *ModuleLPP) ModuleName() ModuleName {
+	return m.DefinitionInput.ModuleName
 }
-
-/*
-func (m *ModuleLPP) GetModuleTranslator() moduleTranslator {
-	return m.moduleTranslator
-}
-
-func (m *ModuleLPP) SetModuleTranslator(comp *wizard.CompiledIOP, disc *StandardModuleDiscoverer) {
-	m.moduleTranslator.Wiop = comp
-	m.moduleTranslator.Disc = disc
-} */
 
 // GetMainProverStep returns a [wizard.ProverStep] running [Assign] passing
 // the provided [ModuleWitness] argument.
@@ -316,58 +213,64 @@ func (m *ModuleLPP) Assign(run *wizard.ProverRuntime, witness *ModuleWitnessLPP)
 
 	a := LppWitnessAssignment{ModuleLPP: *m, Round: 0}
 	a.Run(run)
+
+	m.assignPublicInput(run, witness)
 }
 
 func (a LppWitnessAssignment) Run(run *wizard.ProverRuntime) {
 
 	var (
-		witness = run.State.MustGet(moduleWitnessKey).(*ModuleWitnessLPP)
-		m       = a.ModuleLPP
-		round   = a.Round
+		witness         = run.State.MustGet(moduleWitnessKey).(*ModuleWitnessLPP)
+		m               = a.ModuleLPP
+		round           = a.Round
+		definitionInput = m.DefinitionInput
 	)
 
-	// Note @alex: It should be fine to look only at m.definitionInputs[round]
-	// instead of scanning through all the definitionInputs.
-	for _, definitionInput := range m.DefinitionInputs {
+	if witness.ModuleIndex != m.DefinitionInput.ModuleIndex {
+		utils.Panic("witness.ModuleIndex: %v != m.DefinitionInput.ModuleIndex: %v", witness.ModuleIndex, m.DefinitionInput.ModuleIndex)
+	}
 
-		// [definitionInput.Columns] stores the list of columns to assign.
-		// Though, it stores the columns as in the origin CompiledIOP so we
-		// cannot directly use them to refer to columns of the current IOP.
-		// Yet, the column share the same names.
-		for _, col := range definitionInput.Columns {
+	if witness.ModuleName != m.DefinitionInput.ModuleName {
+		utils.Panic("witness.ModuleName: %v != m.DefinitionInput.ModuleName: %v", witness.ModuleName, m.DefinitionInput.ModuleName)
+	}
 
-			colName := col.GetColID()
+	// [definitionInput.Columns] stores the list of columns to assign.
+	// Though, it stores the columns as in the origin CompiledIOP so we
+	// cannot directly use them to refer to columns of the current IOP.
+	// Yet, the column share the same names.
+	for _, col := range definitionInput.Columns {
 
-			// Skips the non-LPP columns
-			if _, ok := definitionInput.ColumnsLPPSet[colName]; !ok {
-				continue
-			}
+		colName := col.GetColID()
 
-			newCol := m.Wiop.Columns.GetHandle(colName)
-
-			if newCol.Round() != round {
-				continue
-			}
-
-			if m.Wiop.Precomputed.Exists(colName) {
-				continue
-			}
-
-			colWitness, ok := witness.Columns[colName]
-			if !ok {
-				utils.Panic(
-					"witness of column %v was not found, module=%v witness-columns=%v module-columns=%v module-column-LPP=%v",
-					colName,
-					m.ModuleNames(),
-					utils.SortedKeysOf(witness.Columns, func(a, b ifaces.ColID) bool { return a < b }),
-					m.DefinitionInputs[0].Columns,
-					m.DefinitionInputs[0].ColumnsLPPSet,
-				)
-			}
-
-			run.AssignColumn(colName, colWitness)
-			delete(witness.Columns, colName)
+		// Skips the non-LPP columns
+		if _, ok := definitionInput.ColumnsLPPSet[colName]; !ok {
+			continue
 		}
+
+		newCol := m.Wiop.Columns.GetHandle(colName)
+
+		if newCol.Round() != round {
+			continue
+		}
+
+		if m.Wiop.Precomputed.Exists(colName) {
+			continue
+		}
+
+		colWitness, ok := witness.Columns[colName]
+		if !ok {
+			utils.Panic(
+				"witness of column %v was not found, module=%v witness-columns=%v module-columns=%v module-column-LPP=%v",
+				colName,
+				m.ModuleName(),
+				utils.SortedKeysOf(witness.Columns, func(a, b ifaces.ColID) bool { return a < b }),
+				m.DefinitionInput.Columns,
+				m.DefinitionInput.ColumnsLPPSet,
+			)
+		}
+
+		run.AssignColumn(colName, colWitness)
+		delete(witness.Columns, colName)
 	}
 }
 
@@ -421,7 +324,8 @@ func (a AssignLPPQueries) Run(run *wizard.ProverRuntime) {
 	moduleWitness := run.State.MustGet(moduleWitnessKey).(*ModuleWitnessLPP)
 	run.State.Del(moduleWitnessKey)
 
-	logDerivativeArgs, grandProductArgs, hornerArgs := getQueryArgs(a.DefinitionInputs)
+	logDerivativeArgs, grandProductArgs, hornerArgs := a.DefinitionInput.LogDerivativeArgs,
+		a.DefinitionInput.GrandProductArgs, a.DefinitionInput.HornerArgs
 
 	if len(hornerArgs) > 0 {
 		hornerParams := a.getHornerParams(run, moduleWitness.N0Values)
@@ -445,6 +349,8 @@ func (a AssignLPPQueries) Run(run *wizard.ProverRuntime) {
 
 		run.AssignLogDerivSum(a.LogDerivativeSum.ID, y)
 	}
+
+	a.ModuleLPP.assignMultiSetHash(run)
 }
 
 func (m ModuleLPP) getHornerParams(run *wizard.ProverRuntime, n0Values []int) query.HornerParams {
@@ -456,43 +362,53 @@ func (m ModuleLPP) getHornerParams(run *wizard.ProverRuntime, n0Values []int) qu
 		})
 	}
 
-	hornerParams.SetResult(run, m.Horner)
+	hornerParams.SetResult(run, *m.Horner)
 	return hornerParams
 }
 
 func (a *CheckNxHash) Run(run wizard.Runtime) error {
 
-	var (
-		hornerParams  = run.GetHornerParams(a.Horner.ID)
-		n0HashAlleged = a.N0Hash.GetColAssignmentAt(run, 0)
-		n1HashAlleged = a.N1Hash.GetColAssignmentAt(run, 0)
-		n0Hash        = hashNxs(hornerParams, 0)
-		n1Hash        = hashNxs(hornerParams, 1)
-	)
+	if a.Horner != nil {
 
-	if n1HashAlleged != n1Hash {
-		return fmt.Errorf("n0Hash %v != n1HashAlleged %v", n1Hash, n1HashAlleged)
+		var (
+			hornerParams  = run.GetHornerParams(a.Horner.ID)
+			n0HashAlleged = a.N0Hash.GetColAssignmentAt(run, 0)
+			n1HashAlleged = a.N1Hash.GetColAssignmentAt(run, 0)
+			n0Hash        = hashNxs(hornerParams, 0)
+			n1Hash        = hashNxs(hornerParams, 1)
+		)
+
+		if n1HashAlleged != n1Hash {
+			return fmt.Errorf("n0Hash %v != n1HashAlleged %v", n1Hash, n1HashAlleged)
+		}
+
+		if n0HashAlleged != n0Hash {
+			return fmt.Errorf("n0Hash %v != n0HashAlleged %v", n0Hash, n0HashAlleged)
+		}
 	}
 
-	if n0HashAlleged != n0Hash {
-		return fmt.Errorf("n0Hash %v != n0HashAlleged %v", n0Hash, n0HashAlleged)
-	}
+	a.checkMultiSetHash(run)
 
 	return nil
 }
 
 func (a *CheckNxHash) RunGnark(api frontend.API, run wizard.GnarkRuntime) {
 
-	var (
-		hornerParams  = run.GetHornerParams(a.Horner.ID)
-		n0HashAlleged = a.N0Hash.GetColAssignmentGnarkAt(run, 0)
-		n1HashAlleged = a.N1Hash.GetColAssignmentGnarkAt(run, 0)
-		n0Hash        = hashNxsGnark(run.GetHasherFactory(), hornerParams, 0)
-		n1Hash        = hashNxsGnark(run.GetHasherFactory(), hornerParams, 1)
-	)
+	if a.Horner != nil {
 
-	api.AssertIsEqual(n0Hash, n0HashAlleged)
-	api.AssertIsEqual(n1Hash, n1HashAlleged)
+		var (
+			hornerParams  = run.GetHornerParams(a.Horner.ID)
+			n0HashAlleged = a.N0Hash.GetColAssignmentGnarkAt(run, 0)
+			n1HashAlleged = a.N1Hash.GetColAssignmentGnarkAt(run, 0)
+			n0Hash        = hashNxsGnark(run.GetHasherFactory(), hornerParams, 0)
+			n1Hash        = hashNxsGnark(run.GetHasherFactory(), hornerParams, 1)
+		)
+
+		api.AssertIsEqual(n0Hash, n0HashAlleged)
+		api.AssertIsEqual(n1Hash, n1HashAlleged)
+	}
+
+	a.checkGnarkMultiSetHash(api, run)
 }
 
 func (a *CheckNxHash) Skip() {
@@ -571,17 +487,243 @@ func hashNxsGnark(factory mimc.HasherFactory, params query.GnarkHornerParams, x 
 	return hsh.Sum()
 }
 
-// getQueryArgs groups the args of the [FilteredModuleInputs] provided
-// by the caller.
-func getQueryArgs(moduleInputs []FilteredModuleInputs) (
-	logDerivativeArgs []query.LogDerivativeSumPart,
-	grandProductArgs [][2]*symbolic.Expression,
-	hornerArgs []query.HornerPart,
-) {
-	for _, moduleInput := range moduleInputs {
-		logDerivativeArgs = append(logDerivativeArgs, moduleInput.LogDerivativeArgs...)
-		grandProductArgs = append(grandProductArgs, moduleInput.GrandProductArgs...)
-		hornerArgs = append(hornerArgs, moduleInput.HornerArgs...)
+func (modLPP *ModuleLPP) declarePublicInput() {
+
+	var (
+		nbModules = len(modLPP.DefinitionInput.Disc.Modules)
+		// segmentCountGl is an array of zero.
+		segmentCountGl = make([]field.Element, nbModules)
+		// segmenCountLpp is an array of zero with a one at the position
+		// corresponding to the current module.
+		segmentCountLpp = make([]field.Element, nbModules)
+		defInp          = modLPP.DefinitionInput
+	)
+
+	modLPP.SegmentModuleIndex = modLPP.Wiop.InsertProof(0, "SEGMENT_MODULE_INDEX", 1)
+	segmentCountLpp[modLPP.Disc.IndexOf(modLPP.DefinitionInput.ModuleName)] = field.One()
+
+	modLPP.PublicInputs = LimitlessPublicInput[wizard.PublicInput]{
+		VKeyMerkleRoot:      declarePiColumn(modLPP.Wiop, VerifyingKeyMerkleRootPublicInput),
+		TargetNbSegments:    declareListOfPiColumns(modLPP.Wiop, 0, TargetNbSegmentPublicInputBase, nbModules),
+		SegmentCountGL:      declareListOfConstantPi(modLPP.Wiop, SegmentCountGLPublicInputBase, segmentCountGl),
+		SegmentCountLPP:     declareListOfConstantPi(modLPP.Wiop, SegmentCountLPPPublicInputBase, segmentCountLpp),
+		GeneralMultiSetHash: declareListOfPiColumns(modLPP.Wiop, 1, GeneralMultiSetPublicInputBase, mimc.MSetHashSize),
+
+		SharedRandomnessMultiSetHash: declareListOfConstantPi(
+			modLPP.Wiop,
+			SharedRandomnessMultiSetPublicInputBase,
+			make([]field.Element, mimc.MSetHashSize),
+		),
+
+		SharedRandomness: modLPP.Wiop.InsertPublicInput(
+			InitialRandomnessPublicInput,
+			accessors.NewFromPublicColumn(modLPP.InitialFiatShamirState, 0),
+		),
 	}
-	return logDerivativeArgs, grandProductArgs, hornerArgs
+
+	// These are the "dummy" public inputs that are only here so that the
+	// moduleGL and moduleLPP have identical set of public inputs. The order
+	// of declaration is also important. Namely, these needs to be declared before
+	// the non-dummy ones.
+	for _, pi := range defInp.PublicInputs {
+		modLPP.Wiop.InsertPublicInput(pi.Name, accessors.NewConstant(field.Zero()))
+	}
+
+	// This section adds the public inputs for the log-derivative, grand-product
+	// horner-sum.
+	if modLPP.Horner != nil {
+		modLPP.PublicInputs.HornerSum = modLPP.Wiop.InsertPublicInput(
+			HornerPublicInput,
+			accessors.NewFromHornerAccessorFinalValue(modLPP.Horner),
+		)
+	} else {
+		modLPP.PublicInputs.HornerSum = modLPP.Wiop.InsertPublicInput(
+			HornerPublicInput,
+			accessors.NewConstant(field.Zero()),
+		)
+	}
+
+	if modLPP.LogDerivativeSum != nil {
+		modLPP.PublicInputs.LogDerivativeSum = modLPP.Wiop.InsertPublicInput(
+			LogDerivativeSumPublicInput,
+			accessors.NewLogDerivSumAccessor(*modLPP.LogDerivativeSum),
+		)
+	} else {
+		modLPP.PublicInputs.LogDerivativeSum = modLPP.Wiop.InsertPublicInput(
+			LogDerivativeSumPublicInput,
+			accessors.NewConstant(field.Zero()),
+		)
+	}
+
+	if modLPP.GrandProduct != nil {
+		modLPP.PublicInputs.GrandProduct = modLPP.Wiop.InsertPublicInput(
+			GrandProductPublicInput,
+			accessors.NewGrandProductAccessor(*modLPP.GrandProduct),
+		)
+	} else {
+		modLPP.PublicInputs.GrandProduct = modLPP.Wiop.InsertPublicInput(
+			GrandProductPublicInput,
+			accessors.NewConstant(field.One()),
+		)
+	}
+}
+
+func (modLPP *ModuleLPP) assignPublicInput(run *wizard.ProverRuntime, witness *ModuleWitnessLPP) {
+
+	// This assigns the segment module index proof column
+	run.AssignColumn(
+		modLPP.SegmentModuleIndex.GetColID(),
+		smartvectors.NewConstant(field.NewElement(uint64(witness.SegmentModuleIndex)), 1),
+	)
+
+	// This assigns the VKeyMerkleRoot
+	assignPiColumn(run, modLPP.PublicInputs.VKeyMerkleRoot.Name, witness.VkMerkleRoot)
+
+	// This assigns the columns corresponding to the public input indicating
+	// the number of segments
+	assignListOfPiColumns(run, TargetNbSegmentPublicInputBase, vector.ForTest(witness.TotalSegmentCount...))
+}
+
+// assignLPPCommitmentMSetGL assigns the LPP commitment MSet. It is meant to be
+// run as part of a prover action.
+func (modLPP *ModuleLPP) assignMultiSetHash(run *wizard.ProverRuntime) {
+
+	var lppCommitments field.Element
+	if run.HasPublicInput(lppMerkleRootPublicInput + "_0") {
+		lppCommitments = run.GetPublicInput(lppMerkleRootPublicInput + "_0")
+	}
+
+	var (
+		segmentIndex           = modLPP.SegmentModuleIndex.GetColAssignmentAt(run, 0)
+		typeOfProof            = field.NewElement(uint64(proofTypeLPP))
+		hasHorner              = modLPP.Horner != nil
+		mset                   = mimc.MSetHash{}
+		defInp                 = modLPP.DefinitionInput
+		moduleIndex            = field.NewElement(uint64(defInp.ModuleIndex))
+		segmentIndexInt        = segmentIndex.Uint64()
+		numSegmentOfCurrModule = modLPP.PublicInputs.TargetNbSegments[defInp.ModuleIndex].Acc.GetVal(run)
+	)
+
+	mset.Remove(moduleIndex, segmentIndex, lppCommitments)
+
+	// If the segment is not the last one of its module we add the "sent" value
+	// in the multiset.
+	if hasHorner && segmentIndexInt < numSegmentOfCurrModule.Uint64()-1 {
+		n1Hash := modLPP.N1Hash.GetColAssignmentAt(run, 0)
+		mset.Insert(moduleIndex, segmentIndex, typeOfProof, n1Hash)
+	}
+
+	// If the segment is not the first one of its module, we add the received
+	// value in the multiset
+	if hasHorner && !segmentIndex.IsZero() {
+
+		var (
+			prevSegmentIndex field.Element
+			one              = field.One()
+			n0Hash           = modLPP.N0Hash.GetColAssignmentAt(run, 0)
+		)
+
+		prevSegmentIndex.Sub(&segmentIndex, &one)
+		mset.Remove(moduleIndex, prevSegmentIndex, typeOfProof, n0Hash)
+	}
+
+	assignListOfPiColumns(run, GeneralMultiSetPublicInputBase, mset[:])
+}
+
+// checkLPPCommitmentMSetGL checks that the LPP commitment MSet is correctly
+// assigned. It is meant to be run as part of a verifier action.
+func (modLPP *ModuleLPP) checkMultiSetHash(run wizard.Runtime) error {
+
+	var (
+		targetMSet             = GetPublicInputList(run, GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+		lppCommitments         = run.GetPublicInput(lppMerkleRootPublicInput + "_0")
+		segmentIndex           = modLPP.SegmentModuleIndex.GetColAssignmentAt(run, 0)
+		typeOfProof            = field.NewElement(uint64(proofTypeLPP))
+		hasHorner              = modLPP.Horner != nil
+		mset                   = mimc.MSetHash{}
+		defInp                 = modLPP.DefinitionInput
+		moduleIndex            = field.NewElement(uint64(defInp.ModuleIndex))
+		numModule              = len(defInp.Disc.Modules)
+		segmentIndexInt        = segmentIndex.Uint64()
+		numSegmentOfLastModule = modLPP.PublicInputs.TargetNbSegments[numModule-1].Acc.GetVal(run)
+	)
+
+	mset.Remove(moduleIndex, segmentIndex, lppCommitments)
+
+	// If the segment is not the last one of its module we add the "sent" value
+	// in the multiset.
+	if hasHorner && segmentIndexInt < numSegmentOfLastModule.Uint64()-1 {
+		n1Hash := modLPP.N1Hash.GetColAssignmentAt(run, 0)
+		// This is a local module
+		mset.Remove(moduleIndex, segmentIndex, typeOfProof, n1Hash)
+	}
+
+	// If the segment is not the first one of its module, we add the received
+	// value in the multiset
+	if hasHorner && !segmentIndex.IsZero() {
+
+		var (
+			prevSegmentIndex field.Element
+			one              = field.One()
+			n0Hash           = modLPP.N0Hash.GetColAssignmentAt(run, 0)
+		)
+
+		prevSegmentIndex.Sub(&segmentIndex, &one)
+		mset.Insert(moduleIndex, prevSegmentIndex, typeOfProof, n0Hash)
+	}
+
+	if !vector.Equal(targetMSet, mset[:]) {
+		return fmt.Errorf("LPP commitment MSet mismatch, expected: %v, got: %v", targetMSet, mset[:])
+	}
+
+	return nil
+}
+
+// checkGnarkMultiSetHash checks that the commitment MSet and the randomness MSet
+// are correctly set. It is meant to be run as part of a verifier action..
+func (modLPP *ModuleLPP) checkGnarkMultiSetHash(api frontend.API, run wizard.GnarkRuntime) error {
+
+	var (
+		targetMSetGeneral      = GetPublicInputListGnark(api, run, GeneralMultiSetPublicInputBase, mimc.MSetHashSize)
+		lppCommitments         = run.GetPublicInput(api, lppMerkleRootPublicInput+"_0")
+		segmentIndex           = modLPP.SegmentModuleIndex.GetColAssignmentGnarkAt(run, 0)
+		typeOfProof            = field.NewElement(uint64(proofTypeLPP))
+		hasHorner              = modLPP.Horner != nil
+		hasher                 = run.GetHasherFactory().NewHasher()
+		multiSetGeneral        = mimc.EmptyMSetHashGnark(hasher)
+		defInp                 = modLPP.DefinitionInput
+		moduleIndex            = field.NewElement(uint64(defInp.ModuleIndex))
+		numSegmentOfCurrModule = modLPP.PublicInputs.TargetNbSegments[defInp.ModuleIndex].Acc.GetFrontendVariable(api, run)
+		isFirst                = api.IsZero(segmentIndex)
+		isLast                 = api.IsZero(api.Sub(numSegmentOfCurrModule, segmentIndex, 1))
+	)
+
+	multiSetGeneral.Remove(api, moduleIndex, segmentIndex, lppCommitments)
+
+	if hasHorner {
+
+		// If the segment is not the last one, we can add the "n1 hash" to the
+		// multiset.
+		n1Hash := modLPP.N1Hash.GetColAssignmentGnarkAt(run, 0)
+		n1HashSingletonMsetHash := mimc.MsetOfSingletonGnark(api, hasher, moduleIndex, segmentIndex, typeOfProof, n1Hash)
+		for i := 0; i < mimc.MSetHashSize; i++ {
+			n1HashSingletonMsetHash.Inner[i] = api.Mul(n1HashSingletonMsetHash.Inner[i], api.Sub(1, isLast))
+			multiSetGeneral.Inner[i] = api.Add(multiSetGeneral.Inner[i], n1HashSingletonMsetHash.Inner[i])
+		}
+
+		// If the segment is not the first one, we can remove the "n0 hash" from the
+		// multiset.
+		n0Hash := modLPP.N0Hash.GetColAssignmentGnarkAt(run, 0)
+		n0HashSingletonMsetHash := mimc.MsetOfSingletonGnark(api, hasher, moduleIndex, api.Sub(segmentIndex, 1), typeOfProof, n0Hash)
+		for i := 0; i < mimc.MSetHashSize; i++ {
+			n0HashSingletonMsetHash.Inner[i] = api.Mul(n0HashSingletonMsetHash.Inner[i], api.Sub(1, isFirst))
+			multiSetGeneral.Inner[i] = api.Sub(multiSetGeneral.Inner[i], n0HashSingletonMsetHash.Inner[i])
+		}
+	}
+
+	for i := range multiSetGeneral.Inner {
+		api.AssertIsEqual(multiSetGeneral.Inner[i], targetMSetGeneral[i])
+	}
+
+	return nil
 }

--- a/prover/protocol/distributed/segment_compilation.go
+++ b/prover/protocol/distributed/segment_compilation.go
@@ -2,11 +2,11 @@ package distributed
 
 import (
 	"fmt"
-	"sort"
+	"slices"
+	"strings"
 
 	"github.com/consensys/linea-monorepo/prover/crypto/ringsis"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
-	"github.com/consensys/linea-monorepo/prover/protocol/accessors"
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler"
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/cleanup"
 	"github.com/consensys/linea-monorepo/prover/protocol/compiler/logdata"
@@ -22,28 +22,49 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	// fixedNbRowPlonkCircuit is the number of rows in the plonk circuit,
-	// the value is empirical and corresponds to the lowest value that works.
-	fixedNbRowPlonkCircuit   = 1 << 20
-	fixedNbRowExternalHasher = 1 << 17
-	verifyingKeyPublicInput  = "VERIFYING_KEY"
-	verifyingKey2PublicInput = "VERIFYING_KEY_2"
-	lppMerkleRootPublicInput = "LPP_COLUMNS_MERKLE_ROOTS"
+// CompilationParams gather the different compilation parameters to use to
+// compile the segments.
+type CompilationParams struct {
 
-	// initialCompilerSize sets the target number of rows of the first invokation
-	// of [compiler.Arcane] of the pre-recursion pass of [CompileSegment]. It is
-	// also the length of the column in the [DefaultModule].
-	initialCompilerSize int = 1 << 17
-)
+	// FixedNbRowPlonkCircuit is the number of rows in the plonk circuit, if
+	// the compilation process generates a recursion circuit with more rows than
+	// this number, then the compilation will fail with panic. If the number of
+	// rows is less, then we add dummy padding rows.
+	FixedNbRowPlonkCircuit int
 
-var (
-	// numColumnProfileMpts tells the last invokation of Vortex prior to the self-
-	// recursion to use a plonk circuit with a fixed number of rows. The values
-	// are completely empirical and set to make the compilation work.
-	numColumnProfileMpts            = []int{17, 361, 42, 3, 9, 7, 0, 1}
-	numColumnProfileMptsPrecomputed = 36
-)
+	// FixedNbRowExternalHasher is the number of rows in the external hasher
+	// circuit. It works the same way as [FixedNbRowPlonkCircuit] but for the
+	// number of calls to the external hasher.
+	FixedNbRowExternalHasher int
+
+	// FixedNbPublicInput is the size of the public input vector of the
+	// recursion circuit. It works the same way as [FixedNbRowPlonkCircuit]
+	// but for the number of public inputs.
+	FixedNbPublicInput int
+
+	// InitialCompilerSize sets the target number of rows of the first
+	// invokation of [compiler.Arcane] of the pre-recursion pass of
+	// [CompileSegment]. It is applicable only for the GL and LPP proofs. The
+	// conglomeration circuit uses a different parameter.
+	InitialCompilerSize int
+
+	// InitialCompilerSizeConglo sets the target number of rows of the first
+	// invokation of [compiler.Arcane] of the pre-recursion pass of
+	// [CompileSegment] for the conglomeration circuit.
+	InitialCompilerSizeConglo int
+
+	// ColumnProfileMPTS gives the number of rows for each round to target
+	// before the recursion step.
+	ColumnProfileMPTS []int
+
+	// ColumnProfileMPTSPrecomputed is the number of rows for the precomputed
+	// round.
+	ColumnProfileMPTSPrecomputed int
+
+	// FullDebugMode tells the compiler to add debugging steps to help track
+	// errors.
+	FullDebugMode bool
+}
 
 // RecursedSegmentCompilation collects all the wizard compilation artefacts
 // to compile a segment of the protocol into a standardized recursed proof.
@@ -54,43 +75,59 @@ type RecursedSegmentCompilation struct {
 	ModuleGL *ModuleGL
 	// ModuleLPP is optional and is set if the segment is a LPP segment.
 	ModuleLPP *ModuleLPP
-	// ModuleDefault is optional and is set if the segment is default module
-	// segment.
-	DefaultModule *DefaultModule
+	// HierarchicalConglomeration is optional and is set if the segment is a
+	// conglomerated segment.
+	HierarchicalConglomeration *ModuleConglo
 	// RecursionComp is the compiled IOP of the recursed wizard.
 	RecursionComp *wizard.CompiledIOP
 	// Recursion is the wizard construction context of the recursed wizard.
 	Recursion *recursion.Recursion
 }
 
+// SegmentProof stores a proof for a segment or for the conglomeration proof
+type SegmentProof struct {
+	Witness      recursion.Witness
+	ProofType    ProofType
+	ModuleIndex  int
+	SegmentIndex int
+	// LppCommitment is the commitment of the LPP witness. It is only populated
+	// for a GL segment proof.
+	LppCommitment field.Element
+}
+
 // CompileSegment applies all the compilation steps required to compile an LPP
 // or a GL module of the protocol. The function accepts either a *[ModuleLPP]
 // or a *[ModuleGL].
-func CompileSegment(mod any) *RecursedSegmentCompilation {
+func CompileSegment(mod any, params CompilationParams) *RecursedSegmentCompilation {
 
 	var (
-		modIOP            *wizard.CompiledIOP
-		res               = &RecursedSegmentCompilation{}
-		numActualLppRound = 0
-		isLPP             bool
-		subscript         string
+		modIOP              *wizard.CompiledIOP
+		res                 = &RecursedSegmentCompilation{}
+		proofType           ProofType
+		subscript           string
+		initialCompilerSize = params.InitialCompilerSize
 	)
 
 	switch m := mod.(type) {
 	case *ModuleGL:
 		modIOP = m.Wiop
 		res.ModuleGL = m
-		subscript = string(m.DefinitionInput.ModuleName)
+		subscript = string(m.DefinitionInput.ModuleName) + "-GL"
+		proofType = proofTypeGL
+
 	case *ModuleLPP:
 		modIOP = m.Wiop
 		res.ModuleLPP = m
-		numActualLppRound = len(m.ModuleNames())
-		isLPP = true
-		subscript = fmt.Sprintf("%v", m.ModuleNames())
-	case *DefaultModule:
+		proofType = proofTypeLPP
+		subscript = string(m.ModuleName()) + "-LPP"
+
+	case *ModuleConglo:
 		modIOP = m.Wiop
-		res.DefaultModule = m
-		subscript = "default-module"
+		res.HierarchicalConglomeration = m
+		subscript = "hierarchical-conglomeration"
+		proofType = proofTypeConglo
+		initialCompilerSize = params.InitialCompilerSizeConglo
+
 	default:
 		utils.Panic("unexpected type: %T", mod)
 	}
@@ -98,12 +135,8 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 	sisInstance := ringsis.Params{LogTwoBound: 16, LogTwoDegree: 6}
 
 	wizard.ContinueCompilation(modIOP,
-		// This ensures that all the public inputs are declared in the same order to
-		// prevent bugs in the conglomeration. This will not affect the future position
-		// of the public inputs we declare afterwards.
-		sortPublicInput,
-		// @alex: unsure why we need to compile with MiMC since it should be done
-		// pre-bootstrapping.
+		// @alex: unsure if/why we need to compile with MiMC since it should be
+		// done pre-bootstrapping.
 		mimc.CompileMiMC,
 		// The reason why 1 works is because it will work for all the GL modules
 		// and because the LPP module do not have Plonk-in-wizards query.
@@ -125,11 +158,13 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 			//
 			// For now, the current solution is fine and we can update the value from
 			// time to time if not too frequent.
-			compiler.WithStitcherMinSize(1<<4),
+			compiler.WithStitcherMinSize(2),
 			compiler.WithoutMpts(),
 			// @alex: in principle, the value of 1 would be used only for the GL
 			// prover but AFAIK, the GL modules never have inner-products to compile.
-			compiler.WithInnerProductMinimalRound(max(1, numActualLppRound)),
+			compiler.WithInnerProductMinimalRound(1),
+			// Uncomment to enable the debugging mode
+			// compiler.WithDebugMode(subscript+"_initial"),
 		),
 		mpts.Compile(mpts.AddUnconstrainedColumns()),
 	)
@@ -138,7 +173,17 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 	logrus.Infof("[Before first Vortex] module=%v numCellsCommitted=%v numCellsPrecomputed=%v numCellsProof=%v",
 		subscript, initialWizardStats.NumCellsCommitted, initialWizardStats.NumCellsPrecomputed, initialWizardStats.NumCellsProof)
 
-	if !isLPP {
+	if proofType == proofTypeConglo {
+
+		wizard.ContinueCompilation(modIOP,
+			vortex.Compile(
+				2,
+				vortex.ForceNumOpenedColumns(256),
+				vortex.WithSISParams(&sisInstance),
+				vortex.WithOptionalSISHashingThreshold(64),
+			),
+		)
+	} else {
 
 		wizard.ContinueCompilation(modIOP,
 			vortex.Compile(
@@ -149,26 +194,6 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 				vortex.WithOptionalSISHashingThreshold(64),
 			),
 		)
-
-		for i := 1; i < lppGroupingArity; i++ {
-			modIOP.InsertPublicInput(fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, i), accessors.NewConstant(field.Zero()))
-		}
-
-	} else {
-
-		wizard.ContinueCompilation(modIOP,
-			vortex.Compile(
-				2,
-				vortex.ForceNumOpenedColumns(256),
-				vortex.WithSISParams(&sisInstance),
-				vortex.AddMerkleRootToPublicInputs(lppMerkleRootPublicInput, utils.RangeSlice(numActualLppRound, 0)),
-				vortex.WithOptionalSISHashingThreshold(64),
-			),
-		)
-
-		for i := numActualLppRound; i < lppGroupingArity; i++ {
-			modIOP.InsertPublicInput(fmt.Sprintf("%v_%v", lppMerkleRootPublicInput, i), accessors.NewConstant(field.Zero()))
-		}
 	}
 
 	wizard.ContinueCompilation(modIOP,
@@ -177,6 +202,9 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 		mimc.CompileMiMC,
 		compiler.Arcane(
 			compiler.WithTargetColSize(1<<15),
+			compiler.WithStitcherMinSize(2),
+			// Uncomment to enable the debugging mode
+			compiler.MaybeWith(params.FullDebugMode, compiler.WithDebugMode(subscript+"_0")),
 		),
 		vortex.Compile(
 			8,
@@ -188,7 +216,10 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 		cleanup.CleanUp,
 		mimc.CompileMiMC,
 		compiler.Arcane(
-			compiler.WithTargetColSize(1<<13),
+			compiler.WithTargetColSize(1<<14),
+			compiler.WithStitcherMinSize(2),
+			// Uncomment to enable the debugging mode
+			compiler.MaybeWith(params.FullDebugMode, compiler.WithDebugMode(subscript+"_1")),
 		),
 		// This extra step is to ensure the tightness of the final wizard by
 		// adding an optional second layer of compilation when we have very
@@ -203,36 +234,51 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 		cleanup.CleanUp,
 		mimc.CompileMiMC,
 		compiler.Arcane(
-			compiler.WithTargetColSize(1<<13),
-		),
-		// This final step expectedly always generate always the same profile.
-		vortex.Compile(
-			8,
-			vortex.ForceNumOpenedColumns(32),
-			vortex.WithSISParams(&sisInstance),
-			vortex.WithOptionalSISHashingThreshold(64),
-		),
-		selfrecursion.SelfRecurse,
-		cleanup.CleanUp,
-		mimc.CompileMiMC,
-		compiler.Arcane(
-			compiler.WithTargetColSize(1<<13),
+			compiler.WithTargetColSize(1<<14),
+			compiler.WithStitcherMinSize(2),
 			compiler.WithoutMpts(),
+			// Uncomment to enable the debugging mode
+			compiler.MaybeWith(params.FullDebugMode, compiler.WithDebugMode(subscript+"_2")),
 		),
 		// This final step expectedly always generate always the same profile.
+		// Most of the time, it is ineffective and could be skipped so there is
+		// a pending optimization.
 		logdata.Log("just-before-recursion"),
-		mpts.Compile(mpts.WithNumColumnProfileOpt(numColumnProfileMpts, numColumnProfileMptsPrecomputed)),
+		mpts.Compile(mpts.WithNumColumnProfileOpt(params.ColumnProfileMPTS, params.ColumnProfileMPTSPrecomputed)),
 		vortex.Compile(
 			8,
 			vortex.ForceNumOpenedColumns(32),
 			vortex.WithSISParams(&sisInstance),
 			vortex.PremarkAsSelfRecursed(),
-			vortex.AddPrecomputedMerkleRootToPublicInputs(verifyingKeyPublicInput),
+			vortex.AddPrecomputedMerkleRootToPublicInputs(VerifyingKeyPublicInput),
 			vortex.WithOptionalSISHashingThreshold(64),
 		),
 	)
 
 	var recCtx *recursion.Recursion
+	// The loops below are there to filter the public inputs so that
+	// Important: this must remain nil by default.
+	var publicInputRestriction []string
+
+	if proofType == proofTypeConglo {
+		for _, pi := range modIOP.PublicInputs {
+			if strings.HasPrefix(pi.Name, "conglomeration") {
+				continue
+			}
+			publicInputRestriction = append(publicInputRestriction, pi.Name)
+		}
+	}
+
+	if proofType == proofTypeLPP || proofType == proofTypeGL {
+		for _, pi := range modIOP.PublicInputs {
+			if strings.Contains(pi.Name, lppMerkleRootPublicInput) {
+				continue
+			}
+			publicInputRestriction = append(publicInputRestriction, pi.Name)
+		}
+	}
+
+	sortPublicInput(modIOP, publicInputRestriction)
 
 	defineRecursion := func(build2 *wizard.Builder) {
 		recCtx = recursion.DefineRecursionOf(
@@ -242,10 +288,13 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 				Name:                   "wizard-recursion",
 				WithoutGkr:             true,
 				MaxNumProof:            1,
-				FixedNbRowPlonkCircuit: fixedNbRowPlonkCircuit,
+				FixedNbRowPlonkCircuit: params.FixedNbRowPlonkCircuit,
 				WithExternalHasherOpts: true,
-				ExternalHasherNbRows:   fixedNbRowExternalHasher,
+				ExternalHasherNbRows:   params.FixedNbRowExternalHasher,
+				FixedNbPublicInput:     params.FixedNbPublicInput,
 				Subscript:              subscript,
+				SkipRecursionPrefix:    true,
+				RestrictPublicInputs:   publicInputRestriction,
 			},
 		)
 	}
@@ -255,6 +304,8 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 		plonkinwizard.Compile,
 		compiler.Arcane(
 			compiler.WithTargetColSize(1<<15),
+			compiler.WithStitcherMinSize(2),
+			// Uncomment to enable the debugging mode
 			// compiler.WithDebugMode("post-recursion-arcane"),
 		),
 		logdata.Log("just-after-recursion-expanded"),
@@ -262,28 +313,17 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 			8,
 			vortex.ForceNumOpenedColumns(32),
 			vortex.WithSISParams(&sisInstance),
-			vortex.AddPrecomputedMerkleRootToPublicInputs(verifyingKey2PublicInput),
+			vortex.AddPrecomputedMerkleRootToPublicInputs(VerifyingKey2PublicInput),
 			vortex.WithOptionalSISHashingThreshold(64),
 		),
 		selfrecursion.SelfRecurse,
 		cleanup.CleanUp,
 		mimc.CompileMiMC,
 		compiler.Arcane(
-			compiler.WithTargetColSize(1<<13),
+			compiler.WithTargetColSize(1<<14),
+			compiler.WithStitcherMinSize(2),
+			// Uncomment to enable the debugging mode
 			// compiler.WithDebugMode("post-recursion-arcane-2"),
-		),
-		vortex.Compile(
-			8,
-			vortex.ForceNumOpenedColumns(32),
-			vortex.WithSISParams(&sisInstance),
-			vortex.WithOptionalSISHashingThreshold(64),
-		),
-		selfrecursion.SelfRecurse,
-		cleanup.CleanUp,
-		mimc.CompileMiMC,
-		compiler.Arcane(
-			compiler.WithTargetColSize(1<<13),
-			// compiler.WithDebugMode("post-recursion-arcane-3"),
 		),
 		vortex.Compile(
 			8,
@@ -299,40 +339,63 @@ func CompileSegment(mod any) *RecursedSegmentCompilation {
 
 	// It is necessary to add the extradata from the compiled IOP to the
 	// recursed one otherwise, it will not be found.
-	res.RecursionComp.ExtraData[verifyingKeyPublicInput] = modIOP.ExtraData[verifyingKeyPublicInput]
+	res.RecursionComp.ExtraData[VerifyingKeyPublicInput] = modIOP.ExtraData[VerifyingKeyPublicInput]
 
 	return res
 }
 
 // ProveSegment runs the prover for a segment of the protocol
-func (r *RecursedSegmentCompilation) ProveSegment(wit any) *wizard.ProverRuntime {
+func (r *RecursedSegmentCompilation) ProveSegment(wit any) SegmentProof {
 
 	var (
-		comp        *wizard.CompiledIOP
-		proverStep  wizard.MainProverStep
-		moduleName  any
-		moduleIndex int
+		comp               *wizard.CompiledIOP
+		proverStep         wizard.MainProverStep
+		moduleName         any
+		moduleIndex        int
+		segmentModuleIndex int
+		proofType          ProofType
 	)
 
 	switch m := wit.(type) {
+
 	case *ModuleWitnessLPP:
 		comp = r.ModuleLPP.Wiop
 		proverStep = r.ModuleLPP.GetMainProverStep(m)
 		moduleName = m.ModuleName
 		moduleIndex = m.ModuleIndex
+		segmentModuleIndex = m.SegmentModuleIndex
+		proofType = proofTypeLPP
+
+		if m.ModuleIndex != r.ModuleLPP.DefinitionInput.ModuleIndex {
+			utils.Panic("m.ModuleIndex: %v != r.ModuleLPP.ModuleIndex: %v", m.ModuleIndex, r.ModuleLPP.DefinitionInput.ModuleIndex)
+		}
+
+		if m.ModuleName != r.ModuleLPP.DefinitionInput.ModuleName {
+			utils.Panic("m.ModuleName: %v != r.ModuleLPP.ModuleName: %v", m.ModuleName, r.ModuleLPP.DefinitionInput.ModuleName)
+		}
+
 	case *ModuleWitnessGL:
 		comp = r.ModuleGL.Wiop
 		proverStep = r.ModuleGL.GetMainProverStep(m)
 		moduleName = m.ModuleName
 		moduleIndex = m.ModuleIndex
-	case nil:
-		if r.DefaultModule == nil {
-			utils.Panic("witness is nil but module is not default")
+		segmentModuleIndex = m.SegmentModuleIndex
+		proofType = proofTypeGL
+
+		if m.ModuleIndex != r.ModuleGL.DefinitionInput.ModuleIndex {
+			utils.Panic("m.ModuleIndex: %v != r.ModuleGL.ModuleIndex: %v", m.ModuleIndex, r.ModuleGL.DefinitionInput.ModuleIndex)
 		}
-		comp = r.DefaultModule.Wiop
-		proverStep = r.DefaultModule.Assign
-		moduleName = "default-module"
-		moduleIndex = 0
+
+		if m.ModuleName != r.ModuleGL.DefinitionInput.ModuleName {
+			utils.Panic("m.ModuleName: %v != r.ModuleGL.ModuleName: %v", m.ModuleName, r.ModuleGL.DefinitionInput.ModuleName)
+		}
+
+	case *ModuleWitnessConglo:
+		comp = r.HierarchicalConglomeration.Wiop
+		proverStep = r.HierarchicalConglomeration.GetMainProverStep(m)
+		moduleName = "hierachical-conglo"
+		proofType = proofTypeConglo
+
 	default:
 		utils.Panic("unexpected type")
 	}
@@ -374,25 +437,75 @@ func (r *RecursedSegmentCompilation) ProveSegment(wit any) *wizard.ProverRuntime
 	logrus.
 		WithField("moduleName", moduleName).
 		WithField("moduleIndex", moduleIndex).
+		WithField("segmentModuleIndex", segmentModuleIndex).
 		WithField("initial-time", initialTime).
 		WithField("recursion-time", recursionTime).
 		WithField("segment-type", fmt.Sprintf("%T", wit)).
 		Infof("Ran prover segment")
 
-	return run
+	segmentProof := SegmentProof{
+		ModuleIndex:  moduleIndex,
+		SegmentIndex: segmentModuleIndex,
+		ProofType:    proofType,
+		Witness:      recursion.ExtractWitness(run),
+	}
+
+	if proofType == proofTypeGL {
+		segmentProof.LppCommitment = getLppCommitmentFromRuntime(proverRun)
+	}
+
+	return segmentProof
+}
+
+// GetVerifyingKeyPair returns the verifying keys of the compiled segment.
+func (c *RecursedSegmentCompilation) GetVerifyingKeyPair() [2]field.Element {
+	vk0, vk1 := getVerifyingKeyPair(c.RecursionComp)
+	return [2]field.Element{vk0, vk1}
 }
 
 // sortPublicInput is small compiler sorting the public inputs by name.
 // This helps ensuring that the order of public inputs is identical between all types
-// of module. This is to avoid errors in the conglomeration phase where public inputs
-// are only identified by their positions.
+// of module.
 //
-// Normally, they should already be declared in identical order so, in theory, this
-// function solves nothing but it's hard to debug when that changes so we keep the
-// function for "safety". Not that this will however change the initial ordering of
-// the public inputs.
-func sortPublicInput(comp *wizard.CompiledIOP) {
-	sort.Slice(comp.PublicInputs, func(i, j int) bool {
-		return comp.PublicInputs[i].Name < comp.PublicInputs[j].Name
-	})
+// The function additionally takes a "restriction" input list which contains
+// a list of "restricted" public inputs. They denote the public inputs that are
+// actually "bubbled up" to the next instance. If the provided list is non-nil
+// then, the public inputs are sorted based on whether they are in the list or
+// not and then by alphabetical order.
+func sortPublicInput(comp *wizard.CompiledIOP, restrictedList []string) {
+
+	cmpName := func(a, b wizard.PublicInput) int {
+		switch {
+		case a.Name < b.Name:
+			return -1
+		case a.Name > b.Name:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	if restrictedList == nil {
+		slices.SortStableFunc(comp.PublicInputs, cmpName)
+		return
+	}
+
+	var (
+		included = []wizard.PublicInput{}
+		excluded = []wizard.PublicInput{}
+	)
+
+	for _, pub := range comp.PublicInputs {
+		// This is a list scan per iteration. So this is O(n**2) in total but
+		// this is also not worth optimizing.
+		if slices.Contains(restrictedList, pub.Name) {
+			included = append(included, pub)
+		} else {
+			excluded = append(excluded, pub)
+		}
+	}
+
+	slices.SortStableFunc(included, cmpName)
+	slices.SortStableFunc(excluded, cmpName)
+	comp.PublicInputs = append(included, excluded...)
 }


### PR DESCRIPTION
…tributed

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce hierarchical (pairwise) conglomeration with VK Merkle-tree and multiset-based public inputs, refactoring modules, compilation, and tests accordingly.
> 
> - **Hierarchical Conglomeration**:
>   - Add `ModuleConglo` with pairwise aggregation (`aggregationArity=2`).
>   - Verify child proofs via VK Merkle tree (`VerificationKeyMerkleTree`, membership checks), expose `VK_MERKLE_ROOT` and per-instance VK proofs.
>   - Aggregate public inputs (log-derivative sum, grand product, horner sum) and multiset hashes (`GENERAL_MULTI_SET`, `SHARED_RANDOMNESS_MULTI_SET`).
>   - Track per-module segment counts: `TARGET_NB_SEGMENTS`, `GL_SEGMENT_COUNT`, `LPP_SEGMENT_COUNT`.
>   - Provide gnark and native verifier actions.
> - **Module Refactors (GL/LPP)**:
>   - Add `LimitlessPublicInput` exposure in GL/LPP (segment indices, VK root, multisets, segment counts, shared randomness).
>   - Compute and check multisets for LPP commitments and send/receive hashes; enforce `IS_FIRST/IS_LAST` correctness.
>   - LPP now hashes Horner N0/N1 conditionally; GL/LPP assign new PI columns.
> - **Compilation Pipeline**:
>   - Introduce `CompilationParams` (fixed rows, PI size, profiles, debug) used by `CompileSegments`, `CompileSegment`, and `Conglomerate`.
>   - Filter/sort bubbled public inputs; adjust recursion and vortex/mpts steps; expose verifying key PIs.
> - **Distribution/Discovery**:
>   - Update segmentation and witness structures (module/segment indices, total segment counts, VK root).
>   - Add `IndexOf`, fix grouping/splitting heuristics, padding/segment boundary logic.
>   - Compute shared randomness from GL proofs via multiset over (module,segment,commitment).
> - **Tests/Docs**:
>   - Replace legacy conglomeration tests with hierarchical aggregation flow and FIFO combine loop.
>   - Add `hierarchical-doc.md` describing the scheme.
> - **Removal/Deprecation**:
>   - Old `conglomeration.go` implementation commented out; remove `lppGroupingArity` and default-module paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b884f4247629f4b5b2bf3d35a805158456aadad2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->