### PR TITLE
EIP1559GasProvider, Web3j to EthApi migration 1/N

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/MessageAnchoringAppConfigurator.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/MessageAnchoringAppConfigurator.kt
@@ -56,6 +56,7 @@ object MessageAnchoringAppConfigurator {
       ),
       l2MessageService = Web3JL2MessageServiceSmartContractClient.create(
         web3jClient = l2Web3jClient,
+        ethApiClient = createEthApiClient(web3jClient = l2Web3jClient, requestRetryConfig = null, vertx = vertx),
         contractAddress = configs.protocol.l2.contractAddress,
         gasLimit = configs.messageAnchoring.gas.gasLimit,
         maxFeePerGasCap = configs.messageAnchoring.gas.maxFeePerGasCap,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -259,7 +259,6 @@ class ConflationApp(
       description = "Highest consecutive proven aggregation block number",
       measurementSupplier = highestConsecutiveAggregationTracker,
     )
-
     ProofAggregationCoordinatorService.Companion
       .create(
         vertx = vertx,
@@ -286,6 +285,7 @@ class ConflationApp(
         ),
         l2MessageService = Web3JL2MessageServiceSmartContractClient.createReadOnly(
           web3jClient = l2Web3jClient,
+          ethApiClient = createEthApiClient(web3jClient = l2Web3jClient, requestRetryConfig = null, vertx = vertx),
           contractAddress = configs.protocol.l2.contractAddress,
           smartContractErrors = configs.smartContractErrors,
           smartContractDeploymentBlockNumber = configs.protocol.l2.contractDeploymentBlockNumber?.getNumber(),

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l2/Web3JL2MessageServiceSmartContractClient.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l2/Web3JL2MessageServiceSmartContractClient.kt
@@ -4,6 +4,7 @@ import linea.contract.ContractDeploymentBlockNumberProvider
 import linea.contract.EventBasedContractDeploymentBlockNumberProvider
 import linea.contract.StaticContractDeploymentBlockNumberProvider
 import linea.domain.BlockParameter
+import linea.ethapi.EthApiClient
 import linea.kotlin.encodeHex
 import linea.kotlin.toBigInteger
 import linea.kotlin.toULong
@@ -36,6 +37,7 @@ class Web3JL2MessageServiceSmartContractClient(
   companion object {
     fun create(
       web3jClient: Web3j,
+      ethApiClient: EthApiClient,
       contractAddress: String,
       gasLimit: ULong,
       maxFeePerGasCap: ULong,
@@ -46,7 +48,7 @@ class Web3JL2MessageServiceSmartContractClient(
       smartContractDeploymentBlockNumber: ULong?,
     ): Web3JL2MessageServiceSmartContractClient {
       val gasProvider = EIP1559GasProvider(
-        web3jClient = web3jClient,
+        ethApiClient = ethApiClient,
         config = EIP1559GasProvider.Config(
           gasLimit = gasLimit,
           maxFeePerGasCap = maxFeePerGasCap,
@@ -80,6 +82,7 @@ class Web3JL2MessageServiceSmartContractClient(
 
     fun createReadOnly(
       web3jClient: Web3j,
+      ethApiClient: EthApiClient,
       contractAddress: String,
       smartContractErrors: SmartContractErrors,
       smartContractDeploymentBlockNumber: ULong?,
@@ -91,6 +94,7 @@ class Web3JL2MessageServiceSmartContractClient(
       )
       return create(
         web3jClient = web3jClient,
+        ethApiClient = ethApiClient,
         contractAddress = contractAddress,
         gasLimit = 0UL,
         maxFeePerGasCap = 0UL,

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/gas/EIP1559GasProvider.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/gas/EIP1559GasProvider.kt
@@ -1,18 +1,16 @@
 package linea.web3j.gas
 
+import linea.domain.BlockParameter
+import linea.ethapi.EthApiClient
 import linea.kotlin.toBigInteger
 import linea.kotlin.toIntervalString
 import linea.web3j.domain.blocksRange
-import linea.web3j.domain.toLineaDomain
-import linea.web3j.requestAsync
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.web3j.protocol.Web3j
-import org.web3j.protocol.core.DefaultBlockParameterName
 import java.math.BigInteger
 import kotlin.math.min
 
-class EIP1559GasProvider(private val web3jClient: Web3j, private val config: Config) :
+class EIP1559GasProvider(private val ethApiClient: EthApiClient, private val config: Config) :
   AtomicContractEIP1559GasProvider {
   private val log: Logger = LogManager.getLogger(this::class.java)
 
@@ -29,22 +27,21 @@ class EIP1559GasProvider(private val web3jClient: Web3j, private val config: Con
     }
   }
 
-  private val chainId: Long = web3jClient.ethChainId().send().chainId.toLong()
+  private val chainId: Long = ethApiClient.ethChainId().get().toLong()
   private var cacheIsValidForBlockNumber: BigInteger = BigInteger.ZERO
   private var feesCache: EIP1559GasFees = getRecentFees()
   private var gasLimitOverride = BigInteger.valueOf(Long.MAX_VALUE)
 
   private fun getRecentFees(): EIP1559GasFees {
-    val currentBlockNumber = web3jClient.ethBlockNumber().send().blockNumber
+    val currentBlockNumber = ethApiClient.ethBlockNumber().get().toBigInteger()
     if (currentBlockNumber > cacheIsValidForBlockNumber) {
-      web3jClient
+      ethApiClient
         .ethFeeHistory(
           config.feeHistoryBlockCount.toInt(),
-          DefaultBlockParameterName.LATEST,
+          BlockParameter.Tag.LATEST,
           listOf(config.feeHistoryRewardPercentile),
         )
-        .requestAsync { feeHistoryResponse ->
-          val feeHistory = feeHistoryResponse.feeHistory.toLineaDomain()
+        .thenApply { feeHistory ->
           var maxPriorityFeePerGas = feeHistory.reward.sumOf { it[0] } / feeHistory.reward.size.toUInt()
 
           if (maxPriorityFeePerGas > config.maxFeePerGasCap) {
@@ -66,7 +63,7 @@ class EIP1559GasProvider(private val web3jClient: Web3j, private val config: Con
             )
             log.debug(
               "New fees estimation: fees={} l2Blocks={}",
-              feeHistoryResponse.feeHistory.blocksRange().toIntervalString(),
+              feeHistory.blocksRange().toIntervalString(),
               feesCache,
             )
           } else {


### PR DESCRIPTION
This PR implements issue(s) #1790 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch EIP1559GasProvider and L2 message service setup from Web3j to EthApiClient and wire through app configurators.
> 
> - **Libraries**:
>   - **`EIP1559GasProvider`**: Replace `Web3j` with `EthApiClient` (chainId, block number, fee history); update fee history query to use `BlockParameter.Tag.LATEST`; simplify fee history handling and logging.
>   - **`Web3JL2MessageServiceSmartContractClient`**: `create`/`createReadOnly` now accept `ethApiClient` and pass it to `EIP1559GasProvider`.
> - **Apps**:
>   - **Message Anchoring**: Provide `ethApiClient` when creating `Web3JL2MessageServiceSmartContractClient`.
>   - **Conflation**: Provide `ethApiClient` for read-only `Web3JL2MessageServiceSmartContractClient` in proof aggregation setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a074bec4f7a6a5e87e647db1e63179a801990352. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->