### PR TITLE
fix(bridge-ui): incorrect text color in native bridge and humanity verified sections

### DIFF
--- a/bridge-ui/src/components/bridge/form/bridge-form.module.scss
+++ b/bridge-ui/src/components/bridge/form/bridge-form.module.scss
@@ -21,6 +21,7 @@
 
     .transaction-button {
       padding: 0.5rem;
+      color: var(--color-indigo);
 
       &:hover {
         background-color: var(--color-smoke);

--- a/bridge-ui/src/components/bridge/from-chain/from-chain.module.scss
+++ b/bridge-ui/src/components/bridge/from-chain/from-chain.module.scss
@@ -34,6 +34,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  color: var(--color-black);
 
   .info-value {
     font-size: 1rem;

--- a/bridge-ui/src/components/poh-check/poh-check.module.scss
+++ b/bridge-ui/src/components/poh-check/poh-check.module.scss
@@ -27,6 +27,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   line-height: 1.4;
+  color: var(--color-black);
 }
 
 .icon {


### PR DESCRIPTION
https://github.com/Consensys/linea-hub/issues/1646
Fix Incorrect text color in native bridge and humanity verified sections

* Add color to transaction button in SCSS
* Add color property to from-chain styles
* Add color property to text class in SCSS

---------

This PR implements issue(s) # 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes text colors across bridge UI components for consistent styling.
> 
> - Set `color: var(--color-indigo)` on `transaction-button` in `bridge-form.module.scss`
> - Added `color: var(--color-black)` to `.info` in `from-chain.module.scss`
> - Added `color: var(--color-black)` to `.text` in `poh-check.module.scss`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed3ee4df556ca58852563f822114cbe180da1764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->