### PR TITLE
[5.9] Pause staking in fundYieldProvider

### DIFF
--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -487,6 +487,7 @@ contract YieldManager is
     onlyRole(YIELD_PROVIDER_STAKING_ROLE)
     onlyWhenWithdrawalReserveHealthy
   {
+    if (getTargetReserveDeficit() > 0) _pauseStakingIfNotAlready(_yieldProvider);
     _delegatecallYieldProvider(
       _yieldProvider,
       abi.encodeCall(IYieldProvider.fundYieldProvider, (_yieldProvider, _amount))

--- a/contracts/test/yield/helpers/setup.ts
+++ b/contracts/test/yield/helpers/setup.ts
@@ -38,9 +38,9 @@ export const fundYieldProviderForWithdrawal = async (
   const mockYieldProviderAddress = await mockYieldProvider.getAddress();
   const yieldManagerAddress = await testYieldManager.getAddress();
   // Funding cannot happen if withdrawal reserve in deficit
-  const minimumReserveAmount = await testYieldManager.minimumWithdrawalReserveAmount();
+  const targetReserveAmount = await testYieldManager.targetWithdrawalReserveAmount();
   const l1MessageServiceAddress = await testYieldManager.getL1MessageService();
-  await ethers.provider.send("hardhat_setBalance", [l1MessageServiceAddress, ethers.toBeHex(minimumReserveAmount)]);
+  await ethers.provider.send("hardhat_setBalance", [l1MessageServiceAddress, ethers.toBeHex(targetReserveAmount)]);
   await ethers.provider.send("hardhat_setBalance", [yieldManagerAddress, ethers.toBeHex(withdrawAmount)]);
   await testYieldManager.connect(signer).setWithdrawableValueReturnVal(mockYieldProviderAddress, withdrawAmount);
   await testYieldManager.connect(signer).fundYieldProvider(mockYieldProviderAddress, withdrawAmount);
@@ -100,9 +100,9 @@ export const fundLidoStVaultYieldProvider = async (
   const yieldProviderAddress = await yieldProvider.getAddress();
   const yieldManagerAddress = await testYieldManager.getAddress();
   // Funding cannot happen if withdrawal reserve in deficit
-  const minimumReserveAmount = await testYieldManager.minimumWithdrawalReserveAmount();
+  const targetReserveAmount = await testYieldManager.targetWithdrawalReserveAmount();
   const l1MessageServiceAddress = await testYieldManager.getL1MessageService();
-  await ethers.provider.send("hardhat_setBalance", [l1MessageServiceAddress, ethers.toBeHex(minimumReserveAmount)]);
+  await ethers.provider.send("hardhat_setBalance", [l1MessageServiceAddress, ethers.toBeHex(targetReserveAmount)]);
   await ethers.provider.send("hardhat_setBalance", [yieldManagerAddress, ethers.toBeHex(withdrawAmount)]);
   await testYieldManager.connect(signer).fundYieldProvider(yieldProviderAddress, withdrawAmount);
 };

--- a/contracts/test/yield/unit/YieldManager.funds.ts
+++ b/contracts/test/yield/unit/YieldManager.funds.ts
@@ -23,6 +23,7 @@ import {
   getBalance,
   incrementBalance,
   setBalance,
+  setWithdrawalReserveToMinimum,
   setWithdrawalReserveToTarget,
 } from "../helpers";
 
@@ -213,6 +214,7 @@ describe("YieldManager contract - ETH transfer operations", () => {
       const yieldProviderData = await yieldManager.getYieldProviderData(mockYieldProviderAddress);
       expect(yieldProviderData.userFunds).to.equal(transferAmount);
 
+      expect(await yieldManager.isStakingPaused(mockYieldProviderAddress)).to.be.true;
       expect(await yieldManager.userFundsInYieldProvidersTotal()).to.equal(transferAmount);
     });
   });
@@ -985,10 +987,12 @@ describe("YieldManager contract - ETH transfer operations", () => {
       const { mockYieldProviderAddress, mockYieldProvider, mockWithdrawTarget } =
         await addMockYieldProvider(yieldManager);
       await fundYieldProviderForWithdrawal(yieldManager, mockYieldProvider, nativeYieldOperator, rebalanceAmount / 2n);
+
       // Arrange - setup insufficient YieldManager balance
       const yieldManagerAddress = await yieldManager.getAddress();
       await incrementBalance(yieldManagerAddress, rebalanceAmount / 2n);
       // Arrange - Get before
+      await setWithdrawalReserveToMinimum(yieldManager);
       const l1MessageServiceBalanceBefore = await getBalance(mockLineaRollup);
 
       // Act


### PR DESCRIPTION

- Add check in fundYieldProvider to pause staking if target reserve deficit > 0
- Update test helpers to use target reserve amount instead of minimum
- Add test assertions to verify staking is paused after funding with deficit
- Update test setup to properly configure withdrawal reserve state

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pauses staking during `fundYieldProvider` if `getTargetReserveDeficit() > 0`, and updates test helpers/tests to use target reserve and verify pause behavior.
> 
> - **Smart Contract (`contracts/contracts/yield/YieldManager.sol`)**:
>   - Pause staking in `fundYieldProvider` when `getTargetReserveDeficit() > 0` via `_pauseStakingIfNotAlready`.
> - **Tests/Helpers**:
>   - Switch helper funding precondition from `minimumWithdrawalReserveAmount` to `targetWithdrawalReserveAmount` in `helpers/setup.ts`.
>   - Add `setWithdrawalReserveToMinimum` (and reserve-balance helpers) to configure reserve state using effective thresholds.
>   - Update unit tests (`YieldManager.funds.ts`):
>     - Add assertions that `isStakingPaused` is `true` after funding with target deficit.
>     - Adjust scenarios to set reserve to minimum/target as needed (e.g., before `safeAddToWithdrawalReserve`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f55662ae22ed77ed43c6d2f13c4667efa57394c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->