### PR TITLE
[Self finding] YieldManager::addYieldProvider to increment userFunds and userFundsInYieldProvidersTotal by CONNECT_DEPOSIT

### DIFF
--- a/contracts/contracts/yield/LidoStVaultYieldProvider.sol
+++ b/contracts/contracts/yield/LidoStVaultYieldProvider.sol
@@ -537,7 +537,8 @@ contract LidoStVaultYieldProvider is YieldProviderBase, IGenericErrors {
     registrationData = YieldProviderRegistration({
       yieldProviderVendor: YieldProviderVendor.LIDO_STVAULT,
       primaryEntrypoint: dashboard,
-      ossifiedEntrypoint: vault
+      ossifiedEntrypoint: vault,
+      usersFundsIncrement: CONNECT_DEPOSIT
     });
   }
 

--- a/contracts/contracts/yield/YieldManager.sol
+++ b/contracts/contracts/yield/YieldManager.sol
@@ -992,16 +992,18 @@ contract YieldManager is
       primaryEntrypoint: registrationData.primaryEntrypoint,
       ossifiedEntrypoint: registrationData.ossifiedEntrypoint,
       yieldProviderIndex: yieldProviderIndex,
-      userFunds: 0,
+      userFunds: registrationData.usersFundsIncrement,
       yieldReportedCumulative: 0,
       lstLiabilityPrincipal: 0,
       lastReportedNegativeYield: 0
     });
+    $.userFundsInYieldProvidersTotal += registrationData.usersFundsIncrement;
     emit YieldProviderAdded(
       _yieldProvider,
       registrationData.yieldProviderVendor,
       registrationData.primaryEntrypoint,
-      registrationData.ossifiedEntrypoint
+      registrationData.ossifiedEntrypoint,
+      registrationData.usersFundsIncrement
     );
   }
 

