### PR TITLE
Debug e2e ci failures

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -318,7 +318,7 @@ services:
   web3signer:
     hostname: web3signer
     container_name: web3signer
-    image: consensys/web3signer:25.12.0
+    image: consensys/web3signer:25.2
     profiles: [ "l2", "debug", "external-to-monorepo" ]
     ports:
       - "9000:9000"

--- a/ts-libs/linea-shared-utils/scripts/test-ethereum-mainnet-client-library-web3-signer.ts
+++ b/ts-libs/linea-shared-utils/scripts/test-ethereum-mainnet-client-library-web3-signer.ts
@@ -13,7 +13,7 @@ docker run --rm \
   -p 9000:9000 \
   -v "$(pwd)/docker/web3signer/key-files:/key-files" \
   -v "$(pwd)/docker/web3signer/tls-files:/tls-files" \
-  consensys/web3signer:25.12.0 \
+  consensys/web3signer:25.2 \
   --key-store-path=/key-files/ \
   --tls-keystore-file=/tls-files/web3signer-keystore.p12 \
   --tls-keystore-password-file=/tls-files/web3signer-keystore-password.txt \

--- a/ts-libs/linea-shared-utils/scripts/test-web3-signer-client-adapter.ts
+++ b/ts-libs/linea-shared-utils/scripts/test-web3-signer-client-adapter.ts
@@ -8,7 +8,7 @@ docker run --rm \
   -p 9000:9000 \
   -v "$(pwd)/docker/web3signer/key-files:/key-files" \
   -v "$(pwd)/docker/web3signer/tls-files:/tls-files" \
-  consensys/web3signer:25.12.0 \
+  consensys/web3signer:25.2 \
   --key-store-path=/key-files/ \
   --tls-keystore-file=/tls-files/web3signer-keystore.p12 \
   --tls-keystore-password-file=/tls-files/web3signer-keystore-password.txt \


### PR DESCRIPTION

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures consistent Web3Signer version across local/dev tooling.
> 
> - Updates `image` tag for `web3signer` in `docker/compose-spec-l2-services.yml` to `consensys/web3signer:25.2`
> - Adjusts example `docker run` commands in `scripts/test-ethereum-mainnet-client-library-web3-signer.ts` and `scripts/test-web3-signer-client-adapter.ts` to use `consensys/web3signer:25.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66775d2d58731718b654c1d00f433893396100a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->