### PR TITLE
fix: postman metrics direction condition

### DIFF
--- a/postman/src/services/processors/MessageClaimingPersister.ts
+++ b/postman/src/services/processors/MessageClaimingPersister.ts
@@ -8,7 +8,7 @@ import {
   JsonRpcProvider,
   ErrorDescription,
 } from "ethers";
-import { OnChainMessageStatus } from "@consensys/linea-sdk";
+import { Direction, OnChainMessageStatus } from "@consensys/linea-sdk";
 import { BaseError } from "../../core/errors";
 import { MessageStatus } from "../../core/enums";
 import { ILogger } from "../../core/utils/logging/ILogger";
@@ -211,7 +211,7 @@ export class MessageClaimingPersister implements IMessageClaimingPersister {
     let processingTimeInSeconds: number | undefined;
     let infuraConfirmationTimeInSeconds: number | undefined;
 
-    if (message.claimTxCreationDate) {
+    if (this.config.direction === Direction.L1_TO_L2 && message.claimTxCreationDate) {
       const block = await this.provider.getBlock(receipt.blockNumber);
       if (block) {
         processingTimeInSeconds = block.timestamp - message.claimTxCreationDate.getTime() / 1_000;


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts claim processing/confirmation time metrics to L1_TO_L2 direction in MessageClaimingPersister.
> 
> - **Postman / MessageClaimingPersister**:
>   - Gate transaction processing and Infura confirmation time metrics in `updateReceiptStatus` to when `direction === Direction.L1_TO_L2`.
>   - Import `Direction` from `@consensys/linea-sdk` to support the condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a90d289d904574222f40dcef0fc50a1025bddad7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->