### PR TITLE
Chore: Update Besu to 25.11.0-linea4.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ logcaptor = "2.11.0"
 
 # Runtime
 arithmetization="beta-v4.4-rc7"
-besu = "25.11.0-linea4"
+besu = "25.11.0-linea4.1"
 blobCompressor = "2.1.0-rc1"
 blobShnarfCalculator = "1.2.0"
 bouncycastle = "1.79"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the `besu` runtime dependency in `gradle/libs.versions.toml` from `25.11.0-linea4` to `25.11.0-linea4.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99499e5027fe07e77b87cba35eba31b2d1d660c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->