### PR TITLE
Extend the bundle timeout test to reproduce production behavior

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.java
@@ -14,6 +14,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
 
 public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
 
@@ -63,7 +64,7 @@ public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
     final var mulmodExecutor = deployMulmodExecutor();
 
     final var calls =
-        IntStream.rangeClosed(1, 11)
+        IntStream.rangeClosed(1, 30)
             .mapToObj(
                 nonce ->
                     mulmodOperation(
@@ -75,22 +76,35 @@ public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
             .toArray(MulmodCall[]::new);
 
     final var rawTxs = Arrays.stream(calls).map(MulmodCall::rawTx).toArray(String[]::new);
+
     final var sendBundleRequestSmall =
         new SendBundleRequest(
             new BundleParams(Arrays.copyOfRange(rawTxs, 0, 1), Integer.toHexString(2)));
 
+    // this bundle is meant to go in timeout during its selection
     final var sendBundleRequestBig1 =
         new SendBundleRequest(
-            new BundleParams(Arrays.copyOfRange(rawTxs, 1, 10), Integer.toHexString(2)));
+            new BundleParams(Arrays.copyOfRange(rawTxs, 1, 30), Integer.toHexString(2)));
+
     // second bundle contains one tx only to be fast to execute,
-    // and ensure timeout occurs on the 2nd bundle and 3rd is not event considered
-    final var sendBundleRequestBig2 =
-        new SendBundleRequest(
-            new BundleParams(Arrays.copyOfRange(rawTxs, 1, 2), Integer.toHexString(2)));
+    // and ensure timeout occurs on the 2nd bundle and following are not event considered.
+    // We are sending a bunch of bundles instead of just one to reproduce what happened in
+    // production, where each following bundle where not skipped and would take ~200ms
+    // to the not selected, due to the fact the first tx in the bundle was executed.
+    final int followingBundleCount = 20;
+    final var followingSendBundleRequests = new SendBundleRequest[followingBundleCount];
+    for (int i = 0; i < followingSendBundleRequests.length; i++) {
+      followingSendBundleRequests[i] =
+          new SendBundleRequest(
+              new BundleParams(Arrays.copyOfRange(rawTxs, 1, 2 + i), Integer.toHexString(2)));
+    }
 
     final var sendBundleResponseSmall = sendBundleRequestSmall.execute(minerNode.nodeRequests());
     final var sendBundleResponseBig1 = sendBundleRequestBig1.execute(minerNode.nodeRequests());
-    final var sendBundleResponseBig2 = sendBundleRequestBig2.execute(minerNode.nodeRequests());
+    final var followingBundleResponses =
+        Arrays.stream(followingSendBundleRequests)
+            .map(req -> req.execute(minerNode.nodeRequests()))
+            .toList();
 
     final var transferTxHash =
         accountTransactions
@@ -103,10 +117,18 @@ public class BundleSelectionTimeoutTest extends AbstractSendBundleTest {
     assertThat(sendBundleResponseBig1.hasError()).isFalse();
     assertThat(sendBundleResponseBig1.getResult().bundleHash()).isNotBlank();
 
-    assertThat(sendBundleResponseBig2.hasError()).isFalse();
-    assertThat(sendBundleResponseBig2.getResult().bundleHash()).isNotBlank();
+    followingBundleResponses.forEach(
+        resp -> {
+          assertThat(resp.hasError()).isFalse();
+          assertThat(resp.getResult().bundleHash()).isNotBlank();
+        });
 
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.toHexString()));
+    final var transferReceipt = ethTransactions.getTransactionReceipt(transferTxHash.toHexString());
+    assertThat(transferReceipt.execute(minerNode.nodeRequests()))
+        .isPresent()
+        .map(TransactionReceipt::getBlockNumber)
+        .contains(BigInteger.TWO);
 
     // first bundle is successful
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(calls[0].txHash()));


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends the bundle timeout acceptance test to send many bundles (up to 30 txs) and assert correct selection/timeout behavior, including block number checks.
> 
> - **Tests (BundleSelectionTimeoutTest.java)**:
>   - Expand multiple-bundle scenario:
>     - Increase generated calls from `1..11` to `1..30` and enlarge the "big" bundle (`rawTxs[1..30]`).
>     - Replace single follow-up bundle with a series of 20 follow-up bundles of increasing size to replicate production behavior; execute and validate all responses.
>   - Add verification that the transfer receipt is mined in block `2` using `TransactionReceipt` and `getBlockNumber`.
>   - Maintain behavior checks: first bundle succeeds; all subsequent bundle txs have no receipts (not selected).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1009f23d408f295dc7760a206f6c774e95c39175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->