### PR TITLE
[Fix] [CI] - Remove unconditional build of native yield automation service for E2E tests

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -75,7 +75,9 @@ jobs:
 
   native_yield_automation_service:
     uses: ./.github/workflows/native-yield-automation-service-build-and-publish.yml
-    if: ${{ always() && (inputs.native_yield_automation_service_changed == 'true' || inputs.native_yield_automation_service_image_tagged != 'true') }}
+    if: ${{ inputs.native_yield_automation_service_changed == 'true' }}
+    # Uncomment below later when E2E test cases include native yield functionality.
+    # if: ${{ always() && (inputs.native_yield_automation_service_changed == 'true' || inputs.native_yield_automation_service_image_tagged != 'true') }}
     with:
       commit_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates workflow to run `native_yield_automation_service` job only when changes are detected, removing the previous image-tag/always gating.
> 
> - **CI/Workflows** (`.github/workflows/build-and-publish.yml`):
>   - `native_yield_automation_service` job:
>     - Change condition to `inputs.native_yield_automation_service_changed == 'true'`.
>     - Remove `always()` and image-tag gating from the `if` condition.
>     - Add comment noting potential future reinstatement when E2E covers native yield.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf42cb6903bf95e5b1dbe1d7bc70b80e2a2ffb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->