### PR TITLE
Dump pg database on e2e tests log dump

### DIFF
--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -183,6 +183,7 @@ jobs:
           docker logs l1-el-node --since 1h &>> docker_logs/l1-el-node.txt || true
           docker logs l1-cl-node --since 1h &>> docker_logs/l1-cl-node.txt || true
           docker logs maru --since 1h &>> docker_logs/maru.txt || true
+          docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD:-postgres} postgres pg_dumpall -U ${POSTGRES_USER:-postgres} > docker_logs/db_dump.sql || true
       - name: Archive debug logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() && inputs.e2e-tests-logs-dump }}

--- a/config/coordinator/log4j2-dev.xml
+++ b/config/coordinator/log4j2-dev.xml
@@ -127,7 +127,7 @@
     <!--    <Logger name="clients" level="DEBUG" additivity="false">-->
     <!--      <appender-ref ref="console"/>-->
     <!--    </Logger>-->
-    <Root level="INFO" additivity="true">
+    <Root level="DEBUG" additivity="true">
       <appender-ref ref="console"/>
       <!-- <appender-ref ref="consoleJSON"/>-->
       <!-- <appender-ref ref="consoleJSONCustom"/>-->


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - In `reuse-run-e2e-tests.yml`, on e2e test failure with log dump enabled, executes `docker exec postgres pg_dumpall` and saves to `docker_logs/db_dump.sql` for debugging
> - In `config/coordinator/log4j2-dev.xml`, changes root logger level from `INFO` to `DEBUG` to increase verbosity during development
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4ab839c0219aec3af1bfd4ba65d06ab09c37608. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->