### PR TITLE
Maybe fix TimerTest flakiness

### DIFF
--- a/jvm-libs/linea/core/long-running-service/src/test/kotlin/linea/timer/TimerTest.kt
+++ b/jvm-libs/linea/core/long-running-service/src/test/kotlin/linea/timer/TimerTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -182,7 +183,7 @@ class TimerTest {
   @OptIn(ExperimentalTime::class)
   @Test
   fun `Fixed rate timer executes tasks quickly if one is delayed more than polling interval`() {
-    val invocationTimestamps = mutableListOf<Instant>()
+    val invocationTimestamps = CopyOnWriteArrayList<Instant>()
     val pollingInterval = 50.milliseconds
     val timer = createTimer(
       timerType = VertxTimer::class,
@@ -193,11 +194,12 @@ class TimerTest {
           Thread.sleep(pollingInterval.inWholeMilliseconds * 3)
         }
       },
+      period = pollingInterval,
       errorHandler = { },
     )
     timer.start()
     Awaitility.await()
-      .pollInterval(30.milliseconds.toJavaDuration())
+      .pollInterval(10.milliseconds.toJavaDuration())
       .until { invocationTimestamps.size >= 5 }
     timer.stop()
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the fixed-rate timer test by using CopyOnWriteArrayList, setting explicit period, and reducing Awaitility poll interval.
> 
> - **Tests (`jvm-libs/linea/core/long-running-service/src/test/kotlin/linea/timer/TimerTest.kt`)**
>   - Fixed-rate timer test:
>     - Use `CopyOnWriteArrayList` for `invocationTimestamps`.
>     - Set `period = pollingInterval` when creating the timer.
>     - Reduce Awaitility `pollInterval` from `30.ms` to `10.ms`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7484aaceddbfaae37c0307a925f1625b1f749b2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->