### PR TITLE
fix: nonce issue in burning mechanism cronjob

### DIFF
--- a/operations/src/commands/burn-and-bridge.ts
+++ b/operations/src/commands/burn-and-bridge.ts
@@ -281,6 +281,8 @@ export default class BurnAndBridge extends Command {
       web3SignerTrustedStorePassphrase,
     });
 
+    const senderAddressNonce = await client.getTransactionCount({ address: senderAddress });
+
     const transactionToSerialize: TransactionSerializable = {
       to: rollupRevenueVaultContractAddress,
       type: "eip1559",
@@ -290,6 +292,7 @@ export default class BurnAndBridge extends Command {
       gas: gasLimit,
       maxFeePerGas: baseFeePerGas + priorityFeePerGas,
       maxPriorityFeePerGas: priorityFeePerGas,
+      nonce: senderAddressNonce,
     };
 
     const signature = await this.signBurnAndBridgeTransaction(

--- a/operations/src/commands/submit-invoice.ts
+++ b/operations/src/commands/submit-invoice.ts
@@ -327,6 +327,8 @@ export default class SubmitInvoice extends Command {
           SIGNING TRANSACTION
      ******************************/
 
+    const senderAddressNonce = await client.getTransactionCount({ address: senderAddress });
+
     const transactionToSerialize: TransactionSerializable = {
       to: contractAddress,
       type: "eip1559",
@@ -336,6 +338,7 @@ export default class SubmitInvoice extends Command {
       gas: gasLimit,
       maxFeePerGas: baseFeePerGas + priorityFeePerGas,
       maxPriorityFeePerGas: priorityFeePerGas,
+      nonce: senderAddressNonce,
     };
 
     const httpsAgent = this.buildHttpsAgentIfNeeded({


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fetches the sender’s transaction count and sets `nonce` on serialized EIP-1559 transactions in both `burn-and-bridge` and `submit-invoice` commands.
> 
> - **Operations**
>   - **Transaction nonce handling**:
>     - In `operations/src/commands/burn-and-bridge.ts`:
>       - Fetch `senderAddress` transaction count via `client.getTransactionCount`.
>       - Set `nonce` on `TransactionSerializable` before signing.
>     - In `operations/src/commands/submit-invoice.ts`:
>       - Fetch `senderAddress` transaction count via `client.getTransactionCount`.
>       - Set `nonce` on `TransactionSerializable` before signing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d6ac4c9464af26979fb43c962d46568e3672fb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->