### PR TITLE
N07 - add YieldProviderIndexOutOfBounds error to yieldProviderByIndex fn

### DIFF
--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -308,6 +308,10 @@ contract YieldManager is
    */
   function yieldProviderByIndex(uint256 _index) external view override returns (address yieldProvider) {
     YieldManagerStorage storage $ = _getYieldManagerStorage();
+    uint256 length = $.yieldProviders.length;
+    if (_index == 0 || _index >= length) {
+      revert YieldProviderIndexOutOfBounds(_index, Math256.safeSub(length, 1));
+    }
     yieldProvider = $.yieldProviders[_index];
   }
 

--- a/contracts/test/yield/unit/YieldManager.basic.ts
+++ b/contracts/test/yield/unit/YieldManager.basic.ts
@@ -162,8 +162,13 @@ describe("YieldManager contract - basic operations", () => {
       expect(await yieldManager.isL2YieldRecipientKnown(existingRecipient)).to.be.true;
     });
 
-    it("Should return zero address for index 0 yield provider", async () => {
-      expect(await yieldManager.yieldProviderByIndex(0)).to.equal(ZeroAddress);
+    it("Should revert for index 0 yield provider", async () => {
+      await expectRevertWithCustomError(
+        yieldManager,
+        yieldManager.yieldProviderByIndex(0),
+        "YieldProviderIndexOutOfBounds",
+        [0n, 0n],
+      );
     });
 
     it("Should not register the zero address as a known yield provider", async () => {
@@ -930,7 +935,12 @@ describe("YieldManager contract - basic operations", () => {
 
       expect(await yieldManager.isYieldProviderKnown(mockYieldProviderAddress)).to.be.false;
       expect(await yieldManager.yieldProviderCount()).to.equal(0n);
-      expect(await yieldManager.yieldProviderByIndex(0)).to.equal(ZeroAddress);
+      await expectRevertWithCustomError(
+        yieldManager,
+        yieldManager.yieldProviderByIndex(0),
+        "YieldProviderIndexOutOfBounds",
+        [0n, 0n],
+      );
       await expectRevertWithCustomError(
         yieldManager,
         yieldManager.getYieldProviderData(mockYieldProviderAddress),
@@ -1000,6 +1010,12 @@ describe("YieldManager contract - basic operations", () => {
       expect(await yieldManager.isYieldProviderKnown(providerThree)).to.equal(true);
 
       expect(await yieldManager.yieldProviderCount()).equal(2n);
+      await expectRevertWithCustomError(
+        yieldManager,
+        yieldManager.yieldProviderByIndex(3),
+        "YieldProviderIndexOutOfBounds",
+        [3n, 2n],
+      );
     });
   });
 
@@ -1047,7 +1063,12 @@ describe("YieldManager contract - basic operations", () => {
 
       expect(await yieldManager.isYieldProviderKnown(mockYieldProviderAddress)).to.be.false;
       expect(await yieldManager.yieldProviderCount()).to.equal(0n);
-      expect(await yieldManager.yieldProviderByIndex(0)).to.equal(ZeroAddress);
+      await expectRevertWithCustomError(
+        yieldManager,
+        yieldManager.yieldProviderByIndex(0),
+        "YieldProviderIndexOutOfBounds",
+        [0n, 0n],
+      );
       await expectRevertWithCustomError(
         yieldManager,
         yieldManager.getYieldProviderData(mockYieldProviderAddress),


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces 1-based indexing with out-of-bounds revert in `yieldProviderByIndex` and updates unit tests to expect the new `YieldProviderIndexOutOfBounds` error.
> 
> - **Contracts**:
>   - `contracts/contracts/yield/YieldManager.sol`
>     - Add bounds check in `yieldProviderByIndex` and revert with `YieldProviderIndexOutOfBounds(_index, maxIndex)` when `_index == 0` or `_index >= length`.
> - **Tests**:
>   - `contracts/test/yield/unit/YieldManager.basic.ts`
>     - Update expectations to revert for index `0` and after provider removals.
>     - Add checks for out-of-range indices (e.g., index `3` when count is `2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b289dacfaa0bb0db6652f3849903c40649b94b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->