### PR TITLE
Add logging for l1-cl-node in e2e tests workflow

### DIFF
--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -182,6 +182,7 @@ jobs:
           docker logs sequencer --since 1h &>> docker_logs/sequencer.txt || true
           docker logs l1-el-node --since 1h &>> docker_logs/l1-el-node.txt || true
           docker logs maru --since 1h &>> docker_logs/maru.txt || true
+          docker logs l1-cl-node --since 1h &>> docker_logs/l1-cl-node.txt || true
       - name: Archive debug logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() && inputs.e2e-tests-logs-dump }}


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `l1-cl-node` to the Docker logs collected during e2e test failures in the reusable workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e26ea64833b5f6fd0bb189cc54ceb36213dcac5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->