### PR TITLE
L03 - fixed 0.8.30 pragma

### DIFF
--- a/contracts/contracts/yield/LidoStVaultYieldProvider.sol
+++ b/contracts/contracts/yield/LidoStVaultYieldProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import { YieldProviderBase } from "./YieldProviderBase.sol";
 import { IGenericErrors } from "../interfaces/IGenericErrors.sol";

--- a/contracts/contracts/yield/LidoStVaultYieldProviderFactory.sol
+++ b/contracts/contracts/yield/LidoStVaultYieldProviderFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import { LidoStVaultYieldProvider } from "./LidoStVaultYieldProvider.sol";
 import { ErrorUtils } from "../lib/ErrorUtils.sol";

--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.30;
+pragma solidity 0.8.30;
 
 import { YieldManagerStorageLayout } from "./YieldManagerStorageLayout.sol";
 import { IYieldManager } from "./interfaces/IYieldManager.sol";


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins Solidity compiler to 0.8.30 in `LidoStVaultYieldProvider`, `LidoStVaultYieldProviderFactory`, and `YieldManager`.
> 
> - **Solidity versioning**:
>   - Change pragma from `^0.8.30` to `0.8.30` in:
>     - `contracts/contracts/yield/LidoStVaultYieldProvider.sol`
>     - `contracts/contracts/yield/LidoStVaultYieldProviderFactory.sol`
>     - `contracts/contracts/yield/YieldManager.sol`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fafb8075aef1f627dc11b028629a6bac6af62ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->