### PR TITLE
[Chore] Use transient storage on Linea

### DIFF
--- a/contracts/src/bridging/token/TokenBridgeBase.sol
+++ b/contracts/src/bridging/token/TokenBridgeBase.sol
@@ -9,7 +9,7 @@ import { IERC20MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/t
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
-import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { TransientStorageReentrancyGuardUpgradeable } from "../../security/reentrancy/TransientStorageReentrancyGuardUpgradeable.sol";
 
 import { BridgedToken } from "./BridgedToken.sol";
 import { MessageServiceBase } from "../../messaging/MessageServiceBase.sol";
@@ -28,7 +28,7 @@ import { EfficientLeftRightKeccak } from "../../libraries/EfficientLeftRightKecc
  */
 abstract contract TokenBridgeBase is
   ITokenBridge,
-  ReentrancyGuardUpgradeable,
+  TransientStorageReentrancyGuardUpgradeable,
   AccessControlUpgradeable,
   MessageServiceBase,
   TokenBridgePauseManager,
@@ -140,7 +140,6 @@ abstract contract TokenBridgeBase is
    * @param _initializationData The initial data used for initializing the TokenBridge contract.
    */
   function __TokenBridge_init(InitializationData calldata _initializationData) internal virtual {
-    __ReentrancyGuard_init();
     __MessageServiceBase_init(_initializationData.messageService);
     __PauseManager_init(_initializationData.pauseTypeRoles, _initializationData.unpauseTypeRoles);
 

--- a/contracts/src/messaging/l2/L2MessageServiceBase.sol
+++ b/contracts/src/messaging/l2/L2MessageServiceBase.sol
@@ -52,7 +52,6 @@ abstract contract L2MessageServiceBase is
     __RateLimiter_init(_rateLimitPeriod, _rateLimitAmount);
 
     __PauseManager_init(_pauseTypeRoleAssignments, _unpauseTypeRoleAssignments);
-    __ReentrancyGuard_init();
 
     if (_defaultAdmin == address(0)) {
       revert ZeroAddressNotAllowed();
@@ -68,7 +67,6 @@ abstract contract L2MessageServiceBase is
 
     nextMessageNumber = 1;
 
-    _messageSender = DEFAULT_SENDER_ADDRESS;
     minimumFeeInWei = 0.0001 ether;
   }
 

--- a/contracts/src/messaging/l2/v1/L2MessageServiceV1.sol
+++ b/contracts/src/messaging/l2/v1/L2MessageServiceV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.30;
 
-import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { TransientStorageReentrancyGuardUpgradeable } from "../../../security/reentrancy/TransientStorageReentrancyGuardUpgradeable.sol";
 import { IMessageService } from "../../interfaces/IMessageService.sol";
 import { IL2MessageServiceV1 } from "./interfaces/IL2MessageServiceV1.sol";
 import { IGenericErrors } from "../../../interfaces/IGenericErrors.sol";
@@ -17,7 +17,7 @@ import { MessageHashing } from "../../libraries/MessageHashing.sol";
 abstract contract L2MessageServiceV1 is
   RateLimiter,
   L2MessageManagerV1,
-  ReentrancyGuardUpgradeable,
+  TransientStorageReentrancyGuardUpgradeable,
   IMessageService,
   IL2MessageServiceV1,
   IGenericErrors
@@ -31,11 +31,16 @@ abstract contract L2MessageServiceV1 is
    */
   uint256[50] private __gap_L2MessageServiceV1;
 
+  address transient TRANSIENT_MESSAGE_SENDER;
+
   /// @notice The role required to set the minimum DDOS fee.
   bytes32 public constant MINIMUM_FEE_SETTER_ROLE = keccak256("MINIMUM_FEE_SETTER_ROLE");
 
-  /// @dev The temporary message sender set when claiming a message.
-  address internal _messageSender;
+  /// @notice The default value for the message sender reset to post claiming using the MESSAGE_SENDER_TRANSIENT_KEY.
+  address internal constant DEFAULT_MESSAGE_SENDER_TRANSIENT_VALUE = address(0);
+
+  /// @dev DEPRECATED in favor of new transient storage with `MESSAGE_SENDER_TRANSIENT_KEY` key.
+  address private _messageSender_DEPRECATED;
 
   // @notice initialize to save user cost with existing slot.
   uint256 public nextMessageNumber;
@@ -45,9 +50,6 @@ abstract contract L2MessageServiceV1 is
 
   // @dev adding these should not affect storage as they are constants and are stored in bytecode.
   uint256 internal constant REFUND_OVERHEAD_IN_GAS = 44596;
-
-  /// @dev The default message sender address reset after claiming a message.
-  address internal constant DEFAULT_SENDER_ADDRESS = address(123456789);
 
   /// @dev Total contract storage is 53 slots including the gap above. NB: Above!
 
@@ -165,7 +167,7 @@ abstract contract L2MessageServiceV1 is
     /// @dev Status check and revert is in the message manager.
     _updateL1L2MessageStatusToClaimed(messageHash);
 
-    _messageSender = _from;
+    TRANSIENT_MESSAGE_SENDER = _from;
 
     (bool callSuccess, bytes memory returnData) = _to.call{ value: _value }(_calldata);
     if (!callSuccess) {
@@ -179,7 +181,7 @@ abstract contract L2MessageServiceV1 is
       }
     }
 
-    _messageSender = DEFAULT_SENDER_ADDRESS;
+    TRANSIENT_MESSAGE_SENDER = DEFAULT_MESSAGE_SENDER_TRANSIENT_VALUE;
     emit MessageClaimed(messageHash);
   }
 
