### PR TITLE
Chore: update Besu to 25.12.0-linea4

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/EstimateGasTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/EstimateGasTest.kt
@@ -226,7 +226,7 @@ open class EstimateGasTest : LineaPluginPoSTestBase() {
     // 0x5d539a1 ~= (0x1234 * 21_000 gas) + 1 value (since the tx is a simple transfer)
     assertThat(respLinea.error.message)
       .isEqualTo(
-        "transaction up-front cost 0x5d539a1 exceeds transaction sender account balance 0x0",
+        "transaction up-front cost 0x5d539a1 exceeds transaction sender account balance 0x0 for sender %s".format(sender.address),
       )
   }
 

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactory.java
@@ -14,6 +14,7 @@ import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.PLUGIN
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTION_CANCELLED;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -34,6 +35,7 @@ import net.consensys.linea.sequencer.liveness.LivenessService;
 import net.consensys.linea.sequencer.txselection.selectors.LineaTransactionSelector;
 import net.consensys.linea.sequencer.txselection.selectors.TransactionEventFilter;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.plugin.services.BlockchainService;
@@ -115,8 +117,10 @@ public class LineaTransactionSelectorFactory implements PluginTransactionSelecto
     return selector;
   }
 
+  @Override
   public void selectPendingTransactions(
-      final BlockTransactionSelectionService bts, final ProcessableBlockHeader pendingBlockHeader) {
+      final BlockTransactionSelectionService bts, final ProcessableBlockHeader pendingBlockHeader,
+      final List<? extends PendingTransaction> candidatePendingTransactions) {
     try {
       // check and send liveness bundle if any
       checkAndSendLivenessBundle(bts, pendingBlockHeader.getNumber());

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
@@ -147,7 +147,7 @@ class LineaTransactionSelectorFactoryTest {
 
     when(mockBts.evaluatePendingTransaction(any())).thenReturn(TransactionSelectionResult.SELECTED);
 
-    factory.selectPendingTransactions(mockBts, mockPendingBlockHeader);
+    factory.selectPendingTransactions(mockBts, mockPendingBlockHeader, Collections.emptyList());
 
     verify(mockBts).commit();
   }
@@ -165,7 +165,7 @@ class LineaTransactionSelectorFactoryTest {
 
     when(mockBts.evaluatePendingTransaction(any())).thenReturn(failStatus);
 
-    factory.selectPendingTransactions(mockBts, mockPendingBlockHeader);
+    factory.selectPendingTransactions(mockBts, mockPendingBlockHeader, Collections.emptyList());
 
     verify(mockBts).rollback();
   }
@@ -176,7 +176,7 @@ class LineaTransactionSelectorFactoryTest {
     var mockPendingBlockHeader = mock(ProcessableBlockHeader.class);
     when(mockPendingBlockHeader.getNumber()).thenReturn(1L);
 
-    factory.selectPendingTransactions(mockBts, mockPendingBlockHeader);
+    factory.selectPendingTransactions(mockBts, mockPendingBlockHeader, Collections.emptyList());
 
     verifyNoInteractions(mockBts);
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ undercouchDownload = "5.6.0"
 
 # Runtime
 arithmetization="beta-v4.4-rc7.3"
-besu = "25.12.0-linea2"
+besu = "25.12.0-linea4"
 blobCompressor = "2.1.0-rc1"
 blobShnarfCalculator = "1.2.0"
 bouncycastle = "1.79"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Upgrade Besu runtime**
> 
> - Bumps `besu` version to `25.12.0-linea4` in `gradle/libs.versions.toml`
> 
> **Adapt to Besu API changes**
> 
> - Extends `selectPendingTransactions` in `LineaTransactionSelectorFactory` to accept `List<? extends PendingTransaction>` and annotates with `@Override`
> - Updates unit tests to use the new method signature (pass `Collections.emptyList()`)
> 
> **Test assertion tweak**
> 
> - `EstimateGasTest`: expected error now includes the sender address in the message
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c2e13af96e72f2c3101745688a5bf30e86b13e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->