### PR TITLE
fix: update default postman docker image

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -254,7 +254,7 @@ services:
   postman:
     container_name: postman
     hostname: postman
-    image: consensys/linea-postman:${POSTMAN_TAG:-5f458b5}
+    image: consensys/linea-postman:${POSTMAN_TAG:-bbf345e}
     profiles: [ "l2", "debug" ]
     restart: on-failure
     ports:


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Docker Compose L2 services to use a newer `consensys/linea-postman` image by changing the default tag from `5f458b5` to `bbf345e`.
> 
> - In `docker/compose-spec-l2-services.yml`, the `postman` service `image` default tag is updated
> - No other services or configurations are modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a47fb3cec69058c2c26d12dde57a450ccbbb14c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->