### PR TITLE
chore: move to default ubuntu 24 runners

### DIFF
--- a/.github/workflows/all-tools.yml
+++ b/.github/workflows/all-tools.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   changes:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Filter commit changes
     outputs:
       all-tools: ${{ steps.filter.outputs['all-tools'] }}
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/reuse-store-image-name-and-tags.yml
 
   check_image_tags_exist:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Check image tags exist
     needs: [changes, store_image_name_and_tags]
     if: ${{ needs.changes.outputs['all-tools'] == 'false' }}
@@ -58,7 +58,7 @@ jobs:
           image_name: consensys/linea-alltools
 
   all-tools-tag-only:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: All tools tag only
     needs: [changes, store_image_name_and_tags, check_image_tags_exist]
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs['all-tools'] == 'false' }}
@@ -83,7 +83,7 @@ jobs:
     needs: [changes, store_image_name_and_tags, all-tools-tag-only]
     if: ${{ always() && (needs.changes.outputs['all-tools'] == 'true' || needs.all-tools-tag-only.result != 'success' || needs.all-tools-tag-only.outputs.image_tagged != 'true') }}
     # ~0.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     env:
       COMMIT_TAG: ${{ needs.store_image_name_and_tags.outputs.commit_tag }}
       DEVELOP_TAG: ${{ needs.store_image_name_and_tags.outputs.develop_tag }}

--- a/.github/workflows/bridge-ui-e2e-tests.yml
+++ b/.github/workflows/bridge-ui-e2e-tests.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   run-e2e-tests:
     if: github.event.pull_request.head.repo.fork == false
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/bridge-ui-publish.yml
+++ b/.github/workflows/bridge-ui-publish.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     if: github.event.pull_request.head.repo.fork == false
     # ~1 min saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     strategy:
       matrix:
         environment: [development, production]
@@ -98,7 +98,7 @@ jobs:
   test-build:
     if: github.event.pull_request.head.repo.fork == true
     # ~1 min saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Test Build Bridge UI
     steps:
       - name: Checkout

--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   get-commit-tag:
     if: github.event.workflow_run.head_repository.fork == true
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: get-commit-tag
     outputs:
       commit-tag: ${{ steps.compute-commit-tag.outputs.COMMIT_TAG }}
@@ -47,7 +47,7 @@ jobs:
 
   upload-codecov-coordinator:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-coordinator
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
 
   upload-codecov-smart-contracts:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-smart-contracts
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     outputs:
       languages: ${{ steps.set-matrix.outputs.languages }}
     permissions:
@@ -71,7 +71,7 @@ jobs:
 
   analyze:
     name: Analyze
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     needs: changes
     if: ${{ needs.changes.outputs.languages != '[]' }}
     permissions:
@@ -100,7 +100,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      
+
       - name: Setup Tracer Environment
         if: matrix.language == 'java-kotlin'
         uses: ./.github/actions/setup-tracer-environment

--- a/.github/workflows/coordinator-build-and-publish.yml
+++ b/.github/workflows/coordinator-build-and-publish.yml
@@ -56,7 +56,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     name: Coordinator build
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -28,7 +28,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # ? Seems to fail more often on xl
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     name: Coordinator tests
     steps:
       - name: Checkout

--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   get-has-changes-requiring-e2e-testing:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     outputs:
       has_changes_requiring_e2e_testing: ${{ steps.eval.outputs.has_changes_requiring_e2e_testing }}
     steps:

--- a/.github/workflows/github-release-besu-plugin.yml
+++ b/.github/workflows/github-release-besu-plugin.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   release:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/linea-besu-package-build-and-upload.yml
+++ b/.github/workflows/linea-besu-package-build-and-upload.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   build-and-upload-artifact:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     outputs:
       linea_besu_package_tag: ${{ steps.assemble.outputs.dockertag }}
       expected_traces_api_version: ${{ steps.assemble.outputs.tracer_plugin_version }}

--- a/.github/workflows/linea-besu-package-release.yml
+++ b/.github/workflows/linea-besu-package-release.yml
@@ -47,7 +47,7 @@ permissions:
 
 jobs:
   filter-commit-changes:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Filter commit changes
     if: ${{ github.event_name != 'workflow_dispatch' }}
     outputs:

--- a/.github/workflows/linea-sequencer-plugin-release.yml
+++ b/.github/workflows/linea-sequencer-plugin-release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21

