### PR TITLE
[Coordinator] Web3j to EthApiMigration 7/N

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -69,7 +69,6 @@ import net.consensys.zkevm.persistence.BlobsRepository
 import net.consensys.zkevm.persistence.dao.batch.persistence.BatchProofHandlerImpl
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import org.web3j.protocol.Web3j
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds


### PR DESCRIPTION
This PR implements issue(s) #1790 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `ConflationApp` from Web3j to `EthApiClient` for L2 block access and simplifies deadline runner wiring.
> 
> - Replace `ExtendedWeb3JImpl`/`Web3j` block fetch with `l2EthClient.ethGetBlockByNumberTxHashes(lastProcessedBlockNumber.toBlockParameter())`
> - Make `createDeadlineConflationCalculatorRunner()` no-arg and use `GethCliqueSafeBlockProvider(l2EthClient)` internally
> - `Web3JL2MessageServiceSmartContractClient.createReadOnly` now builds its own Web3j HTTP client inline instead of reusing a shared instance
> - Cleanup imports (use `BlockParameter.toBlockParameter`) and remove unused Web3j constructs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eb7fc56f159ab0e38e9bfa31f118297b32dcab5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->