### PR TITLE
[Chore] Add note for initialization sequence

### DIFF
--- a/contracts/src/bridging/token/CustomBridgedToken.sol
+++ b/contracts/src/bridging/token/CustomBridgedToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import { BridgedToken } from "./BridgedToken.sol";
 
@@ -8,6 +8,17 @@ import { BridgedToken } from "./BridgedToken.sol";
  * @notice Custom ERC-20 token manually deployed for the Linea TokenBridge.
  */
 contract CustomBridgedToken is BridgedToken {
+  /**
+   * @notice Reinitializes an existing deployed contract.
+   * @dev NB: If this is being used for a fresh deploy, DO NOT target the initialize function,
+   *          only call the initializeV2 (unless you call both in the same transaction) because:
+   *          1. It is cheaper gas wise.
+   *          2. It avoids a front-running attack where someone else can call initializeV2 first.
+   * @param _tokenName The token name.
+   * @param _tokenSymbol The token symbol.
+   * @param _tokenDecimals The token decimals.
+   * @param _bridge The TokenBridge Address.
+   */
   function initializeV2(
     string memory _tokenName,
     string memory _tokenSymbol,


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `initializeV2` to `CustomBridgedToken` for safe reinitialization and pins Solidity to `0.8.30`.
> 
> - **Contracts**:
>   - **`contracts/src/bridging/token/CustomBridgedToken.sol`**:
>     - Add `initializeV2` (`reinitializer(2)`) to set `name`, `symbol`, `decimals`, and `bridge` via `__ERC20_init`, `__ERC20Permit_init`, and assignments.
>     - Pin Solidity pragma from `^0.8.30` to `0.8.30`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c02987d7853fe192f0b69eedcd3d3f10367a26cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->