### PR TITLE
fix: remove unused function in contracts deployment scripts

### DIFF
--- a/contracts/deploy/18_deploy_RollupRevenueVault.ts
+++ b/contracts/deploy/18_deploy_RollupRevenueVault.ts
@@ -1,6 +1,6 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { deployUpgradableFromFactory } from "../scripts/hardhat/utils";
-import { tryVerifyContract, LogContractDeployment } from "../common/helpers";
+import { tryVerifyContract, LogContractDeployment, getRequiredEnvVar } from "../common/helpers";
 import { ROLLUP_REVENUE_VAULT_INITIALIZE_SIGNATURE } from "../common/constants";
 
 const func: DeployFunction = async function () {

--- a/contracts/deploy/18_deploy_RollupRevenueVaultWithReinitialization.ts
+++ b/contracts/deploy/18_deploy_RollupRevenueVaultWithReinitialization.ts
@@ -1,24 +1,12 @@
 import { DeployFunction } from "hardhat-deploy/types";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { tryVerifyContract, getDeployedContractAddress, getRequiredEnvVar } from "../common/helpers";
+import { tryVerifyContract, getRequiredEnvVar } from "../common/helpers";
 import { ethers, upgrades } from "hardhat";
 import { RollupRevenueVault__factory } from "contracts/typechain-types";
 
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments } = hre;
-
+const func: DeployFunction = async function () {
   const contractName = "RollupRevenueVault";
-  const existingContractAddress = await getDeployedContractAddress(contractName, deployments);
-
-  // RollupRevenueVault DEPLOYED AS UPGRADEABLE PROXY
-  if (!existingContractAddress) {
-    console.log(`Deploying initial version, NB: the address will be saved if env SAVE_ADDRESS=true.`);
-  } else {
-    console.log(`Deploying new version, NB: ${existingContractAddress} will be overwritten if env SAVE_ADDRESS=true.`);
-  }
 
   const proxyAddress = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_ADDRESS");
-
   const lastInvoiceDate = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_LAST_INVOICE_DATE");
   const securityCouncil = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_SECURITY_COUNCIL");
   const invoiceSubmitter = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_INVOICE_SUBMITTER");
@@ -29,6 +17,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const l1LineaTokenBurner = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_L1_LINEA_TOKEN_BURNER");
   const lineaToken = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_LINEA_TOKEN");
   const dexSwapAdapter = getRequiredEnvVar("ROLLUP_REVENUE_VAULT_DEX_SWAP_ADAPTER");
+
   const factory = await ethers.getContractFactory(contractName);
 
   console.log("Deploying Contract...");

--- a/contracts/deploy/19_deploy_L1LineaTokenBurner.ts
+++ b/contracts/deploy/19_deploy_L1LineaTokenBurner.ts
@@ -1,27 +1,12 @@
 import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import {
-  getRequiredEnvVar,
-  getDeployedContractAddress,
-  LogContractDeployment,
-  tryVerifyContractWithConstructorArgs,
-} from "../common/helpers";
+import { getRequiredEnvVar, LogContractDeployment, tryVerifyContractWithConstructorArgs } from "../common/helpers";
 
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments } = hre;
-
+const func: DeployFunction = async function () {
   const contractName = "L1LineaTokenBurner";
-  const existingContractAddress = await getDeployedContractAddress(contractName, deployments);
 
   const messageService = getRequiredEnvVar("LINEA_TOKEN_BURNER_MESSAGE_SERVICE");
   const lineaToken = getRequiredEnvVar("LINEA_TOKEN_BURNER_LINEA_TOKEN");
-
-  if (!existingContractAddress) {
-    console.log(`Deploying initial version, NB: the address will be saved if env SAVE_ADDRESS=true.`);
-  } else {
-    console.log(`Deploying new version, NB: ${existingContractAddress} will be overwritten if env SAVE_ADDRESS=true.`);
-  }
 
   const factory = await ethers.getContractFactory(contractName);
   const contract = await factory.deploy(messageService, lineaToken);

--- a/contracts/deploy/20_deploy_V3DexSwapAdapter.ts
+++ b/contracts/deploy/20_deploy_V3DexSwapAdapter.ts
@@ -1,29 +1,14 @@
 import { ethers } from "hardhat";
 import { DeployFunction } from "hardhat-deploy/types";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import {
-  getRequiredEnvVar,
-  getDeployedContractAddress,
-  LogContractDeployment,
-  tryVerifyContractWithConstructorArgs,
-} from "../common/helpers";
+import { getRequiredEnvVar, LogContractDeployment, tryVerifyContractWithConstructorArgs } from "../common/helpers";
 
-const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments } = hre;
-
+const func: DeployFunction = async function () {
   const contractName = "V3DexSwapAdapter";
-  const existingContractAddress = await getDeployedContractAddress(contractName, deployments);
 
   const router = getRequiredEnvVar("V3_DEX_SWAP_ADAPTER_ROUTER");
   const wethToken = getRequiredEnvVar("V3_DEX_SWAP_ADAPTER_WETH_TOKEN");
   const lineaToken = getRequiredEnvVar("V3_DEX_SWAP_ADAPTER_LINEA_TOKEN");
   const poolTickSpacing = getRequiredEnvVar("V3_DEX_SWAP_ADAPTER_POOL_TICK_SPACING");
-
-  if (!existingContractAddress) {
-    console.log(`Deploying initial version, NB: the address will be saved if env SAVE_ADDRESS=true.`);
-  } else {
-    console.log(`Deploying new version, NB: ${existingContractAddress} will be overwritten if env SAVE_ADDRESS=true.`);
-  }
 
   const factory = await ethers.getContractFactory(contractName);
   const contract = await factory.deploy(router, wethToken, lineaToken, poolTickSpacing);


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies deploy scripts by dropping HardhatRuntimeEnvironment/deployments and unused helpers/logging, and adds missing helper import for RollupRevenueVault.
> 
> - **Deploy scripts**:
>   - `contracts/deploy/18_deploy_RollupRevenueVaultWithReinitialization.ts`:
>     - Remove `HardhatRuntimeEnvironment` and `getDeployedContractAddress` usage; simplify function signature.
>     - Keep upgrade implementation deployment and encoded reinitialization call; retain verification.
>   - `contracts/deploy/19_deploy_L1LineaTokenBurner.ts` and `contracts/deploy/20_deploy_V3DexSwapAdapter.ts`:
>     - Remove `HardhatRuntimeEnvironment`/`deployments` and related logging; deploy directly and verify with constructor args.
>   - `contracts/deploy/18_deploy_RollupRevenueVault.ts`:
>     - Add `getRequiredEnvVar` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9087a9b6b84961161f7db0129ecbec06f8b5c3df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->