### PR TITLE
chore: set go-corset version v1.1.31

### DIFF
--- a/.github/actions/setup-go-corset/action.yml
+++ b/.github/actions/setup-go-corset/action.yml
@@ -12,4 +12,4 @@ runs:
 
     - name: Install Go Corset
       shell: bash
-      run: go install github.com/consensys/go-corset/cmd/go-corset@1aee6f95c28b1ca2f66f6d8347a0d247d8be38a4 # v1.2.0-rc3
+      run: go install github.com/consensys/go-corset/cmd/go-corset@22aafb6e1e6b723ec55700efdfe9c7e35f667f4d # v1.1.31


### PR DESCRIPTION
The purpose of this is to provide a baseline performance.  **_This is not intended to be merged._**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns CI to a stable `go-corset` version.
> 
> - In `./github/actions/setup-go-corset/action.yml`, update install step to `github.com/consensys/go-corset/cmd/go-corset@22aafb6e1e6b723ec55700efdfe9c7e35f667f4d` (`v1.1.31`), replacing `v1.2.0-rc3`.
> - No other changes to the action or workflow configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e546bc8dde3e8d96670d9b0c7145355d07c1873d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->