### PR TITLE
[Coordinator] Break prover client interface for creating requests

### DIFF
--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.map
 import io.vertx.core.Vertx
 import linea.domain.BlockInterval
 import net.consensys.linea.errors.ErrorResponse
+import net.consensys.zkevm.coordinator.clients.ProverProofRequestCreator
 import net.consensys.zkevm.coordinator.clients.ProverProofResponseChecker
 import net.consensys.zkevm.domain.ProofIndex
 import net.consensys.zkevm.fileio.FileMonitor
@@ -36,7 +37,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
   private val responseMapper: (ResponseDto) -> Response,
   private val proofTypeLabel: String,
   private val log: Logger = LogManager.getLogger(GenericFileBasedProverClient::class.java),
-) : ProverProofResponseChecker<Response>, Supplier<Number>
+) : ProverProofResponseChecker<Response>, Supplier<Number>, ProverProofRequestCreator<Request>
   where Request : BlockInterval,
         Response : Any,
         RequestDto : Any,
@@ -78,10 +79,39 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
       }
   }
 
-  fun requestProof(proofRequest: Request): SafeFuture<Response> {
+  override fun createProofRequest(proofRequest: Request): SafeFuture<ProofIndex> {
     val proofIndex = proofIndexProvider(proofRequest)
     val requestFileName = requestFileNameProvider.getFileName(proofIndex)
     val requestFilePath = config.requestsDirectory.resolve(requestFileName)
+
+    return findRequestFileIfAlreadyInFileSystem(requestFileName)
+      .thenCompose { requestFileFound: String? ->
+        responsesWaiting.incrementAndGet()
+        if (requestFileFound != null) {
+          log.debug(
+            "request already in file system: {}={} reusedRequest={}",
+            proofTypeLabel,
+            proofIndex.intervalString(),
+            requestFileFound,
+          )
+          SafeFuture.completedFuture(proofIndex)
+        } else {
+          requestMapper(proofRequest)
+            .thenCompose { proofRequestDto ->
+              fileWriter.write(
+                proofRequestDto,
+                requestFilePath,
+                config.inprogressRequestWritingSuffix,
+              ).thenApply {
+                proofIndex
+              }
+            }
+        }
+      }
+  }
+
+  fun requestProof(proofRequest: Request): SafeFuture<Response> {
+    val proofIndex = proofIndexProvider(proofRequest)
     val responseFilePath = config.responsesDirectory.resolve(responseFileNameProvider.getFileName(proofIndex))
 
     return findProofResponse(proofIndex)
@@ -89,30 +119,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
         if (response != null) {
           SafeFuture.completedFuture(response)
         } else {
-          findRequestFileIfAlreadyInFileSystem(requestFileName)
-            .thenCompose { requestFileFound: String? ->
-              responsesWaiting.incrementAndGet()
-              if (requestFileFound != null) {
-                log.debug(
-                  "request already in file system: {}={} reusedRequest={}",
-                  proofTypeLabel,
-                  proofIndex.intervalString(),
-                  requestFileFound,
-                )
-                SafeFuture.completedFuture(Unit)
-              } else {
-                requestMapper(proofRequest)
-                  .thenCompose { proofRequestDto ->
-                    fileWriter.write(
-                      proofRequestDto,
-                      requestFilePath,
-                      config.inprogressRequestWritingSuffix,
-                    ).thenApply {
-                      Unit
-                    }
-                  }
-              }
-            }
+          createProofRequest(proofRequest)
             .thenCompose { waitForResponse(responseFilePath) }
             .thenCompose {
               responsesWaiting.decrementAndGet()

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/ProverClient.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/ProverClient.kt
@@ -12,8 +12,12 @@ interface ProverProofResponseChecker<ProofResponse> {
     findProofResponse(proofRequestId).thenApply { it != null }
 }
 
+interface ProverProofRequestCreator<ProofRequest> {
+  fun createProofRequest(proofRequest: ProofRequest): SafeFuture<ProofIndex>
+}
+
 interface ProverClient<ProofRequest, ProofResponse> :
-  ProverProofResponseChecker<ProofResponse> {
+  ProverProofResponseChecker<ProofResponse>, ProverProofRequestCreator<ProofRequest> {
   fun requestProof(proofRequest: ProofRequest): SafeFuture<ProofResponse>
 }
 


### PR DESCRIPTION
This PR implements issue(s) #1740 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `createProofRequest` via new `ProverProofRequestCreator` and refactor file-based prover client and router to delegate and reuse request creation.
> 
> - **Core (`coordinator/core/.../ProverClient.kt`)**:
>   - Add `ProverProofRequestCreator` with `createProofRequest`.
>   - Update `ProverClient` to extend `ProverProofRequestCreator`.
> - **File-based client (`GenericFileBasedProverClient`)**:
>   - Implement `createProofRequest`; extract request file creation logic from `requestProof`.
>   - Update `requestProof` to call `createProofRequest` then wait/parse response.
> - **Router (`ABProverClientRouter`)**:
>   - Add `getProver` helper and delegate `findProofResponse`, `requestProof`, and new `createProofRequest` based on predicate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b55a66a4bb40099eea7b8c10b2f62c9386c55e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->