--- a/.github/workflows/linea-sequencer-plugin-testing.yml
+++ b/.github/workflows/linea-sequencer-plugin-testing.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   run-linea-sequencer-plugins-unit-tests:
     name: "Linea Sequencer Plugin Unit Tests"
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
 
   run-linea-sequencer-plugins-acceptance-tests:
     name: "Linea Sequencer Plugin Acceptance Tests"
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/linea-tracer-plugin-release.yml
+++ b/.github/workflows/linea-tracer-plugin-release.yml
@@ -125,7 +125,7 @@ jobs:
   # ==================================================================
   replay-tests:
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -172,7 +172,7 @@ jobs:
   publish:
     needs: [ build ]
     if: github.event_name != 'pull_request'
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     env:
       architecture: "amd64"
       GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   run-load-test:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Run Load Test
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   filter-commit-changes:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Filter commit changes
     outputs:
       changed-file-count: ${{ steps.filter.outputs.all_count }}
@@ -193,7 +193,7 @@ jobs:
       contracts_excluding_local_deployment_artifacts_count: ${{ needs.filter-commit-changes.outputs.contracts-excluding-local-deployment-artifacts-count }}
 
   manual-docker-build-and-e2e-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     needs: [check-and-tag-images, get-has-changes-requiring-e2e-testing]
     if: ${{ needs.get-has-changes-requiring-e2e-testing.outputs.has-changes-requiring-e2e-testing == 'true' }}
     environment: ${{ github.ref != 'refs/heads/main' && 'docker-build-and-e2e' || '' }}
@@ -275,7 +275,7 @@ jobs:
   cleanup-deployments:
     needs: [run-e2e-tests]
     if: ${{ always() && github.event.pull_request.head.repo.fork == false }}
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/maven-release-all.yml
+++ b/.github/workflows/maven-release-all.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   release:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Set version
         id: name

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/native-yield-automation-service-build-and-publish.yml
+++ b/.github/workflows/native-yield-automation-service-build-and-publish.yml
@@ -57,7 +57,7 @@ concurrency:
 jobs:
   build-and-publish:
     # ~1 min saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: native-yield-automation-service
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/native-yield-automation-service-testing.yml
+++ b/.github/workflows/native-yield-automation-service-testing.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: native-yield-automation-service-testing
     steps:
       - name: Checkout
@@ -26,8 +26,8 @@ jobs:
         run: |
           pnpm --filter @consensys/linea-shared-utils build
           pnpm --filter @consensys/linea-native-yield-automation-service build
-        
+
       - name: Run tests and generate coverage report
         run: |
           pnpm --filter @consensys/linea-shared-utils test
-          pnpm --filter @consensys/linea-native-yield-automation-service test 
+          pnpm --filter @consensys/linea-native-yield-automation-service test

--- a/.github/workflows/postman-build-and-publish.yml
+++ b/.github/workflows/postman-build-and-publish.yml
@@ -57,7 +57,7 @@ concurrency:
 jobs:
   build-and-publish:
     # ~1 min saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Postman build
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/postman-testing.yml
+++ b/.github/workflows/postman-testing.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     name: Postman & SDK tests
     steps:
       - name: Checkout

--- a/.github/workflows/prover-build-and-publish.yml
+++ b/.github/workflows/prover-build-and-publish.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   build-and-publish:
     # ~1 min saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Prover build
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -26,7 +26,7 @@ on:
 jobs:
 
   build-linux:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
           path: ./prover/target
 
   build-linux-arm64:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-arm64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-arm64-med
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
   release_artefacts:
     name: Release artefacts
     needs: [ build-linux, build-linux-arm64, build-mac-os]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Load cached binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   staticcheck:
     # ~1.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Prover static check
     steps:
     - name: checkout code
@@ -59,7 +59,7 @@ jobs:
       matrix:
         go-version: [1.24.x]
     # ~1 min saved vs large
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
     name: Prover testing
     needs:
       - staticcheck

--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -27,7 +27,7 @@ jobs:
   # Blockchain ref Tests
   # ==================================================================
   blockchain-reference-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-tracer-nightly-tests.yml
+++ b/.github/workflows/reusable-tracer-nightly-tests.yml
@@ -18,7 +18,7 @@ jobs:
   # Nightly Tests
   # ==================================================================
   nightly-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-tracer-unit-tests.yml
+++ b/.github/workflows/reusable-tracer-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
   # Unit Tests
   # ==================================================================
   unit-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-tracer-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-prc-tests.yml
@@ -15,7 +15,7 @@ jobs:
   # Weekly PRC Call Tests
   # ==================================================================
   weekly-prc-calltests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reusable-tracer-weekly-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-tests.yml
@@ -15,7 +15,7 @@ jobs:
   # Weekly Tests
   # ==================================================================
   weekly-unit-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/reuse-check-images-tags-and-push.yml