@@ -196,11 +198,11 @@ abstract contract L2MessageServiceV1 is
   }
 
   /**
-   * @dev The _messageSender address is set temporarily when claiming.
-   * @return originalSender The original sender stored temporarily at the _messageSender address in storage.
+   * @dev The message sender address is set temporarily in the transient storage when claiming.
+   * @return originalSender The message sender address that is stored temporarily in the transient storage when claiming.
    */
-  function sender() external view virtual returns (address originalSender) {
-    originalSender = _messageSender;
+  function sender() external view returns (address originalSender) {
+    originalSender = TRANSIENT_MESSAGE_SENDER;
   }
 
   /**

--- a/contracts/test/hardhat/bridging/token/TokenBridge.ts
+++ b/contracts/test/hardhat/bridging/token/TokenBridge.ts
@@ -975,9 +975,10 @@ describe("TokenBridge", function () {
 
       await reentrancyContract.setToken(maliciousERC777.getAddress());
 
-      await expectRevertWithReason(
+      await expectRevertWithCustomError(
+        l1TokenBridge,
         l1TokenBridge.bridgeToken(await maliciousERC777.getAddress(), 1, owner.address),
-        "ReentrancyGuard: reentrant call",
+        "ReentrantCall",
       );
     });
   });

--- a/contracts/test/hardhat/messaging/MessageServiceBase.ts
+++ b/contracts/test/hardhat/messaging/MessageServiceBase.ts
@@ -122,11 +122,15 @@ describe("MessageServiceBase", () => {
     });
 
     it("Should succeed if original sender is allowed", async () => {
-      const messageServiceBase = (await deployUpgradableFromFactory("TestMessageServiceBase", [
-        await messageService.getAddress(),
-        "0x00000000000000000000000000000000075BCd15",
-      ])) as unknown as TestMessageServiceBase;
-      await expect(messageServiceBase.withOnlyAuthorizedRemoteSender()).to.not.be.reverted;
+      // Construct a call A from `remoteSender` to `messageService`
+      // Call A will created a nested call from `messageService` to `messageServiceBase`, invoking onlyAuthorizedRemoteSender modifier
+      const call = messageService.claimMessageWithoutChecks(
+        remoteSender,
+        messageServiceBase,
+        0,
+        "0xfcd38105", // keccak256("withOnlyAuthorizedRemoteSender()")
+      );
+      await expect(call).to.not.be.reverted;
     });
   });
 });

--- a/contracts/test/hardhat/messaging/l2/L2MessageService.ts
+++ b/contracts/test/hardhat/messaging/l2/L2MessageService.ts
@@ -1164,7 +1164,7 @@ describe("L2MessageService", () => {
             1,
           );
 
-        await expectRevertWithReason(claimMessageCall, "ReentrancyGuard: reentrant call");
+        await expectRevertWithCustomError(l2MessageService, claimMessageCall, "ReentrantCall");
       });
 
       it("Should fail when the destination errors through receive", async () => {


### PR DESCRIPTION
This PR implements:

1. Uses TSTORE for reentrancy on the TokenBridge (saves gas on L1 and L2)
2. Uses TSTORE for the L2MessageService

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches reentrancy protection and L2 message sender tracking to transient storage and updates tests to new semantics/errors.
> 
> - **Core Contracts**:
>   - `bridging/token/TokenBridgeBase.sol`: Replace `ReentrancyGuardUpgradeable` with `TransientStorageReentrancyGuardUpgradeable`; remove `__ReentrancyGuard_init()` from init.
>   - `messaging/l2/v1/L2MessageServiceV1.sol`:
>     - Replace `ReentrancyGuardUpgradeable` with `TransientStorageReentrancyGuardUpgradeable`.
>     - Introduce transient `TRANSIENT_MESSAGE_SENDER` and `DEFAULT_MESSAGE_SENDER_TRANSIENT_VALUE`.
>     - Update `_claimMessage` to set/reset `TRANSIENT_MESSAGE_SENDER`; deprecate `_messageSender`; update `sender()` to return transient value.
>   - `messaging/l2/L2MessageServiceBase.sol`: Remove `__ReentrancyGuard_init()` and default `_messageSender` init.
>   - `/_testing/unit/messaging/TestL2MessageService.sol`: Add `claimMessageWithoutChecks(...)` using transient sender helper.
> - **Tests**:
>   - Update reentrancy assertions to expect custom error `ReentrantCall` in `TokenBridge.ts` and `L2MessageService.ts`.
>   - Adjust `MessageServiceBase.ts` to simulate authorized remote sender via `claimMessageWithoutChecks(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 279fadf85fb74a1b8275b6672ecba9bf03679528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->