### PR TITLE
fix(dcc): add BaseFee and CoinBase to PI hash computation

### DIFF
--- a/prover/circuits/execution/pi.go
+++ b/prover/circuits/execution/pi.go
@@ -162,6 +162,8 @@ func (spi *FunctionalPublicInputSnark) Sum(api frontend.API) frontend.Variable {
 		initialRollingHash[1],
 		spi.FirstRollingHashUpdateNumber,
 		spi.ChainID,
+		spi.BaseFee,
+		spi.CoinBase,
 		spi.L2MessageServiceAddr,
 	)
 

--- a/prover/circuits/execution/pi_test.go
+++ b/prover/circuits/execution/pi_test.go
@@ -43,7 +43,7 @@ func TestPIConsistency(t *testing.T) {
 
 	snarkPi := FunctionalPublicInputSnark{
 		FunctionalPublicInputQSnark: FunctionalPublicInputQSnark{
-			L2MessageHashes: L2MessageHashes{Values: make([][32]frontend.Variable, 3)},
+			L2MessageHashes: L2MessageHashes{Values: make([][32]frontend.Variable, 2)},
 		},
 	}
 	require.NoError(t, snarkPi.Assign(&pi))


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major prover/public-input upgrades and pipeline refactor.
> 
> - Replace `blobdecompression` with `dataavailability` v2 circuits and wiring; update PI interconnection and config; new batch checks and public input hashing
> - Include `BaseFee` and `CoinBase` in execution/aggregation functional PIs and runtime checks; extend chain config propagation and validation
> - Migrate hashes/types: MiMC → Poseidon2, `Bytes32` → `Bls12377Fr`/`KoalaOctuplet`; update state manager (ordering, hashing), exec checksum, and tests accordingly
> - Refactor execution-limitless flow: GL/LPP proof streaming, hierarchical conglomeration, VK Merkle tree usage, concurrency tuning, and setup loading; update serialization and proof inputs
> - Misc: bump Go image to 1.24.6, update golangci-lint to v8, expand tests/Makefile targets, and adjust .gitattributes/.gitignore
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f51f216ea6ddebb5e0f6c8a940170ccd2585c6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->