### PR TITLE
feat: update postman and prover image version in local stack

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -233,7 +233,7 @@ services:
   prover-v3: # prover compatible with the traces from zkbesu
     container_name: prover-v3
     hostname: prover-v3
-    image: consensys/linea-prover:${PROVER_TAG:-56c4809}
+    image: consensys/linea-prover:${PROVER_TAG:-5f458b5}
     platform: linux/amd64
     # to avoid spinning up on CI for now
     profiles: [ "l2" ]
@@ -254,7 +254,7 @@ services:
   postman:
     container_name: postman
     hostname: postman
-    image: consensys/linea-postman:${POSTMAN_TAG:-19735ce}
+    image: consensys/linea-postman:${POSTMAN_TAG:-5f458b5}
     profiles: [ "l2", "debug" ]
     restart: on-failure
     ports:


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Docker tags in the local L2 compose stack.
> 
> - Bumps `consensys/linea-prover` for `prover-v3` to `5f458b5` in `docker/compose-spec-l2-services.yml`
> - Bumps `consensys/linea-postman` for `postman` to `5f458b5` in `docker/compose-spec-l2-services.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ca79194b61312906be64971ce0045d977926dcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->