### PR TITLE
coordinator: fix regression o block creation monitor

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitor.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitor.kt
@@ -111,7 +111,6 @@ class BlockCreationMonitor(
             _nexBlockNumberToFetch.get() - lastProvenBlockNumber,
             config.blocksFetchLimit,
           )
-          this.stop()
           SafeFuture.COMPLETE
         } else if (config.lastL2BlockNumberToProcessInclusive != null &&
           nexBlockNumberToFetch.toULong() > config.lastL2BlockNumberToProcessInclusive

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitorTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitorTest.kt
@@ -79,12 +79,12 @@ class BlockCreationMonitorTest {
     config: BlockCreationMonitor.Config = this.config,
   ): BlockCreationMonitor {
     return BlockCreationMonitor(
-      this.vertx,
-      ethApiClient,
+      vertx = this.vertx,
+      ethApi = ethApiClient,
       startingBlockNumberExclusive = startingBlockNumberExclusive,
-      blockCreationListener,
-      lastProvenBlockNumberProvider,
-      config,
+      blockCreationListener = blockCreationListener,
+      lastProvenBlockNumberProviderAsync = lastProvenBlockNumberProvider,
+      config = config,
     )
   }
 
@@ -394,6 +394,9 @@ class BlockCreationMonitorTest {
     assertThat(blockCreationListener.blocksReceived.last().number).isEqualTo(110UL)
 
     // simulate prover catchup
+    // wait a bit to ensure next monitor tick happens
+    // and it was not stopped
+    Thread.sleep(1000)
     lastProvenBlockNumberProvider.lastProvenBlock.set(120)
 
     // assert it resumes conflation


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> BlockCreationMonitor no longer stops when the gap exceeds the fetch limit; it logs and pauses, allowing automatic resume once the prover catches up, with tests updated accordingly.
> 
> - **Coordinator**:
>   - **BlockCreationMonitor**: On gap overflow between last proven and next L2 block, log and return without stopping (`stop()` removed in this path), enabling automatic resume when the prover catches up.
> - **Tests**:
>   - Update `createBlockCreationMonitor` to use named parameters (`ethApi`, `lastProvenBlockNumberProviderAsync`).
>   - Enhance gap-overflow test to ensure the monitor doesn’t stop and resumes after prover catchup (added small delay and assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd69666cad58813fdd2e45bac82127b5f1fba0f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->