### PR TITLE
N08 - move pendingPermissionlessUnstake decrement to receive function

### DIFF
--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -658,8 +658,6 @@ contract YieldManager is
 
   /**
    * @notice Helper function to withdraw from a yield provider and update state accordingly.
-   * @dev Any withdrawals from the YieldProvider will greedily decrement `pendingPermissionlessUnstake` on the assumption
-   *      that the requested withdrawl has arrived at a YieldProvider.
    * @param _yieldProvider The yield provider address.
    * @param _amount Amount to withdraw.
    */
@@ -671,8 +669,6 @@ contract YieldManager is
     );
     $$.userFunds -= _amount;
     _getYieldManagerStorage().userFundsInYieldProvidersTotal -= _amount;
-    // Greedily reduce pendingPermissionlessUnstake with every withdrawal made from the yield provider.
-    _decrementPendingPermissionlessUnstake(_amount);
   }
 
   /**
@@ -955,7 +951,12 @@ contract YieldManager is
   }
 
   /// @notice Function to receive a basic ETH transfer.
-  receive() external payable {}
+  /// @dev Any withdrawals from the YieldProvider will greedily decrement `pendingPermissionlessUnstake` on the assumption
+  ///      that the requested withdrawal has arrived at a YieldProvider.
+  receive() external payable {
+    // Greedily reduce pendingPermissionlessUnstake with every donation or YieldProvider withdrawal.
+    _decrementPendingPermissionlessUnstake(msg.value);
+  }
 
   /**
    * @notice Register a new YieldProvider adaptor instance.

--- a/contracts/test/yield/integration/YieldManager.integration.ts
+++ b/contracts/test/yield/integration/YieldManager.integration.ts
@@ -525,7 +525,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
     });
   });
 
-  describe("Multiple yield providers", () => {
+  describe("unstakePermissionless", () => {
     it("Unstake permissionless cap should be shared globally across all yield providers", async () => {
       // Arrange - add additional yield provider
       const { yieldProviderAddress: yieldProvider2Address, mockStakingVaultAddress: mockStakingVault2Address } =
@@ -585,6 +585,40 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
         call,
         "PermissionlessUnstakeRequestPlusAvailableFundsExceedsTargetDeficit",
       );
+    });
+    it("Should decrement pendingPermissionlessUnstake on withdrawal from YieldProvider", async () => {
+      // Arrange - Prepare first unstakePermissionless
+      const targetDeficit = await yieldManager.getTargetReserveDeficit();
+      const { validatorWitness, pubkey } = await generateLidoUnstakePermissionlessWitness(
+        sszMerkleTree,
+        testVerifier,
+        mockStakingVaultAddress,
+        MAX_0X2_VALIDATOR_EFFECTIVE_BALANCE_GWEI,
+      );
+      const refundAddress = nativeYieldOperator.address;
+      const unstakeAmount = [targetDeficit / ONE_GWEI];
+      const withdrawalParams = ethers.AbiCoder.defaultAbiCoder().encode(
+        ["bytes", "uint64[]", "address"],
+        [pubkey, unstakeAmount, refundAddress],
+      );
+      const withdrawalParamsProof = ethers.AbiCoder.defaultAbiCoder().encode(
+        [VALIDATOR_WITNESS_TYPE],
+        [validatorWitness],
+      );
+      // Arrange - first unstake
+      await yieldManager.unstakePermissionless(yieldProviderAddress, withdrawalParams, withdrawalParamsProof);
+      expect(await yieldManager.pendingPermissionlessUnstake()).eq(targetDeficit);
+
+      // Arrange - setup user funds
+      const initialFundAmount = ONE_ETHER * 10n;
+      await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, initialFundAmount);
+
+      // Act
+      await mockDashboard.setWithdrawableValueReturn(ONE_ETHER);
+      await yieldManager.connect(nativeYieldOperator).safeWithdrawFromYieldProvider(yieldProviderAddress, ONE_ETHER);
+
+      // Assert
+      expect(await yieldManager.pendingPermissionlessUnstake()).eq(targetDeficit - ONE_ETHER);
     });
   });
 

--- a/contracts/test/yield/unit/YieldManager.basic.ts
+++ b/contracts/test/yield/unit/YieldManager.basic.ts
@@ -48,6 +48,12 @@ describe("YieldManager contract - basic operations", () => {
     it("Should successfully accept ETH via receive() fn", async () => {
       await expect(sendEthToContract(EMPTY_CALLDATA)).to.not.be.reverted;
     });
+
+    it("Should decrement pendingPermissionlessUnstake when ETH is received", async () => {
+      await yieldManager.setPendingPermissionlessUnstake(MINIMUM_FEE);
+      await expect(sendEthToContract(EMPTY_CALLDATA)).to.not.be.reverted;
+      expect(await yieldManager.pendingPermissionlessUnstake()).to.equal(ZERO_VALUE);
+    });
   });
 
   describe("Constructor", () => {


### PR DESCRIPTION
- Move _decrementPendingPermissionlessUnstake call from _delegatecallWithdrawFromYieldProvider to receive()
- This ensures pendingPermissionlessUnstake is decremented whenever ETH arrives, not just during explicit withdrawals
- Update comments to reflect that withdrawals decrement via receive() function
- Add integration test to verify pendingPermissionlessUnstake decrements on withdrawal
- Add unit test to verify pendingPermissionlessUnstake decrements when ETH is received

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move pendingPermissionlessUnstake decrement from provider withdrawal path to the contract receive() so it reduces on any incoming ETH; add tests verifying behavior.
> 
> - **Contracts (`contracts/contracts/yield/YieldManager.sol`)**:
>   - Route pending permissionless unstake reduction to `receive()` by calling `_decrementPendingPermissionlessUnstake(msg.value)`.
>   - Remove `_decrementPendingPermissionlessUnstake` call from `_delegatecallWithdrawFromYieldProvider`.
>   - Update receive function docs/comments accordingly.
> - **Tests**:
>   - **Integration (`contracts/test/yield/integration/YieldManager.integration.ts`)**:
>     - Add case asserting `pendingPermissionlessUnstake` decreases after `safeWithdrawFromYieldProvider` (via `receive`).
>     - Reorganize/rename describe block around `unstakePermissionless`.
>   - **Unit (`contracts/test/yield/unit/YieldManager.basic.ts`)**:
>     - Add test verifying `pendingPermissionlessUnstake` is decremented when ETH is received by `receive()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50af7a91423872c2214f721472a543d86e1d9999. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->