### PR TITLE
fix: add block range options for events in postman

### DIFF
--- a/postman/src/core/clients/blockchain/ethereum/ILineaRollupClient.ts
+++ b/postman/src/core/clients/blockchain/ethereum/ILineaRollupClient.ts
@@ -21,9 +21,13 @@ export interface ILineaRollupClient<
   getMessageSiblings(messageHash: string, messageHashes: string[], treeDepth: number): string[];
   getMessageProof(messageHash: string): Promise<Proof>;
   getMessageStatusUsingMessageHash(messageHash: string, overrides: Overrides): Promise<OnChainMessageStatus>;
-  getMessageStatusUsingMerkleTree(messageHash: string, overrides: Overrides): Promise<OnChainMessageStatus>;
+  getMessageStatusUsingMerkleTree(params: {
+    messageHash: string;
+    messageBlockNumber?: number;
+    overrides?: Overrides;
+  }): Promise<OnChainMessageStatus>;
   estimateClaimGas(
-    message: (MessageSent | MessageProps) & { feeRecipient?: string },
+    message: (MessageSent | MessageProps) & { feeRecipient?: string; messageBlockNumber?: number },
     opts?: {
       claimViaAddress?: string;
       overrides?: Overrides;

--- a/postman/src/core/services/contracts/IMessageServiceContract.ts
+++ b/postman/src/core/services/contracts/IMessageServiceContract.ts
@@ -8,12 +8,16 @@ export interface IMessageServiceContract<
   ContractTransactionResponse,
   ErrorDescription,
 > {
-  getMessageStatus(messageHash: string, overrides?: Overrides): Promise<OnChainMessageStatus>;
+  getMessageStatus(params: {
+    messageHash: string;
+    messageBlockNumber?: number;
+    overrides?: Overrides;
+  }): Promise<OnChainMessageStatus>;
   getMessageByMessageHash(messageHash: string): Promise<MessageSent | null>;
   getMessagesByTransactionHash(transactionHash: string): Promise<MessageSent[] | null>;
   getTransactionReceiptByMessageHash(messageHash: string): Promise<TransactionReceipt | null>;
   claim(
-    message: (MessageSent | MessageProps) & { feeRecipient?: string },
+    message: (MessageSent | MessageProps) & { feeRecipient?: string; messageBlockNumber?: number },
     opts?: {
       claimViaAddress?: string;
       overrides?: Overrides;

--- a/postman/src/services/EthereumTransactionValidationService.ts
+++ b/postman/src/services/EthereumTransactionValidationService.ts
@@ -71,6 +71,7 @@ export class EthereumTransactionValidationService implements ITransactionValidat
         {
           ...message,
           feeRecipient,
+          messageBlockNumber: message.sentBlockNumber,
         },
         { claimViaAddress },
       ),

--- a/postman/src/services/processors/MessageAnchoringProcessor.ts
+++ b/postman/src/services/processors/MessageAnchoringProcessor.ts
@@ -59,7 +59,7 @@ export class MessageAnchoringProcessor implements IMessageAnchoringProcessor {
    *
    * @returns {Promise<void>} A promise that resolves when the processing is complete.
    */
-  public async process() {
+  public async process(): Promise<void> {
     try {
       const messages = await this.databaseService.getNFirstMessagesSent(
         this.maxFetchMessagesFromDb,
@@ -77,8 +77,10 @@ export class MessageAnchoringProcessor implements IMessageAnchoringProcessor {
       const latestBlockNumber = await this.provider.getBlockNumber();
 
       for (const message of messages) {
-        const messageStatus = await this.contractClient.getMessageStatus(message.messageHash, {
-          blockTag: latestBlockNumber,
+        const messageStatus = await this.contractClient.getMessageStatus({
+          messageHash: message.messageHash,
+          messageBlockNumber: message.sentBlockNumber,
+          overrides: { blockTag: latestBlockNumber },
         });
 
         if (messageStatus === OnChainMessageStatus.CLAIMABLE) {

--- a/postman/src/services/processors/MessageClaimingPersister.ts
+++ b/postman/src/services/processors/MessageClaimingPersister.ts
@@ -107,6 +107,7 @@ export class MessageClaimingPersister implements IMessageClaimingPersister {
         const retryTransactionReceipt = await this.retryTransaction(
           firstPendingMessage.claimTxHash,
           firstPendingMessage.messageHash,
+          firstPendingMessage.sentBlockNumber,
         );
         if (!retryTransactionReceipt) return;
         const receiptReceivedAt = new Date();
@@ -135,10 +136,16 @@ export class MessageClaimingPersister implements IMessageClaimingPersister {
    * @param {string} messageHash - The hash of the message associated with the transaction.
    * @returns {Promise<TransactionReceipt | null>} The receipt of the retried transaction, or null if the retry was unsuccessful.
    */
-  private async retryTransaction(transactionHash: string, messageHash: string): Promise<TransactionReceipt | null> {
+  private async retryTransaction(
+    transactionHash: string,
+    messageHash: string,
+    messageBlockNumber: number,
+  ): Promise<TransactionReceipt | null> {
     try {
-      const messageStatus = await this.messageServiceContract.getMessageStatus(messageHash, {
-        blockTag: "latest",
+      const messageStatus = await this.messageServiceContract.getMessageStatus({
+        messageHash,
+        messageBlockNumber,
+        overrides: { blockTag: "latest" },
       });
 
       if (messageStatus === OnChainMessageStatus.CLAIMED) {

--- a/postman/src/services/processors/MessageClaimingProcessor.ts
+++ b/postman/src/services/processors/MessageClaimingProcessor.ts
@@ -77,7 +77,10 @@ export class MessageClaimingProcessor implements IMessageClaimingProcessor {
         return;
       }
 
-      const messageStatus = await this.messageServiceContract.getMessageStatus(nextMessageToClaim.messageHash);
+      const messageStatus = await this.messageServiceContract.getMessageStatus({
+        messageHash: nextMessageToClaim.messageHash,
+        messageBlockNumber: nextMessageToClaim.sentBlockNumber,
+      });
 
       if (messageStatus === OnChainMessageStatus.CLAIMED) {
         this.logger.info("Found already claimed message: messageHash=%s", nextMessageToClaim.messageHash);
@@ -173,6 +176,7 @@ export class MessageClaimingProcessor implements IMessageClaimingProcessor {
         {
           ...message,
           feeRecipient: this.config.feeRecipientAddress,
+          messageBlockNumber: message.sentBlockNumber,
         },
         {
           claimViaAddress: this.config.claimViaAddress,

--- a/sdk/sdk-ethers/src/clients/ethereum/L1ClaimingService.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/L1ClaimingService.ts
@@ -196,7 +196,7 @@ export class L1ClaimingService {
     messageHash: string,
     overrides: Overrides = {},
   ): Promise<OnChainMessageStatus> {
-    return this.l1ContractClient.getMessageStatusUsingMerkleTree(messageHash, overrides);
+    return this.l1ContractClient.getMessageStatusUsingMerkleTree({ messageHash, overrides });
   }
 
   /**

--- a/sdk/sdk-ethers/src/clients/ethereum/LineaRollupClient.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/LineaRollupClient.ts
@@ -137,10 +137,11 @@ export class LineaRollupClient
   /**
    * Retrieves the message proof for claiming the message on L1.
    * @param {string} messageHash - The message hash.
+   * @param {number} messageBlockNumber - The L2 block number where the message was sent. Defaults to `undefined`.
    * @returns {Promise<Proof>} The merkle root, the merkle proof and the message leaf index.
    */
-  public async getMessageProof(messageHash: string): Promise<Proof> {
-    return this.merkleTreeService.getMessageProof(messageHash);
+  public async getMessageProof(messageHash: string, messageBlockNumber?: number): Promise<Proof> {
+    return this.merkleTreeService.getMessageProof(messageHash, messageBlockNumber);
   }
 
   public async getGasFees(): Promise<GasFees> {
@@ -195,25 +196,39 @@ export class LineaRollupClient
 
   /**
    * Retrieves the L2 message status on L1.
-   * @param {string} messageHash - The hash of the message sent on L2.
-   * @param {Overrides} [overrides={}] - Ethers call overrides. Defaults to `{}` if not specified.
+   * @param {string} params - The parameters object.
+   * @param {string} params.messageHash - The hash of the message sent on L2.
+   * @param {number} [params.messageBlockNumber] - The L2 block number where the message was sent. Defaults to `undefined`.
+   * @param {Overrides} [params.overrides={}] - Ethers call overrides. Defaults to `{}` if not specified.
    * @returns {Promise<OnChainMessageStatus>} The message status (CLAIMED, CLAIMABLE, UNKNOWN).
    */
-  public async getMessageStatus(messageHash: string, overrides: Overrides = {}): Promise<OnChainMessageStatus> {
-    return this.getMessageStatusUsingMerkleTree(messageHash, overrides);
+  public async getMessageStatus(params: {
+    messageHash: string;
+    messageBlockNumber?: number;
+    overrides?: Overrides;
+  }): Promise<OnChainMessageStatus> {
+    const { messageHash, messageBlockNumber, overrides = {} } = params;
+    return this.getMessageStatusUsingMerkleTree({ messageHash, messageBlockNumber, overrides });
   }
 
   /**
    * Retrieves the L2 message status on L1 using merkle tree (for messages sent after migration).
    * @param {string} messageHash - The hash of the message sent on L2.
+   * @param {number} [messageBlockNumber] - The L2 block number where the message was sent. Defaults to `undefined`.
    * @param {Overrides} [overrides={}] - Ethers call overrides. Defaults to `{}` if not specified.
    * @returns {Promise<OnChainMessageStatus>} The message status (CLAIMED, CLAIMABLE, UNKNOWN).
    */
-  public async getMessageStatusUsingMerkleTree(
-    messageHash: string,
-    overrides: Overrides = {},
-  ): Promise<OnChainMessageStatus> {
-    const [messageEvent] = await this.l2MessageServiceLogClient.getMessageSentEventsByMessageHash({ messageHash });
+  public async getMessageStatusUsingMerkleTree(params: {
+    messageHash: string;
+    messageBlockNumber?: number;
+    overrides?: Overrides;
+  }): Promise<OnChainMessageStatus> {
+    const { messageHash, messageBlockNumber, overrides = {} } = params;
+    const [messageEvent] = await this.l2MessageServiceLogClient.getMessageSentEventsByMessageHash({
+      messageHash,
+      fromBlock: messageBlockNumber,
+      toBlock: messageBlockNumber,
+    });
 
     if (!messageEvent) {
       throw makeBaseError(`Message hash does not exist on L2. Message hash: ${messageHash}`);
@@ -317,12 +332,12 @@ export class LineaRollupClient
 
   /**
    * Estimates the gas required for the claimMessageWithProof transaction.
-   * @param {Message & { feeRecipient?: string }} message - The message information.
+   * @param {Message & { feeRecipient?: string; messageBlockNumber?: number }} message - The message information.
    * @param {Overrides} [opts={}] - Claiming options and Ethers payable overrides. Defaults to `{}` if not specified.
    * @returns {Promise<bigint>} The estimated gas.
    */
   public async estimateClaimGas(
-    message: Message & { feeRecipient?: string },
+    message: Message & { feeRecipient?: string; messageBlockNumber?: number },
     opts: {
       claimViaAddress?: string;
       overrides?: Overrides;
@@ -334,7 +349,10 @@ export class LineaRollupClient
 
     const { messageSender, destination, fee, value, calldata, messageNonce, feeRecipient } = message;
 
-    const { proof, leafIndex, root } = await this.merkleTreeService.getMessageProof(message.messageHash);
+    const { proof, leafIndex, root } = await this.merkleTreeService.getMessageProof(
+      message.messageHash,
+      message.messageBlockNumber,
+    );
 
     const l1FeeRecipient = feeRecipient ?? ZERO_ADDRESS;
 
@@ -367,12 +385,12 @@ export class LineaRollupClient
 
   /**
    * Claims the message using merkle proof on L1.
-   * @param {Message & { feeRecipient?: string }} message - The message information.
+   * @param {Message & { feeRecipient?: string; messageBlockNumber?: number }} message - The message information.
    * @param {Overrides} [opts={}] - Claiming options and Ethers payable overrides. Defaults to `{}` if not specified.
    * @returns {Promise<ContractTransactionResponse>} The transaction response.
    */
   public async claim(
-    message: Message & { feeRecipient?: string },
+    message: Message & { feeRecipient?: string; messageBlockNumber?: number },
     opts: {
       claimViaAddress?: string;
       overrides?: Overrides;
@@ -386,7 +404,10 @@ export class LineaRollupClient
 
     const l1FeeRecipient = feeRecipient ?? ZERO_ADDRESS;
 
-    const { proof, leafIndex, root } = await this.merkleTreeService.getMessageProof(message.messageHash);
+    const { proof, leafIndex, root } = await this.merkleTreeService.getMessageProof(
+      message.messageHash,
+      message.messageBlockNumber,
+    );
 
     const claimingContract = opts.claimViaAddress ? this.getContract(opts.claimViaAddress, this.signer) : this.contract;
 

--- a/sdk/sdk-ethers/src/clients/ethereum/MerkleTreeService.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/MerkleTreeService.ts
@@ -50,8 +50,12 @@ export class MerkleTreeService implements IMerkleTreeService {
    * @param {string} messageHash - The message hash.
    * @returns {Promise<Proof>} The merkle root, the merkle proof and the message leaf index.
    */
-  public async getMessageProof(messageHash: string): Promise<Proof> {
-    const [messageEvent] = await this.l2MessageServiceLogClient.getMessageSentEventsByMessageHash({ messageHash });
+  public async getMessageProof(messageHash: string, messageBlockNumber?: number): Promise<Proof> {
+    const [messageEvent] = await this.l2MessageServiceLogClient.getMessageSentEventsByMessageHash({
+      messageHash,
+      fromBlock: messageBlockNumber,
+      toBlock: messageBlockNumber,
+    });
 
     if (!messageEvent) {
       throw makeBaseError(`Message hash does not exist on L2. Message hash: ${messageHash}`);

--- a/sdk/sdk-ethers/src/clients/ethereum/__tests__/LineaRollupClient.test.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/__tests__/LineaRollupClient.test.ts
@@ -129,7 +129,7 @@ describe("TestLineaRollupClient", () => {
       jest.spyOn(lineaRollupLogClient, "getL2MessagingBlockAnchoredEvents").mockResolvedValue([]);
       jest.spyOn(lineaRollupMock, "isMessageClaimed").mockResolvedValue(false);
 
-      const messageStatus = await lineaRollupClient.getMessageStatus(TEST_MESSAGE_HASH);
+      const messageStatus = await lineaRollupClient.getMessageStatus({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.UNKNOWN);
     });
@@ -143,7 +143,7 @@ describe("TestLineaRollupClient", () => {
         .mockResolvedValue([testL2MessagingBlockAnchoredEvent]);
       jest.spyOn(lineaRollupMock, "isMessageClaimed").mockResolvedValue(false);
 
-      const messageStatus = await lineaRollupClient.getMessageStatus(TEST_MESSAGE_HASH);
+      const messageStatus = await lineaRollupClient.getMessageStatus({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.CLAIMABLE);
     });
@@ -155,7 +155,7 @@ describe("TestLineaRollupClient", () => {
       jest.spyOn(lineaRollupLogClient, "getL2MessagingBlockAnchoredEvents").mockResolvedValue([]);
       jest.spyOn(lineaRollupMock, "isMessageClaimed").mockResolvedValue(true);
 
-      const messageStatus = await lineaRollupClient.getMessageStatus(TEST_MESSAGE_HASH);
+      const messageStatus = await lineaRollupClient.getMessageStatus({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.CLAIMED);
     });
@@ -165,9 +165,9 @@ describe("TestLineaRollupClient", () => {
     it("should throw error when the corresponding message sent event was not found on L2", async () => {
       jest.spyOn(l2MessageServiceLogClient, "getMessageSentEventsByMessageHash").mockResolvedValue([]);
 
-      await expect(lineaRollupClient.getMessageStatusUsingMerkleTree(TEST_MESSAGE_HASH)).rejects.toThrow(
-        new BaseError(`Message hash does not exist on L2. Message hash: ${TEST_MESSAGE_HASH}`),
-      );
+      await expect(
+        lineaRollupClient.getMessageStatusUsingMerkleTree({ messageHash: TEST_MESSAGE_HASH }),
+      ).rejects.toThrow(new BaseError(`Message hash does not exist on L2. Message hash: ${TEST_MESSAGE_HASH}`));
     });
 
     it("should return UNKNOWN when l2MessagingBlockAnchoredEvent is absent and isMeessageClaimed return false", async () => {
@@ -177,7 +177,7 @@ describe("TestLineaRollupClient", () => {
       jest.spyOn(lineaRollupLogClient, "getL2MessagingBlockAnchoredEvents").mockResolvedValue([]);
       jest.spyOn(lineaRollupMock, "isMessageClaimed").mockResolvedValue(false);
 
-      const messageStatus = await lineaRollupClient.getMessageStatusUsingMerkleTree(TEST_MESSAGE_HASH);
+      const messageStatus = await lineaRollupClient.getMessageStatusUsingMerkleTree({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.UNKNOWN);
     });
@@ -191,7 +191,7 @@ describe("TestLineaRollupClient", () => {
         .mockResolvedValue([testL2MessagingBlockAnchoredEvent]);
       jest.spyOn(lineaRollupMock, "isMessageClaimed").mockResolvedValue(false);
 
-      const messageStatus = await lineaRollupClient.getMessageStatusUsingMerkleTree(TEST_MESSAGE_HASH);
+      const messageStatus = await lineaRollupClient.getMessageStatusUsingMerkleTree({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.CLAIMABLE);
     });
@@ -203,7 +203,7 @@ describe("TestLineaRollupClient", () => {
       jest.spyOn(lineaRollupLogClient, "getL2MessagingBlockAnchoredEvents").mockResolvedValue([]);
       jest.spyOn(lineaRollupMock, "isMessageClaimed").mockResolvedValue(true);
 
-      const messageStatus = await lineaRollupClient.getMessageStatusUsingMerkleTree(TEST_MESSAGE_HASH);
+      const messageStatus = await lineaRollupClient.getMessageStatusUsingMerkleTree({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.CLAIMED);
     });

--- a/sdk/sdk-ethers/src/clients/linea/L2MessageServiceClient.ts
+++ b/sdk/sdk-ethers/src/clients/linea/L2MessageServiceClient.ts
@@ -120,11 +120,13 @@ export class L2MessageServiceClient
   /**
    * Retrieves the L1 message status on L2.
    *
-   * @param {string} messageHash - The hash of the message sent on L1.
-   * @param {Overrides} [overrides={}] - Ethers call overrides. Defaults to `{}` if not specified.
+   * @param {Object} params - The parameters for retrieving the message status.
+   * @param {string} params.messageHash - The hash of the L1 message.
+   * @param {Overrides} [params.overrides={}] - Ethers call overrides. Defaults to `{}` if not specified.
    * @returns {Promise<OnChainMessageStatus>} Message status (CLAIMED, CLAIMABLE, UNKNOWN).
    */
-  public async getMessageStatus(messageHash: string, overrides: Overrides = {}): Promise<OnChainMessageStatus> {
+  public async getMessageStatus(params: { messageHash: string; overrides?: Overrides }): Promise<OnChainMessageStatus> {
+    const { messageHash, overrides = {} } = params;
     const status = await this.contract.inboxL1L2MessageStatus(messageHash, overrides);
     return formatMessageStatus(status);
   }

--- a/sdk/sdk-ethers/src/clients/linea/__tests__/L2MessageServiceClient.test.ts
+++ b/sdk/sdk-ethers/src/clients/linea/__tests__/L2MessageServiceClient.test.ts
@@ -64,7 +64,7 @@ describe("TestL2MessageServiceClient", () => {
     it("should return UNKNOWN when on chain message status === 0", async () => {
       jest.spyOn(l2MessageServiceMock, "inboxL1L2MessageStatus").mockResolvedValue(0n);
 
-      const messageStatus = await l2MessageServiceClient.getMessageStatus(TEST_MESSAGE_HASH);
+      const messageStatus = await l2MessageServiceClient.getMessageStatus({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.UNKNOWN);
     });
@@ -72,7 +72,7 @@ describe("TestL2MessageServiceClient", () => {
     it("should return CLAIMABLE when on chain message status === 1", async () => {
       jest.spyOn(l2MessageServiceMock, "inboxL1L2MessageStatus").mockResolvedValue(1n);
 
-      const messageStatus = await l2MessageServiceClient.getMessageStatus(TEST_MESSAGE_HASH);
+      const messageStatus = await l2MessageServiceClient.getMessageStatus({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.CLAIMABLE);
     });
@@ -80,7 +80,7 @@ describe("TestL2MessageServiceClient", () => {
     it("should return CLAIMED when on chain message status === 2", async () => {
       jest.spyOn(l2MessageServiceMock, "inboxL1L2MessageStatus").mockResolvedValue(2n);
 
-      const messageStatus = await l2MessageServiceClient.getMessageStatus(TEST_MESSAGE_HASH);
+      const messageStatus = await l2MessageServiceClient.getMessageStatus({ messageHash: TEST_MESSAGE_HASH });
 
       expect(messageStatus).toStrictEqual(OnChainMessageStatus.CLAIMED);
     });

--- a/sdk/sdk-ethers/src/core/clients/IMessageServiceContract.ts
+++ b/sdk/sdk-ethers/src/core/clients/IMessageServiceContract.ts
@@ -1,4 +1,3 @@
-import { OnChainMessageStatus } from "../enums";
 import { Message, MessageSent } from "../types";
 
 export interface IMessageServiceContract<
@@ -8,7 +7,6 @@ export interface IMessageServiceContract<
   ContractTransactionResponse,
   ErrorDescription,
 > {
-  getMessageStatus(messageHash: string, overrides?: Overrides): Promise<OnChainMessageStatus>;
   getMessageByMessageHash(messageHash: string): Promise<MessageSent | null>;
   getMessagesByTransactionHash(transactionHash: string): Promise<MessageSent[] | null>;
   getTransactionReceiptByMessageHash(messageHash: string): Promise<TransactionReceipt | null>;

--- a/sdk/sdk-ethers/src/core/clients/ethereum/ILineaRollupClient.ts
+++ b/sdk/sdk-ethers/src/core/clients/ethereum/ILineaRollupClient.ts
@@ -16,14 +16,23 @@ export interface ILineaRollupClient<
     ContractTransactionResponse,
     ErrorDescription
   > {
+  getMessageStatus(params: {
+    messageHash: string;
+    messageBlockNumber?: number;
+    overrides?: Overrides;
+  }): Promise<OnChainMessageStatus>;
   getFinalizationMessagingInfo(transactionHash: string): Promise<FinalizationMessagingInfo>;
   getL2MessageHashesInBlockRange(fromBlock: number, toBlock: number): Promise<string[]>;
   getMessageSiblings(messageHash: string, messageHashes: string[], treeDepth: number): string[];
-  getMessageProof(messageHash: string): Promise<Proof>;
+  getMessageProof(messageHash: string, messageBlockNumber?: number): Promise<Proof>;
   getMessageStatusUsingMessageHash(messageHash: string, overrides: Overrides): Promise<OnChainMessageStatus>;
-  getMessageStatusUsingMerkleTree(messageHash: string, overrides: Overrides): Promise<OnChainMessageStatus>;
+  getMessageStatusUsingMerkleTree(params: {
+    messageHash: string;
+    messageBlockNumber?: number;
+    overrides?: Overrides;
+  }): Promise<OnChainMessageStatus>;
   estimateClaimGas(
-    message: Message & { feeRecipient?: string },
+    message: Message & { feeRecipient?: string; messageBlockNumber?: number },
     opts?: {
       claimViaAddress?: string;
       overrides?: Overrides;

--- a/sdk/sdk-ethers/src/core/clients/ethereum/IMerkleTreeService.ts
+++ b/sdk/sdk-ethers/src/core/clients/ethereum/IMerkleTreeService.ts
@@ -16,7 +16,7 @@ export type Proof = {
 };
 
 export interface IMerkleTreeService {
-  getMessageProof(messageHash: string): Promise<Proof>;
+  getMessageProof(messageHash: string, messageBlockNumber?: number): Promise<Proof>;
   getFinalizationMessagingInfo(transactionHash: string): Promise<FinalizationMessagingInfo>;
   getL2MessageHashesInBlockRange(fromBlock: number, toBlock: number): Promise<string[]>;
   getMessageSiblings(messageHash: string, messageHashes: string[], treeDepth: number): string[];

--- a/sdk/sdk-ethers/src/core/clients/linea/IL2MessageServiceClient.ts
+++ b/sdk/sdk-ethers/src/core/clients/linea/IL2MessageServiceClient.ts
@@ -1,6 +1,7 @@
 import { Message } from "../../types";
 import { IMessageServiceContract } from "../IMessageServiceContract";
 import { LineaGasFees } from "../IGasProvider";
+import { OnChainMessageStatus } from "../../enums";
 
 export interface IL2MessageServiceClient<
   Overrides,
@@ -16,6 +17,7 @@ export interface IL2MessageServiceClient<
     ContractTransactionResponse,
     ErrorDescription
   > {
+  getMessageStatus(params: { messageHash: string; overrides?: Overrides }): Promise<OnChainMessageStatus>;
   encodeClaimMessageTransactionData(message: Message & { feeRecipient?: string }): string;
   estimateClaimGasFees(
     message: Message & { feeRecipient?: string },


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional messageBlockNumber across SDK and Postman APIs, switching getMessageStatus to param objects and filtering L2 events by block to improve status/proof/claim operations.
> 
> - **API changes**:
>   - `IMessageServiceContract.getMessageStatus` now accepts `{ messageHash, messageBlockNumber?, overrides? }`.
>   - `ILineaRollupClient`: `getMessageStatus`, `getMessageStatusUsingMerkleTree`, `getMessageProof`, and `estimateClaimGas` accept `messageBlockNumber` (and param-object forms where applicable).
>   - `IL2MessageServiceClient.getMessageStatus` now accepts a params object; interfaces updated accordingly.
> - **Implementation**:
>   - `LineaRollupClient` and `MerkleTreeService` query L2 events with `fromBlock/toBlock = messageBlockNumber`; proof/status generation updated.
>   - Postman processors (`MessageAnchoringProcessor`, `MessageClaimingProcessor`, `MessageClaimingPersister`) and validation service pass `sentBlockNumber` when estimating gas, checking status, claiming, and retrying.
> - **Tests**:
>   - Updated unit tests to use new param-object signatures and to validate block-range behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bade89b7a3a3907a1b1738c5d3642d877988e2d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->