--- a/contracts/contracts/yield/interfaces/IYieldManager.sol
+++ b/contracts/contracts/yield/interfaces/IYieldManager.sol
@@ -183,12 +183,14 @@ interface IYieldManager {
    * @param yieldProviderVendor Specific type of YieldProvider adaptor.
    * @param primaryEntrypoint Contract used for operations when not-ossified.
    * @param ossifiedEntrypoint Contract used for operations once ossification is finalized.
+   * @param usersFundsIncrement Initial amount of userFunds that should be accounted for when registering the yield provider.
    */
   event YieldProviderAdded(
     address indexed yieldProvider,
     YieldProviderVendor indexed yieldProviderVendor,
     address primaryEntrypoint,
-    address indexed ossifiedEntrypoint
+    address indexed ossifiedEntrypoint,
+    uint256 usersFundsIncrement
   );
 
   /**

--- a/contracts/contracts/yield/interfaces/YieldTypes.sol
+++ b/contracts/contracts/yield/interfaces/YieldTypes.sol
@@ -21,9 +21,11 @@ enum ProgressOssificationResult {
  * @param yieldProviderVendor Specific type of YieldProvider adaptor.
  * @param primaryEntrypoint Contract used for operations when not-ossified.
  * @param ossifiedEntrypoint Contract used for operations once ossification is finalized.
+ * @param usersFundsIncrement Initial amount of userFunds that should be accounted for when registering the yield provider.
  */
 struct YieldProviderRegistration {
   YieldProviderVendor yieldProviderVendor;
   address primaryEntrypoint;
   address ossifiedEntrypoint;
+  uint256 usersFundsIncrement;
 }

--- a/contracts/test/common/constants/yield.ts
+++ b/contracts/test/common/constants/yield.ts
@@ -6,6 +6,7 @@ export const TARGET_WITHDRAWAL_RESERVE_PERCENTAGE_BPS = 2500;
 export const MINIMUM_WITHDRAWAL_RESERVE_AMOUNT = ethers.parseEther("1000");
 export const TARGET_WITHDRAWAL_RESERVE_AMOUNT = ethers.parseEther("1250");
 export const MAX_BPS = 10000n;
+export const CONNECT_DEPOSIT = ethers.parseEther("1");
 
 // Values from constructor params for Lido PreDepositGuarantee.sol Hoodi deployment - https://hoodi.etherscan.io/address/0x8b289fc1af2bbc589f5990b94061d851c48683a3#code
 export const GI_FIRST_VALIDATOR_PREV = "0x0000000000000000000000000000000000000000000000000096000000000028";

--- a/contracts/test/yield/helpers/mocks.ts
+++ b/contracts/test/yield/helpers/mocks.ts
@@ -11,6 +11,7 @@ export const buildMockYieldProviderRegistration = (
     yieldProviderVendor: number;
     primaryEntrypoint: string;
     ossifiedEntrypoint: string;
+    usersFundsIncrement: bigint;
   }> = {},
 ): YieldProviderRegistration => ({
   yieldProviderVendor:
@@ -19,6 +20,7 @@ export const buildMockYieldProviderRegistration = (
       : YieldProviderVendor.LIDO_ST_VAULT_YIELD_PROVIDER_VENDOR,
   primaryEntrypoint: overrides.primaryEntrypoint ?? ethers.Wallet.createRandom().address,
   ossifiedEntrypoint: overrides.ossifiedEntrypoint ?? ethers.Wallet.createRandom().address,
+  usersFundsIncrement: overrides.usersFundsIncrement ?? 0n,
 });
 
 export const buildVendorExitData = (

--- a/contracts/test/yield/helpers/types.ts
+++ b/contracts/test/yield/helpers/types.ts
@@ -16,6 +16,7 @@ export interface YieldProviderRegistration {
   yieldProviderVendor: number;
   primaryEntrypoint: string;
   ossifiedEntrypoint: string;
+  usersFundsIncrement: bigint;
 }
 
 export interface ValidatorContainer {

--- a/contracts/test/yield/integration/YieldManager.integration.ts
+++ b/contracts/test/yield/integration/YieldManager.integration.ts
@@ -37,6 +37,7 @@ import { expect } from "chai";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { ethers } from "hardhat";
 import {
+  CONNECT_DEPOSIT,
   EMPTY_CALLDATA,
   MAX_0X2_VALIDATOR_EFFECTIVE_BALANCE_GWEI,
   ONE_ETHER,
@@ -92,6 +93,14 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
     l1MessageServiceAddress = await lineaRollup.getAddress();
     yieldManagerAddress = await yieldManager.getAddress();
     mockStakingVaultAddress = await mockStakingVault.getAddress();
+  });
+
+  describe("Initial state", () => {
+    it("userFunds should be equivalent to CONNECT_DEPOSIT amount", async () => {
+      const connectDeposit = await yieldProvider.CONNECT_DEPOSIT();
+      expect(await yieldManager.userFunds(yieldProviderAddress)).eq(connectDeposit);
+      expect(await yieldManager.userFundsInYieldProvidersTotal()).eq(connectDeposit);
+    });
   });
 
   describe("Transfering to the YieldManager", () => {
@@ -210,7 +219,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       // Arrange - setup withdrawal reserve deficit
       await setBalance(l1MessageServiceAddress, ZERO_VALUE);
       // Arrange - setup L1MessageService message
-      const withdrawAmount = initialFundAmount * 2n;
+      const withdrawAmount = initialFundAmount * 2n + CONNECT_DEPOSIT;
       const recipientAddress = await nonAuthorizedAccount.getAddress();
       const claimParams = await setupLineaRollupMessageMerkleTree(
         lineaRollup,
@@ -307,7 +316,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, initialFundAmount);
       // Arrange - Setup positive yield
       const yieldEarned = ONE_ETHER / 10n;
-      await mockDashboard.setTotalValueReturn(initialFundAmount + yieldEarned);
+      await mockDashboard.setTotalValueReturn(initialFundAmount + CONNECT_DEPOSIT + yieldEarned);
       // Arrange - Get message params
       const nextMessageNumberBefore = await lineaRollup.nextMessageNumber();
 
@@ -348,7 +357,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, initialFundAmount);
       // Arrange - Setup negative yield
       const yieldEarned = 0n;
-      await mockDashboard.setTotalValueReturn(yieldEarned);
+      await mockDashboard.setTotalValueReturn(yieldEarned + CONNECT_DEPOSIT);
       // Arrange - Get message params
       const nextMessageNumberBefore = await lineaRollup.nextMessageNumber();
 
@@ -389,7 +398,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, initialFundAmount);
       // Arrange - Setup positive yield
       const yieldEarned = ONE_ETHER / 10n;
-      await mockDashboard.setTotalValueReturn(initialFundAmount + yieldEarned);
+      await mockDashboard.setTotalValueReturn(initialFundAmount + CONNECT_DEPOSIT + yieldEarned);
       // Arrange - Get message params
       const nextMessageNumberBefore = await lineaRollup.nextMessageNumber();
 
@@ -435,7 +444,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, initialFundAmount);
       // Arrange - Setup negative yield
       const yieldEarned = 0n;
-      await mockDashboard.setTotalValueReturn(yieldEarned);
+      await mockDashboard.setTotalValueReturn(yieldEarned + CONNECT_DEPOSIT);
       // Arrange - Get message params
       const nextMessageNumberBefore = await lineaRollup.nextMessageNumber();
 
@@ -597,10 +606,10 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       const userFundsBefore = await yieldManager.userFunds(yieldProviderAddress);
       // Arrange - Setup first negative yield
       const firstNegativeYield = ONE_ETHER * 5n;
-      await mockDashboard.setTotalValueReturn(initialFundAmount - firstNegativeYield);
-      // Arrange - Setup second negative yield
       const secondNegativeYield = ONE_ETHER * 5n;
-      await mockDashboard.setTotalValueReturn(initialFundAmount - firstNegativeYield - secondNegativeYield);
+      await mockDashboard.setTotalValueReturn(
+        initialFundAmount + CONNECT_DEPOSIT - firstNegativeYield - secondNegativeYield,
+      );
 
       // Act
       const [newReportedYield, outstandingNegativeYield] = await yieldManager
@@ -735,7 +744,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
 
       // First negative yield event for -5 ETH
       const firstNegativeYield = ONE_ETHER * 5n;
-      await mockDashboard.setTotalValueReturn(initialFundAmount - firstNegativeYield);
+      await mockDashboard.setTotalValueReturn(initialFundAmount + CONNECT_DEPOSIT - firstNegativeYield);
       await decrementBalance(mockStakingVaultAddress, firstNegativeYield);
       {
         const [newReportedYield, outstandingNegativeYield] = await yieldManager
@@ -760,7 +769,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
         expect(outstandingNegativeYield).eq(firstNegativeYield + firstObligationsPaid);
       }
       await yieldManager.connect(nativeYieldOperator).reportYield(yieldProviderAddress, l2YieldRecipient);
-      expect(await yieldManager.userFunds(yieldProviderAddress)).eq(initialFundAmount);
+      expect(await yieldManager.userFunds(yieldProviderAddress)).eq(initialFundAmount + CONNECT_DEPOSIT);
       expect(await getBalance(mockStakingVault)).eq(mockStakingVaultBalance - firstObligationsPaid);
       await mockDashboard.setTotalValueReturn((await mockDashboard.totalValue()) - firstObligationsPaid);
       await mockDashboard.setObligationsFeesToSettleReturn(0n);
@@ -859,6 +868,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
 
       // Earn 5 ETH positive yield
       const firstPositiveYield = ONE_ETHER * 5n;
+      await mockDashboard.setTotalValueReturn((await mockDashboard.totalValue()) + CONNECT_DEPOSIT);
       await incurPositiveYield(
         yieldManager,
         mockDashboard,

--- a/contracts/test/yield/unit/LidoStVaultYieldProvider.basic.ts
+++ b/contracts/test/yield/unit/LidoStVaultYieldProvider.basic.ts
@@ -563,6 +563,7 @@ describe("LidoStVaultYieldProvider contract - basic operations", () => {
       await expect(call).to.be.reverted;
     });
     it("Should succeed with expected return values, and transfer 1 ether to Lido contracts", async () => {
+      await yieldManager.setYieldProviderUserFunds(yieldProviderAddress, 0n);
       await yieldManager.connect(securityCouncil).removeYieldProvider(yieldProviderAddress, buildVendorExitData());
       const expectedVaultAddress = ethers.Wallet.createRandom().address;
       const expectedDashboardAddress = ethers.Wallet.createRandom().address;
@@ -586,6 +587,7 @@ describe("LidoStVaultYieldProvider contract - basic operations", () => {
       expect(await getBalance(mockVaultFactory)).eq(beforeVaultFactoryBalance + ONE_ETHER);
     });
     it("Should revert if YieldManager lacks the CONNECT_DEPOSIT of 1 ether", async () => {
+      await yieldManager.setYieldProviderUserFunds(yieldProviderAddress, 0n);
       await yieldManager.connect(securityCouncil).removeYieldProvider(yieldProviderAddress, buildVendorExitData());
       const expectedVaultAddress = ethers.Wallet.createRandom().address;
       const expectedDashboardAddress = ethers.Wallet.createRandom().address;
@@ -604,6 +606,7 @@ describe("LidoStVaultYieldProvider contract - basic operations", () => {
       await expectRevertWithCustomError(yieldProvider, call, "ContextIsNotYieldManager");
     });
     it("Should revert with empty vendorExitData", async () => {
+      await yieldManager.setYieldProviderUserFunds(yieldProviderAddress, 0n);
       const call = yieldManager.connect(securityCouncil).removeYieldProvider(yieldProviderAddress, EMPTY_CALLDATA);
       await expectRevertWithCustomError(yieldProvider, call, "NoVendorExitDataProvided");
     });
@@ -615,6 +618,7 @@ describe("LidoStVaultYieldProvider contract - basic operations", () => {
     });
     it("When non-ossified, should succeed with call to Dashboard", async () => {
       await yieldManager.setYieldProviderIsOssified(yieldProviderAddress, false);
+      await yieldManager.setYieldProviderUserFunds(yieldProviderAddress, 0n);
       const call = yieldManager
         .connect(securityCouncil)
         .removeYieldProvider(yieldProviderAddress, buildVendorExitData());
@@ -624,6 +628,7 @@ describe("LidoStVaultYieldProvider contract - basic operations", () => {
     });
     it("When ossified, should succeed with call to StakingVault", async () => {
       await yieldManager.setYieldProviderIsOssified(yieldProviderAddress, true);
+      await yieldManager.setYieldProviderUserFunds(yieldProviderAddress, 0n);
       const call = yieldManager
         .connect(securityCouncil)
         .removeYieldProvider(yieldProviderAddress, buildVendorExitData());

--- a/contracts/test/yield/unit/LidoStVaultYieldProvider.yield.ts
+++ b/contracts/test/yield/unit/LidoStVaultYieldProvider.yield.ts
@@ -16,7 +16,7 @@ import {
 } from "contracts/typechain-types";
 import { expect } from "chai";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
-import { ONE_ETHER, OperationType, ZERO_VALUE, YieldProviderVendor } from "../../common/constants";
+import { ONE_ETHER, OperationType, ZERO_VALUE, YieldProviderVendor, CONNECT_DEPOSIT } from "../../common/constants";
 import { ethers } from "hardhat";
 
 describe("LidoStVaultYieldProvider contract - yield operations", () => {
@@ -366,7 +366,7 @@ describe("LidoStVaultYieldProvider contract - yield operations", () => {
       const userFunds = ONE_ETHER;
       await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, userFunds);
       const vaultValue = ONE_ETHER * 2n;
-      await mockDashboard.setTotalValueReturn(vaultValue);
+      await mockDashboard.setTotalValueReturn(vaultValue + CONNECT_DEPOSIT);
 
       // Act
       const [newReportedYield, outstandingNegativeYield] = await yieldManager
@@ -383,7 +383,7 @@ describe("LidoStVaultYieldProvider contract - yield operations", () => {
       const userFunds = ONE_ETHER * 2n;
       await fundLidoStVaultYieldProvider(yieldManager, yieldProvider, nativeYieldOperator, userFunds);
       const vaultValue = ONE_ETHER;
-      await mockDashboard.setTotalValueReturn(vaultValue);
+      await mockDashboard.setTotalValueReturn(vaultValue + CONNECT_DEPOSIT);
 
       // Act
       const [newReportedYield, outstandingNegativeYield] = await yieldManager
@@ -406,7 +406,7 @@ describe("LidoStVaultYieldProvider contract - yield operations", () => {
       const nodeOperatorFees = ONE_ETHER;
       await mockDashboard.setAccruedFeeReturn(nodeOperatorFees);
       const vaultValue = ONE_ETHER * 5n;
-      await mockDashboard.setTotalValueReturn(vaultValue);
+      await mockDashboard.setTotalValueReturn(vaultValue + CONNECT_DEPOSIT);
 
       // Act
       const [newReportedYield, outstandingNegativeYield] = await yieldManager
@@ -429,7 +429,7 @@ describe("LidoStVaultYieldProvider contract - yield operations", () => {
       const nodeOperatorFees = ONE_ETHER;
       await mockDashboard.setAccruedFeeReturn(nodeOperatorFees);
       const vaultValue = ONE_ETHER;
-      await mockDashboard.setTotalValueReturn(vaultValue);
+      await mockDashboard.setTotalValueReturn(vaultValue + CONNECT_DEPOSIT);
 
       // Act
       const [newReportedYield, outstandingNegativeYield] = await yieldManager

--- a/contracts/test/yield/unit/YieldManager.basic.ts
+++ b/contracts/test/yield/unit/YieldManager.basic.ts
@@ -807,6 +807,7 @@ describe("YieldManager contract - basic operations", () => {
           registration.yieldProviderVendor,
           registration.primaryEntrypoint,
           registration.ossifiedEntrypoint,
+          registration.usersFundsIncrement,
         );
 
       expect(await yieldManager.isYieldProviderKnown(providerAddress)).to.be.true;


### PR DESCRIPTION
YieldManager::addYieldProvider needs to increment userFunds and userFundsInYieldProvidersTotal by CONNECT_DEPOSIT

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize newly added yield providers with CONNECT_DEPOSIT via registration struct, update totals and events, and adjust tests accordingly.
> 
> - **Contracts**:
>   - `LidoStVaultYieldProvider.initializeVendorContracts` now returns `YieldProviderRegistration` with `usersFundsIncrement: CONNECT_DEPOSIT` (1 ETH).
>   - `YieldManager.addYieldProvider` initializes `userFunds` with `registrationData.usersFundsIncrement`, increments `userFundsInYieldProvidersTotal`, and emits `YieldProviderAdded` including this value.
> - **Interfaces/Types**:
>   - Extend `YieldProviderRegistration` with `usersFundsIncrement` in `yield/interfaces/YieldTypes.sol`.
>   - Update `IYieldManager` `YieldProviderAdded` event to include `usersFundsIncrement`.
> - **Tests**:
>   - Add `CONNECT_DEPOSIT` constant and update expectations (initial `userFunds`, totals, yield calculations, withdrawal caps) to include the 1 ETH connect deposit.
>   - Update mocks/types (`buildMockYieldProviderRegistration`) to support `usersFundsIncrement` and adjust event assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06ae1b46faa502eb211665334d53c477b87edc4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->