### PR TITLE
M07-add-reentrancy-guard

### DIFF
--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -11,6 +11,7 @@ import { ErrorUtils } from "../lib/ErrorUtils.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { PermissionsManager } from "../lib/PermissionsManager.sol";
 import { ProgressOssificationResult, YieldProviderRegistration } from "./interfaces/YieldTypes.sol";
+import { TransientStorageReentrancyGuardUpgradeable } from "../messageService/l1/TransientStorageReentrancyGuardUpgradeable.sol";
 
 /**
  * @title Contract to handle native yield operations.
@@ -23,6 +24,7 @@ contract YieldManager is
   YieldManagerPauseManager,
   PermissionsManager,
   YieldManagerStorageLayout,
+  TransientStorageReentrancyGuardUpgradeable,
   IYieldManager
 {
   /// @notice The role required to send ETH to a yield provider.
@@ -584,6 +586,7 @@ contract YieldManager is
     whenTypeAndGeneralNotPaused(PauseType.NATIVE_YIELD_PERMISSIONLESS_ACTIONS)
     onlyKnownYieldProvider(_yieldProvider)
     onlyWhenWithdrawalReserveInDeficit
+    nonReentrant
     returns (uint256 maxUnstakeAmount)
   {
     bytes memory data = _delegatecallYieldProvider(
@@ -755,6 +758,7 @@ contract YieldManager is
     whenTypeAndGeneralNotPaused(PauseType.NATIVE_YIELD_PERMISSIONLESS_ACTIONS)
     onlyKnownYieldProvider(_yieldProvider)
     onlyWhenWithdrawalReserveInDeficit
+    nonReentrant
   {
     uint256 targetDeficit = getTargetReserveDeficit();
 


### PR DESCRIPTION
Add TransientStorageReentrancyGuardUpgradeable inheritance and apply nonReentrant modifier to unstakeNativeYield and unstakeNativeYieldWithTargetDeficit to prevent reentrancy attacks.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TransientStorageReentrancyGuardUpgradeable and applies nonReentrant to `unstakePermissionless` and `replenishWithdrawalReserve` in `contracts/contracts/yield/YieldManager.sol`.
> 
> - **Contracts**
>   - **Security hardening** in `contracts/contracts/yield/YieldManager.sol`:
>     - Inherit from `TransientStorageReentrancyGuardUpgradeable`.
>     - Add `nonReentrant` to `unstakePermissionless(...)` and `replenishWithdrawalReserve(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee9c6399d70797a7796e4f1f12a6bd0227fc971a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->