### PR TITLE
Chore: Update Gradle plugin for Besu plugins to 0.1.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ dependencyLicenseReport = { id = "com.github.jk1.dependency-license-report", ver
 lombok = { id = "io.freefair.lombok", version = "8.6" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.51.0" }
 dependencyManagement = { id = "io.spring.dependency-management", version = "1.1.5" }
-besuPluginLibrary = { id = "net.consensys.besu-plugin-library", version = "0.1.1" }
-besuPluginDistribution = { id = "net.consensys.besu-plugin-distribution", version = "0.1.1" }
+besuPluginLibrary = { id = "net.consensys.besu-plugin-library", version = "0.1.4" }
+besuPluginDistribution = { id = "net.consensys.besu-plugin-distribution", version = "0.1.4" }
 
 [libraries]
 jreleaser = { group = "org.jreleaser", name = "jreleaser-gradle-plugin", version = "1.15.0" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,3 @@
-pluginManagement {
-  //    includeBuild '../besu-plugin-gradle-plugin'
-  repositories {
-    gradlePluginPortal()
-    maven {
-      url = uri('https://raw.githubusercontent.com/Consensys/besu-plugin-gradle-plugin-artifacts/main')
-    }
-  }
-}
-
 rootProject.name = 'linea'
 // please keep deps sorted by group and alphabetically
 include 'jvm-libs:generic:serialization:jackson'


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Besu plugin Gradle plugins to 0.1.4 and drop the custom pluginManagement repository block from settings.gradle.
> 
> - **Build/Gradle**:
>   - Update `besuPluginLibrary` and `besuPluginDistribution` plugin versions in `gradle/libs.versions.toml` from `0.1.1` to `0.1.4`.
> - **Settings**:
>   - Remove the `pluginManagement` repository configuration block from `settings.gradle`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32cc47cf9178f9b1b97efb2f0f8c8a7a33c21ede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->