### PR TITLE
fix: postman error parsing issue

### DIFF
--- a/postman/src/utils/ErrorParser.ts
+++ b/postman/src/utils/ErrorParser.ts
@@ -83,6 +83,7 @@ export class ErrorParser {
     if (isError(error, "CALL_EXCEPTION")) {
       if (
         error.shortMessage.includes("execution reverted") ||
+        error.info?.error?.message?.includes("execution reverted") ||
         error.info?.error?.code === 4001 || //The user rejected the request (EIP-1193)
         error.info?.error?.code === -32603 //Internal JSON-RPC error (EIP-1474)
       ) {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broaden `CALL_EXCEPTION` parsing to catch "execution reverted" in nested error messages and avoid retries.
> 
> - **Utils · Error parsing**
>   - Update `postman/src/utils/ErrorParser.ts` `CALL_EXCEPTION` handling to also detect "execution reverted" via `error.info?.error?.message`, ensuring non-retry mitigation and using nested message when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0582c709078980333de45e12395db7005a2554dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->