### PR TITLE
chore: tidy up SETUP.md

### DIFF
--- a/tracer/SETUP.md
+++ b/tracer/SETUP.md
@@ -107,6 +107,16 @@ ______________________________________________________________________
 - Install [Spotless Gradle](https://plugins.jetbrains.com/plugin/18321-spotless-gradle) plugin to re-format through
   the IDE according to spotless configuration.
 
+## Debugging Traces
+
+- JSON files can be debugged with the following command:
+
+```shell
+go-corset check --report <LT/JSON FILE> tracer/linea-constraints/zkevm_osaka.bin
+```
+
+See [here](https://github.com/Consensys/go-corset) for more options when running `go-corset` directly.
+
 ## Plugins
 
 Plugins are documented [here](PLUGINS.md).


### PR DESCRIPTION
This tidies up the SETUP.md file to correctly indicate how to install go-corset, and also to adjust some other notes as a result of moving into the monorepo.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes tracer setup and testing docs for the monorepo.
> 
> - Replace Rust/Corset with `go-corset` install and usage; add link to `go-corset` options
> - Update constraints submodule reference to `linea-constraints`
> - Refresh Gradle commands to scoped tasks: `tracer:arithmetization:test`, `tracer:arithmetization:fastReplayTests`, and `tracer:reference-tests:referenceBlockchainTests`
> - Remove outdated sections (e.g., old reference tests list, capture replay notes) and streamline instructions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0d3b3e0cb63c08c41c6f0938c279941c901f3d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->