### PR TITLE
Timer polling service refactor adds test for isolation

### DIFF
--- a/jvm-libs/linea/core/long-running-service/src/test/kotlin/linea/GenericPeriodicPollingServiceTest.kt
+++ b/jvm-libs/linea/core/long-running-service/src/test/kotlin/linea/GenericPeriodicPollingServiceTest.kt
@@ -382,7 +382,7 @@ class GenericPeriodicPollingServiceTest {
     poller1.start()
 
     await()
-      .atMost(5.seconds.toJavaDuration())
+      .atMost(20.seconds.toJavaDuration())
       .untilAsserted {
         assertThat(poller1Calls.get()).isGreaterThanOrEqualTo(1)
         assertThat(poller2Calls.get()).isGreaterThanOrEqualTo(1)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new test ensuring independent timers don’t block each other and simplifies the test PollingService by removing Vertx dependency and adjusting assertions.
> 
> - **Tests**:
>   - Add parameterized test `should not allow action of one timer affect or delay another timer` to verify multiple timers run independently with different intervals.
>   - Update assertions:
>     - Relax error verification to accept any message in `action handles a throw`.
>     - Remove strict error log count verification in `continues to poll after throwing exception`.
> - **Test Helper Refactor** (`PollingService` in `GenericPeriodicPollingServiceTest.kt`):
>   - Remove `Vertx` dependency from constructor and `action()`; now directly executes `mockAction`.
>   - Update all test instantiations to omit `vertx` argument; remove unnecessary mocked `Vertx` in idempotency test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c022cc6ebe621d8b50bc690735388990755d209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->