### PR TITLE
add interfaces segregation to alt-da Validium

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/smartcontract/LineaRollupSmartContractClient.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/smartcontract/LineaRollupSmartContractClient.kt
@@ -1,6 +1,8 @@
 package net.consensys.zkevm.coordinator.clients.smartcontract
 
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
+import linea.contract.l1.LineaSmartContractClientReadOnly
+import linea.contract.l1.LineaValidiumSmartContractClientReadOnly
 import linea.domain.gas.GasPriceCaps
 import net.consensys.zkevm.domain.BlobRecord
 import net.consensys.zkevm.domain.ProofToFinalize
@@ -11,7 +13,7 @@ data class BlockAndNonce(
   val nonce: ULong,
 )
 
-interface LineaRollupSmartContractClient : LineaRollupSmartContractClientReadOnly {
+interface LineaSmartContractClient : LineaSmartContractClientReadOnly {
 
   fun currentNonce(): ULong
 
@@ -21,28 +23,12 @@ interface LineaRollupSmartContractClient : LineaRollupSmartContractClientReadOnl
    */
   fun updateNonceAndReferenceBlockToLastL1Block(): SafeFuture<BlockAndNonce>
 
-  /**
-   *  Simulates the sending of a list of blobs to the smart contract, with EIP4844 transaction.
-   */
-  fun submitBlobsEthCall(
-    blobs: List<BlobRecord>,
-    gasPriceCaps: GasPriceCaps?,
-  ): SafeFuture<String?>
-
   fun finalizeBlocksEthCall(
     aggregation: ProofToFinalize,
     aggregationLastBlob: BlobRecord,
     parentL1RollingHash: ByteArray,
     parentL1RollingHashMessageNumber: Long,
   ): SafeFuture<String?>
-
-  /**
-   * Submit a list of blobs to the smart contract, with EIP4844 transaction
-   */
-  fun submitBlobs(
-    blobs: List<BlobRecord>,
-    gasPriceCaps: GasPriceCaps?,
-  ): SafeFuture<String>
 
   fun finalizeBlocks(
     aggregation: ProofToFinalize,
@@ -57,6 +43,46 @@ interface LineaRollupSmartContractClient : LineaRollupSmartContractClientReadOnl
     aggregationLastBlob: BlobRecord,
     parentL1RollingHash: ByteArray,
     parentL1RollingHashMessageNumber: Long,
+    gasPriceCaps: GasPriceCaps?,
+  ): SafeFuture<String>
+}
+
+interface LineaRollupSmartContractClient :
+  LineaRollupSmartContractClientReadOnly,
+  LineaSmartContractClient {
+  /**
+   *  Simulates the sending of a list of blobs to the smart contract, with EIP4844 transaction.
+   */
+  fun submitBlobsEthCall(
+    blobs: List<BlobRecord>,
+    gasPriceCaps: GasPriceCaps?,
+  ): SafeFuture<String?>
+
+  /**
+   * Submit a list of blobs to the smart contract, with EIP4844 transaction
+   */
+  fun submitBlobs(
+    blobs: List<BlobRecord>,
+    gasPriceCaps: GasPriceCaps?,
+  ): SafeFuture<String>
+}
+
+interface LineaValidiumSmartContractClient :
+  LineaValidiumSmartContractClientReadOnly,
+  LineaSmartContractClient {
+  /**
+   *  Simulates the sending of a list of blobs to the smart contract, with EIP4844 transaction.
+   */
+  fun acceptShnarfsEthCall(
+    blobs: List<BlobRecord>,
+    gasPriceCaps: GasPriceCaps?,
+  ): SafeFuture<String?>
+
+  /**
+   * Submit a list of blobs to the smart contract, with EIP4844 transaction
+   */
+  fun acceptShnarfs(
+    blobs: List<BlobRecord>,
     gasPriceCaps: GasPriceCaps?,
   ): SafeFuture<String>
 }

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
@@ -7,7 +7,11 @@ enum class LineaContractVersion : Comparable<LineaContractVersion> {
   V6, // more efficient data submission and new events for state recovery
 }
 
-interface LineaRollupSmartContractClientReadOnly : ContractVersionProvider<LineaContractVersion> {
+enum class LineaValidiumContractVersion : Comparable<LineaValidiumContractVersion> {
+  V1,
+}
+
+interface LineaSmartContractClientReadOnly {
 
   fun getAddress(): String
 
@@ -44,3 +48,10 @@ interface LineaRollupSmartContractClientReadOnly : ContractVersionProvider<Linea
     lineaL2BlockNumber: ULong,
   ): SafeFuture<ByteArray>
 }
+
+interface LineaRollupSmartContractClientReadOnly :
+  LineaSmartContractClientReadOnly,
+  ContractVersionProvider<LineaContractVersion>
+interface LineaValidiumSmartContractClientReadOnly :
+  LineaSmartContractClientReadOnly,
+  ContractVersionProvider<LineaValidiumContractVersion>


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce shared `LineaSmartContractClient(ReadOnly)` and add Validium-specific interfaces/versioning, moving blob submission methods to Rollup (`submitBlobs*`) and Validium (`acceptShnarfs*`) while keeping finalize methods common.
> 
> - **Interfaces segregation**:
>   - Introduce shared `linea.contract.l1.LineaSmartContractClientReadOnly` and coordinator `LineaSmartContractClient` (with `finalize*` and nonce/block helpers).
>   - Split clients:
>     - `LineaRollupSmartContractClient` extends shared interfaces; holds `submitBlobsEthCall` and `submitBlobs`.
>     - `LineaValidiumSmartContractClient` extends shared interfaces; adds `acceptShnarfsEthCall` and `acceptShnarfs`.
> - **Versioning**:
>   - Add `LineaValidiumContractVersion` enum and `LineaValidiumSmartContractClientReadOnly` extending shared read-only + version provider.
>   - Keep `LineaRollupSmartContractClientReadOnly` but make it extend shared read-only + version provider.
> - **Cleanup**:
>   - Remove blob submission methods from the common interface and relocate to Rollup/Validium-specific clients.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96d301567cf9d9e4e28da8a63c90a26620fa9cd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->