+++ b/.github/workflows/reuse-check-images-tags-and-push.yml
@@ -55,7 +55,7 @@ concurrency:
 
 jobs:
   check_image_tags_exist:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Check image tags exist
     env:
       # REF_NAME: ${{ github.ref_name }}
@@ -84,7 +84,7 @@ jobs:
           fi
           echo LAST_COMMIT_TAG=$(git rev-parse --short=7 "${{ env.EVENT_BEFORE }}") >> $GITHUB_OUTPUT
           echo DEVELOP_TAG=develop >> $GITHUB_OUTPUT
-      
+
       - name: Show version tags
         run: |
           echo "COMMIT_TAG: ${{ steps.compute-version-tags.outputs.COMMIT_TAG }}"
@@ -133,7 +133,7 @@ jobs:
           image_name: consensys/linea-transaction-exclusion-api
 
   image_tag_push:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     if: ${{ github.ref == 'refs/heads/main' && inputs.has-changes-requiring-build == 'true' }}
     name: Tag and push images
     needs: [ check_image_tags_exist ]

--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -75,7 +75,7 @@ jobs:
   build-and-push-dockerhub:
     needs: [ run-test, run-e2e-tests ]
     if: ${{ always() && !cancelled() && inputs.push_image && (inputs.skip_e2e_test || needs.run-e2e-test.result == 'skipped' || needs.run-e2e-tests.outputs.tests_outcome == 'success') && (needs.run-test.result == 'skipped' || needs.run-test.result == 'success') }}
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     environment: dockerhub
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -141,7 +141,7 @@ jobs:
           keys-case: lower
           log-variables: true
           load-mode: strict
-      
+
       - name: Calculate the checksum of Besu fleet plugin
         id: besu-fleet-plugin-checksum
         if: ${{ inputs.with_besu_fleet_plugin }}
@@ -153,7 +153,7 @@ jobs:
         shell: bash
         run: |
           rm -fr linea-besu-package/linea-besu/besu/plugins/besu-fleet-plugin* || true
-      
+
       - name: build and push the combined manifest (without Besu fleet plugin)
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         env:
@@ -190,12 +190,12 @@ jobs:
           echo "| Module | Version | SHA-256 |" >> output.md
           echo "|--------|---------|--------------|" >> output.md
           echo "| linea-besu | ${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }} | $(sha256sum ../linea-besu-package/tmp/${{ steps.dotenv.outputs.LINEA_BESU_FILENAME_PREFIX }}-${{ steps.dotenv.outputs.LINEA_BESU_TAR_GZ }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
