### PR TITLE
(fix): detect ecrecover overflow

### DIFF
--- a/prover/zkevm/prover/ecdsa/antichamber.go
+++ b/prover/zkevm/prover/ecdsa/antichamber.go
@@ -187,6 +187,14 @@ func (ac *antichamber) assignAntichamber(run *wizard.ProverRuntime, nbEcRecInsta
 	var (
 		maxNbEcRecover = ac.Inputs.Settings.MaxNbEcRecover
 		maxNbTx        = ac.Inputs.Settings.MaxNbTx
+
+		// Calculate the Logical Limit (The "Contract")
+		// This is the maximum row space we claimed we would need in your config.
+		// The circuit is built to exactly this capacity.
+		configuredLimitRows = nbRowsPerEcRec*maxNbEcRecover + nbRowsPerTxSign*maxNbTx
+
+		// Calculate Actual Usage (The "Reality") - This is how many rows your trace actually demands.
+		actualUsageRows = nbRowsPerEcRec*nbEcRecInstances + nbRowsPerTxSign*nbTxInstances
 	)
 
 	if nbRowsPerEcRec*maxNbEcRecover+nbRowsPerTxSign*maxNbTx > ac.Size {
@@ -208,6 +216,17 @@ func (ac *antichamber) assignAntichamber(run *wizard.ProverRuntime, nbEcRecInsta
 			fmt.Errorf("not enough space in ECDSA antichamber to store all the data. Need %d, got %d",
 				nbTxInstances*nbRowsPerTxSign+nbEcRecInstances*nbRowsPerEcRec, ac.Size,
 			),
+		)
+	}
+
+	// This catches the case where the data fits in the physical buffer (ac.Size)
+	// but exceeds the logical capacity the circuit was built for.
+	if actualUsageRows > configuredLimitRows {
+		exit.OnLimitOverflow(
+			configuredLimitRows,
+			actualUsageRows,
+			fmt.Errorf("ECDSA antichamber row limit exceeded: trace requires %d rows (EcRec:%d, Tx:%d), but config limits to %d rows (MaxEcRec:%d, MaxTx:%d)",
+				actualUsageRows, nbEcRecInstances, nbTxInstances, configuredLimitRows, maxNbEcRecover, maxNbTx),
 		)
 	}
 


### PR DESCRIPTION
This PR fixes a limit-handling bug in the `ECDSA` antichamber.

We now enforce logical capacity limits in addition to the physical antichamber size. An explicit check ensures that the combined row usage from transactions and precompile calls does not exceed the configuration limits for which the circuit was built. When this logical limit is exceeded, we correctly trigger a limit-overflow error.

This causes the request to be retried with the `execution-large` circuit in the `full` prover, or allows the bootstrapper in the limitless prover to automatically scale up, instead of silently proceeding with an invalid layout.

The fix has been tested with the limitless prover in `prover/osaka` branch, where the bootstrapper now properly autoscales and successfully generates the proof. 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a safeguard so traces that fit the physical buffer but exceed the configured circuit capacity fail fast.
> 
> - Introduces `configuredLimitRows` and `actualUsageRows` in `assignAntichamber` and errors via `exit.OnLimitOverflow` when actual rows (`EcRec`/`Tx`) surpass configured `MaxNbEcRecover`/`MaxNbTx` limits
> - Keeps existing size checks; only `antichamber.go` updated with comments and validations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a98804b3a589c659dc057b11a90f68b2488bc286. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->