### PR TITLE
[Coordinator] Refactor blob compression proof flow part 2 (b)

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -343,6 +343,7 @@ class ConflationApp(
         conflationAndProofGenerationRetryBackoffDelay = 5.seconds,
         executionProofPollingInterval = 100.milliseconds,
       ),
+      metricsFacade = metricsFacade,
     )
   }
 

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
@@ -86,7 +86,6 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
 
     return findRequestFileIfAlreadyInFileSystem(requestFileName)
       .thenCompose { requestFileFound: String? ->
-        responsesWaiting.incrementAndGet()
         if (requestFileFound != null) {
           log.debug(
             "request already in file system: {}={} reusedRequest={}",
@@ -119,6 +118,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
         if (response != null) {
           SafeFuture.completedFuture(response)
         } else {
+          responsesWaiting.incrementAndGet()
           createProofRequest(proofRequest)
             .thenCompose { waitForResponse(responseFilePath) }
             .thenCompose {

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofPoller.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofPoller.kt
@@ -1,0 +1,76 @@
+package net.consensys.zkevm.ethereum.coordination.blob
+
+import io.vertx.core.Vertx
+import linea.timer.TimerSchedule
+import linea.timer.VertxPeriodicPollingService
+import net.consensys.linea.metrics.LineaMetricsCategory
+import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
+import net.consensys.zkevm.domain.BlobRecord
+import net.consensys.zkevm.domain.ProofIndex
+import org.apache.logging.log4j.Logger
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.ConcurrentLinkedDeque
+import kotlin.time.Duration.Companion.milliseconds
+
+class BlobCompressionProofPoller(
+  private val blobCompressionProverClient: BlobCompressionProverClientV2,
+  private val blobCompressionProofHandler: BlobCompressionProofHandler,
+  vertx: Vertx,
+  private val log: Logger,
+  pollingIntervalMs: Long = 100.milliseconds.inWholeMilliseconds,
+  name: String = "BlobCompressionProofPoller",
+  timerSchedule: TimerSchedule = TimerSchedule.FIXED_DELAY,
+  metricsFacade: MetricsFacade,
+) : VertxPeriodicPollingService(
+  vertx = vertx,
+  pollingIntervalMs = pollingIntervalMs,
+  log = log,
+  name = name,
+  timerSchedule = timerSchedule,
+) {
+  data class ProofInProgress(
+    val proofIndex: ProofIndex,
+    val unProvenBlobRecord: BlobRecord,
+  )
+
+  private val proofRequestsInProgress = ConcurrentLinkedDeque<ProofInProgress>()
+
+  init {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BLOB,
+      name = "prover.pending_proofs",
+      description = "Number of blob compression proof waiting responses",
+      measurementSupplier = { proofRequestsInProgress.size },
+    )
+  }
+
+  @Synchronized
+  fun addProofRequestsInProgressForPolling(proofIndex: ProofIndex, unProvenBlobRecord: BlobRecord) {
+    proofRequestsInProgress.add(ProofInProgress(proofIndex, unProvenBlobRecord))
+  }
+
+  override fun action(): SafeFuture<*> {
+    return if (proofRequestsInProgress.isNotEmpty()) {
+      val proofInProgress = proofRequestsInProgress.peekFirst()
+      blobCompressionProverClient.findProofResponse(proofInProgress.proofIndex)
+        .thenCompose { proofResponse ->
+          if (proofResponse != null) {
+            log.info(
+              "blob compression proof generated: blob={}",
+              proofInProgress.unProvenBlobRecord.intervalString(),
+            )
+            val provenBlobRecord = proofInProgress.unProvenBlobRecord.copy(blobCompressionProof = proofResponse)
+            blobCompressionProofHandler.acceptNewBlobCompressionProof(provenBlobRecord)
+              .thenApply {
+                proofRequestsInProgress.remove(proofInProgress)
+              }
+          } else {
+            SafeFuture.completedFuture(Unit)
+          }
+        }
+    } else {
+      SafeFuture.completedFuture(Unit)
+    }
+  }
+}

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -11,6 +11,8 @@ import linea.domain.Block
 import linea.timer.TimerSchedule
 import linea.timer.VertxPeriodicPollingService
 import net.consensys.linea.async.AsyncRetryer
+import net.consensys.linea.metrics.LineaMetricsCategory
+import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.domain.Batch
 import net.consensys.zkevm.domain.BlocksConflation
 import net.consensys.zkevm.domain.ProofIndex
@@ -29,6 +31,7 @@ class ProofGeneratingConflationHandlerImpl(
   private val vertx: Vertx,
   private val config: Config,
   private val log: Logger = LogManager.getLogger(ProofGeneratingConflationHandlerImpl::class.java),
+  metricsFacade: MetricsFacade,
 ) : ConflationHandler,
   VertxPeriodicPollingService(
     vertx = vertx,
@@ -44,6 +47,15 @@ class ProofGeneratingConflationHandlerImpl(
   )
 
   private val proofRequestsInProgress = ConcurrentLinkedDeque<ProofIndex>()
+
+  init {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BATCH,
+      name = "prover.pending_proofs",
+      description = "Number of execution proof waiting responses",
+      measurementSupplier = { proofRequestsInProgress.size },
+    )
+  }
 
   override fun action(): SafeFuture<*> {
     return if (proofRequestsInProgress.isNotEmpty()) {

--- a/coordinator/persistence/blob/src/integrationTest/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofCoordinatorIntTest.kt
+++ b/coordinator/persistence/blob/src/integrationTest/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofCoordinatorIntTest.kt
@@ -19,6 +19,7 @@ import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
 import net.consensys.zkevm.domain.Blob
 import net.consensys.zkevm.domain.ConflationCalculationResult
 import net.consensys.zkevm.domain.ConflationTrigger
+import net.consensys.zkevm.domain.ProofIndex
 import net.consensys.zkevm.domain.createBlobRecord
 import net.consensys.zkevm.persistence.BlobsRepository
 import net.consensys.zkevm.persistence.dao.blob.BlobsPostgresDao
@@ -74,6 +75,7 @@ class BlobCompressionProofCoordinatorIntTest : CleanDbTestSuiteParallel() {
     fixedClock.now().plus(1200.seconds).toEpochMilliseconds(),
   )
   private var expectedBlobCompressionProofResponse: BlobCompressionProof? = null
+  private val proofIndexExpectedProofResponseMap: MutableMap<ProofIndex, BlobCompressionProof> = mutableMapOf()
 
   private val zkStateClientMock = mock<StateManagerClientV1>()
   private val blobCompressionProverClientMock = mock<BlobCompressionProverClientV2>()
@@ -88,6 +90,7 @@ class BlobCompressionProofCoordinatorIntTest : CleanDbTestSuiteParallel() {
 
   @BeforeEach
   fun beforeEach(vertx: Vertx) {
+    proofIndexExpectedProofResponseMap.clear()
     blobsPostgresDao =
       BlobsPostgresDao(
         config = BlobsPostgresDao.Config(
@@ -118,7 +121,7 @@ class BlobCompressionProofCoordinatorIntTest : CleanDbTestSuiteParallel() {
           ),
         ),
       )
-    whenever(blobCompressionProverClientMock.requestProof(any()))
+    whenever(blobCompressionProverClientMock.createProofRequest(any()))
       .thenAnswer { invocationMock ->
         val proofReq = invocationMock.arguments[0] as BlobCompressionProofRequest
         expectedBlobCompressionProofResponse = BlobCompressionProof(
@@ -143,7 +146,19 @@ class BlobCompressionProofCoordinatorIntTest : CleanDbTestSuiteParallel() {
           kzgProofContract = Random.nextBytes(48),
           kzgProofSidecar = Random.nextBytes(48),
         )
-        SafeFuture.completedFuture(expectedBlobCompressionProofResponse)
+        val proofIndex = ProofIndex(
+          startBlockNumber = proofReq.startBlockNumber,
+          endBlockNumber = proofReq.conflations.last().endBlockNumber,
+          hash = proofReq.expectedShnarfResult.dataHash,
+        )
+        proofIndexExpectedProofResponseMap[proofIndex] = expectedBlobCompressionProofResponse!!
+        SafeFuture.completedFuture(proofIndex)
+      }
+
+    whenever(blobCompressionProverClientMock.findProofResponse(any()))
+      .thenAnswer { invocationMock ->
+        val proofIndex = invocationMock.arguments[0] as ProofIndex
+        SafeFuture.completedFuture(proofIndexExpectedProofResponseMap[proofIndex])
       }
 
     mockShnarfCalculator = spy(FakeBlobShnarfCalculator())
@@ -264,7 +279,8 @@ class BlobCompressionProofCoordinatorIntTest : CleanDbTestSuiteParallel() {
         assertThat(blobCompressionProof?.parentDataHash).isEqualTo(prevBlobRecord.blobHash)
         assertThat(blobCompressionProof?.prevShnarf).isEqualTo(prevBlobRecord.expectedShnarf)
         verify(mockShnarfCalculator).calculateShnarf(any(), any(), any(), any(), any())
-        verify(blobCompressionProverClientMock).requestProof(any())
+        verify(blobCompressionProverClientMock).createProofRequest(any())
+        verify(blobCompressionProverClientMock).findProofResponse(any())
       }
     testContext.completeNow()
   }


### PR DESCRIPTION
This PR implements issue(s) #2044

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts blob compression proofing to an async request + periodic polling model and adds observability for pending proofs.
> 
> - Introduces `BlobCompressionProofPoller` and wires it into `BlobCompressionProofCoordinator`; coordinator now calls `createProofRequest` and enqueues requests for polling instead of blocking on responses
> - Updates service lifecycle to start/stop the new poller; minor cleanup and logging tweaks
> - Adds metrics gauges for pending proofs: blob (`BLOB.prover.pending_proofs`) and execution/batch (`BATCH.prover.pending_proofs`); passes `metricsFacade` into `ProofGeneratingConflationHandlerImpl`
> - Adjusts `GenericFileBasedProverClient` to increment/decrement `responsesWaiting` only in the synchronous `requestProof` path (not in `createProofRequest`)
> - Updates tests to reflect new API (`createProofRequest` + `findProofResponse`) and polling behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed7b80f196575b929a0fa29502b89339bca14c01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->