### PR TITLE
Chore: Update Besu and Arithmetization

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.java
@@ -63,7 +63,7 @@ public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
     final var mulmodExecutor = deployMulmodExecutor();
 
     final var calls =
-        IntStream.rangeClosed(1, 6)
+        IntStream.rangeClosed(1, 10)
             .mapToObj(
                 nonce ->
                     mulmodOperation(

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/EstimateGasTest.java
@@ -395,7 +395,7 @@ public class EstimateGasTest extends LineaPluginTestBase {
                 null,
                 null));
     final var respLinea = reqLinea.execute(minerNode.nodeRequests());
-    assertThat(respLinea.getCode()).isEqualTo(-32000);
+    assertThat(respLinea.getCode()).isEqualTo(3);
     assertThat(respLinea.getMessage()).isEqualTo("Execution reverted");
     assertThat(respLinea.getData()).isEqualTo("\"0x\"");
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,8 +27,8 @@ wiremock = "3.13.0"
 logcaptor = "2.11.0"
 
 # Runtime
-arithmetization="beta-v4.0-rc19"
-besu = "25.11.0-RC1-linea2"
+arithmetization="beta-v4.0-rc23"
+besu = "25.11.0-linea1"
 blobCompressor = "2.1.0-rc1"
 blobShnarfCalculator = "1.2.0"
 bouncycastle = "1.79"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Besu and arithmetization versions; adjusts acceptance tests to expect code 3 for reverted executions and increases bundle timeout test calls to 10.
> 
> - **Dependencies**:
>   - Update `gradle/libs.versions.toml` runtime versions:
>     - `arithmetization` → `beta-v4.0-rc23`
>     - `besu` → `25.11.0-linea1`
> - **Acceptance Tests**:
>   - `BundleSelectionTimeoutTest`: increase generated calls from `IntStream.rangeClosed(1, 6)` to `IntStream.rangeClosed(1, 10)` in `multipleBundleSelectionTimeout`.
>   - `EstimateGasTest`: for reverted transactions, expect error `code` `3` with message `Execution reverted` and data `"0x"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 775b25ac7c2248edc0a55c036377a03024269b4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->