### PR TITLE
Fix/interrupt bundle selection on timeout test fix

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.java
@@ -63,7 +63,7 @@ public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
     final var mulmodExecutor = deployMulmodExecutor();
 
     final var calls =
-        IntStream.rangeClosed(1, 20)
+        IntStream.rangeClosed(1, 11)
             .mapToObj(
                 nonce ->
                     mulmodOperation(
@@ -82,9 +82,11 @@ public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
     final var sendBundleRequestBig1 =
         new SendBundleRequest(
             new BundleParams(Arrays.copyOfRange(rawTxs, 1, 10), Integer.toHexString(2)));
+    // second bundle contains one tx only to be fast to execute,
+    // and ensure timeout occurs on the 2nd bundle and 3rd is not event considered
     final var sendBundleRequestBig2 =
         new SendBundleRequest(
-            new BundleParams(Arrays.copyOfRange(rawTxs, 10, 20), Integer.toHexString(2)));
+            new BundleParams(Arrays.copyOfRange(rawTxs, 1, 2), Integer.toHexString(2)));
 
     final var sendBundleResponseSmall = sendBundleRequestSmall.execute(minerNode.nodeRequests());
     final var sendBundleResponseBig1 = sendBundleRequestBig1.execute(minerNode.nodeRequests());


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors acceptance tests to adjust bundle slicing and execution order so multi-bundle timeout reliably triggers on the second bundle.
> 
> - **Acceptance Tests (`BundleSelectionTimeoutTest.java`)**:
>   - Refactor multi-bundle timeout scenario: compute `rawTxs` once; set bundles to `[0..1)`, `[1..10)`, and `[1..2)` to isolate the first tx and make the second bundle heavy while the third is single-tx.
>   - Reorder execution to send all constructed requests after setup; add clarifying comment to ensure timeout occurs on the second bundle and the third isn’t considered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ff651a53b8c97d4f24f36aa48d0d4070702f22f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->