### PR TITLE
feat: add ssl option to postman db options

### DIFF
--- a/postman/scripts/runPostman.ts
+++ b/postman/scripts/runPostman.ts
@@ -153,6 +153,14 @@ async function main() {
       username: process.env.POSTGRES_USER ?? "postgres",
       password: process.env.POSTGRES_PASSWORD ?? "postgres",
       database: process.env.POSTGRES_DB ?? "postman_db",
+      ...(process.env.POSTGRES_SSL === "true"
+        ? {
+            ssl: {
+              rejectUnauthorized: process.env.POSTGRES_SSL_REJECT_UNAUTHORIZED === "true",
+              ca: process.env.POSTGRES_SSL_CA_PATH ?? undefined,
+            },
+          }
+        : {}),
     },
     databaseCleanerOptions: {
       enabled: process.env.DB_CLEANER_ENABLED === "true",

--- a/postman/src/application/postman/persistence/dataSource.ts
+++ b/postman/src/application/postman/persistence/dataSource.ts
@@ -1,5 +1,6 @@
 import { DataSource } from "typeorm";
 import { SnakeNamingStrategy } from "typeorm-naming-strategies";
+import fs from "fs";
 import { InitialDatabaseSetup1685985945638 } from "./migrations/1685985945638-InitialDatabaseSetup";
 import { AddNewColumns1687890326970 } from "./migrations/1687890326970-AddNewColumns";
 import { UpdateStatusColumn1687890694496 } from "./migrations/1687890694496-UpdateStatusColumn";
@@ -30,6 +31,14 @@ export class DB {
       migrationsTableName: "migrations",
       logging: ["error"],
       migrationsRun: true,
+      ...(config.type === "postgres" && typeof config.ssl === "object"
+        ? {
+            ssl: {
+              rejectUnauthorized: config.ssl.rejectUnauthorized,
+              ca: typeof config.ssl.ca === "string" ? fs.readFileSync(config.ssl.ca).toString() : undefined,
+            },
+          }
+        : {}),
     });
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional SSL support for Postgres by wiring env-based SSL options in `runPostman.ts` and applying them in the TypeORM `DataSource` with CA file loading.
> 
> - **Database (Postman)**
>   - **Config inputs** (`postman/scripts/runPostman.ts`):
>     - Add optional `ssl` block to `databaseOptions` when `POSTGRES_SSL === "true"`, supporting `rejectUnauthorized` and `ca` via `POSTGRES_SSL_REJECT_UNAUTHORIZED` and `POSTGRES_SSL_CA_PATH`.
>   - **TypeORM setup** (`postman/src/application/postman/persistence/dataSource.ts`):
>     - When `config.ssl` is provided, pass `ssl.rejectUnauthorized` and load `ssl.ca` from file path (if string) using `fs.readFileSync`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a508bc14c25c22f9534cdaa65c5aaf3e5efc4f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->