### PR TITLE
Test: Re-enable Bundle timeout acceptance tests in limitless mode

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/LineaPluginTestBase.java
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/java/linea/plugin/acc/test/LineaPluginTestBase.java
@@ -32,6 +32,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt32;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.ImmutableMiningConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
@@ -47,6 +48,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.NodeConfigur
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationFactory;
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationFactory.CliqueOptions;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.txpool.TxPoolTransactions;
+import org.hyperledger.besu.util.number.PositiveNumber;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.web3j.crypto.Credentials;
@@ -135,7 +137,19 @@ public abstract class LineaPluginTestBase extends AcceptanceTestBase {
     final var nodeConfBuilder =
         new BesuNodeConfigurationBuilder()
             .name(name)
-            .miningEnabled()
+            .miningConfiguration(
+                // enable mining
+                // allow for a single iteration to take all the slot time
+                // set plugin max selection time to 5% of slot time
+                ImmutableMiningConfiguration.builder()
+                    .poaBlockTxsSelectionMaxTime(
+                        PositiveNumber.fromInt(BLOCK_PERIOD_SECONDS * 1000))
+                    .pluginBlockTxsSelectionMaxTime(PositiveNumber.fromInt(5))
+                    .mutableInitValues(
+                        ImmutableMiningConfiguration.MutableInitValues.builder()
+                            .isMiningEnabled(true)
+                            .build())
+                    .build())
             .jsonRpcConfiguration(node.createJsonRpcWithCliqueEnabledConfig(extraRpcApis))
             .webSocketConfiguration(node.createWebSocketEnabledConfig())
             .inProcessRpcConfiguration(node.createInProcessRpcConfiguration(extraRpcApis))


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables and refactors bundle selection acceptance tests to run in limitless mode, adds log-based assertions, and configures mining selection timing via ImmutableMiningConfiguration.
> 
> - **Acceptance Tests (limitless mode)**:
>   - Re-enable `BundleSelectionTimeoutTest`; add CLI options (`--plugin-linea-module-limit-file-path`, `--plugin-linea-limitless-enabled`) and assert logs on `PLUGIN_SELECTION_TIMEOUT`.
>   - Update scenarios: reduce bundle sizes, ensure only first bundle mined; verify no receipts for non-selected txs.
> - **SendBundleTest**:
>   - Add same CLI options; replace prior overflow-based invalid tx with `ExcludedPrecompiles`-based tx via new `createInvalidTransaction` helper.
>   - Add/rename scenarios: `bundleWithFirstNotSelectedTxIsNotMined`, `bundleWithLastNotSelectedTxIsNotMined`; adjust nonces/params; assert specific failure reasons in logs (`TX_MODULE_LINE_COUNT_OVERFLOW`, `INVALID(NONCE_TOO_LOW)`).
> - **Node Config**:
>   - Replace `.miningEnabled()` with detailed `miningConfiguration` using `ImmutableMiningConfiguration` to set PoA and plugin tx selection max times and enable mining.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774233db237dc4ff5b7572254355ec4b85d95b28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->