### PR TITLE
fix: add missing await keywords in test assertions

### DIFF
--- a/contracts/test/hardhat/recovery/RecoverFunds.ts
+++ b/contracts/test/hardhat/recovery/RecoverFunds.ts
@@ -111,7 +111,7 @@ describe("RecoverFunds contract", () => {
       const functionCall = recoverFunds
         .connect(nonAuthorizedAccount)
         .executeExternalCall(nonAuthorizedAccount, EMPTY_CALLDATA, 1000n);
-      expectRevertWithReason(functionCall, buildAccessErrorMessage(nonAuthorizedAccount, FUNCTION_EXECUTOR_ROLE));
+      await expectRevertWithReason(functionCall, buildAccessErrorMessage(nonAuthorizedAccount, FUNCTION_EXECUTOR_ROLE));
     });
 
     it("Should send half of the ETH sent", async () => {

--- a/contracts/test/hardhat/yield/integration/YieldManager.integration.ts
+++ b/contracts/test/hardhat/yield/integration/YieldManager.integration.ts
@@ -263,7 +263,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
         .claimMessageWithProofAndWithdrawLST(claimParams, yieldProviderAddress);
 
       // Assert
-      expectRevertWithCustomError(lineaRollup, claimCall, "CallerNotLSTWithdrawalRecipient");
+      await expectRevertWithCustomError(lineaRollup, claimCall, "CallerNotLSTWithdrawalRecipient");
     });
     it("Should revert if LST withdrawal > rate limit", async () => {
       const rateLimit = await lineaRollup.limitInWei();
@@ -750,8 +750,8 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       const secondWithdrawLSTCall = lineaRollup
         .connect(nonAuthorizedAccount)
         .claimMessageWithProofAndWithdrawLST(claimParams2, yieldProviderAddress);
-      expectRevertWithCustomError(yieldManager, secondWithdrawLSTCall, "LSTWithdrawalExceedsYieldProviderFunds");
-      expectRevertWithCustomError(
+      await expectRevertWithCustomError(yieldManager, secondWithdrawLSTCall, "LSTWithdrawalExceedsYieldProviderFunds");
+      await expectRevertWithCustomError(
         yieldManager,
         yieldManager.replenishWithdrawalReserve(yieldProviderAddress),
         "NoAvailableFundsToReplenishWithdrawalReserve",
@@ -970,7 +970,7 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       // Bridge funds decrement to deficit
       await setWithdrawalReserveToMinimum(yieldManager);
       await decrementBalance(l1MessageServiceAddress, ONE_ETHER * 10n);
-      expectRevertWithCustomError(
+      await expectRevertWithCustomError(
         yieldManager,
         lineaRollup.connect(nativeYieldOperator).transferFundsForNativeYield(1n),
         "InsufficientWithdrawalReserve",

--- a/contracts/test/hardhat/yield/unit/LidoStVaultYieldProvider.basic.ts
+++ b/contracts/test/hardhat/yield/unit/LidoStVaultYieldProvider.basic.ts
@@ -613,7 +613,7 @@ describe("LidoStVaultYieldProvider contract - basic operations", () => {
       const call = yieldManager
         .connect(securityCouncil)
         .exitVendorContracts(yieldProviderAddress, buildVendorExitData({ newVaultOwner: ZeroAddress }));
-      expectRevertWithCustomError(yieldManager, call, "ZeroAddressNotAllowed");
+      await expectRevertWithCustomError(yieldManager, call, "ZeroAddressNotAllowed");
     });
     it("When non-ossified, should succeed with call to Dashboard", async () => {
       await yieldManager.setYieldProviderIsOssified(yieldProviderAddress, false);

--- a/contracts/test/hardhat/yield/unit/LineaRollupYieldExtension.ts
+++ b/contracts/test/hardhat/yield/unit/LineaRollupYieldExtension.ts
@@ -90,7 +90,7 @@ describe("Linea Rollup Yield Extension", () => {
   describe("fund() to receive funding", () => {
     it("Should revert if 0 value received", async () => {
       const fundCall = lineaRollup.connect(nonAuthorizedAccount).fund({ value: ZERO_VALUE });
-      expectRevertWithCustomError(lineaRollup, fundCall, "NoEthSent");
+      await expectRevertWithCustomError(lineaRollup, fundCall, "NoEthSent");
     });
 
     it("Should succeed with permissionless call and emit the correct event", async () => {

--- a/contracts/test/hardhat/yield/unit/ValidatorContainerProofVerifier.ts
+++ b/contracts/test/hardhat/yield/unit/ValidatorContainerProofVerifier.ts
@@ -251,7 +251,7 @@ describe("ValidatorContainerProofVerifier", () => {
       0,
       ACTIVE_0X01_VALIDATOR_PROOF.beaconBlockHeader.proposerIndex,
     );
-    expectRevertWithCustomError(verifier, call, "RootNotFound");
+    await expectRevertWithCustomError(verifier, call, "RootNotFound");
   });
 
   it("can verify against dynamic merkle tree", async () => {

--- a/contracts/test/hardhat/yield/unit/YieldManager.funds.ts
+++ b/contracts/test/hardhat/yield/unit/YieldManager.funds.ts
@@ -1264,7 +1264,7 @@ describe("YieldManager contract - ETH transfer operations", () => {
       const call = yieldManager.connect(nativeYieldOperator).replenishWithdrawalReserve(mockYieldProviderAddress);
 
       // Assert
-      expectRevertWithCustomError(yieldManager, call, "NoAvailableFundsToReplenishWithdrawalReserve");
+      await expectRevertWithCustomError(yieldManager, call, "NoAvailableFundsToReplenishWithdrawalReserve");
     });
 
     it("If YieldManager balance > targetDeficit, settle targetDeficit from YieldManager balance", async () => {


### PR DESCRIPTION
Add await keywords before expectRevertWithReason and expectRevertWithCustomError calls to ensure proper async handling in test files.

- Add await before expectRevertWithReason in RecoverFunds.ts
- Add await before 8 instances of expectRevertWithCustomError across yield test files

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures async revert assertions are properly awaited in test suite.
> 
> - Add `await` to `expectRevertWithReason`/`expectRevertWithCustomError` calls in `RecoverFunds.ts`, `YieldManager.integration.ts`, `LidoStVaultYieldProvider.basic.ts`, `LineaRollupYieldExtension.ts`, `ValidatorContainerProofVerifier.ts`, and `YieldManager.funds.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34918ddad68e46a375f38a9465506b47e722a2f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->