### PR TITLE
Updating geth nodes in the getting started doc to 1.16.7

### DIFF
--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -85,7 +85,7 @@ services:
 
   # Geth initialization
   geth-init:
-    image: ethereum/client-go:v1.16.5
+    image: ethereum/client-go:v1.16.7
     command:
       - init
       - /genesis.json
@@ -97,7 +97,7 @@ services:
   geth-node:
     hostname: el-client
     container_name: geth-node
-    image: ethereum/client-go:v1.16.5
+    image: ethereum/client-go:v1.16.7
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   # Geth initialization
   geth-init:
-    image: ethereum/client-go:v1.16.5
+    image: ethereum/client-go:v1.16.7
     command:
       - init
       - /genesis.json
@@ -95,7 +95,7 @@ services:
   geth-node:
     hostname: el-client
     container_name: geth-node
-    image: ethereum/client-go:v1.16.5
+    image: ethereum/client-go:v1.16.7
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Geth Docker images from v1.16.5 to v1.16.7 for both linea-mainnet and linea-sepolia (`geth-init` and `geth-node`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 533be7f2867e48194b3799286dc37f4e9be828ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->