### PR TITLE
feat: remove tracer-setup from coordinator-testing workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,7 +246,7 @@ jobs:
 
   publish-images-after-run-tests-success-on-main:
     needs: [filter-commit-changes, check-and-tag-images, testing, run-e2e-tests]
-    if: ${{ always() && github.ref == 'refs/heads/main' && needs.testing.result == 'success' && (needs.run-e2e-tests.result == 'skipped' || needs.run-e2e-tests.outputs.tests_outcome == 'success') }}
+    if: ${{ always() && github.ref == 'refs/heads/main' && needs.testing.result == 'success' && needs.run-e2e-tests.outputs.tests_outcome == 'success' }}
     uses: ./.github/workflows/build-and-publish.yml
     with:
       push_image: true


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unused tracer setup from the coordinator testing workflow while keeping build, integration tests, and Jacoco reporting intact.
> 
> - Deletes the `Setup Tracer Environment` step in `.github/workflows/coordinator-testing.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65f4819216df00f235f6d6905847ad572ca7c6d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->