### PR TITLE
perf: optimize GnarkEvaluateLagrangeExt and GnarkCheckStatementAndCodeWord

### DIFF
--- a/prover/protocol/compiler/standard_benchmark_test.go
+++ b/prover/protocol/compiler/standard_benchmark_test.go
@@ -430,7 +430,7 @@ func benchmarkCompilerWithSelfRecursionAndGnarkVerifier(b *testing.B, sbc StdBen
 		}
 
 		circuit := verifierCircuit{}
-		nbRounds := 10 // comp.NumRounds() //17 // TODO setting this to comp.NumRounds() make the number of constraint explode, need to investigate
+		nbRounds := comp.NumRounds() // comp.NumRounds() //17 // TODO setting this to comp.NumRounds() make the number of constraint explode, need to investigate
 		fmt.Printf("using nbRounds=%d instead of %d\n", nbRounds, comp.NumRounds())
 		{
 			c := wizard.AllocateWizardCircuit(comp, nbRounds, isBLS)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves polynomial evaluation and refactors verifier flow for clarity and efficiency.
> 
> - Adds barycentric-form `GnarkEvaluateLagrangeExt` and an optimized batched variant sharing precomputed weights; reduces multiplications and divisions per evaluation
> - Refactors `GnarkCheckStatementAndCodeWord`: performs codeword check at a random challenge with Lagrange eval, asserts RS zero tail, then does statement check via canonical eval at `x`; removes previous dual-point batch eval and reorders steps
> - Benchmark: `standard_benchmark_test.go` now sets `nbRounds` to `comp.NumRounds()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6992e4c014ba61304496e223350863d3ace5a974. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->