-          echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-sequencer-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-tracer-${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-staterecovery-plugin | ${{ steps.dotenv.outputs.LINEA_STATERECOVERY_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-staterecovery-besu-plugin-v${{ steps.dotenv.outputs.LINEA_STATERECOVERY_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md    
+          echo "| linea-sequencer-plugin | ${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-sequencer-v${{ steps.dotenv.outputs.LINEA_SEQUENCER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md
+          echo "| linea-tracer-plugin | ${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-tracer-${{ steps.dotenv.outputs.LINEA_TRACER_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md
+          echo "| linea-staterecovery-plugin | ${{ steps.dotenv.outputs.LINEA_STATERECOVERY_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-staterecovery-besu-plugin-v${{ steps.dotenv.outputs.LINEA_STATERECOVERY_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md
           echo "| shomei-plugin | ${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.dotenv.outputs.SHOMEI_PLUGIN_VERSION }}.jar | awk '{ print $1 }' ) |" >> output.md
           if [[ "${{ inputs.with_besu_fleet_plugin }}" == "true" ]]; then
-            echo "| besu-fleet-plugin | ${{ steps.dotenv.outputs.BESU_FLEET_PLUGIN_VERSION }} | ${{ steps.besu-fleet-plugin-checksum.outputs.sha256sum }} |" >> output.md    
+            echo "| besu-fleet-plugin | ${{ steps.dotenv.outputs.BESU_FLEET_PLUGIN_VERSION }} | ${{ steps.besu-fleet-plugin-checksum.outputs.sha256sum }} |" >> output.md
           fi
           echo "" >> output.md
 

--- a/.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
+++ b/.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
@@ -55,7 +55,7 @@ jobs:
     outputs:
       tests_outcome: ${{ steps.run_e2e_tests.outcome }}
     # xl saves ~0 mins
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
     steps:
       - name: Setup upterm session
         if: ${{ inputs.e2e-tests-with-ssh }}

--- a/.github/workflows/reuse-linea-besu-package-run-test.yml
+++ b/.github/workflows/reuse-linea-besu-package-run-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   list-profiles:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     outputs:
       profile-files: ${{ steps.list-profiles.outputs.files }}
     steps:
@@ -26,7 +26,7 @@ jobs:
 
   test-profile:
     timeout-minutes: 4
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     continue-on-error: true
     needs: [ list-profiles ]
     strategy:

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -82,7 +82,7 @@ jobs:
     outputs:
       tests_outcome: ${{ steps.run_e2e_tests.outcome }}
     # xl saves ~0 mins
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
     steps:
       - name: Setup upterm session
         if: ${{ inputs.e2e-tests-with-ssh }}

--- a/.github/workflows/reuse-store-image-name-and-tags.yml
+++ b/.github/workflows/reuse-store-image-name-and-tags.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   store_image_name_and_tags:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Compute version tags
     env:
       # REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   run-contract-tests:
     # ~2 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Run smart contracts tests
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -80,7 +80,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   solidity-format-check:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Solidity format check
     steps:
       - name: Checkout

--- a/.github/workflows/security-report-to-csv.yml
+++ b/.github/workflows/security-report-to-csv.yml
@@ -8,7 +8,7 @@ permissions:
 on: workflow_dispatch
 jobs:
   data_gathering:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: CSV export
         uses: advanced-security/ghas-to-csv@v2

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   notify:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
 
     steps:
       - name: Compute context values
@@ -116,7 +116,7 @@ jobs:
                   type: plain_text
                   text: ":x: ${{ inputs.title }}"
                   emoji: true
-              
+
               - type: rich_text
                 elements:
                   - type: rich_text_section
@@ -127,7 +127,7 @@ jobs:
                           bold: true
                       - type: text
                         text: "${{ steps.ctx.outputs.repo }}"
-              
+
               - type: rich_text
                 elements:
                   - type: rich_text_section

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - uses: actions/stale@v8
         with:

--- a/.github/workflows/staterecovery-testing.yml
+++ b/.github/workflows/staterecovery-testing.yml
@@ -28,7 +28,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       # CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # ~2.5 mins saved vs large
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     name: Staterecovery tests
     steps:
       - name: Checkout

--- a/.github/workflows/tracer-gradle-besu-node-tests.yml
+++ b/.github/workflows/tracer-gradle-besu-node-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   unit-tests-with-besu-node:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/tracer-gradle-nightly-tests.yml
+++ b/.github/workflows/tracer-gradle-nightly-tests.yml
@@ -23,7 +23,7 @@ jobs:
   # Replay Tests
   # ==================================================================
   nightly-replay-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/tracer-gradle-tests.yml
+++ b/.github/workflows/tracer-gradle-tests.yml
@@ -26,7 +26,7 @@ jobs:
     # if: github.event.pull_request.draft == false && github.base_ref != 'main'
     # if: ${{ github.ref != 'refs/heads/main' }}
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Show metadata
         run: |
@@ -77,7 +77,7 @@ jobs:
     # if: ${{ github.ref != 'refs/heads/main' }}
     if: ${{ github.event.pull_request.draft == false }}
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/tracer-gradle-weekly-tests.yml
+++ b/.github/workflows/tracer-gradle-weekly-tests.yml
@@ -25,7 +25,7 @@ jobs:
       zkevm_fork: OSAKA
 
   weekly-replay-tests:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/transaction-exclusion-api-build-and-publish.yml
+++ b/.github/workflows/transaction-exclusion-api-build-and-publish.yml
@@ -56,7 +56,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Transaction exclusion api build
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/transaction-exclusion-api-testing.yml
+++ b/.github/workflows/transaction-exclusion-api-testing.yml
@@ -29,7 +29,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     # ~1.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     name: Transaction exclusion api tests
     steps:
       - name: Checkout

--- a/.github/workflows/valid-audit-pr-has-tags.yml
+++ b/.github/workflows/valid-audit-pr-has-tags.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves CI to Ubuntu 24 runners across the repository.
> 
> - Replaces `runs-on` labels from `gha-runner-scale-set-ubuntu-22.04-*` to `gha-runner-scale-set-ubuntu-24-*` in build, test, publish, e2e, CodeQL, Codecov, release, tracer, prover, coordinator, postman, native-yield, transaction-exclusion-api, linea-besu-package, and utility workflows
> - Retains size/arch variants (`small/med/large/xl/xxl`, `amd64/arm64`); no substantive step/logic changes
> - Minor whitespace/formatting fixes in several YAMLs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4df59854c7a0ef899e2ea6aa44341ad7af5c17a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->