### PR TITLE
[ZkTracer] update `go-corset` to version `v1.1.31-rc1`

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@1aee6f95c28b1ca2f66f6d8347a0d247d8be38a4 # v1.2.0-rc3
+      run: go install github.com/consensys/go-corset/cmd/go-corset@d4efce1a84c63507822f127ad1833db64a8e25a3 # v1.1.31-rc1


### PR DESCRIPTION
This PR implements issue(s) #1969

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub composite action for setting up Go Corset.
> 
> - Changes `go-corset` install in `.github/actions/setup-go-corset/action.yml` to pin commit `d4efce1` (`v1.1.31-rc1`), replacing the previous SHA (`v1.2.0-rc3`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdc8e6f8d97ddd39dceb86a8ee70665731d8dbcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->