### PR TITLE
Chore: update Gradle Besu plugin

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/EcDataLimitsTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/EcDataLimitsTest.kt
@@ -32,8 +32,11 @@ class EcDataLimitsTest : LineaPluginPoSTestBase() {
   }
 
   override fun getCliqueOptions(): GenesisConfigurationFactory.CliqueOptions {
+    // adding 1 more second to the block period, in order to avoid flakiness on the CI
+    // due to EcParing sometime taking all the selection time before all pending txs
+    // have been evaluated
     return GenesisConfigurationFactory.CliqueOptions(
-      BLOCK_PERIOD_SECONDS,
+      BLOCK_PERIOD_SECONDS+1,
       GenesisConfigurationFactory.CliqueOptions.DEFAULT.epochLength(),
       false,
     )

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginTestBase.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginTestBase.kt
@@ -159,7 +159,7 @@ abstract class LineaPluginTestBase : AcceptanceTestBase() {
         // set plugin max selection time to 5% of slot time
         ImmutableMiningConfiguration.builder()
           .poaBlockTxsSelectionMaxTime(
-            PositiveNumber.fromInt(BLOCK_PERIOD_SECONDS * 1000),
+            PositiveNumber.fromInt(cliqueOptions.blockPeriodSeconds() * 1000),
           )
           .pluginBlockTxsSelectionMaxTime(PositiveNumber.fromInt(2))
           .mutableInitValues(

--- a/besu-plugins/linea-sequencer/build.gradle
+++ b/besu-plugins/linea-sequencer/build.gradle
@@ -4,8 +4,6 @@ buildscript {
   ext {
     distributionIdentifier = "linea-sequencer"
     releaseVersion = "${libs.versions.arithmetization.get()}-SNAPSHOT"
-    besuVersion = "${libs.versions.besu.get()}"
-    besuRepo = "https://artifacts.consensys.net/public/linea-besu/maven/"
   }
 }
 
@@ -13,6 +11,15 @@ plugins {
   alias(libs.plugins.besuPluginLibrary)
   alias(libs.plugins.besuPluginDistribution)
   alias(libs.plugins.dependencyLicenseReport)
+}
+
+allprojects {
+  plugins.withId('net.consensys.besu-plugin-library') {
+    besuPlugin {
+      besuVersion = "${libs.versions.besu.get()}"
+      besuRepo = "https://artifacts.consensys.net/public/linea-besu/maven/"
+    }
+  }
 }
 
 licenseReport {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ dependencyLicenseReport = { id = "com.github.jk1.dependency-license-report", ver
 lombok = { id = "io.freefair.lombok", version = "8.6" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.51.0" }
 dependencyManagement = { id = "io.spring.dependency-management", version = "1.1.5" }
-besuPluginLibrary = { id = "net.consensys.besu-plugin-library", version = "0.1.4" }
-besuPluginDistribution = { id = "net.consensys.besu-plugin-distribution", version = "0.1.4" }
+besuPluginLibrary = { id = "net.consensys.besu-plugin-library", version = "0.1.6" }
+besuPluginDistribution = { id = "net.consensys.besu-plugin-distribution", version = "0.1.6" }
 hierynomusLicense = { id = "com.github.hierynomus.license", version = "0.16.1" }
 testLogger = { id = "com.adarshr.test-logger", version = "4.0.0" }
 sonarQube = { id = "org.sonarqube", version = "4.3.1.3277" }

--- a/tracer/build.gradle
+++ b/tracer/build.gradle
@@ -4,10 +4,8 @@ buildscript {
     besuPluginDir = File.createTempDir("plugins")
     targetReleaseVersion = "beta-v4.4-rc7"
     releaseVersion = findProperty('releaseVersion') ?: targetReleaseVersion
-    besuVersion = "${libs.versions.besu.get()}"
     distributionIdentifier = "linea-tracer"
     distibutionBaseName = "linea-arithmetization"
-    besuRepo = "https://artifacts.consensys.net/public/linea-besu/maven/"
   }
 }
 
@@ -17,6 +15,15 @@ plugins {
   alias(libs.plugins.besuPluginDistribution)
   alias(libs.plugins.sonarQube)
   alias(libs.plugins.testLogger)
+}
+
+allprojects {
+  plugins.withId('net.consensys.besu-plugin-library') {
+    besuPlugin {
+      besuVersion = "${libs.versions.besu.get()}"
+      besuRepo = "https://artifacts.consensys.net/public/linea-besu/maven/"
+    }
+  }
 }
 
 sonar {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates build and test configuration for consistency and stability.
> 
> - Bumps `net.consensys.besu-plugin-*` versions to `0.1.6` in `libs.versions.toml`
> - Centralizes `besuPlugin { besuVersion, besuRepo }` config in `allprojects` for `linea-sequencer` and `tracer` builds; removes duplicated `ext` vars
> - Test tweaks: increase Clique `blockPeriodSeconds` by 1 in `EcDataLimitsTest` and derive `poaBlockTxsSelectionMaxTime` from `cliqueOptions.blockPeriodSeconds()` in `LineaPluginTestBase`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8ba65df862efffaea78e9a2aed71410abaf7bdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->