### PR TITLE
fix: change volume mount of data path for linea besu

### DIFF
--- a/docs/getting-started/linea-mainnet/besu/linea-besu.config.toml
+++ b/docs/getting-started/linea-mainnet/besu/linea-besu.config.toml
@@ -1,7 +1,7 @@
 # data
 network="linea-mainnet"
 #logging="INFO" log is managed via log4j config file
-data-path="/opt/besu/data"
+data-path="/data"
 
 # Sync mode and data layer implementation
 sync-mode="SNAP"

--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - ./besu/log4j.xml:/var/lib/besu/log4j.xml
       - ./execution-layer-static-nodes.json:/var/lib/besu/static-nodes.json:ro
       - ./engine-jwt:/var/lib/besu/jwt:ro
-      - linea-mainnet-besu:/opt/besu
+      - linea-mainnet-besu:/data
 
   # Maru Consensus Layer
   maru-node:

--- a/docs/getting-started/linea-sepolia/besu/linea-besu.config.toml
+++ b/docs/getting-started/linea-sepolia/besu/linea-besu.config.toml
@@ -1,7 +1,7 @@
 # data
 network="linea-sepolia"
 #logging="INFO" log is managed via log4j config file
-data-path="/opt/besu/data"
+data-path="/data"
 
 # Sync mode and data layer implementation
 sync-mode="SNAP"

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - ./besu/log4j.xml:/var/lib/besu/log4j.xml
       - ./execution-layer-static-nodes.json:/var/lib/besu/static-nodes.json:ro
       - ./engine-jwt:/var/lib/besu/jwt:ro
-      - linea-sepolia-besu:/opt/besu
+      - linea-sepolia-besu:/data
 
   # Maru Consensus Layer
   maru-node:


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Besu data directory to /data and updates Docker volume mounts accordingly for Linea mainnet and sepolia setups.
> 
> - **Linea Besu configs**:
>   - Update `data-path` from `/opt/besu/data` to `/data` in `docs/getting-started/linea-mainnet/besu/linea-besu.config.toml` and `docs/getting-started/linea-sepolia/besu/linea-besu.config.toml`.
> - **Docker Compose**:
>   - Change volume mount targets from `/opt/besu` to `/data` for `besu-node` in `docs/getting-started/linea-mainnet/docker-compose.yml` and `docs/getting-started/linea-sepolia/docker-compose.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fffe101d169c517e8703da28dc9ec5b90c3aa7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->