### PR TITLE
[Coordinator] Refactor conflation calculator creation for code reuse

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -3,14 +3,12 @@ package net.consensys.zkevm.coordinator.app.conflation
 import build.linea.clients.StateManagerClientV1
 import build.linea.clients.StateManagerV1JsonRpcClient
 import io.vertx.core.Vertx
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import linea.LongRunningService
 import linea.blob.ShnarfCalculatorVersion
 import linea.contract.l2.Web3JL2MessageServiceSmartContractClient
 import linea.coordinator.config.toJsonRpcRetry
 import linea.coordinator.config.v2.CoordinatorConfig
-import linea.coordinator.config.v2.isDisabled
 import linea.domain.BlockParameter.Companion.toBlockParameter
 import linea.encoding.BlockRLPEncoder
 import linea.ethapi.EthApiClient
@@ -21,6 +19,8 @@ import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
 import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.cleanupDbDataAfterBlockNumbers
+import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.createCalculatorsForBlobsAndConflation
+import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.createDeadlineConflationCalculatorRunner
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resumeAggregationFrom
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resumeConflationFrom
 import net.consensys.zkevm.coordinator.app.conflation.TracesClientFactory.createTracesClients
@@ -46,15 +46,9 @@ import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobShnarfCalculat
 import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProviderImpl
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.BlockToBatchSubmissionCoordinator
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByBlockLimit
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByDataCompressed
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByExecutionTraces
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByTargetBlockNumbers
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByTimeDeadline
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationService
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationServiceImpl
-import net.consensys.zkevm.ethereum.coordination.conflation.DeadlineConflationCalculatorRunner
 import net.consensys.zkevm.ethereum.coordination.conflation.GlobalBlobAwareConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.GlobalBlockConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.ProofGeneratingConflationHandlerImpl
@@ -67,7 +61,6 @@ import net.consensys.zkevm.persistence.BatchesRepository
 import net.consensys.zkevm.persistence.BlobsRepository
 import net.consensys.zkevm.persistence.dao.batch.persistence.BatchProofHandlerImpl
 import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.milliseconds
