### PR TITLE
✨ feat: upgrade Engine API service to V5 methods

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/EngineAPIService.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/org/hyperledger/besu/tests/acceptance/dsl/EngineAPIService.java
@@ -214,25 +214,24 @@ public class EngineAPIService {
     return createEngineCall("engine_newPayloadV4", params);
   }
 
-//   private Call createNewPayloadRequestV5(
-//     final ObjectNode executionPayload,
-//     final ArrayNode expectedBlobVersionedHashes,
-//     final String parentBeaconBlockRoot,
-//     final ArrayNode executionRequests) {
+  //   private Call createNewPayloadRequestV5(
+  //     final ObjectNode executionPayload,
+  //     final ArrayNode expectedBlobVersionedHashes,
+  //     final String parentBeaconBlockRoot,
+  //     final ArrayNode executionRequests) {
 
-//   // Add blockAccessList to executionPayload (required for V5)
-//   // Use "0xc0" for empty BlockAccessList
-//   executionPayload.put("blockAccessList", "0xc0");
+  //   // Add blockAccessList to executionPayload (required for V5)
+  //   // Use "0xc0" for empty BlockAccessList
+  //   executionPayload.put("blockAccessList", "0xc0");
 
-//   ArrayNode params = mapper.createArrayNode();
-//   params.add(executionPayload);
-//   params.add(expectedBlobVersionedHashes);
-//   params.add(parentBeaconBlockRoot);
-//   params.add(executionRequests);
+  //   ArrayNode params = mapper.createArrayNode();
+  //   params.add(executionPayload);
+  //   params.add(expectedBlobVersionedHashes);
+  //   params.add(parentBeaconBlockRoot);
+  //   params.add(executionRequests);
 
-//   return createEngineCall("engine_newPayloadV5", params);
-// }
-
+  //   return createEngineCall("engine_newPayloadV5", params);
+  // }
 
   private Call createEngineCall(final String rpcMethod, ArrayNode params) {
     ObjectNode request = mapper.createObjectNode();


### PR DESCRIPTION
- Update engine_getPayload to use V5 endpoint
- Update engine_newPayload to use V5 endpoint with blockAccessList
- Add blockAccessList field support for V5 payload requests
- Comment out V4 method implementation for reference

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches getPayload to V5, keeps newPayload on V4 with a V5 stub (incl. blockAccessList) commented for future use.
> 
> - **Acceptance tests (`EngineAPIService.java`)**:
>   - Upgrade `engine_getPayload` call from `V4` to `V5` in `createGetPayloadRequest`.
>   - Rename and use `createNewPayloadRequestV4` for `engine_newPayloadV4`; update all callers accordingly.
>   - Add commented `createNewPayloadRequestV5` stub showing `blockAccessList` addition for V5 payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b2af1e5698dfcd917a784ddd265fe350895706c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->