### PR TITLE
Removing geth init

### DIFF
--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -83,16 +83,6 @@ services:
       - "--config"
       - "/opt/consensys/maru/configs/maru-config.toml"
 
-  # Geth initialization
-  geth-init:
-    image: ethereum/client-go:v1.16.7
-    command:
-      - init
-      - /genesis.json
-    volumes:
-      - ./geth/geth-genesis.json:/genesis.json:ro
-      - linea-mainnet-geth:/root/.ethereum
-
   # Geth node
   geth-node:
     hostname: el-client
@@ -101,11 +91,7 @@ services:
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s
-    depends_on:
-      geth-init:
-        condition: service_completed_successfully
     command:
-      - --networkid=59144
       - --syncmode=snap
       - --http
       - --http.addr=0.0.0.0
@@ -120,6 +106,7 @@ services:
       - --authrpc.port=8550
       - --authrpc.vhosts=*
       - --authrpc.jwtsecret=/root/.ethereum/jwt
+      - --override.genesis=/genesis.json
     ports:
       - 30303:30303
       - 30303:30303/udp

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -81,16 +81,6 @@ services:
       - "--config"
       - "/opt/consensys/maru/configs/maru-config.toml"
 
-  # Geth initialization
-  geth-init:
-    image: ethereum/client-go:v1.16.7
-    command:
-      - init
-      - /genesis.json
-    volumes:
-      - ./geth/geth-genesis.json:/genesis.json:ro
-      - linea-sepolia-geth:/root/.ethereum
-
   # Geth node
   geth-node:
     hostname: el-client
@@ -99,11 +89,7 @@ services:
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s
-    depends_on:
-      geth-init:
-        condition: service_completed_successfully
     command:
-      - --networkid=59141
       - --syncmode=snap
       - --http
       - --http.addr=0.0.0.0
@@ -118,6 +104,7 @@ services:
       - --authrpc.port=8550
       - --authrpc.vhosts=*
       - --authrpc.jwtsecret=/root/.ethereum/jwt
+      - --override.genesis=/genesis.json
     ports:
       - 30303:30303
       - 30303:30303/udp


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies Geth setup by removing the init service and networkid, and passing the genesis via --override.genesis in both linea-mainnet and linea-sepolia docker-compose files.
> 
> - **Docker Compose (linea-mainnet & linea-sepolia)**:
>   - Remove `geth-init` service and `geth-node` `depends_on`.
>   - Drop `--networkid` from `geth-node` command.
>   - Add `--override.genesis=/genesis.json` to `geth-node` command.
>   - Keep existing ports, volumes (including `geth-genesis.json` and JWT), and bootnodes unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27da8803d4ff76f22c76f781aef92e9fe73bb393. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->