### PR TITLE
M-01 - replenishWithdrawalReserve - skip 0 yieldprovider withdrawal

### DIFF
--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -757,7 +757,9 @@ contract YieldManager is
     uint256 yieldProviderBalance = withdrawableValue(_yieldProvider);
     if (yieldProviderBalance == 0 && yieldManagerBalance == 0) revert NoAvailableFundsToReplenishWithdrawalReserve();
     uint256 withdrawAmount = Math256.min(yieldProviderBalance, targetDeficit - yieldManagerBalance);
-    _delegatecallWithdrawFromYieldProvider(_yieldProvider, withdrawAmount);
+    if (withdrawAmount > 0) {
+      _delegatecallWithdrawFromYieldProvider(_yieldProvider, withdrawAmount);
+    }
     _fundReserve(yieldManagerBalance + withdrawAmount);
 
     // Pause staking if remaining target deficit


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid delegatecalling withdraw with 0 amount during reserve replenishment; add unit test covering zero provider balance scenario.
> 
> - **Contracts**:
>   - `YieldManager.replenishWithdrawalReserve`: Guard `_delegatecallWithdrawFromYieldProvider` with `if (withdrawAmount > 0)` to skip zero-amount withdrawals.
> - **Tests**:
>   - Add unit test in `contracts/test/yield/unit/YieldManager.funds.ts` verifying reserve replenishment when `withdrawableValue = 0` uses only `YieldManager` balance and pauses staking, with expected events/balances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5b1e92396378a668d2da3c747e06a25de3f1da5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->