### PR TITLE
Update PeriodicPollingService initialDelay constraint for VertxTimer

### DIFF
--- a/jvm-libs/linea/core/long-running-service/src/main/kotlin/linea/timer/PeriodicPollingService.kt
+++ b/jvm-libs/linea/core/long-running-service/src/main/kotlin/linea/timer/PeriodicPollingService.kt
@@ -4,11 +4,13 @@ import linea.LongRunningService
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 abstract class PeriodicPollingService(
   private val timerFactory: TimerFactory,
   private val timerSchedule: TimerSchedule,
   private val pollingInterval: Duration,
+  private val initialDelay: Duration = if (timerFactory is VertxTimerFactory) 1.milliseconds else Duration.ZERO,
   private val log: Logger,
   private val name: String,
 ) : LongRunningService {
@@ -31,7 +33,7 @@ abstract class PeriodicPollingService(
       timer = timerFactory.createTimer(
         name = name,
         task = { action().get() },
-        initialDelay = pollingInterval,
+        initialDelay = initialDelay,
         period = pollingInterval,
         timerSchedule = timerSchedule,
         errorHandler = this::handleError,

--- a/jvm-libs/linea/core/long-running-service/src/main/kotlin/linea/timer/VertxTimer.kt
+++ b/jvm-libs/linea/core/long-running-service/src/main/kotlin/linea/timer/VertxTimer.kt
@@ -24,6 +24,9 @@ class VertxTimer(
   init {
     require(period.inWholeMilliseconds >= 1L) { "Vertx Timer period must be at least 1 ms" }
   }
+  init {
+    require(initialDelay.inWholeMilliseconds >= 1L) { "Vertx Timer initial delay must be at least 1 ms" }
+  }
   private var timerId: Long? = null
   private val invocationCounter = AtomicInteger(0)
   private var firstInvocationTime: AtomicReference<Instant?> = AtomicReference(null)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `PeriodicPollingService` use a configurable `initialDelay` (default 1ms for `VertxTimerFactory`) and validates `VertxTimer` initial delay is at least 1ms.
> 
> - **Timers**:
>   - `VertxTimer`: Add validation requiring `initialDelay >= 1ms`; keep existing `period >= 1ms` check.
> - **Long-running service**:
>   - `PeriodicPollingService`: Introduce `initialDelay` parameter (default `1.ms` when using `VertxTimerFactory`, else `Duration.ZERO`) and pass it to `createTimer` instead of using `pollingInterval` as the initial delay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d70cf8312345e467081dc959a3abe29c528b535. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->