### PR TITLE
[Self finding] Avoid StakingVault.unstage(0)

### DIFF
--- a/contracts/contracts/yield/LidoStVaultYieldProvider.sol
+++ b/contracts/contracts/yield/LidoStVaultYieldProvider.sol
@@ -492,8 +492,11 @@ contract LidoStVaultYieldProvider is YieldProviderBase, IGenericErrors {
       // Ossify
       vault.ossify();
       // Unstage all ETH
-      vault.setDepositor(address(this));
-      vault.unstage(vault.stagedBalance());
+      uint256 stagedBalance = vault.stagedBalance();
+      if (stagedBalance > 0) {
+        vault.setDepositor(address(this));
+        vault.unstage(stagedBalance);
+      }
       progressOssificationResult = ProgressOssificationResult.COMPLETE;
     } else if (VAULT_HUB.isPendingDisconnect(address(vault))) {
       // No-op, needs accounting report to progress.


### PR DESCRIPTION
Add guard check to prevent unnecessary setDepositor and unstage calls when vault staged balance is zero during ossification completion. This optimizes gas usage and avoids unnecessary state changes.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard progressPendingOssification to only setDepositor and unstage when stagedBalance > 0, avoiding unstage(0).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc1523b931d2f30330900577f5c4b0d78e30b946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->