@@ -113,7 +106,15 @@ class ConflationApp(
 
   private val lastProcessedTimestamp = Instant.fromEpochSeconds(lastProcessedBlock!!.timestamp.toLong())
 
-  private val deadlineConflationCalculatorRunner = createDeadlineConflationCalculatorRunner()
+  private val deadlineConflationCalculatorRunner = createDeadlineConflationCalculatorRunner(
+    configs = configs,
+    lastProcessedBlockNumber = lastProcessedBlockNumber,
+    l2EthClient = l2EthClient,
+  ).also {
+    if (it == null) {
+      log.info("Conflation deadline calculator is disabled")
+    }
+  }
 
   private val conflationCalculator: TracesConflationCalculator = run {
     val logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java)
@@ -128,9 +129,24 @@ class ConflationApp(
     val compressedBlobCalculator = ConflationCalculatorByDataCompressed(
       blobCompressor = blobCompressor,
     )
+    val syncCalculators = createCalculatorsForBlobsAndConflation(
+      configs = configs,
+      compressedBlobCalculator = compressedBlobCalculator,
+      lastProcessedTimestamp = lastProcessedTimestamp,
+      logger = logger,
+      metricsFacade = metricsFacade,
+    ).also {
+      it.filterIsInstance<TimestampHardForkConflationCalculator>().forEach { calculator ->
+        log.info(
+          "Added timestamp-based hard fork calculator={} ",
+          calculator,
+        )
+      }
+    }
+
     val globalCalculator = GlobalBlockConflationCalculator(
       lastBlockNumber = lastProcessedBlockNumber,
-      syncCalculators = createCalculatorsForBlobsAndConflation(logger, compressedBlobCalculator),
+      syncCalculators = syncCalculators,
       deferredTriggerConflationCalculators = listOfNotNull(deadlineConflationCalculatorRunner),
       emptyTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
       log = logger,
@@ -453,86 +469,5 @@ class ConflationApp(
 
   fun updateLatestL1FinalizedBlock(blockNumber: Long): SafeFuture<Unit> {
     return lastProvenBlockNumberProvider.updateLatestL1FinalizedBlock(blockNumber)
-  }
-
-  private fun createDeadlineConflationCalculatorRunner(): DeadlineConflationCalculatorRunner? {
-    if (configs.conflation.isDisabled() || configs.conflation.conflationDeadline == null) {
-      log.info("Conflation deadline calculator is disabled")
-      return null
-    }
-
-    return DeadlineConflationCalculatorRunner(
-      conflationDeadlineCheckInterval = configs.conflation.conflationDeadlineCheckInterval,
-      delegate = ConflationCalculatorByTimeDeadline(
-        config = ConflationCalculatorByTimeDeadline.Config(
-          conflationDeadline = configs.conflation.conflationDeadline,
-          conflationDeadlineLastBlockConfirmationDelay =
-          configs.conflation.conflationDeadlineLastBlockConfirmationDelay,
-        ),
-        lastBlockNumber = lastProcessedBlockNumber,
-        clock = Clock.System,
-        latestBlockProvider = GethCliqueSafeBlockProvider(
-          ethApiBlockClient = l2EthClient,
-          config = GethCliqueSafeBlockProvider.Config(blocksToFinalization = 0),
-        ),
-      ),
-    )
-  }
-
-  private fun addBlocksLimitCalculatorIfDefined(calculators: MutableList<ConflationCalculator>) {
-    if (configs.conflation.blocksLimit != null) {
-      calculators.add(
-        ConflationCalculatorByBlockLimit(
-          blockLimit = configs.conflation.blocksLimit,
-        ),
-      )
-    }
-  }
-
-  private fun addTargetEndBlockConflationCalculatorIfDefined(calculators: MutableList<ConflationCalculator>) {
-    if (configs.conflation.proofAggregation.targetEndBlocks?.isNotEmpty() ?: false) {
-      calculators.add(
-        ConflationCalculatorByTargetBlockNumbers(
-          targetEndBlockNumbers = configs.conflation.proofAggregation.targetEndBlocks.toSet(),
-        ),
-      )
-    }
-  }
-
-  private fun addTimestampHardForkCalculatorIfDefined(calculators: MutableList<ConflationCalculator>) {
-    if (configs.conflation.proofAggregation.timestampBasedHardForks.isNotEmpty()) {
-      calculators.add(
-        TimestampHardForkConflationCalculator(
-          hardForkTimestamps = configs.conflation.proofAggregation.timestampBasedHardForks,
-          initialTimestamp = lastProcessedTimestamp,
-        ),
-      )
-      log.info(
-        "Added timestamp-based hard fork calculator with {} timestamps, initialized at {}, timestamps={}",
-        configs.conflation.proofAggregation.timestampBasedHardForks.size,
-        lastProcessedTimestamp,
-        configs.conflation.proofAggregation.timestampBasedHardForks,
-      )
-    }
-  }
-
-  private fun createCalculatorsForBlobsAndConflation(
-    logger: Logger,
-    compressedBlobCalculator: ConflationCalculatorByDataCompressed,
-  ): List<ConflationCalculator> {
-    val calculators: MutableList<ConflationCalculator> =
-      mutableListOf(
-        ConflationCalculatorByExecutionTraces(
-          tracesCountersLimit = configs.conflation.tracesLimits,
-          emptyTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
-          metricsFacade = metricsFacade,
-          log = logger,
-        ),
-        compressedBlobCalculator,
-      )
-    addBlocksLimitCalculatorIfDefined(calculators)
-    addTargetEndBlockConflationCalculatorIfDefined(calculators)
-    addTimestampHardForkCalculatorIfDefined(calculators)
-    return calculators
   }
 }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationAppHelper.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationAppHelper.kt
@@ -1,8 +1,24 @@
 package net.consensys.zkevm.coordinator.app.conflation
 
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import linea.coordinator.config.v2.CoordinatorConfig
+import linea.coordinator.config.v2.isDisabled
+import linea.ethapi.EthApiClient
+import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.zkevm.coordinator.blockcreation.GethCliqueSafeBlockProvider
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByBlockLimit
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByDataCompressed
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByExecutionTraces
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByTargetBlockNumbers
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByTimeDeadline
+import net.consensys.zkevm.ethereum.coordination.conflation.DeadlineConflationCalculatorRunner
+import net.consensys.zkevm.ethereum.coordination.conflation.TimestampHardForkConflationCalculator
 import net.consensys.zkevm.persistence.AggregationsRepository
 import net.consensys.zkevm.persistence.BatchesRepository
 import net.consensys.zkevm.persistence.BlobsRepository
+import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 object ConflationAppHelper {
@@ -51,5 +67,100 @@ object ConflationAppHelper {
         .deleteAggregationsAfterBlockNumber((lastConsecutiveAggregatedBlockNumber + 1u).toLong())
 
     return SafeFuture.allOf(cleanupBatches, cleanupBlobs, cleanupAggregations)
+  }
+
+  fun addBlocksLimitCalculatorIfDefined(
+    configs: CoordinatorConfig,
+    calculators: MutableList<ConflationCalculator>,
+  ) {
+    if (configs.conflation.blocksLimit != null) {
+      calculators.add(
+        ConflationCalculatorByBlockLimit(
+          blockLimit = configs.conflation.blocksLimit,
+        ),
+      )
+    }
+  }
+
+  fun addTargetEndBlockConflationCalculatorIfDefined(
+    configs: CoordinatorConfig,
+    calculators: MutableList<ConflationCalculator>,
+  ) {
+    if (configs.conflation.proofAggregation.targetEndBlocks?.isNotEmpty() ?: false) {
+      calculators.add(
+        ConflationCalculatorByTargetBlockNumbers(
+          targetEndBlockNumbers = configs.conflation.proofAggregation.targetEndBlocks.toSet(),
+        ),
+      )
+    }
+  }
+
+  fun addTimestampHardForkCalculatorIfDefined(
+    configs: CoordinatorConfig,
+    lastProcessedTimestamp: Instant,
+    calculators: MutableList<ConflationCalculator>,
+  ) {
+    if (configs.conflation.proofAggregation.timestampBasedHardForks.isNotEmpty()) {
+      calculators.add(
+        TimestampHardForkConflationCalculator(
+          hardForkTimestamps = configs.conflation.proofAggregation.timestampBasedHardForks,
+          initialTimestamp = lastProcessedTimestamp,
+        ),
+      )
+    }
+  }
+
+  fun createCalculatorsForBlobsAndConflation(
+    configs: CoordinatorConfig,
+    compressedBlobCalculator: ConflationCalculatorByDataCompressed,
+    lastProcessedTimestamp: Instant,
+    logger: Logger,
+    metricsFacade: MetricsFacade,
+  ): List<ConflationCalculator> {
+    val calculators: MutableList<ConflationCalculator> =
+      mutableListOf(
+        ConflationCalculatorByExecutionTraces(
+          tracesCountersLimit = configs.conflation.tracesLimits,
+          emptyTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
+          metricsFacade = metricsFacade,
+          log = logger,
+        ),
+        compressedBlobCalculator,
+      )
+    addBlocksLimitCalculatorIfDefined(configs = configs, calculators = calculators)
+    addTargetEndBlockConflationCalculatorIfDefined(configs = configs, calculators = calculators)
+    addTimestampHardForkCalculatorIfDefined(
+      configs = configs,
+      calculators = calculators,
+      lastProcessedTimestamp = lastProcessedTimestamp,
+    )
+    return calculators
+  }
+
+  fun createDeadlineConflationCalculatorRunner(
+    configs: CoordinatorConfig,
+    lastProcessedBlockNumber: ULong,
+    l2EthClient: EthApiClient,
+  ): DeadlineConflationCalculatorRunner? {
+    if (configs.conflation.isDisabled() || configs.conflation.conflationDeadline == null) {
+      return null
+    }
+
+    return DeadlineConflationCalculatorRunner(
+      conflationDeadlineCheckInterval = configs.conflation.conflationDeadlineCheckInterval,
+      delegate = ConflationCalculatorByTimeDeadline(
+        config = ConflationCalculatorByTimeDeadline.Config(
+          conflationDeadline = configs.conflation.conflationDeadline,
+          conflationDeadlineLastBlockConfirmationDelay =
+          configs.conflation.conflationDeadlineLastBlockConfirmationDelay,
+        ),
+        lastBlockNumber = lastProcessedBlockNumber,
+        clock = Clock.System,
+        latestBlockProvider = GethCliqueSafeBlockProvider(
+          ethApiBlockClient = l2EthClient,
+          config = GethCliqueSafeBlockProvider.Config(blocksToFinalization = 0),
+        ),
+      ),
+    )
   }
 }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/TimestampHardForkConflationCalculator.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/TimestampHardForkConflationCalculator.kt
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.Logger
  */
 class TimestampHardForkConflationCalculator(
   private val hardForkTimestamps: List<Instant>,
-  initialTimestamp: Instant,
+  private val initialTimestamp: Instant,
   private val log: Logger = LogManager.getLogger(TimestampHardForkConflationCalculator::class.java),
 ) : ConflationCalculator {
   override val id: String = "TIMESTAMP_HARD_FORK"
@@ -69,5 +69,10 @@ class TimestampHardForkConflationCalculator(
 
   override fun copyCountersTo(counters: ConflationCounters) {
     // No counters to copy - this calculator doesn't track conflation data
+  }
+
+  override fun toString(): String {
+    return "$id: ${hardForkTimestamps.size} timestamps, initialized at $initialTimestamp, " +
+      "timestamps=$hardForkTimestamps"
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #1932 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors conflation setup for reuse and clarity.
> 
> - Extracts calculator/deadline creation from `ConflationApp` into `ConflationAppHelper` (`createCalculatorsForBlobsAndConflation`, `createDeadlineConflationCalculatorRunner`, plus add-* helpers)
> - `ConflationApp` now wires calculators via helpers and logs presence of `TimestampHardForkConflationCalculator`
> - `TimestampHardForkConflationCalculator`: stores `initialTimestamp` as a private field and adds `toString()` for clearer logging
> 
> No functional logic changes intended beyond improved logging/structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95bb47d8424fc2253e893059d8fa8a1056a42129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->