### PR TITLE
FeeHistoryCachingService Web3j to EthApi migration 5/N

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -619,7 +619,7 @@ class L1DependentApp(
         ),
       )
 
-      val l1Web3jClient = createWeb3jHttpClient(
+      val l1EthApiClient = createEthApiClient(
         rpcUrl = configs.l1Submission.dynamicGasPriceCap.feeHistoryFetcher.l1Endpoint.toString(),
         log = LogManager.getLogger("clients.l1.eth.feehistory-cache"),
       )
@@ -638,7 +638,7 @@ class L1DependentApp(
           configs.l1Submission.dynamicGasPriceCap.feeHistoryFetcher.numOfBlocksBeforeLatest,
         ),
         vertx = vertx,
-        web3jClient = l1Web3jClient,
+        ethApiBlockClient = l1EthApiClient,
         feeHistoryFetcher = l1FeeHistoryFetcher,
         feeHistoriesRepository = l1FeeHistoriesRepository,
       )

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/FeeHistoryCachingService.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/FeeHistoryCachingService.kt
@@ -1,18 +1,18 @@
 package net.consensys.linea.ethereum.gaspricing.dynamiccap
 
 import io.vertx.core.Vertx
+import linea.ethapi.EthApiBlockClient
 import linea.timer.TimerSchedule
 import linea.timer.VertxPeriodicPollingService
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.web3j.protocol.Web3j
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Duration
 
 class FeeHistoryCachingService(
   private val config: Config,
   vertx: Vertx,
-  private val web3jClient: Web3j,
+  private val ethApiBlockClient: EthApiBlockClient,
   private val feeHistoryFetcher: GasPriceCapFeeHistoryFetcher,
   private val feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
   private val log: Logger = LogManager.getLogger(FeeHistoryCachingService::class.java),
@@ -88,13 +88,13 @@ class FeeHistoryCachingService(
   }
 
   override fun action(): SafeFuture<Unit> {
-    return SafeFuture.of(web3jClient.ethBlockNumber().sendAsync())
+    return ethApiBlockClient.ethBlockNumber()
       .thenCompose { latestL1BlockNumber ->
         fetchAndSaveFeeHistories(
           // subtracting the latest L1 block number with a predefined number
           // (default as 4) to avoid requesting fee history of the head block
           // from nodes that were not catching up with the head yet
-          maxL1BlockNumberToFetch = latestL1BlockNumber.blockNumber.toLong()
+          maxL1BlockNumberToFetch = latestL1BlockNumber.toLong()
             .minus(config.numOfBlocksBeforeLatest.toLong())
             .coerceAtLeast(1L),
         )


### PR DESCRIPTION
This PR implements issue(s) #1790 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Web3j block number usage with EthApiBlockClient in fee history caching, wiring it through app config and tests.
> 
> - **Dynamic Gas Price Cap**:
>   - **FeeHistoryCachingService**: Replace `Web3j` dependency with `EthApiBlockClient`; `action()` now uses `ethApiBlockClient.ethBlockNumber()` and handles `ULong`.
>   - **App Wiring**: In `L1DependentApp`, create and pass `EthApi` client (`createEthApiClient`) as `ethApiBlockClient` to `FeeHistoryCachingService`.
>   - **Tests**: Update tests to mock `EthApiBlockClient` and expect `ethBlockNumber()` calls; remove `Web3j`/`EthBlockNumber` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baea1b5eb54d081dc856b0713b37ea495b2bd183. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->