### PR TITLE
GethCliqueSafeBlockProvider: Web3j to EthApi migration 2/N

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -267,7 +267,7 @@ class ConflationApp(
         deadlineCheckInterval = configs.conflation.proofAggregation.deadlineCheckInterval,
         aggregationDeadline = configs.conflation.proofAggregation.deadline,
         latestBlockProvider = GethCliqueSafeBlockProvider(
-          web3j = l2Web3jClient,
+          ethApiBlockClient = l2EthClient,
           config = GethCliqueSafeBlockProvider.Config(0),
         ),
         maxProofsPerAggregation = configs.conflation.proofAggregation.proofsLimit,
@@ -484,8 +484,8 @@ class ConflationApp(
         lastBlockNumber = lastProcessedBlockNumber,
         clock = Clock.System,
         latestBlockProvider = GethCliqueSafeBlockProvider(
-          l2Web3jClient,
-          GethCliqueSafeBlockProvider.Config(blocksToFinalization = 0),
+          ethApiBlockClient = l2EthClient,
+          config = GethCliqueSafeBlockProvider.Config(blocksToFinalization = 0),
         ),
       ),
     )

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/GethCliqueSafeBlockProvider.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/GethCliqueSafeBlockProvider.kt
@@ -1,17 +1,14 @@
 package net.consensys.zkevm.coordinator.blockcreation
 
 import linea.domain.Block
-import linea.domain.BlockParameter.Companion.toBlockParameter
-import linea.web3j.domain.toWeb3j
-import linea.web3j.mappers.toDomain
+import linea.domain.BlockParameter
+import linea.ethapi.EthApiBlockClient
 import net.consensys.linea.async.toSafeFuture
 import net.consensys.zkevm.ethereum.coordination.blockcreation.SafeBlockProvider
-import org.web3j.protocol.Web3j
-import org.web3j.protocol.core.DefaultBlockParameterName
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 class GethCliqueSafeBlockProvider(
-  private val web3j: Web3j,
+  private val ethApiBlockClient: EthApiBlockClient,
   private val config: Config,
 ) : SafeBlockProvider {
   data class Config(
@@ -19,13 +16,11 @@ class GethCliqueSafeBlockProvider(
   )
 
   override fun getLatestSafeBlock(): SafeFuture<Block> {
-    return web3j
-      .ethGetBlockByNumber(DefaultBlockParameterName.LATEST, false).sendAsync()
-      .toSafeFuture()
+    return ethApiBlockClient
+      .ethGetBlockByNumberTxHashes(BlockParameter.Tag.LATEST)
       .thenCompose { block ->
-        val safeBlockNumber = (block.block.number.toLong() - config.blocksToFinalization).coerceAtLeast(0)
-        web3j.ethGetBlockByNumber(safeBlockNumber.toBlockParameter().toWeb3j(), true).sendAsync().toSafeFuture()
+        val safeBlockNumber = (block.number.toLong() - config.blocksToFinalization).coerceAtLeast(0)
+        ethApiBlockClient.ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(safeBlockNumber)).toSafeFuture()
       }
-      .thenApply { it.block.toDomain() }
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #1790 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Web3j with EthApiBlockClient in GethCliqueSafeBlockProvider and update ConflationApp to use the new API.
> 
> - **Block provider (`GethCliqueSafeBlockProvider`)**:
>   - Replace `Web3j` with `EthApiBlockClient`.
>   - Use `ethGetBlockByNumberTxHashes(BlockParameter.Tag.LATEST)` and `ethGetBlockByNumberFullTxs(BlockParameter.fromNumber(...))`.
>   - Update imports and remove Web3j-specific conversions.
> - **Conflation app (`ConflationApp`)**:
>   - Update `GethCliqueSafeBlockProvider` instantiations to pass `ethApiBlockClient = l2EthClient` and named `config`.
>   - Adjust `DeadlineConflationCalculatorRunner` and `ProofAggregationCoordinatorService` to use the new provider signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1270740f8c4066ea30a40c2418a07178bda362d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->