### PR TITLE
fix: apply import order eslint rules

### DIFF
--- a/bridge-ui/src/app/(layerswap)/centralized-exchange/page.tsx
+++ b/bridge-ui/src/app/(layerswap)/centralized-exchange/page.tsx
@@ -1,6 +1,7 @@
-import { Widget } from "@/components/layerswap/widget";
-import styles from "./page.module.scss";
 import FaqHelp from "@/components/bridge/faq-help";
+import { Widget } from "@/components/layerswap/widget";
+
+import styles from "./page.module.scss";
 
 export default function Page() {
   return (

--- a/bridge-ui/src/app/(main)/bridge-aggregator/page.tsx
+++ b/bridge-ui/src/app/(main)/bridge-aggregator/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import FaqHelp from "@/components/bridge/faq-help";
-import styles from "./page.module.scss";
 import { Widget } from "@/components/lifi/widget";
+
+import styles from "./page.module.scss";
 
 export default function Page() {
   return (

--- a/bridge-ui/src/app/(main)/buy/page.tsx
+++ b/bridge-ui/src/app/(main)/buy/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import OnRamperWidget from "@/components/onramper";
-import styles from "./page.module.scss";
 import FaqHelp from "@/components/bridge/faq-help";
+import OnRamperWidget from "@/components/onramper";
+
+import styles from "./page.module.scss";
 
 export default function Page() {
   return (

--- a/bridge-ui/src/app/(main)/faq/page.tsx
+++ b/bridge-ui/src/app/(main)/faq/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 import { useState } from "react";
+
 import { motion } from "motion/react";
+
 import PlusIcon from "@/assets/icons/plus.svg";
+
 import styles from "./page.module.scss";
 
 const faqList = [

--- a/bridge-ui/src/app/(main)/native-bridge/layout.tsx
+++ b/bridge-ui/src/app/(main)/native-bridge/layout.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useTokens } from "@/hooks";
 import { useAccount } from "wagmi";
+
+import { useTokens } from "@/hooks";
 import { FormState, FormStoreProvider, useChainStore } from "@/stores";
 import { CCTPMode, ChainLayer, ClaimType } from "@/types";
 

--- a/bridge-ui/src/app/(main)/native-bridge/page.tsx
+++ b/bridge-ui/src/app/(main)/native-bridge/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import BridgeLayout from "@/components/bridge/bridge-layout";
+
 import styles from "./page.module.scss";
 
 export default function Home() {

--- a/bridge-ui/src/app/(main)/page.tsx
+++ b/bridge-ui/src/app/(main)/page.tsx
@@ -3,6 +3,7 @@
 import FaqHelp from "@/components/bridge/faq-help";
 import { navList } from "@/components/internal-nav";
 import NavItem from "@/components/internal-nav/item";
+
 import styles from "./page.module.scss";
 
 export default function Page() {

--- a/bridge-ui/src/app/RootLayout.tsx
+++ b/bridge-ui/src/app/RootLayout.tsx
@@ -1,15 +1,17 @@
-import { Metadata } from "next";
-import Script from "next/script";
 import clsx from "clsx";
-import { gtmScript, gtmNoScript } from "@/scripts/gtm";
-import { Providers } from "@/components/layouts/Providers";
-import { Layout } from "@/components/layouts/Layout";
+import { Metadata } from "next";
+import { headers } from "next/headers";
+import Script from "next/script";
+
 import atypFont from "@/assets/fonts/atyp";
 import atypTextFont from "@/assets/fonts/atypText";
+import { Layout } from "@/components/layouts/Layout";
+import { Providers } from "@/components/layouts/Providers";
 import FirstVisitModal from "@/components/modal/first-time-visit";
 import { ModalBase } from "@/components/modal-base";
+import { gtmScript, gtmNoScript } from "@/scripts/gtm";
 import { getNavData } from "@/services";
-import { headers } from "next/headers";
+
 import "../scss/app.scss";
 
 const metadata: Metadata = {

--- a/bridge-ui/src/components/bridge/amount/index.tsx
+++ b/bridge-ui/src/components/bridge/amount/index.tsx
@@ -1,7 +1,10 @@
 import { ChangeEvent, useEffect, useState } from "react";
+
 import { formatUnits, parseUnits } from "viem";
+
 import { useTokenPrices } from "@/hooks";
 import { useChainStore, useConfigStore, useFormStore } from "@/stores";
+
 import styles from "./amount.module.scss";
 
 const AMOUNT_REGEX = /^[0-9]*[.,]?[0-9]*$/;

--- a/bridge-ui/src/components/bridge/balance/index.tsx
+++ b/bridge-ui/src/components/bridge/balance/index.tsx
@@ -1,10 +1,13 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
 import { useBlockNumber } from "wagmi";
-import { formatBalance } from "@/utils";
+
 import { useTokenBalance, useSelectedToken } from "@/hooks";
-import styles from "./balance.module.scss";
 import { useFormStore } from "@/stores";
+import { formatBalance } from "@/utils";
+
+import styles from "./balance.module.scss";
 
 export function Balance() {
   // Context

--- a/bridge-ui/src/components/bridge/bridge-layout/index.tsx
+++ b/bridge-ui/src/components/bridge/bridge-layout/index.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
+import { useAccount } from "wagmi";
+
+import { SOLANA_CHAIN } from "@/constants";
+import { useNativeBridgeNavigationStore } from "@/stores";
+
 import Bridge from "../form";
 import TransactionHistory from "../transaction-history";
-import { useNativeBridgeNavigationStore } from "@/stores";
 import BridgeSkeleton from "./skeleton";
 import WrongNetwork from "../wrong-network";
-import { useEffect, useState } from "react";
-import { useAccount } from "wagmi";
-import { SOLANA_CHAIN } from "@/constants";
 
 export default function BridgeLayout() {
   const isTransactionHistoryOpen = useNativeBridgeNavigationStore.useIsTransactionHistoryOpen();

--- a/bridge-ui/src/components/bridge/bridge-layout/skeleton/index.tsx
+++ b/bridge-ui/src/components/bridge/bridge-layout/skeleton/index.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+
 import styles from "./skeleton.module.scss";
 
 export default function BridgeSkeleton() {

--- a/bridge-ui/src/components/bridge/bridge-two-logo/index.tsx
+++ b/bridge-ui/src/components/bridge/bridge-two-logo/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+
 import styles from "./bridge-two-logo.module.scss";
 
 type Props = {

--- a/bridge-ui/src/components/bridge/cctp-mode-dropdown/index.tsx
+++ b/bridge-ui/src/components/bridge/cctp-mode-dropdown/index.tsx
@@ -1,11 +1,14 @@
-import CaretDownIcon from "@/assets/icons/caret-down.svg";
-import { CCTPMode } from "@/types";
-import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import Image from "next/image";
+
+import CaretDownIcon from "@/assets/icons/caret-down.svg";
+import Modal from "@/components/modal";
 import { useDevice } from "@/hooks";
 import { useFormStore } from "@/stores";
+import { CCTPMode } from "@/types";
+
 import styles from "./cctp-mode-dropdown.module.scss";
-import Modal from "@/components/modal";
 
 type CCTPModeOption = {
   value: CCTPMode;

--- a/bridge-ui/src/components/bridge/claiming/bridge-mode/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/bridge-mode/index.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-import styles from "./bridge-mode.module.scss";
+
 import Image from "next/image";
-import { useFormStore } from "@/stores";
+
 import CctpModeDropdown from "@/components/bridge/cctp-mode-dropdown";
+import { useFormStore } from "@/stores";
 import { isCctp } from "@/utils";
+
+import styles from "./bridge-mode.module.scss";
 
 export default function BridgeMode() {
   const token = useFormStore((state) => state.token);

--- a/bridge-ui/src/components/bridge/claiming/estimated-time/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/estimated-time/index.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
+
 import dynamic from "next/dynamic";
+
 import ClockIcon from "@/assets/icons/clock.svg";
-import styles from "./estimated-time.module.scss";
 import { useChainStore, useFormStore } from "@/stores";
-import { getEstimatedTimeText } from "@/utils";
 import { CCTPMode } from "@/types";
+import { getEstimatedTimeText } from "@/utils";
+
+import styles from "./estimated-time.module.scss";
 
 const EstimatedTimeModal = dynamic(() => import("../../modal/estimated-time"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/claiming/fees/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/fees/index.tsx
@@ -1,9 +1,10 @@
-import styles from "./fees.module.scss";
-import ManualClaim from "../manual-claim";
-import EstimatedTime from "../estimated-time";
-import WithFees from "./with-fees";
 import { useFormStore, useChainStore } from "@/stores";
 import { ClaimType } from "@/types";
+
+import styles from "./fees.module.scss";
+import EstimatedTime from "../estimated-time";
+import ManualClaim from "../manual-claim";
+import WithFees from "./with-fees";
 
 export default function Fees() {
   const fromChain = useChainStore.useFromChain();

--- a/bridge-ui/src/components/bridge/claiming/fees/with-fees/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/fees/with-fees/index.tsx
@@ -1,12 +1,15 @@
+import { useState } from "react";
+
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import styles from "./with-fees.module.scss";
-import { useState } from "react";
-import { useFees } from "@/hooks";
-import { useConfigStore, useFormStore } from "@/stores";
-import { useFormattedDigit } from "@/hooks/useFormattedDigit";
-import { useCctpFee } from "@/hooks/transaction-args/cctp/useCctpUtilHooks";
 import { formatUnits } from "viem";
+
+import { useFees } from "@/hooks";
+import { useCctpFee } from "@/hooks/transaction-args/cctp/useCctpUtilHooks";
+import { useFormattedDigit } from "@/hooks/useFormattedDigit";
+import { useConfigStore, useFormStore } from "@/stores";
+
+import styles from "./with-fees.module.scss";
 
 const GasFees = dynamic(() => import("../../../modal/gas-fees"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/claiming/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/index.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
+
 import dynamic from "next/dynamic";
 import { useAccount } from "wagmi";
-import BridgeTwoLogo from "@/components/bridge/bridge-two-logo";
-import styles from "./claiming.module.scss";
+
 import SettingIcon from "@/assets/icons/setting.svg";
+import BridgeTwoLogo from "@/components/bridge/bridge-two-logo";
 import Skeleton from "@/components/bridge/claiming/skeleton";
-import ReceivedAmount from "./received-amount";
-import Fees from "./fees";
 import { useChainStore, useFormStore } from "@/stores";
-import BridgeMode from "./bridge-mode";
 import { BridgeProvider, CCTPMode, ChainLayer } from "@/types";
 import { isCctp } from "@/utils";
+
+import BridgeMode from "./bridge-mode";
+import styles from "./claiming.module.scss";
+import Fees from "./fees";
+import ReceivedAmount from "./received-amount";
 
 const AdvancedSettings = dynamic(() => import("@/components/bridge/modal/advanced-settings"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/claiming/manual-claim/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/manual-claim/index.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
+
 import dynamic from "next/dynamic";
-import styles from "./manual-claim.module.scss";
+
 import AttentionIcon from "@/assets/icons/attention.svg";
+
+import styles from "./manual-claim.module.scss";
 
 const ManualClaimModal = dynamic(() => import("@/components/bridge/modal/manual-claim"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/claiming/received-amount/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/received-amount/index.tsx
@@ -1,12 +1,15 @@
-import { formatUnits } from "viem";
-import styles from "./received-amount.module.scss";
-import { useTokenPrices } from "@/hooks";
-import { useChainStore, useConfigStore, useFormStore } from "@/stores";
-import { formatBalance, isCctp } from "@/utils";
-import { ChainLayer, Token } from "@/types";
 import { useMemo } from "react";
-import { useCctpFee } from "@/hooks/transaction-args/cctp/useCctpUtilHooks";
+
+import { formatUnits } from "viem";
+
 import { ETH_SYMBOL } from "@/constants";
+import { useTokenPrices } from "@/hooks";
+import { useCctpFee } from "@/hooks/transaction-args/cctp/useCctpUtilHooks";
+import { useChainStore, useConfigStore, useFormStore } from "@/stores";
+import { ChainLayer, Token } from "@/types";
+import { formatBalance, isCctp } from "@/utils";
+
+import styles from "./received-amount.module.scss";
 
 function formatReceivedAmount(
   amount: bigint,

--- a/bridge-ui/src/components/bridge/claiming/skeleton/index.tsx
+++ b/bridge-ui/src/components/bridge/claiming/skeleton/index.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+
 import styles from "./skeleton.module.scss";
 
 export default function Skeleton() {

--- a/bridge-ui/src/components/bridge/currency-dropdown/index.tsx
+++ b/bridge-ui/src/components/bridge/currency-dropdown/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useRef } from "react";
+
 import CaretDownIcon from "@/assets/icons/caret-down.svg";
-import styles from "./currency-dropdown.module.scss";
 import { CurrencyOption, useConfigStore } from "@/stores";
+
+import styles from "./currency-dropdown.module.scss";
 
 type Props = {
   disabled?: boolean;

--- a/bridge-ui/src/components/bridge/destination-address/index.tsx
+++ b/bridge-ui/src/components/bridge/destination-address/index.tsx
@@ -1,13 +1,16 @@
 import { ChangeEvent, useEffect, useRef, useState } from "react";
-import { useAccount } from "wagmi";
-import { Address, isAddress } from "viem";
+
 import clsx from "clsx";
 import Link from "next/link";
-import styles from "./destination-address.module.scss";
+import { Address, isAddress } from "viem";
+import { useAccount } from "wagmi";
+
+import ArrowRightIcon from "@/assets/icons/arrow-right.svg";
 import XCircleIcon from "@/assets/icons/x-circle.svg";
 import { useChainStore, useFormStore } from "@/stores";
 import { ChainLayer } from "@/types";
-import ArrowRightIcon from "@/assets/icons/arrow-right.svg";
+
+import styles from "./destination-address.module.scss";
 
 function formatMessage({
   address,

--- a/bridge-ui/src/components/bridge/faq-help/index.tsx
+++ b/bridge-ui/src/components/bridge/faq-help/index.tsx
@@ -1,6 +1,7 @@
-import Link from "next/link";
-import styles from "./faq-help.module.scss";
 import clsx from "clsx";
+import Link from "next/link";
+
+import styles from "./faq-help.module.scss";
 
 export default function FaqHelp() {
   return (

--- a/bridge-ui/src/components/bridge/form/index.tsx
+++ b/bridge-ui/src/components/bridge/form/index.tsx
@@ -1,20 +1,23 @@
 import { useEffect, useState } from "react";
+
 import { useAccount } from "wagmi";
-import FaqHelp from "@/components/bridge/faq-help";
-import TokenList from "@/components/bridge/token-list";
+
 import { Amount } from "@/components/bridge/amount";
-import SwapChain from "@/components/bridge/swap-chain";
-import FromChain from "@/components/bridge/from-chain";
-import ToChain from "@/components/bridge/to-chain";
 import Claiming from "@/components/bridge/claiming";
-import styles from "./bridge-form.module.scss";
+import FaqHelp from "@/components/bridge/faq-help";
+import FromChain from "@/components/bridge/from-chain";
 import { Submit } from "@/components/bridge/submit";
+import SwapChain from "@/components/bridge/swap-chain";
+import ToChain from "@/components/bridge/to-chain";
+import TokenList from "@/components/bridge/token-list";
 import Setting from "@/components/setting";
-import { DestinationAddress } from "../destination-address";
-import Button from "../../ui/button";
-import { useChainStore, useFormStore, useNativeBridgeNavigationStore } from "@/stores";
 import { useTokenBalance } from "@/hooks";
+import { useChainStore, useFormStore, useNativeBridgeNavigationStore } from "@/stores";
 import { ChainLayer, ClaimType } from "@/types";
+
+import styles from "./bridge-form.module.scss";
+import Button from "../../ui/button";
+import { DestinationAddress } from "../destination-address";
 
 export default function BridgeForm() {
   const [isDestinationAddressOpen, setIsDestinationAddressOpen] = useState(false);

--- a/bridge-ui/src/components/bridge/from-chain/index.tsx
+++ b/bridge-ui/src/components/bridge/from-chain/index.tsx
@@ -1,10 +1,13 @@
-import Image from "next/image";
-import dynamic from "next/dynamic";
-import styles from "./from-chain.module.scss";
 import { useState } from "react";
-import { useChainStore } from "@/stores";
+
+import dynamic from "next/dynamic";
+import Image from "next/image";
+
 import { useChains } from "@/hooks";
+import { useChainStore } from "@/stores";
 import { Chain } from "@/types";
+
+import styles from "./from-chain.module.scss";
 
 const SelectNetwork = dynamic(() => import("@/components/bridge/modal/select-network"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/modal/advanced-settings/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/advanced-settings/index.tsx
@@ -1,9 +1,10 @@
-import Modal from "@/components/modal";
 import CheckShieldIcon from "@/assets/icons/check-shield.svg";
-import styles from "./advanced-settings.module.scss";
+import Modal from "@/components/modal";
 import ToggleSwitch from "@/components/ui/toggle-switch";
-import { ChainLayer, ClaimType } from "@/types";
 import { useFormStore, useChainStore } from "@/stores";
+import { ChainLayer, ClaimType } from "@/types";
+
+import styles from "./advanced-settings.module.scss";
 
 type Props = {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/modal/confirm-destination-address/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/confirm-destination-address/index.tsx
@@ -1,11 +1,13 @@
-import { Address } from "viem";
 import Link from "next/link";
-import Modal from "@/components/modal";
-import styles from "./confirm-destination-address.module.scss";
-import Button from "@/components/ui/button";
-import { formatAddress } from "@/utils";
+import { Address } from "viem";
+
 import UnionIcon from "@/assets/icons/union.svg";
+import Modal from "@/components/modal";
+import Button from "@/components/ui/button";
 import { useChainStore } from "@/stores";
+import { formatAddress } from "@/utils";
+
+import styles from "./confirm-destination-address.module.scss";
 
 type Props = {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/modal/destination-address/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/destination-address/index.tsx
@@ -1,12 +1,15 @@
 import { ChangeEvent, useEffect, useState } from "react";
-import { useAccount } from "wagmi";
-import { isAddress } from "viem";
+
 import clsx from "clsx";
-import Modal from "@/components/modal";
-import styles from "./destination-address.module.scss";
-import Button from "@/components/ui/button";
+import { isAddress } from "viem";
+import { useAccount } from "wagmi";
+
 import XCircleIcon from "@/assets/icons/x-circle.svg";
+import Modal from "@/components/modal";
+import Button from "@/components/ui/button";
 import { useFormStore } from "@/stores";
+
+import styles from "./destination-address.module.scss";
 
 type Props = {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/modal/estimated-time/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/estimated-time/index.tsx
@@ -1,9 +1,10 @@
 import Modal from "@/components/modal";
-import styles from "./estimated-time.module.scss";
 import Button from "@/components/ui/button";
 import { useChainStore, useFormStore } from "@/stores";
-import { getEstimatedTimeText } from "@/utils";
 import { ChainLayer, CCTPMode } from "@/types";
+import { getEstimatedTimeText } from "@/utils";
+
+import styles from "./estimated-time.module.scss";
 
 type Props = {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/modal/gas-fees/gas-fees-list/gas-fees-list-item/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/gas-fees/gas-fees-list/gas-fees-list-item/index.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
-import styles from "./gas-fees-list-item.module.scss";
-import { CurrencyOption } from "@/stores";
+
 import { useFormattedDigit } from "@/hooks/useFormattedDigit";
+import { CurrencyOption } from "@/stores";
+
+import styles from "./gas-fees-list-item.module.scss";
 
 type Props = {
   name: string;

--- a/bridge-ui/src/components/bridge/modal/gas-fees/gas-fees-list/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/gas-fees/gas-fees-list/index.tsx
@@ -1,4 +1,5 @@
 import { useConfigStore } from "@/stores";
+
 import GasFeesListItem from "./gas-fees-list-item";
 import styles from "./gas-fees-list.module.scss";
 

--- a/bridge-ui/src/components/bridge/modal/gas-fees/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/gas-fees/index.tsx
@@ -1,7 +1,8 @@
 import Modal from "@/components/modal";
-import styles from "./gas-fees.module.scss";
 import Button from "@/components/ui/button";
+
 import GasFeesList from "./gas-fees-list";
+import styles from "./gas-fees.module.scss";
 
 type Props = {
   fees: {

--- a/bridge-ui/src/components/bridge/modal/manual-claim/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/manual-claim/index.tsx
@@ -1,8 +1,8 @@
 import Modal from "@/components/modal";
-
-import styles from "./manual-claim.module.scss";
 import Button from "@/components/ui/button";
 import { useNativeBridgeNavigationStore } from "@/stores";
+
+import styles from "./manual-claim.module.scss";
 
 type Props = {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/modal/select-network/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/select-network/index.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
+
 import SearchIcon from "@/assets/icons/search.svg";
 import Modal from "@/components/modal";
 import { useDevice } from "@/hooks";
+import { Chain } from "@/types";
+
 import NetworkDetails from "./network-details";
 import styles from "./select-network.module.scss";
-import { Chain } from "@/types";
 
 interface Props {
   networks: Chain[];

--- a/bridge-ui/src/components/bridge/modal/select-network/network-details/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/select-network/network-details/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+
 import styles from "./network-details.module.scss";
 
 type Props = {

--- a/bridge-ui/src/components/bridge/modal/token-modal/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/token-modal/index.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+
 import { isAddress, getAddress, Address, zeroAddress } from "viem";
-import Modal from "@/components/modal";
+import { useAccount } from "wagmi";
+
 import SearchIcon from "@/assets/icons/search.svg";
-import styles from "./token-modal.module.scss";
-import TokenDetails from "./token-details";
+import Modal from "@/components/modal";
 import { useDevice, useTokenPrices, useTokens } from "@/hooks";
 import { useTokenStore, useChainStore, useConfigStore, useFormStore } from "@/stores";
 import { ChainLayer, ClaimType, Token } from "@/types";
 import { safeGetAddress, isEmptyObject, isEth, isCctp } from "@/utils";
-import { useAccount } from "wagmi";
+
+import TokenDetails from "./token-details";
+import styles from "./token-modal.module.scss";
 
 interface TokenModalProps {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/modal/token-modal/token-details/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/token-modal/token-details/index.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import React, { useCallback, useMemo } from "react";
+
 import Image from "next/image";
-import styles from "./token-details.module.scss";
+import { formatUnits } from "viem";
+
 import { useTokenBalance } from "@/hooks";
 import { useFormStore, useTokenStore, useChainStore, CurrencyOption } from "@/stores";
-import { formatUnits } from "viem";
 import { CCTPMode, Token } from "@/types";
 import { formatBalance, isEth } from "@/utils";
+
+import styles from "./token-details.module.scss";
 
 interface TokenDetailsProps {
   isConnected: boolean;

--- a/bridge-ui/src/components/bridge/modal/transaction-confirmed/index.tsx
+++ b/bridge-ui/src/components/bridge/modal/transaction-confirmed/index.tsx
@@ -1,9 +1,11 @@
-import Modal from "@/components/modal";
-import styles from "./transaction-confirmed.module.scss";
-import { useFormStore, useNativeBridgeNavigationStore } from "@/stores";
-import Button from "@/components/ui/button";
 import { useQueryClient } from "@tanstack/react-query";
+
+import Modal from "@/components/modal";
+import Button from "@/components/ui/button";
 import { USDC_SYMBOL } from "@/constants";
+import { useFormStore, useNativeBridgeNavigationStore } from "@/stores";
+
+import styles from "./transaction-confirmed.module.scss";
 
 type Props = {
   isModalOpen: boolean;

--- a/bridge-ui/src/components/bridge/submit/index.tsx
+++ b/bridge-ui/src/components/bridge/submit/index.tsx
@@ -1,13 +1,16 @@
 import { MouseEventHandler, useEffect, useMemo, useState } from "react";
-import { useAccount, useChainId, useSwitchChain } from "wagmi";
+
 import clsx from "clsx";
 import dynamic from "next/dynamic";
-import Button from "@/components/ui/button";
+import { useAccount, useChainId, useSwitchChain } from "wagmi";
+
 import WalletIcon from "@/assets/icons/wallet.svg";
-import styles from "./submit.module.scss";
-import { useFormStore, useChainStore } from "@/stores";
-import { useBridge } from "@/hooks";
 import ConnectButton from "@/components/connect-button";
+import Button from "@/components/ui/button";
+import { useBridge } from "@/hooks";
+import { useFormStore, useChainStore } from "@/stores";
+
+import styles from "./submit.module.scss";
 
 type Props = {
   isDestinationAddressOpen: boolean;

--- a/bridge-ui/src/components/bridge/swap-chain/index.tsx
+++ b/bridge-ui/src/components/bridge/swap-chain/index.tsx
@@ -1,7 +1,8 @@
-import Tooltip from "@/components/ui/tooltip";
 import ArrowRightIcon from "@/assets/icons/arrow-right.svg";
-import styles from "./swap-chain.module.scss";
+import Tooltip from "@/components/ui/tooltip";
 import { useFormStore, useChainStore } from "@/stores";
+
+import styles from "./swap-chain.module.scss";
 
 export default function SwapChain() {
   const switchChainInStore = useChainStore.useSwitchChain();

--- a/bridge-ui/src/components/bridge/to-chain/index.tsx
+++ b/bridge-ui/src/components/bridge/to-chain/index.tsx
@@ -1,10 +1,13 @@
-import Image from "next/image";
-import dynamic from "next/dynamic";
-import styles from "./to-chain.module.scss";
 import { useState } from "react";
-import { useChainStore } from "@/stores";
+
+import dynamic from "next/dynamic";
+import Image from "next/image";
+
 import { useChains } from "@/hooks";
+import { useChainStore } from "@/stores";
 import { Chain } from "@/types";
+
+import styles from "./to-chain.module.scss";
 
 const SelectNetwork = dynamic(() => import("@/components/bridge/modal/select-network"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/token-list/index.tsx
+++ b/bridge-ui/src/components/bridge/token-list/index.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
-import Image from "next/image";
+
 import dynamic from "next/dynamic";
-import Button from "@/components/ui/button";
+import Image from "next/image";
+
 import CaretDownIcon from "@/assets/icons/caret-down.svg";
-import styles from "./token-list.module.scss";
+import Button from "@/components/ui/button";
 import { useFormStore } from "@/stores";
+
+import styles from "./token-list.module.scss";
 
 const TokenModal = dynamic(() => import("@/components/bridge/modal/token-modal"), {
   ssr: false,

--- a/bridge-ui/src/components/bridge/transaction-history/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/index.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useAccount } from "wagmi";
-import styles from "./transaction-history.module.scss";
+
 import ArrowLeftIcon from "@/assets/icons/arrow-left.svg";
+import { useTransactionHistory } from "@/hooks";
 import { useNativeBridgeNavigationStore } from "@/stores";
-import Button from "../../ui/button";
+
 import ListTransaction from "./list-transaction";
 import NoTransaction from "./no-transaction";
-import TransactionNotConnected from "./transaction-not-connected";
-import { useTransactionHistory } from "@/hooks";
 import SkeletonLoader from "./skeleton-loader";
+import styles from "./transaction-history.module.scss";
+import TransactionNotConnected from "./transaction-not-connected";
+import Button from "../../ui/button";
 
 export default function TransactionHistory() {
   const { isConnected } = useAccount();

--- a/bridge-ui/src/components/bridge/transaction-history/list-transaction/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/list-transaction/index.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import styles from "./list-transaction.module.scss";
-import Transaction from "./item";
+
 import TransactionDetails from "@/components/bridge/transaction-history/modal/transaction-details";
 import { BridgeTransaction } from "@/types";
+
+import Transaction from "./item";
+import styles from "./list-transaction.module.scss";
 
 type Props = {
   transactions: BridgeTransaction[];

--- a/bridge-ui/src/components/bridge/transaction-history/list-transaction/item/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/list-transaction/item/index.tsx
@@ -1,11 +1,13 @@
 import clsx from "clsx";
 import { formatUnits } from "viem";
-import styles from "./item.module.scss";
+
 import CheckIcon from "@/assets/icons/check.svg";
 import ClockIcon from "@/assets/icons/clock.svg";
 import BridgeTwoLogo from "@/components/bridge/bridge-two-logo";
-import { getChainLogoPath, formatHex, formatTimestamp, getEstimatedTimeText } from "@/utils";
 import { BridgeTransaction, CCTPMode, TransactionStatus } from "@/types";
+import { getChainLogoPath, formatHex, formatTimestamp, getEstimatedTimeText } from "@/utils";
+
+import styles from "./item.module.scss";
 
 type Props = BridgeTransaction & {
   onClick: (code: string) => void;

--- a/bridge-ui/src/components/bridge/transaction-history/modal/transaction-details/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/modal/transaction-details/index.tsx
@@ -1,15 +1,18 @@
 import { useEffect, useMemo } from "react";
-import Link from "next/link";
-import { useAccount, useSwitchChain, useTransactionReceipt } from "wagmi";
-import { formatEther } from "viem";
+
 import { useQueryClient } from "@tanstack/react-query";
-import Modal from "@/components/modal";
-import styles from "./transaction-details.module.scss";
-import Button from "@/components/ui/button";
+import Link from "next/link";
+import { formatEther } from "viem";
+import { useAccount, useSwitchChain, useTransactionReceipt } from "wagmi";
+
 import ArrowRightIcon from "@/assets/icons/arrow-right.svg";
+import Modal from "@/components/modal";
+import Button from "@/components/ui/button";
 import { useClaim, useClaimingTx, useBridgeTransactionMessage } from "@/hooks";
 import { BridgeTransaction, TransactionStatus } from "@/types";
 import { formatBalance, formatHex, formatTimestamp } from "@/utils";
+
+import styles from "./transaction-details.module.scss";
 
 type Props = {
   transaction: BridgeTransaction | undefined;

--- a/bridge-ui/src/components/bridge/transaction-history/no-transaction/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/no-transaction/index.tsx
@@ -1,7 +1,8 @@
-import styles from "./no-transaction.module.scss";
 import TransactionCircleIcon from "@/assets/icons/transaction-circle.svg";
 import Button from "@/components/ui/button";
 import { useNativeBridgeNavigationStore } from "@/stores";
+
+import styles from "./no-transaction.module.scss";
 
 export default function NoTransaction() {
   const setIsTransactionHistoryOpen = useNativeBridgeNavigationStore.useSetIsTransactionHistoryOpen();

--- a/bridge-ui/src/components/bridge/transaction-history/skeleton-loader/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/skeleton-loader/index.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+
 import styles from "./skeleton-loader.module.scss";
 
 export default function SkeletonLoader() {

--- a/bridge-ui/src/components/bridge/transaction-history/transaction-not-connected/index.tsx
+++ b/bridge-ui/src/components/bridge/transaction-history/transaction-not-connected/index.tsx
@@ -1,6 +1,7 @@
-import styles from "./transaction-not-connected.module.scss";
 import TransactionCircleIcon from "@/assets/icons/transaction-circle.svg";
 import ConnectButton from "@/components/connect-button";
+
+import styles from "./transaction-not-connected.module.scss";
 
 export default function TransactionNotConnected() {
   return (

--- a/bridge-ui/src/components/bridge/wrong-network/index.tsx
+++ b/bridge-ui/src/components/bridge/wrong-network/index.tsx
@@ -1,5 +1,6 @@
-import styles from "./wrong-network.module.scss";
 import TransactionCircleIcon from "@/assets/icons/transaction-circle.svg";
+
+import styles from "./wrong-network.module.scss";
 
 export default function WrongNetwork() {
   return (

--- a/bridge-ui/src/components/connect-button/index.tsx
+++ b/bridge-ui/src/components/connect-button/index.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import clsx from "clsx";
 import { useWeb3Auth, useWeb3AuthConnect } from "@web3auth/modal/react";
-import styles from "./connect-button.module.scss";
+import clsx from "clsx";
+
 import Button from "@/components/ui/button";
+
+import styles from "./connect-button.module.scss";
 
 type ConnectButtonProps = {
   text: string;

--- a/bridge-ui/src/components/copy-to-clipboard/index.tsx
+++ b/bridge-ui/src/components/copy-to-clipboard/index.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
-import Tooltip from "@/components/ui/tooltip";
-import Copy from "@/assets/icons/copy.svg";
+
 import Check from "@/assets/icons/check.svg";
+import Copy from "@/assets/icons/copy.svg";
+import Tooltip from "@/components/ui/tooltip";
+
 import styles from "./copy-to-clipboard.module.scss";
 
 type Props = {

--- a/bridge-ui/src/components/header/desktop-navigation/index.tsx
+++ b/bridge-ui/src/components/header/desktop-navigation/index.tsx
@@ -1,13 +1,16 @@
 "use client";
-import { LinkBlock } from "@/types/index";
-import Link from "next/link";
-import Image from "@/components/ui/image";
-import styles from "./desktop-navigation.module.scss";
-import clsx from "clsx";
 import { useEffect, useState } from "react";
+
+import clsx from "clsx";
+import Link from "next/link";
 import { usePathname } from "next/navigation";
+
 import UnionIcon from "@/assets/icons/union.svg";
 import HeaderConnect from "@/components/header/header-connect";
+import Image from "@/components/ui/image";
+import { LinkBlock } from "@/types/index";
+
+import styles from "./desktop-navigation.module.scss";
 
 type Props = {
   menus: LinkBlock[];

--- a/bridge-ui/src/components/header/header-connect/index.tsx
+++ b/bridge-ui/src/components/header/header-connect/index.tsx
@@ -1,11 +1,13 @@
 "use client";
-import Button from "@/components/ui/button";
-import { useModal } from "@/contexts/ModalProvider";
+import { useEffect } from "react";
+
 import { useWeb3Auth, useWeb3AuthConnect } from "@web3auth/modal/react";
 import { useAccount } from "wagmi";
+
+import Button from "@/components/ui/button";
 import UserAvatar from "@/components/user-avatar";
+import { useModal } from "@/contexts/ModalProvider";
 import { usePrefetchPoh } from "@/hooks/useCheckPoh";
-import { useEffect } from "react";
 import { useEnsInfo } from "@/hooks/user/useEnsInfo";
 
 export default function HeaderConnect() {

--- a/bridge-ui/src/components/header/index.tsx
+++ b/bridge-ui/src/components/header/index.tsx
@@ -1,15 +1,18 @@
 import { useRef } from "react";
-import Link from "next/link";
+
 import { useGSAP } from "@gsap/react";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
-import { DesktopNavigation } from "./desktop-navigation";
-import { MobileNavigation } from "./mobile-navigation";
+import Link from "next/link";
+
 import LineaLogo from "@/assets/logos/linea.svg";
-import { LinkBlock } from "@/types";
-import { useDevice } from "@/hooks";
 import HeaderConnect from "@/components/header/header-connect";
+import { useDevice } from "@/hooks";
+import { LinkBlock } from "@/types";
+
+import { DesktopNavigation } from "./desktop-navigation";
 import styles from "./header.module.scss";
+import { MobileNavigation } from "./mobile-navigation";
 
 gsap.registerPlugin(ScrollTrigger);
 

--- a/bridge-ui/src/components/header/mobile-navigation/index.tsx
+++ b/bridge-ui/src/components/header/mobile-navigation/index.tsx
@@ -1,13 +1,16 @@
 "use client";
-import Link from "next/link";
-import { LinkBlock } from "@/types/index";
 import { useEffect, useState } from "react";
-import Image from "@/components/ui/image";
+
 import clsx from "clsx";
-import styles from "./mobile-navigation.module.scss";
+import Link from "next/link";
+
 import UnionIcon from "@/assets/icons/union.svg";
 import LineaLogo from "@/assets/logos/linea.svg";
 import ListYourApp from "@/components/list-your-app";
+import Image from "@/components/ui/image";
+import { LinkBlock } from "@/types/index";
+
+import styles from "./mobile-navigation.module.scss";
 
 type Props = {
   menus: LinkBlock[];

--- a/bridge-ui/src/components/internal-nav/index.tsx
+++ b/bridge-ui/src/components/internal-nav/index.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
-import { useDevice } from "@/hooks";
+
 import clsx from "clsx";
+import { motion, AnimatePresence } from "motion/react";
+import { usePathname } from "next/navigation";
+
 import BridgeAggregatorIcon from "@/assets/icons/bridge-aggregator.svg";
-import NativeBridgeIcon from "@/assets/icons/native-bridge.svg";
 import BuyIcon from "@/assets/icons/buy.svg";
 import CentralizedExchangeIcon from "@/assets/icons/centralized-exchange.svg";
+import NativeBridgeIcon from "@/assets/icons/native-bridge.svg";
 import Modal from "@/components/modal";
-import NavItem, { NavItemProps } from "./item";
+import { useDevice } from "@/hooks";
+
 import styles from "./internal-nav.module.scss";
+import NavItem, { NavItemProps } from "./item";
 
 export const navList: NavItemProps[] = [
   {

--- a/bridge-ui/src/components/internal-nav/item/index.tsx
+++ b/bridge-ui/src/components/internal-nav/item/index.tsx
@@ -1,7 +1,9 @@
-import Link from "next/link";
 import clsx from "clsx";
+import Link from "next/link";
+
 import ArrowRightIcon from "@/assets/icons/arrow-right.svg";
 import CaretDownIcon from "@/assets/icons/caret-down.svg";
+
 import styles from "./item.module.scss";
 
 export type NavItemProps = {

--- a/bridge-ui/src/components/layerswap/widget/LayerswapClientWrapper.tsx
+++ b/bridge-ui/src/components/layerswap/widget/LayerswapClientWrapper.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Swap, LayerswapProvider, LayerSwapSettings, ThemeData } from "@layerswap/widget";
 import { EVMProvider } from "@layerswap/wallet-evm";
-import useEVM from "./useCustomEvm";
+import { Swap, LayerswapProvider, LayerSwapSettings, ThemeData } from "@layerswap/widget";
+
 import { config } from "@/config";
+
+import useEVM from "./useCustomEvm";
 
 interface LayerswapClientWrapperProps {
   settings: LayerSwapSettings | undefined;

--- a/bridge-ui/src/components/layerswap/widget/index.tsx
+++ b/bridge-ui/src/components/layerswap/widget/index.tsx
@@ -1,6 +1,8 @@
 import { getSettings } from "@layerswap/widget";
-import { LayerswapClientWrapper } from "./LayerswapClientWrapper";
+
 import { config } from "@/config";
+
+import { LayerswapClientWrapper } from "./LayerswapClientWrapper";
 
 export async function Widget() {
   const settings = await getSettings(config.layerswapApiKey);

--- a/bridge-ui/src/components/layerswap/widget/useCustomEvm.ts
+++ b/bridge-ui/src/components/layerswap/widget/useCustomEvm.ts
@@ -1,5 +1,5 @@
-import { useAccount } from "wagmi";
 import { useCallback, useMemo } from "react";
+
 import { resolveWalletConnectorIcon, NetworkWithTokens, NetworkType } from "@layerswap/widget";
 import {
   WalletConnectionProvider,
@@ -7,8 +7,9 @@ import {
   WalletConnectionProviderProps,
   InternalConnector,
 } from "@layerswap/widget/types";
-import { useWeb3Auth, useWeb3AuthConnect, useWeb3AuthDisconnect } from "@web3auth/modal/react";
 import { CONNECTOR_EVENTS } from "@web3auth/modal";
+import { useWeb3Auth, useWeb3AuthConnect, useWeb3AuthDisconnect } from "@web3auth/modal/react";
+import { useAccount } from "wagmi";
 
 export default function useEVM({ networks }: WalletConnectionProviderProps): WalletConnectionProvider {
   const name = "EVM";

--- a/bridge-ui/src/components/layouts/Layout.tsx
+++ b/bridge-ui/src/components/layouts/Layout.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useInitialiseChain } from "@/hooks";
-import { LinkBlock } from "@/types";
+
 import Header from "@/components/header";
 import InternalNav from "@/components/internal-nav";
+import PageBack from "@/components/page-back";
 import SideBar from "@/components/side-bar";
 import SideBarMobile from "@/components/side-bar-mobile";
-import PageBack from "@/components/page-back";
-import styles from "./layout.module.scss";
+import { useInitialiseChain } from "@/hooks";
+import { LinkBlock } from "@/types";
 import { isHomePage } from "@/utils";
+
+import styles from "./layout.module.scss";
 
 export function Layout({ children, navData }: { children: React.ReactNode; navData: LinkBlock[] }) {
   useInitialiseChain();

--- a/bridge-ui/src/components/layouts/Providers.tsx
+++ b/bridge-ui/src/components/layouts/Providers.tsx
@@ -1,9 +1,10 @@
 import { type ReactNode } from "react";
-import { QueryProvider } from "@/contexts/query.context";
-import { TokenStoreProvider } from "@/stores";
-import { getTokenConfig } from "@/services/tokenService";
-import { Web3Provider } from "@/contexts/Web3Provider";
+
 import { ModalProvider } from "@/contexts/ModalProvider";
+import { QueryProvider } from "@/contexts/query.context";
+import { Web3Provider } from "@/contexts/Web3Provider";
+import { getTokenConfig } from "@/services/tokenService";
+import { TokenStoreProvider } from "@/stores";
 
 type ProvidersProps = {
   children: ReactNode;

--- a/bridge-ui/src/components/lifi/widget/index.tsx
+++ b/bridge-ui/src/components/lifi/widget/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { ChainId, WidgetConfig, WidgetSkeleton } from "@lifi/widget";
 import { useWeb3AuthConnect } from "@web3auth/modal/react";
+import dynamic from "next/dynamic";
+
 import atypTextFont from "@/assets/fonts/atypText";
-import { CHAINS_RPC_URLS, ETH_SYMBOL } from "@/constants";
 import { config as appConfig } from "@/config";
+import { CHAINS_RPC_URLS, ETH_SYMBOL } from "@/constants";
 
 const widgetConfig: Partial<WidgetConfig> = {
   variant: "compact",

--- a/bridge-ui/src/components/list-your-app/index.tsx
+++ b/bridge-ui/src/components/list-your-app/index.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
+
 import PlusIcon from "@/assets/icons/plus-square.svg";
+
 import styles from "./list-your-app.module.scss";
 
 export default function ListYourApp() {

--- a/bridge-ui/src/components/modal-base/index.tsx
+++ b/bridge-ui/src/components/modal-base/index.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useEffect } from "react";
+
 import clsx from "clsx";
-import styles from "./modalBase.module.scss";
-import { useModal } from "@/contexts/ModalProvider";
+
 import { UserWallet } from "@/components/modal-base/user-wallet";
+import { useModal } from "@/contexts/ModalProvider";
+
+import styles from "./modalBase.module.scss";
 
 export function ModalBase() {
   const { isModalOpen, isModalType, modalData, updateModal } = useModal();

--- a/bridge-ui/src/components/modal-base/user-wallet/index.tsx
+++ b/bridge-ui/src/components/modal-base/user-wallet/index.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+
+import clsx from "clsx";
+import { usePathname } from "next/navigation";
+import { useAccount, useDisconnect } from "wagmi";
+
 import Close from "@/assets/icons/close.svg";
+import UserWalletInfo from "@/components/modal-base/user-wallet/user-wallet-info";
+import PohCheck from "@/components/poh-check";
+import SideBarMobile from "@/components/side-bar-mobile";
 import Button from "@/components/ui/button";
 import { useModal } from "@/contexts/ModalProvider";
-import { useAccount, useDisconnect } from "wagmi";
 import { useCheckPoh } from "@/hooks/useCheckPoh";
-import clsx from "clsx";
-import PohCheck from "@/components/poh-check";
-import UserWalletInfo from "@/components/modal-base/user-wallet/user-wallet-info";
-import SideBarMobile from "@/components/side-bar-mobile";
-import { usePathname } from "next/navigation";
+
 import styles from "./user-wallet.module.scss";
 
 export enum PohStep {

--- a/bridge-ui/src/components/modal-base/user-wallet/user-wallet-info/index.tsx
+++ b/bridge-ui/src/components/modal-base/user-wallet/user-wallet-info/index.tsx
@@ -1,10 +1,12 @@
-import CopyToClipboard from "@/components/copy-to-clipboard";
-import UserAvatar from "@/components/user-avatar";
 import clsx from "clsx";
 import { useAccount } from "wagmi";
+
+import CopyToClipboard from "@/components/copy-to-clipboard";
+import UserAvatar from "@/components/user-avatar";
 import { useEnsInfo } from "@/hooks/user/useEnsInfo";
-import styles from "./user-wallet-info.module.scss";
 import { shortenAddress } from "@/utils/format";
+
+import styles from "./user-wallet-info.module.scss";
 
 export default function UserWalletInfo() {
   const { address } = useAccount();

--- a/bridge-ui/src/components/modal/first-time-visit/index.tsx
+++ b/bridge-ui/src/components/modal/first-time-visit/index.tsx
@@ -1,13 +1,16 @@
 "use client";
 import { useCallback, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
-import { useConfigStore } from "@/stores";
-import Modal from "@/components/modal";
-import styles from "./first-time-visit.module.scss";
-import Button from "@/components/ui/button";
+
 import Image from "next/image";
-import LineaIcon from "@/assets/logos/linea.svg";
+import { usePathname } from "next/navigation";
+
 import CloseIcon from "@/assets/icons/close.svg";
+import LineaIcon from "@/assets/logos/linea.svg";
+import Modal from "@/components/modal";
+import Button from "@/components/ui/button";
+import { useConfigStore } from "@/stores";
+
+import styles from "./first-time-visit.module.scss";
 
 export type VisitedModalType = "all-bridges" | "native-bridge" | "buy";
 

--- a/bridge-ui/src/components/modal/index.tsx
+++ b/bridge-ui/src/components/modal/index.tsx
@@ -1,9 +1,12 @@
-import { createPortal } from "react-dom";
-import { motion, AnimatePresence } from "motion/react";
-import CloseIcon from "@/assets/icons/close.svg";
-import styles from "./modal.module.scss";
 import { JSX, useEffect, useState } from "react";
+
 import clsx from "clsx";
+import { motion, AnimatePresence } from "motion/react";
+import { createPortal } from "react-dom";
+
+import CloseIcon from "@/assets/icons/close.svg";
+
+import styles from "./modal.module.scss";
 
 type Props = {
   isOpen: boolean;

--- a/bridge-ui/src/components/onramper/index.tsx
+++ b/bridge-ui/src/components/onramper/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { config } from "@/config";
+
 import styles from "./onramper.module.scss";
 
 const onRamperConfig: Record<string, string | string[]> = {

--- a/bridge-ui/src/components/page-back/index.tsx
+++ b/bridge-ui/src/components/page-back/index.tsx
@@ -1,6 +1,8 @@
-import { useRouter } from "next/navigation";
-import ArrowLeftIcon from "@/assets/icons/arrow-left.svg";
 import clsx from "clsx";
+import { useRouter } from "next/navigation";
+
+import ArrowLeftIcon from "@/assets/icons/arrow-left.svg";
+
 import styles from "./page-back.module.scss";
 
 type Props = {

--- a/bridge-ui/src/components/poh-check/index.tsx
+++ b/bridge-ui/src/components/poh-check/index.tsx
@@ -1,13 +1,16 @@
-import clsx from "clsx";
-import { useAccount, useSignMessage } from "wagmi";
-import { Loader } from "@/components/ui/loader";
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
-import { PohStep } from "@/components/modal-base/user-wallet";
-import CloudCheck from "@/assets/icons/cloud-check.svg";
-import CloudCheckOutline from "@/assets/icons/cloud-check-outline.svg";
-import styles from "./poh-check.module.scss";
+
+import clsx from "clsx";
 import { getAddress } from "viem";
 import { linea } from "viem/chains";
+import { useAccount, useSignMessage } from "wagmi";
+
+import CloudCheckOutline from "@/assets/icons/cloud-check-outline.svg";
+import CloudCheck from "@/assets/icons/cloud-check.svg";
+import { PohStep } from "@/components/modal-base/user-wallet";
+import { Loader } from "@/components/ui/loader";
+
+import styles from "./poh-check.module.scss";
 
 type Props = {
   isHuman: boolean;

--- a/bridge-ui/src/components/setting/index.tsx
+++ b/bridge-ui/src/components/setting/index.tsx
@@ -1,14 +1,17 @@
 "use client";
-import styles from "./setting.module.scss";
-import clsx from "clsx";
-import SettingIcon from "@/assets/icons/setting.svg";
-import ToggleSwitch from "@/components/ui/toggle-switch";
 import { HTMLAttributes, useEffect, useRef, useState } from "react";
+
+import clsx from "clsx";
+
+import SettingIcon from "@/assets/icons/setting.svg";
 import CurrencyDropdown from "@/components/bridge/currency-dropdown";
-import { useConfigStore, useChainStore, useFormStore } from "@/stores";
-import { useChains } from "@/hooks";
-import { ChainLayer } from "@/types";
+import ToggleSwitch from "@/components/ui/toggle-switch";
 import { config } from "@/config";
+import { useChains } from "@/hooks";
+import { useConfigStore, useChainStore, useFormStore } from "@/stores";
+import { ChainLayer } from "@/types";
+
+import styles from "./setting.module.scss";
 
 interface SettingProps extends HTMLAttributes<HTMLDivElement> {
   "data-testid": string;

--- a/bridge-ui/src/components/side-bar-mobile/index.tsx
+++ b/bridge-ui/src/components/side-bar-mobile/index.tsx
@@ -1,9 +1,11 @@
-import AppIcon from "@/assets/icons/app.svg";
-import LineaIcon from "@/assets/logos/linea.svg";
-import RewardsIcon from "@/assets/icons/reward.svg";
-import TokensIcon from "@/assets/icons/tokens.svg";
 import clsx from "clsx";
 import Link from "next/link";
+
+import AppIcon from "@/assets/icons/app.svg";
+import RewardsIcon from "@/assets/icons/reward.svg";
+import TokensIcon from "@/assets/icons/tokens.svg";
+import LineaIcon from "@/assets/logos/linea.svg";
+
 import styles from "./side-bar-mobile.module.scss";
 
 export default function SideBarMobile() {

--- a/bridge-ui/src/components/side-bar/index.tsx
+++ b/bridge-ui/src/components/side-bar/index.tsx
@@ -1,11 +1,13 @@
-import AppIcon from "@/assets/icons/app.svg";
-import LineaFullLogo from "@/assets/logos/linea-full.svg";
-import LineaIcon from "@/assets/logos/linea.svg";
-import RewardsIcon from "@/assets/icons/reward.svg";
-import TokensIcon from "@/assets/icons/tokens.svg";
-import ListYourApp from "@/components/list-your-app";
 import clsx from "clsx";
 import Link from "next/link";
+
+import AppIcon from "@/assets/icons/app.svg";
+import RewardsIcon from "@/assets/icons/reward.svg";
+import TokensIcon from "@/assets/icons/tokens.svg";
+import LineaFullLogo from "@/assets/logos/linea-full.svg";
+import LineaIcon from "@/assets/logos/linea.svg";
+import ListYourApp from "@/components/list-your-app";
+
 import styles from "./side-bar.module.scss";
 
 const navItems = [

--- a/bridge-ui/src/components/top-banner/index.tsx
+++ b/bridge-ui/src/components/top-banner/index.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
+
+import Image from "next/image";
 import Link from "next/link";
+
 import UnionIcon from "@/assets/icons/union.svg";
 import CloseIcon from "@/assets/icons/x-circle.svg";
+
 import styles from "./top-banner.module.scss";
-import Image from "next/image";
 
 type Props = {
   text: string;

--- a/bridge-ui/src/components/ui/button/index.tsx
+++ b/bridge-ui/src/components/ui/button/index.tsx
@@ -1,5 +1,6 @@
-import { clsx } from "clsx";
 import React, { forwardRef, ButtonHTMLAttributes, ReactNode } from "react";
+
+import { clsx } from "clsx";
 
 import styles from "./button.module.scss";
 

--- a/bridge-ui/src/components/ui/loader/index.tsx
+++ b/bridge-ui/src/components/ui/loader/index.tsx
@@ -1,4 +1,5 @@
 import { ComponentPropsWithoutRef } from "react";
+
 import clsx from "clsx";
 
 import styles from "./loader.module.scss";

--- a/bridge-ui/src/components/ui/toggle-switch/index.tsx
+++ b/bridge-ui/src/components/ui/toggle-switch/index.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent, useEffect, useState } from "react";
-import styles from "./toggle-switch.module.scss";
+
 import clsx from "clsx";
+
+import styles from "./toggle-switch.module.scss";
 
 type Props = {
   checked?: boolean;

--- a/bridge-ui/src/components/ui/tooltip/index.tsx
+++ b/bridge-ui/src/components/ui/tooltip/index.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useState } from "react";
+
 import clsx from "clsx";
-import styles from "./tooltip.module.scss";
+
 import { useDevice } from "@/hooks";
+
+import styles from "./tooltip.module.scss";
 
 type TooltipProps = {
   children: React.ReactNode;

--- a/bridge-ui/src/components/user-avatar/index.tsx
+++ b/bridge-ui/src/components/user-avatar/index.tsx
@@ -1,5 +1,7 @@
 import clsx from "clsx";
+
 import Image from "@/components/ui/image";
+
 import styles from "./user-avatar.module.scss";
 
 type Props = {

--- a/bridge-ui/src/config/config.ts
+++ b/bridge-ui/src/config/config.ts
@@ -1,4 +1,5 @@
 import { getAddress, zeroAddress } from "viem";
+
 import { configSchema, Config } from "./config.schema";
 
 export const config: Config = {

--- a/bridge-ui/src/constants/chains.ts
+++ b/bridge-ui/src/constants/chains.ts
@@ -1,4 +1,3 @@
-import { config } from "@/config";
 import { defineChain } from "viem";
 import {
   arbitrum,
@@ -26,6 +25,8 @@ import {
   sonic,
   zksync,
 } from "viem/chains";
+
+import { config } from "@/config";
 
 // This is a local L1 network configuration for testing purposes
 export const localL1Network = defineChain({

--- a/bridge-ui/src/contexts/Web3Provider.tsx
+++ b/bridge-ui/src/contexts/Web3Provider.tsx
@@ -1,17 +1,20 @@
 "use client";
 
 import { ReactNode, useEffect } from "react";
-import { toHex } from "viem";
-import { useWeb3Auth, Web3AuthContextConfig, Web3AuthProvider } from "@web3auth/modal/react";
-import { coinbaseConnector } from "@web3auth/modal/connectors/coinbase-connector";
-import { WagmiProvider } from "@web3auth/modal/react/wagmi";
+
 import { WEB3AUTH_NETWORK, CONNECTOR_EVENTS } from "@web3auth/modal";
-import useGTM from "@/hooks/useGtm";
-import { useCachedIdentityToken } from "@/hooks/useCachedIdentityToken";
-import { useWalletDetection } from "./WalletDetectionProvider";
-import { isProd } from "../../next.config.mjs";
+import { coinbaseConnector } from "@web3auth/modal/connectors/coinbase-connector";
+import { useWeb3Auth, Web3AuthContextConfig, Web3AuthProvider } from "@web3auth/modal/react";
+import { WagmiProvider } from "@web3auth/modal/react/wagmi";
+import { toHex } from "viem";
+
 import { config as appConfig } from "@/config";
 import { localL1Network, localL2Network } from "@/constants";
+import { useCachedIdentityToken } from "@/hooks/useCachedIdentityToken";
+import useGTM from "@/hooks/useGtm";
+
+import { useWalletDetection } from "./WalletDetectionProvider";
+import { isProd } from "../../next.config.mjs";
 
 interface DynamicProviderProps {
   children: ReactNode;

--- a/bridge-ui/src/contexts/query.context.tsx
+++ b/bridge-ui/src/contexts/query.context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 type Web3ProviderProps = {

--- a/bridge-ui/src/contexts/solana-provider.tsx
+++ b/bridge-ui/src/contexts/solana-provider.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import type { PropsWithChildren } from "react";
+
 import { type Adapter, WalletAdapterNetwork } from "@solana/wallet-adapter-base";
-import { clusterApiUrl } from "@solana/web3.js";
 import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react";
+import { clusterApiUrl } from "@solana/web3.js";
 
 const endpoint = clusterApiUrl(WalletAdapterNetwork.Mainnet);
 

--- a/bridge-ui/src/hooks/fees/useBridgingFee.ts
+++ b/bridge-ui/src/hooks/fees/useBridgingFee.ts
@@ -1,13 +1,16 @@
 import { useMemo, useEffect } from "react";
+
 import { Address } from "viem";
+
+import { DEFAULT_ADDRESS_FOR_NON_CONNECTED_USER, MAX_POSTMAN_SPONSOR_GAS_LIMIT } from "@/constants";
+import { useFormStore, useChainStore } from "@/stores";
+import { Token, ClaimType } from "@/types";
+import { isEth, isUndefined } from "@/utils";
+
 import useFeeData from "./useFeeData";
 import useMessageNumber from "../useMessageNumber";
 import useERC20BridgingGasUsed from "./useERC20BridgingGasUsed";
 import useEthBridgingGasUsed from "./useEthBridgingGasUsed";
-import { useFormStore, useChainStore } from "@/stores";
-import { Token, ClaimType } from "@/types";
-import { isEth, isUndefined } from "@/utils";
-import { DEFAULT_ADDRESS_FOR_NON_CONNECTED_USER, MAX_POSTMAN_SPONSOR_GAS_LIMIT } from "@/constants";
 
 type UseBridgingFeeProps = {
   isConnected: boolean;

--- a/bridge-ui/src/hooks/fees/useERC20BridgingGasUsed.ts
+++ b/bridge-ui/src/hooks/fees/useERC20BridgingGasUsed.ts
@@ -1,8 +1,9 @@
-import { Address } from "viem";
 import { useQuery } from "@tanstack/react-query";
+import { Address } from "viem";
+import { useConfig } from "wagmi";
+
 import { BridgeProvider, Chain, ChainLayer, ClaimType, Token } from "@/types";
 import { estimateERC20BridgingGasUsed, isEth } from "@/utils";
-import { useConfig } from "wagmi";
 
 type UseERC20BridgingFeeProps = {
   account?: Address;

--- a/bridge-ui/src/hooks/fees/useEthBridgingGasUsed.ts
+++ b/bridge-ui/src/hooks/fees/useEthBridgingGasUsed.ts
@@ -1,8 +1,9 @@
-import { Address } from "viem";
 import { useQuery } from "@tanstack/react-query";
+import { Address } from "viem";
+import { useConfig } from "wagmi";
+
 import { BridgeProvider, Chain, ChainLayer, ClaimType, Token } from "@/types";
 import { estimateEthBridgingGasUsed, isEth } from "@/utils";
-import { useConfig } from "wagmi";
 
 type UseEthBridgingFeeProps = {
   account?: Address;

--- a/bridge-ui/src/hooks/fees/useFeeData.ts
+++ b/bridge-ui/src/hooks/fees/useFeeData.ts
@@ -1,4 +1,5 @@
 import { useEstimateFeesPerGas, useWatchBlockNumber } from "wagmi";
+
 import { SupportedChainIds } from "@/types";
 
 const useFeeData = (chainId: SupportedChainIds) => {

--- a/bridge-ui/src/hooks/fees/useFees.ts
+++ b/bridge-ui/src/hooks/fees/useFees.ts
@@ -1,13 +1,16 @@
 import { useMemo, useCallback } from "react";
-import { useAccount } from "wagmi";
+
 import { formatEther, zeroAddress } from "viem";
-import useGasFees from "./useGasFees";
-import useMinimumFee from "./useMinimumFee";
-import useBridgingFee from "./useBridgingFee";
-import useTokenPrices from "../useTokenPrices";
+import { useAccount } from "wagmi";
+
 import { useFormStore, useChainStore } from "@/stores";
 import { ClaimType } from "@/types";
 import { isZero, isUndefined } from "@/utils";
+
+import useBridgingFee from "./useBridgingFee";
+import useGasFees from "./useGasFees";
+import useMinimumFee from "./useMinimumFee";
+import useTokenPrices from "../useTokenPrices";
 
 const useFees = () => {
   const { address, isConnected } = useAccount();

--- a/bridge-ui/src/hooks/fees/useGasFees.ts
+++ b/bridge-ui/src/hooks/fees/useGasFees.ts
@@ -1,10 +1,12 @@
 import { Address, maxUint256 } from "viem";
 import { useEstimateGas } from "wagmi";
+
+import { DEFAULT_ADDRESS_FOR_NON_CONNECTED_USER } from "@/constants";
 import { Chain, Token } from "@/types";
+import { isCctp, isEth, isUndefined } from "@/utils";
+
 import useFeeData from "./useFeeData";
 import { useTransactionArgs } from "../transaction-args";
-import { isCctp, isEth, isUndefined } from "@/utils";
-import { DEFAULT_ADDRESS_FOR_NON_CONNECTED_USER } from "@/constants";
 
 type UseGasFeesProps = {
   token: Token;

--- a/bridge-ui/src/hooks/fees/useMinimumFee.ts
+++ b/bridge-ui/src/hooks/fees/useMinimumFee.ts
@@ -1,7 +1,9 @@
 import { useEffect, useMemo } from "react";
+
 import { useReadContract } from "wagmi";
-import { ChainLayer } from "@/types";
+
 import { useFormStore, useChainStore } from "@/stores";
+import { ChainLayer } from "@/types";
 
 const useMinimumFee = () => {
   const fromChain = useChainStore.useFromChain();

--- a/bridge-ui/src/hooks/transaction-args/cctp/useCctpUtilHooks.ts
+++ b/bridge-ui/src/hooks/transaction-args/cctp/useCctpUtilHooks.ts
@@ -1,12 +1,14 @@
 // Break pattern of 1 hook-1 file because TypeScript and CI were going nuts on filenames such as useCctpDestinationDomain.ts
 
 import { useMemo } from "react";
-import { useChainStore, useFormStore } from "@/stores";
-import { getCctpFee } from "@/services/cctp";
+
 import { useQuery } from "@tanstack/react-query";
+
 import { CCTP_MAX_FINALITY_THRESHOLD, CCTP_MIN_FINALITY_THRESHOLD, USDC_DECIMALS } from "@/constants";
-import { isUndefined } from "@/utils";
+import { getCctpFee } from "@/services/cctp";
+import { useChainStore, useFormStore } from "@/stores";
 import { CCTPMode } from "@/types";
+import { isUndefined } from "@/utils";
 
 const useCctpSrcDomain = () => {
   const fromChain = useChainStore.useFromChain();

--- a/bridge-ui/src/hooks/transaction-args/cctp/useDepositForBurnTxArgs.ts
+++ b/bridge-ui/src/hooks/transaction-args/cctp/useDepositForBurnTxArgs.ts
@@ -1,11 +1,14 @@
 import { useMemo } from "react";
+
 import { encodeFunctionData, padHex, zeroHash } from "viem";
-import { useFormStore, useChainStore } from "@/stores";
-import { isCctp } from "@/utils/tokens";
-import { useCctpFee, useCctpDestinationDomain } from "./useCctpUtilHooks";
+
 import { CCTP_MAX_FINALITY_THRESHOLD, CCTP_MIN_FINALITY_THRESHOLD } from "@/constants";
-import { isNull, isUndefined, isUndefinedOrEmptyString } from "@/utils";
+import { useFormStore, useChainStore } from "@/stores";
 import { CCTPMode } from "@/types";
+import { isNull, isUndefined, isUndefinedOrEmptyString } from "@/utils";
+import { isCctp } from "@/utils/tokens";
+
+import { useCctpFee, useCctpDestinationDomain } from "./useCctpUtilHooks";
 
 type UseDepositForBurnTxArgs = {
   allowance?: bigint;

--- a/bridge-ui/src/hooks/transaction-args/useApproveTxArgs.ts
+++ b/bridge-ui/src/hooks/transaction-args/useApproveTxArgs.ts
@@ -1,5 +1,7 @@
 import { useMemo } from "react";
+
 import { encodeFunctionData, erc20Abi } from "viem";
+
 import { useFormStore, useChainStore } from "@/stores";
 import { isEth, isNull, isUndefined } from "@/utils";
 import { isCctp } from "@/utils/tokens";

--- a/bridge-ui/src/hooks/transaction-args/useClaimTransactionTxArgs.ts
+++ b/bridge-ui/src/hooks/transaction-args/useClaimTransactionTxArgs.ts
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
-import { useAccount } from "wagmi";
+
 import { encodeFunctionData, zeroAddress } from "viem";
+import { useAccount } from "wagmi";
+
 import MessageService from "@/abis/MessageService.json";
 import MessageTransmitterV2 from "@/abis/MessageTransmitterV2.json";
 import {
@@ -11,8 +13,8 @@ import {
   NativeBridgeMessage,
   TransactionStatus,
 } from "@/types";
-import { isCctpV2BridgeMessage, isNativeBridgeMessage } from "@/utils/message";
 import { isUndefined, isUndefinedOrEmptyString } from "@/utils";
+import { isCctpV2BridgeMessage, isNativeBridgeMessage } from "@/utils/message";
 
 type UseClaimTxArgsProps = {
   status?: TransactionStatus;

--- a/bridge-ui/src/hooks/transaction-args/useERC20BridgeTxArgs.ts
+++ b/bridge-ui/src/hooks/transaction-args/useERC20BridgeTxArgs.ts
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
+
 import { encodeFunctionData } from "viem";
-import { useFormStore, useChainStore } from "@/stores";
+
 import TokenBridge from "@/abis/TokenBridge.json";
-import { isEth, isNull, isUndefined, isUndefinedOrNull, isZero, isUndefinedOrEmptyString } from "@/utils";
-import { BridgeProvider, ChainLayer, ClaimType } from "@/types";
 import { DEFAULT_ADDRESS_FOR_NON_CONNECTED_USER } from "@/constants";
+import { useFormStore, useChainStore } from "@/stores";
+import { BridgeProvider, ChainLayer, ClaimType } from "@/types";
+import { isEth, isNull, isUndefined, isUndefinedOrNull, isZero, isUndefinedOrEmptyString } from "@/utils";
 
 type UseERC20BridgeTxArgsProps = {
   isConnected: boolean;

--- a/bridge-ui/src/hooks/transaction-args/useEthBridgeTxArgs.ts
+++ b/bridge-ui/src/hooks/transaction-args/useEthBridgeTxArgs.ts
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
+
 import { encodeFunctionData } from "viem";
-import { useFormStore, useChainStore } from "@/stores";
+
 import MessageService from "@/abis/MessageService.json";
-import { isEth, isUndefinedOrNull, isZero, isUndefinedOrEmptyString } from "@/utils";
-import { BridgeProvider, ChainLayer, ClaimType } from "@/types";
 import { DEFAULT_ADDRESS_FOR_NON_CONNECTED_USER } from "@/constants";
+import { useFormStore, useChainStore } from "@/stores";
+import { BridgeProvider, ChainLayer, ClaimType } from "@/types";
+import { isEth, isUndefinedOrNull, isZero, isUndefinedOrEmptyString } from "@/utils";
 
 type UseEthBridgeTxArgsProps = {
   isConnected: boolean;

--- a/bridge-ui/src/hooks/transaction-args/useTransactionArgs.ts
+++ b/bridge-ui/src/hooks/transaction-args/useTransactionArgs.ts
@@ -1,12 +1,14 @@
-import useEthBridgeTxArgs from "./useEthBridgeTxArgs";
-import useERC20BridgeTxArgs from "./useERC20BridgeTxArgs";
-import useApproveTxArgs from "./useApproveTxArgs";
-import useAllowance from "../useAllowance";
-import useDepositForBurnTxArgs from "./cctp/useDepositForBurnTxArgs";
 import { QueryObserverResult, RefetchOptions } from "@tanstack/react-query";
 import { ReadContractErrorType } from "@wagmi/core";
 import { useAccount } from "wagmi";
+
 import { SupportedChainIds } from "@/types";
+
+import useAllowance from "../useAllowance";
+import useDepositForBurnTxArgs from "./cctp/useDepositForBurnTxArgs";
+import useApproveTxArgs from "./useApproveTxArgs";
+import useERC20BridgeTxArgs from "./useERC20BridgeTxArgs";
+import useEthBridgeTxArgs from "./useEthBridgeTxArgs";
 
 type TransactionArgs =
   | {

--- a/bridge-ui/src/hooks/useAllowance.ts
+++ b/bridge-ui/src/hooks/useAllowance.ts
@@ -1,5 +1,6 @@
-import { useAccount, useReadContract } from "wagmi";
 import { erc20Abi } from "viem";
+import { useAccount, useReadContract } from "wagmi";
+
 import { useFormStore, useChainStore } from "@/stores";
 import { isEth } from "@/utils";
 import { isCctp } from "@/utils/tokens";

--- a/bridge-ui/src/hooks/useBridge.ts
+++ b/bridge-ui/src/hooks/useBridge.ts
@@ -1,4 +1,5 @@
 import { useSendTransaction, useWaitForTransactionReceipt } from "wagmi";
+
 import useTransactionArgs from "./transaction-args/useTransactionArgs";
 
 const useBridge = () => {

--- a/bridge-ui/src/hooks/useBridgeTransactionMessage.ts
+++ b/bridge-ui/src/hooks/useBridgeTransactionMessage.ts
@@ -1,5 +1,10 @@
+import { getMessageProof } from "@consensys/linea-sdk-viem";
 import { useQuery } from "@tanstack/react-query";
 import { getPublicClient } from "@wagmi/core";
+import { Address, Client, Hex } from "viem";
+import { useConfig } from "wagmi";
+
+import { config } from "@/config";
 import {
   BridgeTransaction,
   BridgeTransactionType,
@@ -8,12 +13,8 @@ import {
   NativeBridgeMessage,
   TransactionStatus,
 } from "@/types";
-import { isNativeBridgeMessage } from "@/utils/message";
 import { isUndefined, isUndefinedOrEmptyString } from "@/utils";
-import { config } from "@/config";
-import { getMessageProof } from "@consensys/linea-sdk-viem";
-import { Address, Client, Hex } from "viem";
-import { useConfig } from "wagmi";
+import { isNativeBridgeMessage } from "@/utils/message";
 
 const useBridgeTransactionMessage = (
   transaction: BridgeTransaction | undefined,

--- a/bridge-ui/src/hooks/useCachedIdentityToken.ts
+++ b/bridge-ui/src/hooks/useCachedIdentityToken.ts
@@ -1,5 +1,6 @@
-import { useIdentityToken } from "@web3auth/modal/react";
 import { useCallback } from "react";
+
+import { useIdentityToken } from "@web3auth/modal/react";
 
 /**
  * Global cache for Web3Auth identity token (shared across all components)

--- a/bridge-ui/src/hooks/useChains.ts
+++ b/bridge-ui/src/hooks/useChains.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
-import { useConfigStore, useChainStore } from "@/stores";
+
 import { config } from "@/config";
+import { useConfigStore, useChainStore } from "@/stores";
 
 const useChains = () => {
   const chains = useChainStore.useChains();

--- a/bridge-ui/src/hooks/useCheckPoh.ts
+++ b/bridge-ui/src/hooks/useCheckPoh.ts
@@ -1,6 +1,8 @@
-import { checkPoh } from "@/lib/linea-poh/api";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { checkPoh } from "@/lib/linea-poh/api";
 
 export const useCheckPoh = (address: string) => {
   const { data, isLoading, refetch } = useQuery({

--- a/bridge-ui/src/hooks/useClaim.ts
+++ b/bridge-ui/src/hooks/useClaim.ts
@@ -1,6 +1,8 @@
 import { useSendTransaction, useWaitForTransactionReceipt } from "wagmi";
-import useClaimTxArgs from "./transaction-args/useClaimTransactionTxArgs";
+
 import { BridgeTransactionType, CctpV2BridgeMessage, Chain, NativeBridgeMessage, TransactionStatus } from "@/types";
+
+import useClaimTxArgs from "./transaction-args/useClaimTransactionTxArgs";
 
 type UseClaimProps = {
   status?: TransactionStatus;

--- a/bridge-ui/src/hooks/useClaimingTx.ts
+++ b/bridge-ui/src/hooks/useClaimingTx.ts
@@ -1,9 +1,10 @@
-import { BridgeTransaction, BridgeTransactionType, CctpMessageReceivedAbiEvent, TransactionStatus } from "@/types";
-import { getPublicClient } from "@wagmi/core";
-import { isCctpV2BridgeMessage, isNativeBridgeMessage } from "@/utils/message";
 import { useQuery } from "@tanstack/react-query";
-import { getNativeBridgeMessageClaimedTxHash, isUndefined, isUndefinedOrEmptyString } from "@/utils";
+import { getPublicClient } from "@wagmi/core";
 import { Config, useConfig } from "wagmi";
+
+import { BridgeTransaction, BridgeTransactionType, CctpMessageReceivedAbiEvent, TransactionStatus } from "@/types";
+import { getNativeBridgeMessageClaimedTxHash, isUndefined, isUndefinedOrEmptyString } from "@/utils";
+import { isCctpV2BridgeMessage, isNativeBridgeMessage } from "@/utils/message";
 
 const useClaimingTx = (transaction: BridgeTransaction | undefined): string | undefined => {
   const wagmiConfig = useConfig();

--- a/bridge-ui/src/hooks/useFormattedDigit.tsx
+++ b/bridge-ui/src/hooks/useFormattedDigit.tsx
@@ -1,4 +1,5 @@
 import { useMemo, type JSX } from "react";
+
 import { formatUnits } from "viem";
 
 export function useFormattedDigit(value: bigint, decimals: number = 18): JSX.Element {

--- a/bridge-ui/src/hooks/useGtm.ts
+++ b/bridge-ui/src/hooks/useGtm.ts
@@ -1,5 +1,6 @@
-import { sendGTMEvent } from "@next/third-parties/google";
 import { useCallback } from "react";
+
+import { sendGTMEvent } from "@next/third-parties/google";
 
 /**
  * Custom hook for handling Google Tag Manager events

--- a/bridge-ui/src/hooks/useInitialiseChain.ts
+++ b/bridge-ui/src/hooks/useInitialiseChain.ts
@@ -1,10 +1,13 @@
-import { watchAccount } from "@wagmi/core";
 import { useEffect } from "react";
+
+import { watchAccount } from "@wagmi/core";
+import { useConfig } from "wagmi";
+
 import { useChainStore } from "@/stores";
-import useChains from "./useChains";
 import { Chain } from "@/types";
 import { isUndefined } from "@/utils";
-import { useConfig } from "wagmi";
+
+import useChains from "./useChains";
 
 const useInitialiseChain = () => {
   const wagmiConfig = useConfig();

--- a/bridge-ui/src/hooks/useMessageNumber.ts
+++ b/bridge-ui/src/hooks/useMessageNumber.ts
@@ -1,4 +1,5 @@
 import { useReadContract } from "wagmi";
+
 import MessageService from "@/abis/MessageService.json";
 import { Chain, ChainLayer, ClaimType } from "@/types";
 

--- a/bridge-ui/src/hooks/useTokenBalance.tsx
+++ b/bridge-ui/src/hooks/useTokenBalance.tsx
@@ -1,8 +1,9 @@
-import { useAccount, useBalance, useReadContract } from "wagmi";
 import { erc20Abi } from "viem";
+import { useAccount, useBalance, useReadContract } from "wagmi";
+
 import { useChainStore } from "@/stores";
-import { isEth } from "@/utils";
 import { Token } from "@/types";
+import { isEth } from "@/utils";
 
 const useTokenBalance = (token: Token) => {
   const { address } = useAccount();

--- a/bridge-ui/src/hooks/useTokenPrices.tsx
+++ b/bridge-ui/src/hooks/useTokenPrices.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
+
 import { useQuery } from "@tanstack/react-query";
-import { Address } from "viem";
 import log from "loglevel";
+import { Address } from "viem";
+
 import { fetchTokenPrices } from "@/services/tokenService";
 import { useConfigStore } from "@/stores";
 

--- a/bridge-ui/src/hooks/useTokens.ts
+++ b/bridge-ui/src/hooks/useTokens.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
-import { useChainStore, useTokenStore } from "@/stores";
-import { ChainLayer, Token } from "@/types";
+
 import { config } from "@/config";
 import { USDC_SYMBOL } from "@/constants";
+import { useChainStore, useTokenStore } from "@/stores";
+import { ChainLayer, Token } from "@/types";
 import { isUndefined } from "@/utils";
 
 const useTokens = (): Token[] => {

--- a/bridge-ui/src/hooks/useTransactionHistory.ts
+++ b/bridge-ui/src/hooks/useTransactionHistory.ts
@@ -1,8 +1,10 @@
-import { useAccount, useConfig } from "wagmi";
 import { useQuery } from "@tanstack/react-query";
+import { useAccount, useConfig } from "wagmi";
+
 import { HistoryActionsForCompleteTxCaching, useChainStore, useHistoryStore } from "@/stores";
-import useTokens from "./useTokens";
 import { fetchTransactionsHistory } from "@/utils";
+
+import useTokens from "./useTokens";
 
 const useTransactionHistory = () => {
   const { address } = useAccount();

--- a/bridge-ui/src/services/tokenService.ts
+++ b/bridge-ui/src/services/tokenService.ts
@@ -1,10 +1,12 @@
 import { cache } from "react";
+
 import log from "loglevel";
 import { Address } from "viem";
+
 import { config } from "@/config";
+import { PRIORITY_SYMBOLS, USDC_SYMBOL } from "@/constants";
 import { defaultTokensConfig, SupportedCurrencies } from "@/stores";
 import { BridgeProvider, GithubTokenListToken, NetworkTokens, Token } from "@/types";
-import { PRIORITY_SYMBOLS, USDC_SYMBOL } from "@/constants";
 import { isUndefined } from "@/utils";
 
 enum NetworkTypes {

--- a/bridge-ui/src/stores/chainStore.ts
+++ b/bridge-ui/src/stores/chainStore.ts
@@ -1,10 +1,11 @@
-import { create } from "zustand";
 import { createSelectorHooks, ZustandHookSelectors } from "auto-zustand-selectors-hook";
 import { linea, lineaSepolia, mainnet, sepolia } from "viem/chains";
+import { create } from "zustand";
+
+import { config } from "@/config";
+import { localL1Network, localL2Network } from "@/constants";
 import { Chain } from "@/types";
 import { generateChain, generateChains } from "@/utils";
-import { localL1Network, localL2Network } from "@/constants";
-import { config } from "@/config";
 
 export type ChainState = {
   chains: Chain[];

--- a/bridge-ui/src/stores/configStore.ts
+++ b/bridge-ui/src/stores/configStore.ts
@@ -1,9 +1,9 @@
-import { create } from "zustand";
 import { createSelectorHooks, ZustandHookSelectors } from "auto-zustand-selectors-hook";
-import { config } from "@/config";
-
+import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+
 import { VisitedModalType } from "@/components/modal/first-time-visit";
+import { config } from "@/config";
 
 export type SupportedCurrencies = "usd" | "eur";
 

--- a/bridge-ui/src/stores/formStore.ts
+++ b/bridge-ui/src/stores/formStore.ts
@@ -1,8 +1,10 @@
 import { Address } from "viem";
-import { defaultTokensConfig } from "./tokenStore";
 import { createWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/vanilla/shallow";
+
 import { Token, ClaimType, CCTPMode } from "@/types";
+
+import { defaultTokensConfig } from "./tokenStore";
 
 export type FormState = {
   token: Token;

--- a/bridge-ui/src/stores/formStoreProvider.tsx
+++ b/bridge-ui/src/stores/formStoreProvider.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { type ReactNode, createContext, useRef, useContext } from "react";
+
 import { useStore } from "zustand";
-import { FormState, type FormStore, createFormStore } from "./formStore";
+
 import { isUndefined } from "@/utils";
+
+import { FormState, type FormStore, createFormStore } from "./formStore";
 
 export type FormStoreApi = ReturnType<typeof createFormStore>;
 

--- a/bridge-ui/src/stores/historyStore.ts
+++ b/bridge-ui/src/stores/historyStore.ts
@@ -1,6 +1,7 @@
+import { createJSONStorage, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/vanilla/shallow";
-import { createJSONStorage, persist } from "zustand/middleware";
+
 import { config } from "@/config";
 import { BridgeTransaction, TransactionStatus } from "@/types";
 import { getCompleteTxStoreKeyForTx } from "@/utils/history";

--- a/bridge-ui/src/stores/nativeBridgeNavigationStore.ts
+++ b/bridge-ui/src/stores/nativeBridgeNavigationStore.ts
@@ -1,5 +1,5 @@
-import { create } from "zustand";
 import { createSelectorHooks, ZustandHookSelectors } from "auto-zustand-selectors-hook";
+import { create } from "zustand";
 
 export type NativeBridgeNavigationState = {
   isBridgeOpen: boolean;

--- a/bridge-ui/src/stores/tokenStore.ts
+++ b/bridge-ui/src/stores/tokenStore.ts
@@ -1,5 +1,6 @@
 import { createWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/vanilla/shallow";
+
 import { BridgeProvider, NetworkTokens, Token } from "@/types";
 
 export const defaultTokensConfig: NetworkTokens = {

--- a/bridge-ui/src/stores/tokenStoreProvider.tsx
+++ b/bridge-ui/src/stores/tokenStoreProvider.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { type ReactNode, createContext, useRef, useContext } from "react";
+
 import { useStore } from "zustand";
-import { TokenState, type TokenStore, createTokenStore } from "./tokenStore";
+
 import { isUndefined } from "@/utils";
+
+import { TokenState, type TokenStore, createTokenStore } from "./tokenStore";
 
 export type TokenStoreApi = ReturnType<typeof createTokenStore>;
 

--- a/bridge-ui/src/types/bridge.ts
+++ b/bridge-ui/src/types/bridge.ts
@@ -1,5 +1,6 @@
-import { Address } from "viem";
 import { MessageProof } from "@consensys/linea-sdk-viem";
+import { Address } from "viem";
+
 import { Chain, Token, TransactionStatus, CCTPMode } from "@/types";
 
 export type NativeBridgeMessage = {

--- a/bridge-ui/src/types/chain.ts
+++ b/bridge-ui/src/types/chain.ts
@@ -1,5 +1,6 @@
-import { NATIVE_BRIDGE_SUPPORTED_CHAIN_IDS } from "@/constants";
 import { Address } from "viem";
+
+import { NATIVE_BRIDGE_SUPPORTED_CHAIN_IDS } from "@/constants";
 
 export type SupportedChainIds = (typeof NATIVE_BRIDGE_SUPPORTED_CHAIN_IDS)[number];
 

--- a/bridge-ui/src/types/token.ts
+++ b/bridge-ui/src/types/token.ts
@@ -1,4 +1,5 @@
 import { Address } from "viem";
+
 import { BridgeProvider } from "./providers";
 
 export interface GithubTokenListTokenExtension {

--- a/bridge-ui/src/utils/cctp.spec.ts
+++ b/bridge-ui/src/utils/cctp.spec.ts
@@ -1,6 +1,8 @@
 import { test } from "@playwright/test";
 import nock from "nock";
-import { getCctpMessageExpiryBlock, getCctpTransactionStatus } from "./cctp";
+import { lineaSepolia, sepolia } from "viem/chains";
+import { createConfig, http, mock } from "wagmi";
+
 import {
   CctpAttestationMessage,
   CctpAttestationMessageStatus,
@@ -9,8 +11,8 @@ import {
   ChainLayer,
   TransactionStatus,
 } from "@/types";
-import { createConfig, http, mock } from "wagmi";
-import { lineaSepolia, sepolia } from "viem/chains";
+
+import { getCctpMessageExpiryBlock, getCctpTransactionStatus } from "./cctp";
 
 const { expect, describe } = test;
 

--- a/bridge-ui/src/utils/cctp.ts
+++ b/bridge-ui/src/utils/cctp.ts
@@ -1,15 +1,16 @@
-import MessageTransmitterV2 from "@/abis/MessageTransmitterV2.json" assert { type: "json" };
-import { CctpAttestationMessage, CctpAttestationMessageStatus, CCTPMode, Chain, TransactionStatus } from "@/types";
 import { getPublicClient, GetPublicClientReturnType } from "@wagmi/core";
-import { fetchCctpAttestationByTxHash, reattestCctpV2PreFinalityMessage } from "@/services/cctp";
+import { Config } from "wagmi";
+
+import MessageTransmitterV2 from "@/abis/MessageTransmitterV2.json" assert { type: "json" };
 import {
   CCTP_MAX_FINALITY_THRESHOLD,
   CCTP_V2_EXPIRATION_BLOCK_LENGTH,
   CCTP_V2_EXPIRATION_BLOCK_OFFSET,
   CCTP_V2_MESSAGE_HEADER_LENGTH,
 } from "@/constants";
+import { fetchCctpAttestationByTxHash, reattestCctpV2PreFinalityMessage } from "@/services/cctp";
+import { CctpAttestationMessage, CctpAttestationMessageStatus, CCTPMode, Chain, TransactionStatus } from "@/types";
 import { isUndefined } from "@/utils/utils";
-import { Config } from "wagmi";
 
 const isCctpNonceUsed = async (
   client: GetPublicClientReturnType,

--- a/bridge-ui/src/utils/chains.ts
+++ b/bridge-ui/src/utils/chains.ts
@@ -1,8 +1,9 @@
 import { Address } from "viem";
 import { linea, mainnet, Chain as ViemChain, sepolia, lineaSepolia } from "viem/chains";
+
 import { config } from "@/config";
-import { Chain, ChainLayer, SupportedChainIds } from "@/types";
 import { localL1Network, localL2Network } from "@/constants";
+import { Chain, ChainLayer, SupportedChainIds } from "@/types";
 
 const getChainName = (chainId: number) => {
   switch (chainId) {

--- a/bridge-ui/src/utils/events/getNativeBridgeMessageClaimedTxHash.ts
+++ b/bridge-ui/src/utils/events/getNativeBridgeMessageClaimedTxHash.ts
@@ -1,4 +1,5 @@
 import { PublicClient } from "viem";
+
 import { MessageClaimedABIEvent } from "@/types";
 
 export const getNativeBridgeMessageClaimedTxHash = async (

--- a/bridge-ui/src/utils/fees.ts
+++ b/bridge-ui/src/utils/fees.ts
@@ -1,11 +1,13 @@
-import { Address, encodeAbiParameters, encodeFunctionData, zeroAddress } from "viem";
 import { getPublicClient } from "@wagmi/core";
-import TokenBridge from "@/abis/TokenBridge.json";
+import { Address, encodeAbiParameters, encodeFunctionData, zeroAddress } from "viem";
+import { Config } from "wagmi";
+
 import MessageService from "@/abis/MessageService.json";
-import { computeMessageHash, computeMessageStorageSlot } from "./message";
+import TokenBridge from "@/abis/TokenBridge.json";
 import { Chain, ClaimType, Token } from "@/types";
 import { isUndefined } from "@/utils";
-import { Config } from "wagmi";
+
+import { computeMessageHash, computeMessageStorageSlot } from "./message";
 
 interface EstimationParams {
   address: Address;

--- a/bridge-ui/src/utils/format.ts
+++ b/bridge-ui/src/utils/format.ts
@@ -1,6 +1,7 @@
-import { fromUnixTime } from "date-fns/fromUnixTime";
 import { formatDate } from "date-fns/format";
+import { fromUnixTime } from "date-fns/fromUnixTime";
 import { Address, getAddress } from "viem";
+
 import { isUndefinedOrEmptyString } from "@/utils";
 
 /**

--- a/bridge-ui/src/utils/history/fetchCctpBridgeEvents.ts
+++ b/bridge-ui/src/utils/history/fetchCctpBridgeEvents.ts
@@ -1,6 +1,10 @@
-import { Address } from "viem";
 import { getPublicClient } from "@wagmi/core";
+import { Address } from "viem";
+import { Config } from "wagmi";
+
+import { HistoryActionsForCompleteTxCaching } from "@/stores";
 import { BridgeTransaction, BridgeTransactionType, CctpDepositForBurnAbiEvent, Chain, Token } from "@/types";
+import { DepositForBurnLogEvent } from "@/types/events";
 import {
   getCctpMessageByTxHash,
   getCctpModeFromFinalityThreshold,
@@ -8,12 +12,10 @@ import {
   isCctp,
   isUndefined,
 } from "@/utils";
-import { DepositForBurnLogEvent } from "@/types/events";
-import { HistoryActionsForCompleteTxCaching } from "@/stores";
+
 import { isBlockTooOld } from "./isBlockTooOld";
 import { restoreFromTransactionCache } from "./restoreFromTransactionCache";
 import { saveToTransactionCache } from "./saveToTransactionCache";
-import { Config } from "wagmi";
 
 export async function fetchCctpBridgeEvents(
   historyStoreActions: HistoryActionsForCompleteTxCaching,

--- a/bridge-ui/src/utils/history/fetchERC20BridgeEvents.ts
+++ b/bridge-ui/src/utils/history/fetchERC20BridgeEvents.ts
@@ -1,10 +1,14 @@
-import { Address, Client, decodeAbiParameters } from "viem";
-import { getPublicClient } from "@wagmi/core";
 import {
   getL1ToL2MessageStatus,
   getL2ToL1MessageStatus,
   getMessagesByTransactionHash,
 } from "@consensys/linea-sdk-viem";
+import { getPublicClient } from "@wagmi/core";
+import { Address, Client, decodeAbiParameters } from "viem";
+import { Config } from "wagmi";
+
+import { config } from "@/config";
+import { HistoryActionsForCompleteTxCaching } from "@/stores";
 import {
   BridgeTransaction,
   BridgeTransactionType,
@@ -14,14 +18,12 @@ import {
   ChainLayer,
   Token,
 } from "@/types";
-import { formatOnChainMessageStatus } from "./formatOnChainMessageStatus";
-import { HistoryActionsForCompleteTxCaching } from "@/stores";
-import { isBlockTooOld } from "./isBlockTooOld";
 import { isUndefined, isUndefinedOrNull } from "@/utils";
-import { config } from "@/config";
+
+import { formatOnChainMessageStatus } from "./formatOnChainMessageStatus";
+import { isBlockTooOld } from "./isBlockTooOld";
 import { restoreFromTransactionCache } from "./restoreFromTransactionCache";
 import { saveToTransactionCache } from "./saveToTransactionCache";
-import { Config } from "wagmi";
 
 export async function fetchERC20BridgeEvents(
   historyStoreActions: HistoryActionsForCompleteTxCaching,

--- a/bridge-ui/src/utils/history/fetchETHBridgeEvents.ts
+++ b/bridge-ui/src/utils/history/fetchETHBridgeEvents.ts
@@ -1,6 +1,9 @@
-import { Address, Client, Hex } from "viem";
-import { getPublicClient } from "@wagmi/core";
 import { getL1ToL2MessageStatus, getL2ToL1MessageStatus } from "@consensys/linea-sdk-viem";
+import { getPublicClient } from "@wagmi/core";
+import { Address, Client, Hex } from "viem";
+import { Config } from "wagmi";
+
+import { config } from "@/config";
 import { defaultTokensConfig, HistoryActionsForCompleteTxCaching } from "@/stores";
 import {
   BridgeTransaction,
@@ -11,12 +14,11 @@ import {
   MessageSentLogEvent,
   Token,
 } from "@/types";
+
 import { formatOnChainMessageStatus } from "./formatOnChainMessageStatus";
 import { isBlockTooOld } from "./isBlockTooOld";
-import { config } from "@/config";
 import { restoreFromTransactionCache } from "./restoreFromTransactionCache";
 import { saveToTransactionCache } from "./saveToTransactionCache";
-import { Config } from "wagmi";
 
 export async function fetchETHBridgeEvents(
   historyStoreActions: HistoryActionsForCompleteTxCaching,

--- a/bridge-ui/src/utils/history/fetchTransactionsHistory.ts
+++ b/bridge-ui/src/utils/history/fetchTransactionsHistory.ts
@@ -1,11 +1,13 @@
 import { Address } from "viem";
-import { config } from "@/config";
-import { BridgeTransaction, Chain, Token } from "@/types";
-import { fetchETHBridgeEvents } from "./fetchETHBridgeEvents";
-import { fetchERC20BridgeEvents } from "./fetchERC20BridgeEvents";
-import { fetchCctpBridgeEvents } from "./fetchCctpBridgeEvents";
-import { HistoryActionsForCompleteTxCaching } from "@/stores";
 import { Config } from "wagmi";
+
+import { config } from "@/config";
+import { HistoryActionsForCompleteTxCaching } from "@/stores";
+import { BridgeTransaction, Chain, Token } from "@/types";
+
+import { fetchCctpBridgeEvents } from "./fetchCctpBridgeEvents";
+import { fetchERC20BridgeEvents } from "./fetchERC20BridgeEvents";
+import { fetchETHBridgeEvents } from "./fetchETHBridgeEvents";
 
 type TransactionHistoryParams = {
   historyStoreActions: HistoryActionsForCompleteTxCaching;

--- a/bridge-ui/src/utils/history/formatOnChainMessageStatus.ts
+++ b/bridge-ui/src/utils/history/formatOnChainMessageStatus.ts
@@ -1,4 +1,5 @@
 import { OnChainMessageStatus } from "@consensys/linea-sdk-viem";
+
 import { TransactionStatus } from "@/types";
 
 export function formatOnChainMessageStatus(status: OnChainMessageStatus): TransactionStatus {

--- a/bridge-ui/src/utils/history/isBlockTooOld.spec.ts
+++ b/bridge-ui/src/utils/history/isBlockTooOld.spec.ts
@@ -1,7 +1,9 @@
 import { test } from "@playwright/test";
 import { GetBlockReturnType } from "viem";
-import { isBlockTooOld } from "./isBlockTooOld";
+
 import { MESSAGE_TOO_OLD_THRESHOLD_DAYS } from "@/constants/message";
+
+import { isBlockTooOld } from "./isBlockTooOld";
 
 const { expect, describe } = test;
 

--- a/bridge-ui/src/utils/history/isBlockTooOld.ts
+++ b/bridge-ui/src/utils/history/isBlockTooOld.ts
@@ -1,7 +1,8 @@
-import { GetBlockReturnType } from "viem";
-import { fromUnixTime } from "date-fns/fromUnixTime";
 import { compareAsc } from "date-fns/compareAsc";
+import { fromUnixTime } from "date-fns/fromUnixTime";
 import { subDays } from "date-fns/subDays";
+import { GetBlockReturnType } from "viem";
+
 import { MESSAGE_TOO_OLD_THRESHOLD_DAYS } from "@/constants";
 
 export function isBlockTooOld(block: GetBlockReturnType): boolean {

--- a/bridge-ui/src/utils/history/isTimestampTooOld.spec.ts
+++ b/bridge-ui/src/utils/history/isTimestampTooOld.spec.ts
@@ -1,6 +1,8 @@
 import { test } from "@playwright/test";
-import { isTimestampTooOld } from "./isTimestampTooOld";
+
 import { MESSAGE_TOO_OLD_THRESHOLD_DAYS } from "@/constants/message";
+
+import { isTimestampTooOld } from "./isTimestampTooOld";
 
 const { expect, describe } = test;
 

--- a/bridge-ui/src/utils/history/isTimestampTooOld.ts
+++ b/bridge-ui/src/utils/history/isTimestampTooOld.ts
@@ -1,6 +1,7 @@
-import { fromUnixTime } from "date-fns/fromUnixTime";
 import { compareAsc } from "date-fns/compareAsc";
+import { fromUnixTime } from "date-fns/fromUnixTime";
 import { subDays } from "date-fns/subDays";
+
 import { MESSAGE_TOO_OLD_THRESHOLD_DAYS } from "@/constants";
 
 export function isTimestampTooOld(timestamp: bigint): boolean {

--- a/bridge-ui/src/utils/history/restoreFromTransactionCache.ts
+++ b/bridge-ui/src/utils/history/restoreFromTransactionCache.ts
@@ -1,5 +1,6 @@
-import { BridgeTransaction, SupportedChainIds } from "@/types";
 import { HistoryActionsForCompleteTxCaching } from "@/stores";
+import { BridgeTransaction, SupportedChainIds } from "@/types";
+
 import { getCompleteTxStoreKey } from "./getCompleteTxStoreKey";
 import { isTimestampTooOld } from "./isTimestampTooOld";
 

--- a/bridge-ui/src/utils/history/saveToTransactionCache.ts
+++ b/bridge-ui/src/utils/history/saveToTransactionCache.ts
@@ -1,5 +1,6 @@
-import { BridgeTransaction } from "@/types";
 import { HistoryActionsForCompleteTxCaching } from "@/stores";
+import { BridgeTransaction } from "@/types";
+
 import { isTimestampTooOld } from "./isTimestampTooOld";
 
 /**

--- a/bridge-ui/src/utils/message.ts
+++ b/bridge-ui/src/utils/message.ts
@@ -1,6 +1,8 @@
 import { keccak256, encodeAbiParameters, Address } from "viem";
-import { CctpV2BridgeMessage, Chain, ChainLayer, NativeBridgeMessage, Token, CCTPMode } from "@/types";
+
 import { INBOX_L1L2_MESSAGE_STATUS_MAPPING_SLOT } from "@/constants";
+import { CctpV2BridgeMessage, Chain, ChainLayer, NativeBridgeMessage, Token, CCTPMode } from "@/types";
+
 import { isCctp } from "./tokens";
 
 export function computeMessageHash(

--- a/bridge-ui/src/utils/tokens.ts
+++ b/bridge-ui/src/utils/tokens.ts
@@ -1,4 +1,5 @@
 import { isAddress, isAddressEqual, zeroAddress } from "viem";
+
 import { USDC_SYMBOL } from "@/constants";
 import { BridgeProvider, Token } from "@/types";
 

--- a/bridge-ui/test/e2e/bridge-l1-l2.spec.ts
+++ b/bridge-ui/test/e2e/bridge-l1-l2.spec.ts
@@ -1,4 +1,5 @@
 import { testWithSynpress } from "@synthetixio/synpress";
+
 import { test as advancedFixtures } from "../advancedFixtures";
 import {
   USDC_SYMBOL,

--- a/bridge-ui/test/e2e/bridge-l2-l1.spec.ts
+++ b/bridge-ui/test/e2e/bridge-l2-l1.spec.ts
@@ -1,4 +1,5 @@
 import { testWithSynpress } from "@synthetixio/synpress";
+
 import { test as advancedFixtures } from "../advancedFixtures";
 import { WEI_AMOUNT, ETH_SYMBOL, ERC20_SYMBOL, ERC20_AMOUNT, L2_ACCOUNT_METAMASK_NAME } from "../constants";
 

--- a/bridge-ui/test/e2e/general.spec.ts
+++ b/bridge-ui/test/e2e/general.spec.ts
@@ -1,4 +1,5 @@
 import { testWithSynpress } from "@synthetixio/synpress";
+
 import { test as advancedFixtures } from "../advancedFixtures";
 import { TEST_URL, WEI_AMOUNT, ETH_SYMBOL, LOCAL_L2_NETWORK, L1_ACCOUNT_METAMASK_NAME } from "../constants";
 

--- a/bridge-ui/test/global.setup.ts
+++ b/bridge-ui/test/global.setup.ts
@@ -1,4 +1,3 @@
-import { localL1Network, localL2Network } from "@/constants";
 import { test as setup } from "@playwright/test";
 import {
   createPublicClient,
@@ -11,7 +10,10 @@ import {
 } from "viem";
 import { mnemonicToAccount, privateKeyToAccount } from "viem/accounts";
 import { waitForTransactionReceipt } from "viem/actions";
-import { sendTransactionsToGenerateTrafficWithInterval } from "./utils/utils";
+import { estimateGas } from "viem/linea";
+
+import { localL1Network, localL2Network } from "@/constants";
+
 import {
   L1_TEST_ERC2O_CONTRACT_ADDRESS,
   L2_ACCOUNT_PRIVATE_KEY,
@@ -19,7 +21,7 @@ import {
   LOCAL_L1_NETWORK,
   LOCAL_L2_NETWORK,
 } from "./constants";
-import { estimateGas } from "viem/linea";
+import { sendTransactionsToGenerateTrafficWithInterval } from "./utils/utils";
 
 setup.setTimeout(200_000);
 

--- a/bridge-ui/test/utils/selectTokenAndWaitForBalance.ts
+++ b/bridge-ui/test/utils/selectTokenAndWaitForBalance.ts
@@ -1,4 +1,5 @@
 import { Page } from "@playwright/test";
+
 import { POLLING_INTERVAL, PAGE_TIMEOUT } from "../constants";
 
 export async function selectTokenAndWaitForBalance(tokenSymbol: string, page: Page, waitForBalance = true) {

--- a/bridge-ui/test/utils/utils.ts
+++ b/bridge-ui/test/utils/utils.ts
@@ -1,7 +1,8 @@
-import { localL1Network, localL2Network } from "@/constants";
 import { Client, Hex, parseEther } from "viem";
 import { estimateMaxPriorityFeePerGas, getAddresses, sendTransaction, waitForTransactionReceipt } from "viem/actions";
 import { estimateGas } from "viem/linea";
+
+import { localL1Network, localL2Network } from "@/constants";
 
 export async function sendTransactionsToGenerateTrafficWithInterval(client: Client, pollingInterval: number = 1_000) {
   let timeoutId: NodeJS.Timeout | null = null;

--- a/bridge-ui/test/wallet-setup/metamask.setup.ts
+++ b/bridge-ui/test/wallet-setup/metamask.setup.ts
@@ -1,4 +1,8 @@
 import { Locator, Page } from "@playwright/test";
+import { defineWalletSetup } from "@synthetixio/synpress";
+import { MetaMask, getExtensionId } from "@synthetixio/synpress/playwright";
+import { z } from "zod";
+
 import {
   L1_ACCOUNT_ADDRESS,
   L1_ACCOUNT_PRIVATE_KEY,
@@ -8,9 +12,6 @@ import {
   METAMASK_PASSWORD,
   METAMASK_SEED_PHRASE,
 } from "../constants";
-import { defineWalletSetup } from "@synthetixio/synpress";
-import { MetaMask, getExtensionId } from "@synthetixio/synpress/playwright";
-import { z } from "zod";
 
 const closeRenameAccountButtonSelector = 'button[aria-label="Close"]';
 

--- a/contract-integrity-verifier/verifier-core/src/config.ts
+++ b/contract-integrity-verifier/verifier-core/src/config.ts
@@ -8,6 +8,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { resolve, dirname, extname } from "path";
+
 import { VerifierConfig, ChainConfig, ContractConfig } from "./types";
 import { parseMarkdownConfig } from "./utils/markdown-config";
 

--- a/contract-integrity-verifier/verifier-core/src/utils/abi.ts
+++ b/contract-integrity-verifier/verifier-core/src/utils/abi.ts
@@ -9,7 +9,7 @@
 
 import { readFileSync } from "fs";
 import { basename } from "path";
-import type { Web3Adapter } from "../adapter";
+
 import {
   AbiElement,
   AbiInput,
@@ -20,6 +20,8 @@ import {
   FoundryArtifact,
   ImmutableReference,
 } from "../types";
+
+import type { Web3Adapter } from "../adapter";
 
 // ============================================================================
 // Artifact Format Detection

--- a/contract-integrity-verifier/verifier-core/src/utils/markdown-config.ts
+++ b/contract-integrity-verifier/verifier-core/src/utils/markdown-config.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync } from "fs";
 import { dirname, resolve } from "path";
+
 import {
   VerifierConfig,
   ChainConfig,

--- a/contract-integrity-verifier/verifier-core/src/utils/storage.ts
+++ b/contract-integrity-verifier/verifier-core/src/utils/storage.ts
@@ -7,7 +7,7 @@
 
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import type { Web3Adapter } from "../adapter";
+
 import {
   StorageSchema,
   StorageStructDef,
@@ -20,6 +20,8 @@ import {
   NamespaceConfig,
   NamespaceResult,
 } from "../types";
+
+import type { Web3Adapter } from "../adapter";
 
 // ============================================================================
 // ERC-7201 Slot Calculation

--- a/contract-integrity-verifier/verifier-core/src/verifier.ts
+++ b/contract-integrity-verifier/verifier-core/src/verifier.ts
@@ -5,7 +5,7 @@
  * against local artifact files.
  */
 
-import type { Web3Adapter } from "./adapter";
+import { EIP1967_IMPLEMENTATION_SLOT } from "./constants";
 import {
   VerifierConfig,
   ContractConfig,
@@ -17,8 +17,8 @@ import {
   ViewCallResult,
   AbiElement,
 } from "./types";
-import { compareBytecode, extractSelectorsFromBytecode, validateImmutablesAgainstArgs } from "./utils/bytecode";
 import { loadArtifact, extractSelectorsFromArtifact, compareSelectors } from "./utils/abi";
+import { compareBytecode, extractSelectorsFromBytecode, validateImmutablesAgainstArgs } from "./utils/bytecode";
 import {
   calculateErc7201BaseSlot,
   verifySlot,
@@ -26,7 +26,8 @@ import {
   verifyStoragePath,
   loadStorageSchema,
 } from "./utils/storage";
-import { EIP1967_IMPLEMENTATION_SLOT } from "./constants";
+
+import type { Web3Adapter } from "./adapter";
 
 /**
  * Options for verification operations.

--- a/contract-integrity-verifier/verifier-ethers/src/cli.ts
+++ b/contract-integrity-verifier/verifier-ethers/src/cli.ts
@@ -8,13 +8,14 @@
  *   npx @consensys/linea-contract-integrity-verifier-ethers -c config.json -v
  */
 
-import { resolve, dirname } from "path";
 import {
   loadConfig,
   Verifier,
   printSummary,
   type ContractVerificationResult,
 } from "@consensys/linea-contract-integrity-verifier";
+import { resolve, dirname } from "path";
+
 import { EthersAdapter } from "./index";
 
 // ============================================================================

--- a/contract-integrity-verifier/verifier-ethers/src/index.ts
+++ b/contract-integrity-verifier/verifier-ethers/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { ethers } from "ethers";
+
 import type { Web3Adapter, Web3AdapterOptions, AbiElement } from "@consensys/linea-contract-integrity-verifier";
 
 /**

--- a/contract-integrity-verifier/verifier-viem/src/cli.ts
+++ b/contract-integrity-verifier/verifier-viem/src/cli.ts
@@ -8,13 +8,14 @@
  *   npx @consensys/linea-contract-integrity-verifier-viem -c config.json -v
  */
 
-import { resolve, dirname } from "path";
 import {
   loadConfig,
   Verifier,
   printSummary,
   type ContractVerificationResult,
 } from "@consensys/linea-contract-integrity-verifier";
+import { resolve, dirname } from "path";
+
 import { ViemAdapter } from "./index";
 
 // ============================================================================

--- a/contract-integrity-verifier/verifier-viem/src/index.ts
+++ b/contract-integrity-verifier/verifier-viem/src/index.ts
@@ -21,6 +21,7 @@ import {
   type Hex,
   type Chain,
 } from "viem";
+
 import type { Web3Adapter, Web3AdapterOptions, AbiElement } from "@consensys/linea-contract-integrity-verifier";
 
 /**

--- a/contracts/eslint.config.mjs
+++ b/contracts/eslint.config.mjs
@@ -13,6 +13,10 @@ export default [
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    rules: {
+      // TODO: this plugin is disabled for now to avoid a lot of files changes
+      "import/order": "off",
+    }
   },
   {
     files: ["test/**/*.ts"],

--- a/e2e/eslint.config.mjs
+++ b/e2e/eslint.config.mjs
@@ -10,5 +10,9 @@ export default [
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    rules: {
+      // TODO: this plugin is disabled for now to avoid a lot of files changes
+      "import/order": "off",
+    }
   },
 ];

--- a/native-yield-operations/automation-service/eslint.config.mjs
+++ b/native-yield-operations/automation-service/eslint.config.mjs
@@ -10,5 +10,9 @@ export default [
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    rules: {
+      // TODO: this plugin is disabled for now to avoid a lot of files changes
+      "import/order": "off",
+    }
   },
 ];

--- a/operations/src/commands/burn-and-bridge.ts
+++ b/operations/src/commands/burn-and-bridge.ts
@@ -1,4 +1,7 @@
 import { Command, Flags } from "@oclif/core";
+import { addSeconds } from "date-fns";
+import { fromZonedTime } from "date-fns-tz";
+import { Result } from "neverthrow";
 import {
   Address,
   Client,
@@ -10,14 +13,12 @@ import {
   parseEventLogs,
   SendTransactionParameters,
 } from "viem";
-import { linea, lineaSepolia } from "viem/chains";
-import { fromZonedTime } from "date-fns-tz";
-import { Result } from "neverthrow";
-import { addSeconds } from "date-fns";
+import { privateKeyToAccount, privateKeyToAddress } from "viem/accounts";
 import { getBalance } from "viem/actions";
-import { estimateTransactionGas, sendTransaction } from "../utils/common/transactions.js";
-import { validateUrl } from "../utils/common/validation.js";
-import { address, hexString } from "../utils/common/custom-flags.js";
+import { linea, lineaSepolia } from "viem/chains";
+
+import { ARREARS_PAID_EVENT_ABI, ETH_BURNT_SWAPPED_AND_BRIDGED_EVENT_ABI } from "../utils/burn-and-bridge/abi.js";
+import { LINEA_TOKEN_ADDRESS, WETH_TOKEN_ADDRESS } from "../utils/burn-and-bridge/constants.js";
 import {
   computeBurnAndBridgeCalldata,
   computeSwapCalldata,
@@ -25,9 +26,9 @@ import {
   getMinimumFee,
   getQuote,
 } from "../utils/burn-and-bridge/contract.js";
-import { LINEA_TOKEN_ADDRESS, WETH_TOKEN_ADDRESS } from "../utils/burn-and-bridge/constants.js";
-import { ARREARS_PAID_EVENT_ABI, ETH_BURNT_SWAPPED_AND_BRIDGED_EVENT_ABI } from "../utils/burn-and-bridge/abi.js";
-import { privateKeyToAccount, privateKeyToAddress } from "viem/accounts";
+import { address, hexString } from "../utils/common/custom-flags.js";
+import { estimateTransactionGas, sendTransaction } from "../utils/common/transactions.js";
+import { validateUrl } from "../utils/common/validation.js";
 
 export default class BurnAndBridge extends Command {
   static examples = [

--- a/operations/src/commands/eth-transfer.ts
+++ b/operations/src/commands/eth-transfer.ts
@@ -1,7 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { Agent } from "https";
-import { address, hexString } from "../utils/common/custom-flags.js";
-import { validateUrl } from "../utils/common/validation.js";
+import { Result } from "neverthrow";
 import {
   Client,
   createPublicClient,
@@ -14,12 +13,14 @@ import {
   TransactionSerializable,
 } from "viem";
 import { linea } from "viem/chains";
-import { Result } from "neverthrow";
-import { calculateRewards } from "../utils/eth-transfer/rewards.js";
-import { validateETHThreshold } from "../utils/eth-transfer/validation.js";
+
+import { address, hexString } from "../utils/common/custom-flags.js";
 import { buildHttpsAgent } from "../utils/common/https-agent.js";
 import { getWeb3SignerSignature } from "../utils/common/signature.js";
 import { estimateTransactionGas, sendRawTransaction } from "../utils/common/transactions.js";
+import { validateUrl } from "../utils/common/validation.js";
+import { calculateRewards } from "../utils/eth-transfer/rewards.js";
+import { validateETHThreshold } from "../utils/eth-transfer/validation.js";
 
 export default class EthTransfer extends Command {
   static examples = [

--- a/operations/src/commands/submit-invoice.ts
+++ b/operations/src/commands/submit-invoice.ts
@@ -1,4 +1,9 @@
+import { GetCostAndUsageCommandInput } from "@aws-sdk/client-cost-explorer";
 import { Command, Flags } from "@oclif/core";
+import { addDays } from "date-fns";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
+import { Agent } from "https";
+import { Result } from "neverthrow";
 import {
   Address,
   Client,
@@ -12,25 +17,21 @@ import {
   serializeTransaction,
   TransactionSerializable,
 } from "viem";
-import { linea, lineaSepolia } from "viem/chains";
 import { getBlock } from "viem/actions";
-import { Agent } from "https";
-import { GetCostAndUsageCommandInput } from "@aws-sdk/client-cost-explorer";
-import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
-import { addDays } from "date-fns";
-import { Result } from "neverthrow";
-import { computeInvoicePeriod, InvoicePeriod } from "../utils/submit-invoice/time.js";
-import { generateQueryParameters, getDuneClient, runDuneQuery } from "../utils/common/dune.js";
-import { estimateTransactionGas, sendRawTransaction } from "../utils/common/transactions.js";
-import { getWeb3SignerSignature } from "../utils/common/signature.js";
-import { INVOICE_PROCESSED_EVENT_ABI } from "../utils/submit-invoice/abi.js";
-import { buildHttpsAgent } from "../utils/common/https-agent.js";
+import { linea, lineaSepolia } from "viem/chains";
+
 import { createAwsCostExplorerClient, flattenResultsByTime, getDailyAwsCosts } from "../utils/common/aws.js";
-import { computeSubmitInvoiceCalldata, getLastInvoiceDate } from "../utils/submit-invoice/contract.js";
-import { validateUrl } from "../utils/common/validation.js";
-import { address, hexString } from "../utils/common/custom-flags.js";
-import { awsCostsApiFilters } from "../utils/submit-invoice/custom-flags.js";
 import { fetchEthereumPrice } from "../utils/common/coingecko.js";
+import { address, hexString } from "../utils/common/custom-flags.js";
+import { generateQueryParameters, getDuneClient, runDuneQuery } from "../utils/common/dune.js";
+import { buildHttpsAgent } from "../utils/common/https-agent.js";
+import { getWeb3SignerSignature } from "../utils/common/signature.js";
+import { estimateTransactionGas, sendRawTransaction } from "../utils/common/transactions.js";
+import { validateUrl } from "../utils/common/validation.js";
+import { INVOICE_PROCESSED_EVENT_ABI } from "../utils/submit-invoice/abi.js";
+import { computeSubmitInvoiceCalldata, getLastInvoiceDate } from "../utils/submit-invoice/contract.js";
+import { awsCostsApiFilters } from "../utils/submit-invoice/custom-flags.js";
+import { computeInvoicePeriod, InvoicePeriod } from "../utils/submit-invoice/time.js";
 
 export default class SubmitInvoice extends Command {
   static examples = [

--- a/operations/src/commands/synctx.ts
+++ b/operations/src/commands/synctx.ts
@@ -1,6 +1,7 @@
 import { Command, Flags } from "@oclif/core";
 import { ethers } from "ethers";
 import { readFileSync } from "fs";
+
 import {
   getPendingTransactions,
   isLocalPort,

--- a/operations/src/utils/burn-and-bridge/contract.ts
+++ b/operations/src/utils/burn-and-bridge/contract.ts
@@ -1,6 +1,7 @@
 import { err, ok, Result } from "neverthrow";
 import { Address, BaseError, Client, encodeFunctionData, Hex } from "viem";
 import { readContract, simulateContract } from "viem/actions";
+
 import { BURN_AND_BRIDGE_ABI, QUOTE_EXACT_INPUT_SINGLE_ABI, SWAP_ABI } from "./abi.js";
 
 export async function getInvoiceArrears(client: Client, contractAddress: Address): Promise<Result<bigint, BaseError>> {

--- a/operations/src/utils/common/__tests__/validation.test.ts
+++ b/operations/src/utils/common/__tests__/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 import { ethers } from "ethers";
+
 import { isValidProtocolUrl, validateEthereumAddress, validateHexString, validateUrl } from "../validation.js";
 
 describe("Validation utils", () => {

--- a/operations/src/utils/common/custom-flags.ts
+++ b/operations/src/utils/common/custom-flags.ts
@@ -1,5 +1,6 @@
-import { Address, Hex } from "viem";
 import { Flags } from "@oclif/core";
+import { Address, Hex } from "viem";
+
 import { validateEthereumAddress, validateHexString } from "./validation.js";
 
 export const address = Flags.custom<Address>({

--- a/operations/src/utils/common/https-agent.ts
+++ b/operations/src/utils/common/https-agent.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from "fs";
 import { Agent } from "https";
 import forge from "node-forge";
-import { readFileSync } from "fs";
 import path from "path";
 
 function convertToPem(p12base64: string | forge.util.ByteStringBuffer, password: string) {

--- a/operations/src/utils/common/transactions.ts
+++ b/operations/src/utils/common/transactions.ts
@@ -1,11 +1,11 @@
-import { BaseError, Client, Hex, SendTransactionParameters, TransactionReceipt } from "viem";
-import { estimateGas, EstimateGasParameters, EstimateGasReturnType } from "viem/linea";
 import { err, ok, Result } from "neverthrow";
+import { BaseError, Client, Hex, SendTransactionParameters, TransactionReceipt } from "viem";
 import {
   sendRawTransaction as viemSendRawTransaction,
   waitForTransactionReceipt,
   sendTransaction as viemSendTransaction,
 } from "viem/actions";
+import { estimateGas, EstimateGasParameters, EstimateGasReturnType } from "viem/linea";
 
 export async function estimateTransactionGas(
   client: Client,

--- a/operations/src/utils/submit-invoice/__tests__/time.test.ts
+++ b/operations/src/utils/submit-invoice/__tests__/time.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
-import { computeInvoicePeriod } from "../time.js";
 import { fromZonedTime } from "date-fns-tz";
+
+import { computeInvoicePeriod } from "../time.js";
 
 describe("Time", () => {
   describe("computeInvoiceDatesWithDelay", () => {

--- a/operations/src/utils/submit-invoice/contract.ts
+++ b/operations/src/utils/submit-invoice/contract.ts
@@ -1,7 +1,8 @@
+import { err, ok, Result } from "neverthrow";
 import { Address, BaseError, Client, encodeFunctionData, Hex } from "viem";
 import { readContract } from "viem/actions";
+
 import { SUBMIT_INVOICE_ABI } from "./abi.js";
-import { err, ok, Result } from "neverthrow";
 
 export async function getLastInvoiceDate(client: Client, contractAddress: Address): Promise<Result<bigint, BaseError>> {
   try {

--- a/postman/scripts/manualTestSendMessages.ts
+++ b/postman/scripts/manualTestSendMessages.ts
@@ -36,14 +36,15 @@ npx ts-node postman/scripts/manualTestSendMessages.ts \
  * Should be auto-claimed on L2
  */
 
+import { LineaRollup, LineaRollup__factory } from "@consensys/linea-sdk";
 import { config } from "dotenv";
+import { Wallet, JsonRpcProvider, ContractTransactionResponse } from "ethers";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+
 import { sanitizePrivKey } from "./cli";
-import { Wallet, JsonRpcProvider, ContractTransactionResponse } from "ethers";
-import { LineaRollup, LineaRollup__factory } from "@consensys/linea-sdk";
-import { SendMessageArgs } from "./types";
 import { encodeSendMessage } from "./helpers";
+import { SendMessageArgs } from "./types";
 
 // CONFIG INPUT
 config();

--- a/postman/scripts/runPostman.ts
+++ b/postman/scripts/runPostman.ts
@@ -1,5 +1,6 @@
 import * as dotenv from "dotenv";
 import { transports } from "winston";
+
 import { PostmanServiceClient } from "../src/application/postman/app/PostmanServiceClient";
 
 dotenv.config();

--- a/postman/scripts/sendMessageOnL1.ts
+++ b/postman/scripts/sendMessageOnL1.ts
@@ -1,11 +1,12 @@
-import { BytesLike, ContractTransactionReceipt, Overrides, Wallet, JsonRpcProvider } from "ethers";
-import { config } from "dotenv";
 import { L2MessageService, L2MessageService__factory, LineaRollup, LineaRollup__factory } from "@consensys/linea-sdk";
+import { config } from "dotenv";
+import { BytesLike, ContractTransactionReceipt, Overrides, Wallet, JsonRpcProvider } from "ethers";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { SendMessageArgs } from "./types";
+
 import { sanitizeAddress, sanitizePrivKey } from "./cli";
 import { encodeSendMessage } from "./helpers";
+import { SendMessageArgs } from "./types";
 
 config();
 

--- a/postman/scripts/sendMessageOnL2.ts
+++ b/postman/scripts/sendMessageOnL2.ts
@@ -1,10 +1,11 @@
-import { ContractTransactionReceipt, Overrides, JsonRpcProvider, Wallet } from "ethers";
+import { L2MessageService, L2MessageService__factory } from "@consensys/linea-sdk";
 import { config } from "dotenv";
+import { ContractTransactionReceipt, Overrides, JsonRpcProvider, Wallet } from "ethers";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { L2MessageService, L2MessageService__factory } from "@consensys/linea-sdk";
-import { SendMessageArgs } from "./types";
+
 import { sanitizeAddress, sanitizePrivKey } from "./cli";
+import { SendMessageArgs } from "./types";
 
 config();
 

--- a/postman/src/application/postman/api/metrics/MessageMetricsUpdater.ts
+++ b/postman/src/application/postman/api/metrics/MessageMetricsUpdater.ts
@@ -1,9 +1,10 @@
-import { EntityManager } from "typeorm";
-import { MessageEntity } from "../../persistence/entities/Message.entity";
-import { IMessageMetricsUpdater, LineaPostmanMetrics, MessagesMetricsAttributes } from "../../../../core/metrics";
 import { Direction } from "@consensys/linea-sdk";
-import { MessageStatus } from "../../../../core/enums";
 import { IMetricsService } from "@consensys/linea-shared-utils";
+import { EntityManager } from "typeorm";
+
+import { MessageStatus } from "../../../../core/enums";
+import { IMessageMetricsUpdater, LineaPostmanMetrics, MessagesMetricsAttributes } from "../../../../core/metrics";
+import { MessageEntity } from "../../persistence/entities/Message.entity";
 
 export class MessageMetricsUpdater implements IMessageMetricsUpdater {
   constructor(

--- a/postman/src/application/postman/api/metrics/PostmanMetricsService.ts
+++ b/postman/src/application/postman/api/metrics/PostmanMetricsService.ts
@@ -1,5 +1,6 @@
-import { LineaPostmanMetrics } from "../../../../core/metrics/LineaPostmanMetrics";
 import { SingletonMetricsService } from "@consensys/linea-shared-utils";
+
+import { LineaPostmanMetrics } from "../../../../core/metrics/LineaPostmanMetrics";
 
 export class PostmanMetricsService extends SingletonMetricsService<LineaPostmanMetrics> {
   constructor(defaultLabels: Record<string, string> = { app: "postman" }) {

--- a/postman/src/application/postman/api/metrics/SponsorshipMetricsUpdater.ts
+++ b/postman/src/application/postman/api/metrics/SponsorshipMetricsUpdater.ts
@@ -1,6 +1,7 @@
-import { ISponsorshipMetricsUpdater, LineaPostmanMetrics } from "../../../../core/metrics";
 import { Direction } from "@consensys/linea-sdk";
 import { IMetricsService } from "@consensys/linea-shared-utils";
+
+import { ISponsorshipMetricsUpdater, LineaPostmanMetrics } from "../../../../core/metrics";
 
 export class SponsorshipMetricsUpdater implements ISponsorshipMetricsUpdater {
   constructor(private readonly metricsService: IMetricsService<LineaPostmanMetrics>) {

--- a/postman/src/application/postman/api/metrics/TransactionMetricsUpdater.ts
+++ b/postman/src/application/postman/api/metrics/TransactionMetricsUpdater.ts
@@ -1,5 +1,6 @@
-import { LineaPostmanMetrics, ITransactionMetricsUpdater } from "../../../../core/metrics";
 import { IMetricsService } from "@consensys/linea-shared-utils";
+
+import { LineaPostmanMetrics, ITransactionMetricsUpdater } from "../../../../core/metrics";
 
 export class TransactionMetricsUpdater implements ITransactionMetricsUpdater {
   constructor(private readonly metricsService: IMetricsService<LineaPostmanMetrics>) {

--- a/postman/src/application/postman/api/metrics/__tests__/MessageMetricsUpdater.test.ts
+++ b/postman/src/application/postman/api/metrics/__tests__/MessageMetricsUpdater.test.ts
@@ -1,10 +1,11 @@
-import { EntityManager, SelectQueryBuilder } from "typeorm";
 import { Direction } from "@consensys/linea-sdk";
-import { MessageMetricsUpdater } from "../MessageMetricsUpdater";
 import { mock, MockProxy } from "jest-mock-extended";
+import { EntityManager, SelectQueryBuilder } from "typeorm";
+
 import { MessageStatus } from "../../../../../core/enums";
-import { PostmanMetricsService } from "../PostmanMetricsService";
 import { IMessageMetricsUpdater } from "../../../../../core/metrics";
+import { MessageMetricsUpdater } from "../MessageMetricsUpdater";
+import { PostmanMetricsService } from "../PostmanMetricsService";
 
 describe("MessageMetricsUpdater", () => {
   let messageMetricsUpdater: IMessageMetricsUpdater;

--- a/postman/src/application/postman/api/metrics/__tests__/SponsorshipMetricsUpdater.test.ts
+++ b/postman/src/application/postman/api/metrics/__tests__/SponsorshipMetricsUpdater.test.ts
@@ -1,7 +1,8 @@
 import { Direction } from "@consensys/linea-sdk";
-import { SponsorshipMetricsUpdater } from "../SponsorshipMetricsUpdater";
-import { PostmanMetricsService } from "../PostmanMetricsService";
+
 import { ISponsorshipMetricsUpdater } from "../../../../../core/metrics";
+import { PostmanMetricsService } from "../PostmanMetricsService";
+import { SponsorshipMetricsUpdater } from "../SponsorshipMetricsUpdater";
 
 describe("SponsorshipMetricsUpdater", () => {
   let sponsorshipMetricsUpdater: ISponsorshipMetricsUpdater;

--- a/postman/src/application/postman/api/metrics/__tests__/TransactionMetricsUpdater.test.ts
+++ b/postman/src/application/postman/api/metrics/__tests__/TransactionMetricsUpdater.test.ts
@@ -1,7 +1,8 @@
-import { PostmanMetricsService } from "../PostmanMetricsService";
-import { ITransactionMetricsUpdater, LineaPostmanMetrics } from "../../../../../core/metrics";
-import { TransactionMetricsUpdater } from "../TransactionMetricsUpdater";
 import { IMetricsService } from "@consensys/linea-shared-utils";
+
+import { ITransactionMetricsUpdater, LineaPostmanMetrics } from "../../../../../core/metrics";
+import { PostmanMetricsService } from "../PostmanMetricsService";
+import { TransactionMetricsUpdater } from "../TransactionMetricsUpdater";
 
 describe("TransactionMetricsUpdater", () => {
   let transactionMetricsUpdater: ITransactionMetricsUpdater;

--- a/postman/src/application/postman/app/PostmanServiceClient.ts
+++ b/postman/src/application/postman/app/PostmanServiceClient.ts
@@ -1,17 +1,21 @@
-import { DataSource } from "typeorm";
 import { LineaSDK, Direction } from "@consensys/linea-sdk";
 import { ExpressApiApplication, ILogger } from "@consensys/linea-shared-utils";
-import { TypeOrmMessageRepository } from "../persistence/repositories/TypeOrmMessageRepository";
-import { IPoller } from "../../../core/services/pollers/IPoller";
-import {
-  MessageAnchoringProcessor,
-  MessageClaimingProcessor,
-  MessageClaimingPersister,
-  MessageSentEventProcessor,
-  L2ClaimMessageTransactionSizeProcessor,
-} from "../../../services/processors";
+import { IMetricsService, IApplication } from "@consensys/linea-shared-utils";
+import { DataSource } from "typeorm";
+
 import { PostmanConfig, PostmanOptions } from "./config/config";
-import { DB } from "../persistence/dataSource";
+import { getConfig } from "./config/utils";
+import {
+  IMessageMetricsUpdater,
+  ISponsorshipMetricsUpdater,
+  ITransactionMetricsUpdater,
+  LineaPostmanMetrics,
+} from "../../../../src/core/metrics";
+import { IPoller } from "../../../core/services/pollers/IPoller";
+import { EthereumTransactionValidationService } from "../../../services/EthereumTransactionValidationService";
+import { L2ClaimTransactionSizeCalculator } from "../../../services/L2ClaimTransactionSizeCalculator";
+import { LineaTransactionValidationService } from "../../../services/LineaTransactionValidationService";
+import { DatabaseCleaner, LineaMessageDBService, EthereumMessageDBService } from "../../../services/persistence";
 import {
   MessageSentEventPoller,
   MessageAnchoringPoller,
@@ -20,24 +24,21 @@ import {
   DatabaseCleaningPoller,
   L2ClaimMessageTransactionSizePoller,
 } from "../../../services/pollers";
-import { DatabaseCleaner, LineaMessageDBService, EthereumMessageDBService } from "../../../services/persistence";
-import { L2ClaimTransactionSizeCalculator } from "../../../services/L2ClaimTransactionSizeCalculator";
-import { LineaTransactionValidationService } from "../../../services/LineaTransactionValidationService";
-import { EthereumTransactionValidationService } from "../../../services/EthereumTransactionValidationService";
-import { getConfig } from "./config/utils";
-import { MessageStatusSubscriber } from "../persistence/subscribers/MessageStatusSubscriber";
-import { PostmanWinstonLogger } from "../../../utils/PostmanWinstonLogger";
-import { PostmanMetricsService } from "../api/metrics/PostmanMetricsService";
-import { MessageMetricsUpdater } from "../api/metrics/MessageMetricsUpdater";
 import {
-  IMessageMetricsUpdater,
-  ISponsorshipMetricsUpdater,
-  ITransactionMetricsUpdater,
-  LineaPostmanMetrics,
-} from "../../../../src/core/metrics";
+  MessageAnchoringProcessor,
+  MessageClaimingProcessor,
+  MessageClaimingPersister,
+  MessageSentEventProcessor,
+  L2ClaimMessageTransactionSizeProcessor,
+} from "../../../services/processors";
+import { PostmanWinstonLogger } from "../../../utils/PostmanWinstonLogger";
+import { MessageMetricsUpdater } from "../api/metrics/MessageMetricsUpdater";
+import { PostmanMetricsService } from "../api/metrics/PostmanMetricsService";
 import { SponsorshipMetricsUpdater } from "../api/metrics/SponsorshipMetricsUpdater";
 import { TransactionMetricsUpdater } from "../api/metrics/TransactionMetricsUpdater";
-import { IMetricsService, IApplication } from "@consensys/linea-shared-utils";
+import { DB } from "../persistence/dataSource";
+import { TypeOrmMessageRepository } from "../persistence/repositories/TypeOrmMessageRepository";
+import { MessageStatusSubscriber } from "../persistence/subscribers/MessageStatusSubscriber";
 
 export class PostmanServiceClient {
   // Metrics services

--- a/postman/src/application/postman/app/__tests__/PostmanServiceClient.test.ts
+++ b/postman/src/application/postman/app/__tests__/PostmanServiceClient.test.ts
@@ -1,8 +1,17 @@
+import { ExpressApiApplication } from "@consensys/linea-shared-utils";
 import { describe, it } from "@jest/globals";
 import { mockClear } from "jest-mock-extended";
 import { DataSource } from "typeorm";
 import { SnakeNamingStrategy } from "typeorm-naming-strategies";
-import { PostmanServiceClient } from "../PostmanServiceClient";
+
+import { DEFAULT_MAX_CLAIM_GAS_LIMIT } from "../../../../core/constants";
+import { DatabaseCleaningPoller } from "../../../../services/pollers/DatabaseCleaningPoller";
+import { L2ClaimMessageTransactionSizePoller } from "../../../../services/pollers/L2ClaimMessageTransactionSizePoller";
+import { MessageAnchoringPoller } from "../../../../services/pollers/MessageAnchoringPoller";
+import { MessageClaimingPoller } from "../../../../services/pollers/MessageClaimingPoller";
+import { MessagePersistingPoller } from "../../../../services/pollers/MessagePersistingPoller";
+import { MessageSentEventPoller } from "../../../../services/pollers/MessageSentEventPoller";
+import { PostmanWinstonLogger } from "../../../../utils/PostmanWinstonLogger";
 import {
   TEST_CONTRACT_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,
@@ -10,25 +19,17 @@ import {
   TEST_L2_SIGNER_PRIVATE_KEY,
   TEST_RPC_URL,
 } from "../../../../utils/testing/constants";
-import { PostmanWinstonLogger } from "../../../../utils/PostmanWinstonLogger";
-import { PostmanOptions } from "../config/config";
+import { MessageMetricsUpdater } from "../../api/metrics/MessageMetricsUpdater";
 import { MessageEntity } from "../../persistence/entities/Message.entity";
 import { InitialDatabaseSetup1685985945638 } from "../../persistence/migrations/1685985945638-InitialDatabaseSetup";
 import { AddNewColumns1687890326970 } from "../../persistence/migrations/1687890326970-AddNewColumns";
 import { UpdateStatusColumn1687890694496 } from "../../persistence/migrations/1687890694496-UpdateStatusColumn";
 import { RemoveUniqueConstraint1689084924789 } from "../../persistence/migrations/1689084924789-RemoveUniqueConstraint";
 import { AddNewIndexes1701265652528 } from "../../persistence/migrations/1701265652528-AddNewIndexes";
-import { MessageSentEventPoller } from "../../../../services/pollers/MessageSentEventPoller";
-import { MessageAnchoringPoller } from "../../../../services/pollers/MessageAnchoringPoller";
-import { MessageClaimingPoller } from "../../../../services/pollers/MessageClaimingPoller";
-import { MessagePersistingPoller } from "../../../../services/pollers/MessagePersistingPoller";
-import { DatabaseCleaningPoller } from "../../../../services/pollers/DatabaseCleaningPoller";
 import { TypeOrmMessageRepository } from "../../persistence/repositories/TypeOrmMessageRepository";
-import { L2ClaimMessageTransactionSizePoller } from "../../../../services/pollers/L2ClaimMessageTransactionSizePoller";
-import { DEFAULT_MAX_CLAIM_GAS_LIMIT } from "../../../../core/constants";
 import { MessageStatusSubscriber } from "../../persistence/subscribers/MessageStatusSubscriber";
-import { MessageMetricsUpdater } from "../../api/metrics/MessageMetricsUpdater";
-import { ExpressApiApplication } from "@consensys/linea-shared-utils";
+import { PostmanOptions } from "../config/config";
+import { PostmanServiceClient } from "../PostmanServiceClient";
 
 jest.mock("ethers", () => {
   const allAutoMocked = jest.createMockFromModule("ethers");

--- a/postman/src/application/postman/app/config/__tests__/utils.test.ts
+++ b/postman/src/application/postman/app/config/__tests__/utils.test.ts
@@ -1,14 +1,5 @@
 import { describe } from "@jest/globals";
-import { getConfig, validateEventsFiltersConfig } from "../utils";
-import {
-  TEST_ADDRESS_1,
-  TEST_ADDRESS_2,
-  TEST_CONTRACT_ADDRESS_1,
-  TEST_CONTRACT_ADDRESS_2,
-  TEST_L1_SIGNER_PRIVATE_KEY,
-  TEST_L2_SIGNER_PRIVATE_KEY,
-  TEST_RPC_URL,
-} from "../../../../../utils/testing/constants";
+
 import {
   DEFAULT_CALLDATA_ENABLED,
   DEFAULT_DB_CLEANER_ENABLED,
@@ -34,6 +25,16 @@ import {
   DEFAULT_PROFIT_MARGIN,
   DEFAULT_RETRY_DELAY_IN_SECONDS,
 } from "../../../../../core/constants";
+import {
+  TEST_ADDRESS_1,
+  TEST_ADDRESS_2,
+  TEST_CONTRACT_ADDRESS_1,
+  TEST_CONTRACT_ADDRESS_2,
+  TEST_L1_SIGNER_PRIVATE_KEY,
+  TEST_L2_SIGNER_PRIVATE_KEY,
+  TEST_RPC_URL,
+} from "../../../../../utils/testing/constants";
+import { getConfig, validateEventsFiltersConfig } from "../utils";
 
 describe("Config utils", () => {
   describe("getConfig", () => {

--- a/postman/src/application/postman/app/config/config.ts
+++ b/postman/src/application/postman/app/config/config.ts
@@ -1,4 +1,5 @@
 import { LoggerOptions } from "winston";
+
 import { DBOptions, DBCleanerOptions, DBCleanerConfig } from "../../persistence/config/types";
 
 type DeepRequired<T> = {

--- a/postman/src/application/postman/app/config/utils.ts
+++ b/postman/src/application/postman/app/config/utils.ts
@@ -1,5 +1,7 @@
 import { Interface, isAddress } from "ethers";
 import { compileExpression, useDotAccessOperator } from "filtrex";
+
+import { ListenerConfig, PostmanConfig, PostmanOptions } from "./config";
 import {
   DEFAULT_CALLDATA_ENABLED,
   DEFAULT_ENABLE_POSTMAN_SPONSORING,
@@ -21,7 +23,6 @@ import {
   DEFAULT_PROFIT_MARGIN,
   DEFAULT_RETRY_DELAY_IN_SECONDS,
 } from "../../../../core/constants";
-import { ListenerConfig, PostmanConfig, PostmanOptions } from "./config";
 
 /**
  * @notice Generates the configuration for the Postman service based on provided options.

--- a/postman/src/application/postman/persistence/dataSource.ts
+++ b/postman/src/application/postman/persistence/dataSource.ts
@@ -1,14 +1,15 @@
+import fs from "fs";
 import { DataSource } from "typeorm";
 import { SnakeNamingStrategy } from "typeorm-naming-strategies";
-import fs from "fs";
+
+import { DBOptions } from "./config/types";
+import { MessageEntity } from "./entities/Message.entity";
 import { InitialDatabaseSetup1685985945638 } from "./migrations/1685985945638-InitialDatabaseSetup";
 import { AddNewColumns1687890326970 } from "./migrations/1687890326970-AddNewColumns";
 import { UpdateStatusColumn1687890694496 } from "./migrations/1687890694496-UpdateStatusColumn";
 import { RemoveUniqueConstraint1689084924789 } from "./migrations/1689084924789-RemoveUniqueConstraint";
 import { AddNewIndexes1701265652528 } from "./migrations/1701265652528-AddNewIndexes";
 import { AddUniqueConstraint1709901138056 } from "./migrations/1709901138056-AddUniqueConstraint";
-import { DBOptions } from "./config/types";
-import { MessageEntity } from "./entities/Message.entity";
 import { AddCompressedTxSizeColumn1718026260629 } from "./migrations/1718026260629-AddCompressedTxSizeColumn";
 import { AddSponsorshipMetrics1745569276097 } from "./migrations/1745569276097-AddSponsorshipMetrics";
 

--- a/postman/src/application/postman/persistence/entities/Message.entity.ts
+++ b/postman/src/application/postman/persistence/entities/Message.entity.ts
@@ -1,6 +1,7 @@
+import { Direction } from "@consensys/linea-sdk";
 import { IsBoolean, IsDate, IsDecimal, IsEnum, IsNumber, IsString } from "class-validator";
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm";
-import { Direction } from "@consensys/linea-sdk";
+
 import { MessageStatus } from "../../../../core/enums";
 
 @Entity({ name: "message" })

--- a/postman/src/application/postman/persistence/mappers/__tests__/messageMappers.test.ts
+++ b/postman/src/application/postman/persistence/mappers/__tests__/messageMappers.test.ts
@@ -1,15 +1,16 @@
-import { describe, it, expect } from "@jest/globals";
 import { Direction } from "@consensys/linea-sdk";
-import { generateMessage, generateMessageEntity } from "../../../../../utils/testing/helpers";
-import { mapMessageEntityToMessage, mapMessageToMessageEntity } from "../messageMappers";
+import { describe, it, expect } from "@jest/globals";
+
+import { Message } from "../../../../../core/entities/Message";
+import { MessageStatus } from "../../../../../core/enums";
 import {
   TEST_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,
   TEST_MESSAGE_HASH,
 } from "../../../../../utils/testing/constants";
-import { MessageStatus } from "../../../../../core/enums";
-import { Message } from "../../../../../core/entities/Message";
+import { generateMessage, generateMessageEntity } from "../../../../../utils/testing/helpers";
+import { mapMessageEntityToMessage, mapMessageToMessageEntity } from "../messageMappers";
 
 describe("Message Mappers", () => {
   describe("mapMessageToMessageEntity", () => {

--- a/postman/src/application/postman/persistence/repositories/TypeOrmMessageRepository.ts
+++ b/postman/src/application/postman/persistence/repositories/TypeOrmMessageRepository.ts
@@ -1,14 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Brackets, DataSource, Repository } from "typeorm";
-import { ContractTransactionResponse } from "ethers";
 import { Direction } from "@consensys/linea-sdk";
+import { ContractTransactionResponse } from "ethers";
+import { Brackets, DataSource, Repository } from "typeorm";
+
 import { Message } from "../../../../core/entities/Message";
-import { mapMessageEntityToMessage, mapMessageToMessageEntity } from "../mappers/messageMappers";
 import { DatabaseErrorType, DatabaseRepoName, MessageStatus } from "../../../../core/enums";
 import { DatabaseAccessError } from "../../../../core/errors";
-import { MessageEntity } from "../entities/Message.entity";
-import { subtractSeconds } from "../../../../core/utils/shared";
 import { IMessageRepository } from "../../../../core/persistence/IMessageRepository";
+import { subtractSeconds } from "../../../../core/utils/shared";
+import { MessageEntity } from "../entities/Message.entity";
+import { mapMessageEntityToMessage, mapMessageToMessageEntity } from "../mappers/messageMappers";
 
 export class TypeOrmMessageRepository<TransactionResponse extends ContractTransactionResponse>
   extends Repository<MessageEntity>

--- a/postman/src/application/postman/persistence/subscribers/MessageStatusSubscriber.ts
+++ b/postman/src/application/postman/persistence/subscribers/MessageStatusSubscriber.ts
@@ -1,3 +1,5 @@
+import { Direction } from "@consensys/linea-sdk";
+import { type ILogger } from "@consensys/linea-shared-utils";
 import {
   EventSubscriber,
   EntitySubscriberInterface,
@@ -6,11 +8,10 @@ import {
   RemoveEvent,
   TransactionCommitEvent,
 } from "typeorm";
-import { Direction } from "@consensys/linea-sdk";
-import { MessageEntity } from "../entities/Message.entity";
-import { type IMessageMetricsUpdater, MessagesMetricsAttributes } from "../../../../core/metrics";
-import { type ILogger } from "@consensys/linea-shared-utils";
+
 import { MessageStatus } from "../../../../core/enums";
+import { type IMessageMetricsUpdater, MessagesMetricsAttributes } from "../../../../core/metrics";
+import { MessageEntity } from "../entities/Message.entity";
 
 @EventSubscriber()
 export class MessageStatusSubscriber implements EntitySubscriberInterface<MessageEntity> {

--- a/postman/src/core/clients/blockchain/ethereum/ILineaRollupClient.ts
+++ b/postman/src/core/clients/blockchain/ethereum/ILineaRollupClient.ts
@@ -1,7 +1,8 @@
-import { MessageProps } from "../../../entities/Message";
 import { MessageSent, OnChainMessageStatus } from "@consensys/linea-sdk";
-import { IMessageServiceContract } from "../../../services/contracts/IMessageServiceContract";
+
 import { FinalizationMessagingInfo, Proof } from "./IMerkleTreeService";
+import { MessageProps } from "../../../entities/Message";
+import { IMessageServiceContract } from "../../../services/contracts/IMessageServiceContract";
 
 export interface ILineaRollupClient<
   Overrides,

--- a/postman/src/core/clients/blockchain/linea/IL2MessageServiceClient.ts
+++ b/postman/src/core/clients/blockchain/linea/IL2MessageServiceClient.ts
@@ -1,4 +1,5 @@
 import { MessageSent } from "@consensys/linea-sdk";
+
 import { MessageProps } from "../../../entities/Message";
 import { IMessageServiceContract } from "../../../services/contracts/IMessageServiceContract";
 import { LineaGasFees } from "../IGasProvider";

--- a/postman/src/core/entities/Message.ts
+++ b/postman/src/core/entities/Message.ts
@@ -1,4 +1,5 @@
 import { Direction } from "@consensys/linea-sdk";
+
 import { MessageStatus } from "../enums";
 
 export type MessageProps = {

--- a/postman/src/core/errors/__tests__/BaseError.test.ts
+++ b/postman/src/core/errors/__tests__/BaseError.test.ts
@@ -1,5 +1,6 @@
-import { describe, it } from "@jest/globals";
 import { serialize } from "@consensys/linea-sdk";
+import { describe, it } from "@jest/globals";
+
 import { BaseError } from "../BaseError";
 
 describe("BaseError", () => {

--- a/postman/src/core/errors/__tests__/DatabaseError.test.ts
+++ b/postman/src/core/errors/__tests__/DatabaseError.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "@jest/globals";
 import { Direction, serialize } from "@consensys/linea-sdk";
-import { DatabaseAccessError } from "../DatabaseErrors";
-import { DatabaseErrorType, DatabaseRepoName, MessageStatus } from "../../enums";
-import { MessageProps } from "../../entities/Message";
+import { describe, it, expect } from "@jest/globals";
+
 import { ZERO_ADDRESS, ZERO_HASH } from "../../constants";
+import { MessageProps } from "../../entities/Message";
+import { DatabaseErrorType, DatabaseRepoName, MessageStatus } from "../../enums";
+import { DatabaseAccessError } from "../DatabaseErrors";
 
 describe("DatabaseAccessError", () => {
   it("Should log error message and reason when we pass a short message and the error", () => {

--- a/postman/src/core/metrics/MessageMetricsAttributes.ts
+++ b/postman/src/core/metrics/MessageMetricsAttributes.ts
@@ -1,5 +1,6 @@
-import { MessageStatus } from "../enums";
 import { Direction } from "@consensys/linea-sdk";
+
+import { MessageStatus } from "../enums";
 
 export type MessagesMetricsAttributes = {
   status: MessageStatus;

--- a/postman/src/core/persistence/IMessageDBService.ts
+++ b/postman/src/core/persistence/IMessageDBService.ts
@@ -1,4 +1,5 @@
 import { Direction } from "@consensys/linea-sdk";
+
 import { Message } from "../entities/Message";
 import { MessageStatus } from "../enums";
 

--- a/postman/src/core/persistence/IMessageRepository.ts
+++ b/postman/src/core/persistence/IMessageRepository.ts
@@ -1,4 +1,5 @@
 import { Direction } from "@consensys/linea-sdk";
+
 import { Message } from "../entities/Message";
 import { MessageStatus } from "../enums";
 

--- a/postman/src/core/services/contracts/IMessageServiceContract.ts
+++ b/postman/src/core/services/contracts/IMessageServiceContract.ts
@@ -1,4 +1,5 @@
 import { OnChainMessageStatus, MessageSent } from "@consensys/linea-sdk";
+
 import { MessageProps } from "../../entities/Message";
 
 export interface IMessageServiceContract<

--- a/postman/src/core/utils/__tests__/shared.test.ts
+++ b/postman/src/core/utils/__tests__/shared.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
+
 import { subtractSeconds } from "../shared";
 
 describe("Shared utils", () => {

--- a/postman/src/services/EthereumTransactionValidationService.ts
+++ b/postman/src/services/EthereumTransactionValidationService.ts
@@ -6,14 +6,15 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
+
+import { ILineaRollupClient } from "../core/clients/blockchain/ethereum/ILineaRollupClient";
+import { IEthereumGasProvider } from "../core/clients/blockchain/IGasProvider";
+import { PROFIT_MARGIN_MULTIPLIER } from "../core/constants";
 import { Message } from "../core/entities/Message";
 import {
   ITransactionValidationService,
   TransactionValidationServiceConfig,
 } from "../core/services/ITransactionValidationService";
-import { PROFIT_MARGIN_MULTIPLIER } from "../core/constants";
-import { ILineaRollupClient } from "../core/clients/blockchain/ethereum/ILineaRollupClient";
-import { IEthereumGasProvider } from "../core/clients/blockchain/IGasProvider";
 import { IPostmanLogger } from "../utils/IPostmanLogger";
 
 export class EthereumTransactionValidationService implements ITransactionValidationService {

--- a/postman/src/services/L2ClaimTransactionSizeCalculator.ts
+++ b/postman/src/services/L2ClaimTransactionSizeCalculator.ts
@@ -1,3 +1,5 @@
+import { GoNativeCompressor } from "@consensys/linea-native-libs";
+import { serialize } from "@consensys/linea-sdk";
 import {
   ContractTransactionResponse,
   ErrorDescription,
@@ -8,12 +10,11 @@ import {
   TransactionReceipt,
   TransactionResponse,
 } from "ethers";
-import { GoNativeCompressor } from "@consensys/linea-native-libs";
-import { serialize } from "@consensys/linea-sdk";
-import { BaseError } from "../core/errors";
-import { MessageProps } from "../core/entities/Message";
-import { IL2MessageServiceClient } from "../core/clients/blockchain/linea/IL2MessageServiceClient";
+
 import { LineaGasFees } from "../core/clients/blockchain/IGasProvider";
+import { IL2MessageServiceClient } from "../core/clients/blockchain/linea/IL2MessageServiceClient";
+import { MessageProps } from "../core/entities/Message";
+import { BaseError } from "../core/errors";
 import { IL2ClaimTransactionSizeCalculator } from "../core/services/processors/IL2ClaimTransactionSizeCalculator";
 
 export class L2ClaimTransactionSizeCalculator implements IL2ClaimTransactionSizeCalculator {

--- a/postman/src/services/LineaTransactionValidationService.ts
+++ b/postman/src/services/LineaTransactionValidationService.ts
@@ -9,15 +9,16 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
-import { BaseError } from "../core/errors";
+
+import { IL2MessageServiceClient } from "../core/clients/blockchain/linea/IL2MessageServiceClient";
+import { ILineaProvider } from "../core/clients/blockchain/linea/ILineaProvider";
+import { MINIMUM_MARGIN, PROFIT_MARGIN_MULTIPLIER } from "../core/constants";
 import { Message } from "../core/entities/Message";
+import { BaseError } from "../core/errors";
 import {
   ITransactionValidationService,
   TransactionValidationServiceConfig,
 } from "../core/services/ITransactionValidationService";
-import { MINIMUM_MARGIN, PROFIT_MARGIN_MULTIPLIER } from "../core/constants";
-import { IL2MessageServiceClient } from "../core/clients/blockchain/linea/IL2MessageServiceClient";
-import { ILineaProvider } from "../core/clients/blockchain/linea/ILineaProvider";
 import { IPostmanLogger } from "../utils/IPostmanLogger";
 
 export class LineaTransactionValidationService implements ITransactionValidationService {

--- a/postman/src/services/persistence/DatabaseCleaner.ts
+++ b/postman/src/services/persistence/DatabaseCleaner.ts
@@ -1,7 +1,8 @@
-import { ContractTransactionResponse } from "ethers";
-import { IMessageDBService } from "../../core/persistence/IMessageDBService";
-import { IDatabaseCleaner } from "../../core/persistence/IDatabaseCleaner";
 import { ILogger } from "@consensys/linea-shared-utils";
+import { ContractTransactionResponse } from "ethers";
+
+import { IDatabaseCleaner } from "../../core/persistence/IDatabaseCleaner";
+import { IMessageDBService } from "../../core/persistence/IMessageDBService";
 
 export class DatabaseCleaner implements IDatabaseCleaner {
   /**

--- a/postman/src/services/persistence/EthereumMessageDBService.ts
+++ b/postman/src/services/persistence/EthereumMessageDBService.ts
@@ -1,11 +1,12 @@
-import { ContractTransactionResponse, TransactionRequest } from "ethers";
 import { Direction } from "@consensys/linea-sdk";
+import { ContractTransactionResponse, TransactionRequest } from "ethers";
+
+import { MessageDBService } from "./MessageDBService";
+import { IGasProvider } from "../../core/clients/blockchain/IGasProvider";
 import { Message } from "../../core/entities/Message";
 import { MessageStatus } from "../../core/enums";
-import { IMessageRepository } from "../../core/persistence/IMessageRepository";
 import { IMessageDBService } from "../../core/persistence/IMessageDBService";
-import { IGasProvider } from "../../core/clients/blockchain/IGasProvider";
-import { MessageDBService } from "./MessageDBService";
+import { IMessageRepository } from "../../core/persistence/IMessageRepository";
 
 export class EthereumMessageDBService
   extends MessageDBService

--- a/postman/src/services/persistence/LineaMessageDBService.ts
+++ b/postman/src/services/persistence/LineaMessageDBService.ts
@@ -1,10 +1,11 @@
-import { ContractTransactionResponse } from "ethers";
 import { Direction } from "@consensys/linea-sdk";
+import { ContractTransactionResponse } from "ethers";
+
+import { MessageDBService } from "./MessageDBService";
 import { Message } from "../../core/entities/Message";
 import { MessageStatus } from "../../core/enums";
-import { IMessageRepository } from "../../core/persistence/IMessageRepository";
 import { IMessageDBService } from "../../core/persistence/IMessageDBService";
-import { MessageDBService } from "./MessageDBService";
+import { IMessageRepository } from "../../core/persistence/IMessageRepository";
 
 export class LineaMessageDBService extends MessageDBService implements IMessageDBService<ContractTransactionResponse> {
   /**

--- a/postman/src/services/persistence/MessageDBService.ts
+++ b/postman/src/services/persistence/MessageDBService.ts
@@ -1,8 +1,9 @@
-import { ContractTransactionResponse } from "ethers";
 import { Direction } from "@consensys/linea-sdk";
+import { ContractTransactionResponse } from "ethers";
+
 import { Message } from "../../core/entities/Message";
-import { IMessageRepository } from "../../core/persistence/IMessageRepository";
 import { MessageStatus } from "../../core/enums";
+import { IMessageRepository } from "../../core/persistence/IMessageRepository";
 
 export abstract class MessageDBService {
   /**

--- a/postman/src/services/persistence/__tests__/DatabaseCleaner.test.ts
+++ b/postman/src/services/persistence/__tests__/DatabaseCleaner.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
-import { ContractTransactionResponse } from "ethers";
-import { DatabaseCleaner } from "../DatabaseCleaner";
 import { ILogger } from "@consensys/linea-shared-utils";
-import { DatabaseAccessError } from "../../../core/errors/DatabaseErrors";
+import { describe, it, beforeEach } from "@jest/globals";
+import { ContractTransactionResponse } from "ethers";
+import { mock } from "jest-mock-extended";
+
 import { DatabaseErrorType, DatabaseRepoName } from "../../../core/enums";
+import { DatabaseAccessError } from "../../../core/errors/DatabaseErrors";
 import { IMessageDBService } from "../../../core/persistence/IMessageDBService";
+import { DatabaseCleaner } from "../DatabaseCleaner";
 
 describe("TestDatabaseCleaner", () => {
   let testDatabaseCleaner: DatabaseCleaner;

--- a/postman/src/services/pollers/DatabaseCleaningPoller.ts
+++ b/postman/src/services/pollers/DatabaseCleaningPoller.ts
@@ -1,8 +1,9 @@
 import { wait } from "@consensys/linea-sdk";
 import { ILogger } from "@consensys/linea-shared-utils";
-import { IPoller } from "../../core/services/pollers/IPoller";
-import { IDatabaseCleaner } from "../../core/persistence/IDatabaseCleaner";
+
 import { DBCleanerConfig } from "../../application/postman/persistence/config/types";
+import { IDatabaseCleaner } from "../../core/persistence/IDatabaseCleaner";
+import { IPoller } from "../../core/services/pollers/IPoller";
 
 export class DatabaseCleaningPoller implements IPoller {
   private isPolling = false;

--- a/postman/src/services/pollers/L2ClaimMessageTransactionSizePoller.ts
+++ b/postman/src/services/pollers/L2ClaimMessageTransactionSizePoller.ts
@@ -1,5 +1,6 @@
 import { Direction, wait } from "@consensys/linea-sdk";
 import { ILogger } from "@consensys/linea-shared-utils";
+
 import { IPoller } from "../../core/services/pollers/IPoller";
 import { L2ClaimMessageTransactionSizeProcessor } from "../processors/L2ClaimMessageTransactionSizeProcessor";
 

--- a/postman/src/services/pollers/MessageAnchoringPoller.ts
+++ b/postman/src/services/pollers/MessageAnchoringPoller.ts
@@ -1,5 +1,6 @@
 import { Direction, wait } from "@consensys/linea-sdk";
 import { ILogger } from "@consensys/linea-shared-utils";
+
 import { IPoller } from "../../core/services/pollers/IPoller";
 import { IMessageAnchoringProcessor } from "../../core/services/processors/IMessageAnchoringProcessor";
 

--- a/postman/src/services/pollers/MessageClaimingPoller.ts
+++ b/postman/src/services/pollers/MessageClaimingPoller.ts
@@ -1,5 +1,6 @@
 import { Direction, wait } from "@consensys/linea-sdk";
 import { ILogger } from "@consensys/linea-shared-utils";
+
 import { IPoller } from "../../core/services/pollers/IPoller";
 import { IMessageClaimingProcessor } from "../../core/services/processors/IMessageClaimingProcessor";
 

--- a/postman/src/services/pollers/MessagePersistingPoller.ts
+++ b/postman/src/services/pollers/MessagePersistingPoller.ts
@@ -1,5 +1,6 @@
 import { Direction, wait } from "@consensys/linea-sdk";
 import { ILogger } from "@consensys/linea-shared-utils";
+
 import { IPoller } from "../../core/services/pollers/IPoller";
 import { IMessageClaimingPersister } from "../../core/services/processors/IMessageClaimingPersister";
 

--- a/postman/src/services/pollers/MessageSentEventPoller.ts
+++ b/postman/src/services/pollers/MessageSentEventPoller.ts
@@ -1,3 +1,4 @@
+import { Direction, wait } from "@consensys/linea-sdk";
 import {
   Block,
   ContractTransactionResponse,
@@ -6,15 +7,15 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
-import { Direction, wait } from "@consensys/linea-sdk";
+
+import { IProvider } from "../../core/clients/blockchain/IProvider";
 import { DEFAULT_INITIAL_FROM_BLOCK } from "../../core/constants";
-import { IPostmanLogger } from "../../utils/IPostmanLogger";
-import { IMessageSentEventProcessor } from "../../core/services/processors/IMessageSentEventProcessor";
 import { Message } from "../../core/entities/Message";
 import { DatabaseAccessError } from "../../core/errors/DatabaseErrors";
-import { IProvider } from "../../core/clients/blockchain/IProvider";
-import { IPoller } from "../../core/services/pollers/IPoller";
 import { IMessageDBService } from "../../core/persistence/IMessageDBService";
+import { IPoller } from "../../core/services/pollers/IPoller";
+import { IMessageSentEventProcessor } from "../../core/services/processors/IMessageSentEventProcessor";
+import { IPostmanLogger } from "../../utils/IPostmanLogger";
 
 type MessageSentEventPollerConfig = {
   direction: Direction;

--- a/postman/src/services/pollers/__tests__/DatabaseCleaningPoller.test.ts
+++ b/postman/src/services/pollers/__tests__/DatabaseCleaningPoller.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, beforeEach } from "@jest/globals";
 import { mock } from "jest-mock-extended";
-import { DatabaseCleaningPoller } from "../DatabaseCleaningPoller";
+
+import { DEFAULT_DB_CLEANING_INTERVAL, DEFAULT_DB_DAYS_BEFORE_NOW_TO_DELETE } from "../../../core/constants";
 import { IDatabaseCleaner } from "../../../core/persistence/IDatabaseCleaner";
 import { TestLogger } from "../../../utils/testing/helpers";
-import { DEFAULT_DB_CLEANING_INTERVAL, DEFAULT_DB_DAYS_BEFORE_NOW_TO_DELETE } from "../../../core/constants";
+import { DatabaseCleaningPoller } from "../DatabaseCleaningPoller";
 
 describe("TestDatabaseCleaningPoller", () => {
   let testDatabaseCleaningPoller: DatabaseCleaningPoller;

--- a/postman/src/services/pollers/__tests__/L2ClaimMessageTransactionSizePoller.test.ts
+++ b/postman/src/services/pollers/__tests__/L2ClaimMessageTransactionSizePoller.test.ts
@@ -1,11 +1,12 @@
+import { Direction } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
 import { MockProxy, mock } from "jest-mock-extended";
-import { Direction } from "@consensys/linea-sdk";
-import { TestLogger } from "../../../utils/testing/helpers";
-import { testL2NetworkConfig } from "../../../utils/testing/constants";
+
 import { IPoller } from "../../../core/services/pollers/IPoller";
-import { L2ClaimMessageTransactionSizePoller } from "../L2ClaimMessageTransactionSizePoller";
+import { testL2NetworkConfig } from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
 import { L2ClaimMessageTransactionSizeProcessor } from "../../processors/L2ClaimMessageTransactionSizeProcessor";
+import { L2ClaimMessageTransactionSizePoller } from "../L2ClaimMessageTransactionSizePoller";
 
 describe("L2ClaimMessageTransactionSizePoller", () => {
   let testClaimMessageTransactionSizePoller: IPoller;

--- a/postman/src/services/pollers/__tests__/MessageAnchoringPoller.test.ts
+++ b/postman/src/services/pollers/__tests__/MessageAnchoringPoller.test.ts
@@ -1,11 +1,12 @@
+import { Direction } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
 import { mock } from "jest-mock-extended";
-import { Direction } from "@consensys/linea-sdk";
-import { MessageAnchoringPoller } from "../MessageAnchoringPoller";
-import { TestLogger } from "../../../utils/testing/helpers";
+
+import { IPoller } from "../../../core/services/pollers/IPoller";
 import { IMessageAnchoringProcessor } from "../../../core/services/processors/IMessageAnchoringProcessor";
 import { testL2NetworkConfig } from "../../../utils/testing/constants";
-import { IPoller } from "../../../core/services/pollers/IPoller";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { MessageAnchoringPoller } from "../MessageAnchoringPoller";
 
 describe("TestMessageAnchoringPoller", () => {
   let testAnchoringPoller: IPoller;

--- a/postman/src/services/pollers/__tests__/MessageClaimingPoller.test.ts
+++ b/postman/src/services/pollers/__tests__/MessageClaimingPoller.test.ts
@@ -1,11 +1,12 @@
+import { Direction } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
 import { mock } from "jest-mock-extended";
-import { Direction } from "@consensys/linea-sdk";
-import { MessageClaimingPoller } from "../MessageClaimingPoller";
-import { TestLogger } from "../../../utils/testing/helpers";
+
+import { IPoller } from "../../../core/services/pollers/IPoller";
 import { IMessageClaimingProcessor } from "../../../core/services/processors/IMessageClaimingProcessor";
 import { testL2NetworkConfig } from "../../../utils/testing/constants";
-import { IPoller } from "../../../core/services/pollers/IPoller";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { MessageClaimingPoller } from "../MessageClaimingPoller";
 
 describe("TestMessageClaimingPoller", () => {
   let testClaimingPoller: IPoller;

--- a/postman/src/services/pollers/__tests__/MessagePersistingPoller.test.ts
+++ b/postman/src/services/pollers/__tests__/MessagePersistingPoller.test.ts
@@ -1,11 +1,12 @@
+import { Direction } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
 import { mock } from "jest-mock-extended";
-import { Direction } from "@consensys/linea-sdk";
-import { MessagePersistingPoller } from "../MessagePersistingPoller";
-import { TestLogger } from "../../../utils/testing/helpers";
+
+import { IPoller } from "../../../core/services/pollers/IPoller";
 import { IMessageClaimingPersister } from "../../../core/services/processors/IMessageClaimingPersister";
 import { testL2NetworkConfig } from "../../../utils/testing/constants";
-import { IPoller } from "../../../core/services/pollers/IPoller";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { MessagePersistingPoller } from "../MessagePersistingPoller";
 
 describe("TestMessagePersistingPoller", () => {
   let testPersistingPoller: IPoller;

--- a/postman/src/services/pollers/__tests__/MessageSentEventPoller.test.ts
+++ b/postman/src/services/pollers/__tests__/MessageSentEventPoller.test.ts
@@ -1,23 +1,24 @@
-import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
-import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
 import { Provider, DefaultGasProvider, Direction, wait } from "@consensys/linea-sdk";
-import { TestLogger } from "../../../utils/testing/helpers";
-import { rejectedMessageProps, testL1NetworkConfig, testMessage } from "../../../utils/testing/constants";
-import { IPoller } from "../../../core/services/pollers/IPoller";
-import { MessageSentEventPoller } from "../MessageSentEventPoller";
-import { IMessageSentEventProcessor } from "../../../core/services/processors/IMessageSentEventProcessor";
+import { describe, it, beforeEach } from "@jest/globals";
+import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
+import { mock } from "jest-mock-extended";
+
 import { IProvider } from "../../../core/clients/blockchain/IProvider";
-import { IMessageRepository } from "../../../core/persistence/IMessageRepository";
-import { DatabaseAccessError } from "../../../core/errors";
-import { DatabaseErrorType, DatabaseRepoName } from "../../../core/enums";
-import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
 import {
   DEFAULT_GAS_ESTIMATION_PERCENTILE,
   DEFAULT_INITIAL_FROM_BLOCK,
   DEFAULT_LISTENER_INTERVAL,
   DEFAULT_MAX_FEE_PER_GAS_CAP,
 } from "../../../core/constants";
+import { DatabaseErrorType, DatabaseRepoName } from "../../../core/enums";
+import { DatabaseAccessError } from "../../../core/errors";
+import { IMessageRepository } from "../../../core/persistence/IMessageRepository";
+import { IPoller } from "../../../core/services/pollers/IPoller";
+import { IMessageSentEventProcessor } from "../../../core/services/processors/IMessageSentEventProcessor";
+import { rejectedMessageProps, testL1NetworkConfig, testMessage } from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { MessageSentEventPoller } from "../MessageSentEventPoller";
 
 describe("TestMessageSentEventPoller", () => {
   let testMessageSentEventPoller: IPoller;

--- a/postman/src/services/processors/L2ClaimMessageTransactionSizeProcessor.ts
+++ b/postman/src/services/processors/L2ClaimMessageTransactionSizeProcessor.ts
@@ -6,17 +6,18 @@ import {
   TransactionReceipt,
   TransactionResponse,
 } from "ethers";
+
+import { IL2MessageServiceClient } from "../../core/clients/blockchain/linea/IL2MessageServiceClient";
+import { Message } from "../../core/entities/Message";
 import { MessageStatus } from "../../core/enums";
 import { IMessageDBService } from "../../core/persistence/IMessageDBService";
-import { IPostmanLogger } from "../../utils/IPostmanLogger";
-import { IL2MessageServiceClient } from "../../core/clients/blockchain/linea/IL2MessageServiceClient";
 import {
   IL2ClaimMessageTransactionSizeProcessor,
   L2ClaimMessageTransactionSizeProcessorConfig,
 } from "../../core/services/processors/IL2ClaimMessageTransactionSizeProcessor";
 import { IL2ClaimTransactionSizeCalculator } from "../../core/services/processors/IL2ClaimTransactionSizeCalculator";
 import { ErrorParser } from "../../utils/ErrorParser";
-import { Message } from "../../core/entities/Message";
+import { IPostmanLogger } from "../../utils/IPostmanLogger";
 
 export class L2ClaimMessageTransactionSizeProcessor implements IL2ClaimMessageTransactionSizeProcessor {
   /**

--- a/postman/src/services/processors/MessageAnchoringProcessor.ts
+++ b/postman/src/services/processors/MessageAnchoringProcessor.ts
@@ -1,3 +1,5 @@
+import { OnChainMessageStatus } from "@consensys/linea-sdk";
+import { ILogger } from "@consensys/linea-shared-utils";
 import {
   Overrides,
   TransactionResponse,
@@ -8,16 +10,15 @@ import {
   JsonRpcProvider,
   ErrorDescription,
 } from "ethers";
-import { OnChainMessageStatus } from "@consensys/linea-sdk";
+
+import { IProvider } from "../../core/clients/blockchain/IProvider";
+import { MessageStatus } from "../../core/enums";
+import { IMessageDBService } from "../../core/persistence/IMessageDBService";
+import { IMessageServiceContract } from "../../core/services/contracts/IMessageServiceContract";
 import {
   IMessageAnchoringProcessor,
   MessageAnchoringProcessorConfig,
 } from "../../core/services/processors/IMessageAnchoringProcessor";
-import { IProvider } from "../../core/clients/blockchain/IProvider";
-import { MessageStatus } from "../../core/enums";
-import { ILogger } from "@consensys/linea-shared-utils";
-import { IMessageServiceContract } from "../../core/services/contracts/IMessageServiceContract";
-import { IMessageDBService } from "../../core/persistence/IMessageDBService";
 import { ErrorParser } from "../../utils/ErrorParser";
 
 export class MessageAnchoringProcessor implements IMessageAnchoringProcessor {

--- a/postman/src/services/processors/MessageClaimingPersister.ts
+++ b/postman/src/services/processors/MessageClaimingPersister.ts
@@ -1,3 +1,5 @@
+import { Direction, OnChainMessageStatus } from "@consensys/linea-sdk";
+import { ILogger } from "@consensys/linea-shared-utils";
 import {
   Overrides,
   TransactionResponse,
@@ -8,20 +10,19 @@ import {
   JsonRpcProvider,
   ErrorDescription,
 } from "ethers";
-import { Direction, OnChainMessageStatus } from "@consensys/linea-sdk";
-import { BaseError } from "../../core/errors";
-import { MessageStatus } from "../../core/enums";
-import { ILogger } from "@consensys/linea-shared-utils";
-import { IMessageServiceContract } from "../../core/services/contracts/IMessageServiceContract";
+
 import { IProvider } from "../../core/clients/blockchain/IProvider";
 import { Message } from "../../core/entities/Message";
+import { MessageStatus } from "../../core/enums";
+import { BaseError } from "../../core/errors";
+import { ISponsorshipMetricsUpdater, ITransactionMetricsUpdater } from "../../core/metrics";
+import { IMessageDBService } from "../../core/persistence/IMessageDBService";
+import { IMessageServiceContract } from "../../core/services/contracts/IMessageServiceContract";
 import {
   IMessageClaimingPersister,
   MessageClaimingPersisterConfig,
 } from "../../core/services/processors/IMessageClaimingPersister";
-import { IMessageDBService } from "../../core/persistence/IMessageDBService";
 import { ErrorParser } from "../../utils/ErrorParser";
-import { ISponsorshipMetricsUpdater, ITransactionMetricsUpdater } from "../../core/metrics";
 
 export class MessageClaimingPersister implements IMessageClaimingPersister {
   private messageBeingRetry: { message: Message | null; retries: number };

--- a/postman/src/services/processors/MessageClaimingProcessor.ts
+++ b/postman/src/services/processors/MessageClaimingProcessor.ts
@@ -1,4 +1,4 @@
-import { ErrorParser } from "../../utils/ErrorParser";
+import { OnChainMessageStatus } from "@consensys/linea-sdk";
 import {
   Overrides,
   TransactionResponse,
@@ -7,17 +7,18 @@ import {
   Signer,
   ErrorDescription,
 } from "ethers";
-import { OnChainMessageStatus } from "@consensys/linea-sdk";
+
+import { Message } from "../../core/entities/Message";
 import { MessageStatus } from "../../core/enums";
+import { IMessageDBService } from "../../core/persistence/IMessageDBService";
+import { IMessageServiceContract } from "../../core/services/contracts/IMessageServiceContract";
+import { ITransactionValidationService } from "../../core/services/ITransactionValidationService";
 import {
   IMessageClaimingProcessor,
   MessageClaimingProcessorConfig,
 } from "../../core/services/processors/IMessageClaimingProcessor";
-import { IMessageServiceContract } from "../../core/services/contracts/IMessageServiceContract";
+import { ErrorParser } from "../../utils/ErrorParser";
 import { IPostmanLogger } from "../../utils/IPostmanLogger";
-import { Message } from "../../core/entities/Message";
-import { IMessageDBService } from "../../core/persistence/IMessageDBService";
-import { ITransactionValidationService } from "../../core/services/ITransactionValidationService";
 
 export class MessageClaimingProcessor implements IMessageClaimingProcessor {
   private readonly maxNonceDiff: number;

--- a/postman/src/services/processors/MessageSentEventProcessor.ts
+++ b/postman/src/services/processors/MessageSentEventProcessor.ts
@@ -1,3 +1,5 @@
+import { serialize, isEmptyBytes, MessageSent } from "@consensys/linea-sdk";
+import { ILogger } from "@consensys/linea-shared-utils";
 import {
   Block,
   ContractTransactionResponse,
@@ -9,18 +11,17 @@ import {
   TransactionResponse,
 } from "ethers";
 import { compileExpression, useDotAccessOperator } from "filtrex";
-import { serialize, isEmptyBytes, MessageSent } from "@consensys/linea-sdk";
+
 import { ILineaRollupLogClient } from "../../core/clients/blockchain/ethereum/ILineaRollupLogClient";
 import { IProvider } from "../../core/clients/blockchain/IProvider";
-import { MessageFactory } from "../../core/entities/MessageFactory";
-import { ILogger } from "@consensys/linea-shared-utils";
-import { MessageStatus } from "../../core/enums";
 import { IL2MessageServiceLogClient } from "../../core/clients/blockchain/linea/IL2MessageServiceLogClient";
+import { MessageFactory } from "../../core/entities/MessageFactory";
+import { MessageStatus } from "../../core/enums";
+import { IMessageDBService } from "../../core/persistence/IMessageDBService";
 import {
   IMessageSentEventProcessor,
   MessageSentEventProcessorConfig,
 } from "../../core/services/processors/IMessageSentEventProcessor";
-import { IMessageDBService } from "../../core/persistence/IMessageDBService";
 
 export class MessageSentEventProcessor implements IMessageSentEventProcessor {
   private readonly maxBlocksToFetchLogs: number;

--- a/postman/src/services/processors/__tests__/EthereumTransactionValidationService.test.ts
+++ b/postman/src/services/processors/__tests__/EthereumTransactionValidationService.test.ts
@@ -1,5 +1,5 @@
+import { DefaultGasProvider, LineaProvider, Provider, testingHelpers } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
 import {
   ContractTransactionResponse,
   ErrorDescription,
@@ -8,14 +8,10 @@ import {
   TransactionResponse,
   Wallet,
 } from "ethers";
-import { DefaultGasProvider, LineaProvider, Provider, testingHelpers } from "@consensys/linea-sdk";
-import {
-  DEFAULT_MAX_FEE_PER_GAS,
-  TEST_CONTRACT_ADDRESS_1,
-  TEST_CONTRACT_ADDRESS_2,
-  TEST_L1_SIGNER_PRIVATE_KEY,
-  testMessage,
-} from "../../../utils/testing/constants";
+import { mock } from "jest-mock-extended";
+
+import { TestLogger } from "../../../../src/utils/testing/helpers";
+import { ILineaRollupClient } from "../../../core/clients/blockchain/ethereum/ILineaRollupClient";
 import {
   DEFAULT_ENABLE_POSTMAN_SPONSORING,
   DEFAULT_GAS_ESTIMATION_PERCENTILE,
@@ -24,9 +20,14 @@ import {
   DEFAULT_MAX_POSTMAN_SPONSOR_GAS_LIMIT,
   DEFAULT_PROFIT_MARGIN,
 } from "../../../core/constants";
+import {
+  DEFAULT_MAX_FEE_PER_GAS,
+  TEST_CONTRACT_ADDRESS_1,
+  TEST_CONTRACT_ADDRESS_2,
+  TEST_L1_SIGNER_PRIVATE_KEY,
+  testMessage,
+} from "../../../utils/testing/constants";
 import { EthereumTransactionValidationService } from "../../EthereumTransactionValidationService";
-import { ILineaRollupClient } from "../../../core/clients/blockchain/ethereum/ILineaRollupClient";
-import { TestLogger } from "../../../../src/utils/testing/helpers";
 
 describe("EthereumTransactionValidationService", () => {
   let lineaTransactionValidationService: EthereumTransactionValidationService;

--- a/postman/src/services/processors/__tests__/L2ClaimMessageTransactionSizeProcessor.test.ts
+++ b/postman/src/services/processors/__tests__/L2ClaimMessageTransactionSizeProcessor.test.ts
@@ -1,5 +1,5 @@
+import { Direction, makeBaseError } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
 import {
   ContractTransactionResponse,
   ErrorDescription,
@@ -9,14 +9,15 @@ import {
   TransactionReceipt,
   TransactionResponse,
 } from "ethers";
-import { Direction, makeBaseError } from "@consensys/linea-sdk";
-import { TestLogger } from "../../../utils/testing/helpers";
+import { mock } from "jest-mock-extended";
+
+import { IL2MessageServiceClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceClient";
 import { MessageStatus } from "../../../core/enums";
 import { testL1NetworkConfig, testMessage, DEFAULT_MAX_FEE_PER_GAS } from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { L2ClaimTransactionSizeCalculator } from "../../L2ClaimTransactionSizeCalculator";
 import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
 import { L2ClaimMessageTransactionSizeProcessor } from "../L2ClaimMessageTransactionSizeProcessor";
-import { L2ClaimTransactionSizeCalculator } from "../../L2ClaimTransactionSizeCalculator";
-import { IL2MessageServiceClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceClient";
 
 describe("L2ClaimMessageTransactionSizeProcessor", () => {
   let transactionSizeProcessor: L2ClaimMessageTransactionSizeProcessor;

--- a/postman/src/services/processors/__tests__/L2ClaimTransactionSizeCalculator.test.ts
+++ b/postman/src/services/processors/__tests__/L2ClaimTransactionSizeCalculator.test.ts
@@ -1,5 +1,5 @@
+import { LineaProvider, serialize, testingHelpers } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
 import {
   ContractTransactionResponse,
   ErrorDescription,
@@ -9,18 +9,19 @@ import {
   TransactionResponse,
   Wallet,
 } from "ethers";
-import { LineaProvider, serialize, testingHelpers } from "@consensys/linea-sdk";
+import { mock } from "jest-mock-extended";
+
+import { IL2MessageServiceClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceClient";
+import { DEFAULT_MAX_FEE_PER_GAS_CAP } from "../../../core/constants";
+import { BaseError } from "../../../core/errors";
 import {
   DEFAULT_MAX_FEE_PER_GAS,
   TEST_CONTRACT_ADDRESS_2,
   TEST_L2_SIGNER_PRIVATE_KEY,
   testMessage,
 } from "../../../utils/testing/constants";
-import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
 import { L2ClaimTransactionSizeCalculator } from "../../L2ClaimTransactionSizeCalculator";
-import { DEFAULT_MAX_FEE_PER_GAS_CAP } from "../../../core/constants";
-import { BaseError } from "../../../core/errors";
-import { IL2MessageServiceClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceClient";
+import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
 
 describe("L2ClaimTransactionSizeCalculator", () => {
   let transactionSizeCalculator: L2ClaimTransactionSizeCalculator;

--- a/postman/src/services/processors/__tests__/LineaTransactionValidationService.test.ts
+++ b/postman/src/services/processors/__tests__/LineaTransactionValidationService.test.ts
@@ -1,5 +1,5 @@
+import { GasProvider, LineaProvider, testingHelpers } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
-import { mock, MockProxy } from "jest-mock-extended";
 import {
   ContractTransactionResponse,
   ErrorDescription,
@@ -9,13 +9,10 @@ import {
   TransactionResponse,
   Wallet,
 } from "ethers";
-import { GasProvider, LineaProvider, testingHelpers } from "@consensys/linea-sdk";
-import {
-  DEFAULT_MAX_FEE_PER_GAS,
-  TEST_CONTRACT_ADDRESS_2,
-  TEST_L2_SIGNER_PRIVATE_KEY,
-  testMessage,
-} from "../../../utils/testing/constants";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { TestLogger } from "../../../../src/utils/testing/helpers";
+import { IL2MessageServiceClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceClient";
 import {
   DEFAULT_ENABLE_POSTMAN_SPONSORING,
   DEFAULT_MAX_CLAIM_GAS_LIMIT,
@@ -23,9 +20,13 @@ import {
   DEFAULT_MAX_POSTMAN_SPONSOR_GAS_LIMIT,
   DEFAULT_PROFIT_MARGIN,
 } from "../../../core/constants";
-import { IL2MessageServiceClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceClient";
+import {
+  DEFAULT_MAX_FEE_PER_GAS,
+  TEST_CONTRACT_ADDRESS_2,
+  TEST_L2_SIGNER_PRIVATE_KEY,
+  testMessage,
+} from "../../../utils/testing/constants";
 import { LineaTransactionValidationService } from "../../LineaTransactionValidationService";
-import { TestLogger } from "../../../../src/utils/testing/helpers";
 
 describe("LineaTransactionValidationService", () => {
   let lineaTransactionValidationService: LineaTransactionValidationService;

--- a/postman/src/services/processors/__tests__/MessageAnchoringProcessor.test.ts
+++ b/postman/src/services/processors/__tests__/MessageAnchoringProcessor.test.ts
@@ -1,5 +1,5 @@
+import { OnChainMessageStatus } from "@consensys/linea-sdk";
 import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
 import {
   Block,
   ContractTransactionResponse,
@@ -10,15 +10,16 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
-import { OnChainMessageStatus } from "@consensys/linea-sdk";
-import { TestLogger } from "../../../utils/testing/helpers";
-import { IMessageAnchoringProcessor } from "../../../core/services/processors/IMessageAnchoringProcessor";
-import { MessageStatus } from "../../../core/enums";
-import { testL1NetworkConfig, testL2NetworkConfig, testMessage } from "../../../utils/testing/constants";
-import { MessageAnchoringProcessor } from "../MessageAnchoringProcessor";
-import { IMessageServiceContract } from "../../../core/services/contracts/IMessageServiceContract";
-import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { mock } from "jest-mock-extended";
+
 import { IProvider } from "../../../core/clients/blockchain/IProvider";
+import { MessageStatus } from "../../../core/enums";
+import { IMessageServiceContract } from "../../../core/services/contracts/IMessageServiceContract";
+import { IMessageAnchoringProcessor } from "../../../core/services/processors/IMessageAnchoringProcessor";
+import { testL1NetworkConfig, testL2NetworkConfig, testMessage } from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { MessageAnchoringProcessor } from "../MessageAnchoringProcessor";
 
 describe("TestMessageAnchoringProcessor", () => {
   let anchoringProcessor: IMessageAnchoringProcessor;

--- a/postman/src/services/processors/__tests__/MessageClaimingPersister.test.ts
+++ b/postman/src/services/processors/__tests__/MessageClaimingPersister.test.ts
@@ -1,10 +1,5 @@
-import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
 import { Direction, OnChainMessageStatus, testingHelpers } from "@consensys/linea-sdk";
-import { TestLogger } from "../../../utils/testing/helpers";
-import { MessageStatus } from "../../../core/enums";
-import { testL2NetworkConfig, testPendingMessage, testPendingMessage2 } from "../../../utils/testing/constants";
-import { IMessageServiceContract } from "../../../core/services/contracts/IMessageServiceContract";
+import { describe, it, beforeEach } from "@jest/globals";
 import {
   Block,
   ContractTransactionResponse,
@@ -15,13 +10,19 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
-import { IGasProvider } from "../../../core/clients/blockchain/IGasProvider";
-import { Message } from "../../../core/entities/Message";
-import { IMessageClaimingPersister } from "../../../core/services/processors/IMessageClaimingPersister";
-import { MessageClaimingPersister } from "../MessageClaimingPersister";
-import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
-import { IProvider } from "../../../core/clients/blockchain/IProvider";
+import { mock } from "jest-mock-extended";
+
 import { ISponsorshipMetricsUpdater, ITransactionMetricsUpdater } from "../../../../src/core/metrics";
+import { IGasProvider } from "../../../core/clients/blockchain/IGasProvider";
+import { IProvider } from "../../../core/clients/blockchain/IProvider";
+import { Message } from "../../../core/entities/Message";
+import { MessageStatus } from "../../../core/enums";
+import { IMessageServiceContract } from "../../../core/services/contracts/IMessageServiceContract";
+import { IMessageClaimingPersister } from "../../../core/services/processors/IMessageClaimingPersister";
+import { testL2NetworkConfig, testPendingMessage, testPendingMessage2 } from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { MessageClaimingPersister } from "../MessageClaimingPersister";
 
 describe("TestMessageClaimingPersister ", () => {
   let messageClaimingPersister: IMessageClaimingPersister;

--- a/postman/src/services/processors/__tests__/MessageClaimingProcessor.test.ts
+++ b/postman/src/services/processors/__tests__/MessageClaimingProcessor.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
 import { DefaultGasProvider, Provider, Direction, OnChainMessageStatus } from "@consensys/linea-sdk";
+import { describe, it, beforeEach } from "@jest/globals";
 import {
   Block,
   ContractTransactionResponse,
@@ -12,24 +11,10 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
-import { TestLogger } from "../../../utils/testing/helpers";
-import { MessageStatus } from "../../../core/enums";
-import {
-  DEFAULT_MAX_FEE_PER_GAS,
-  TEST_ADDRESS_2,
-  TEST_CONTRACT_ADDRESS_2,
-  testAnchoredMessage,
-  testClaimedMessage,
-  testL2NetworkConfig,
-  testUnderpricedAnchoredMessage,
-  testZeroFeeAnchoredMessage,
-} from "../../../utils/testing/constants";
-import { IMessageRepository } from "../../../core/persistence/IMessageRepository";
-import { IMessageClaimingProcessor } from "../../../core/services/processors/IMessageClaimingProcessor";
-import { MessageClaimingProcessor } from "../MessageClaimingProcessor";
-import { Message } from "../../../core/entities/Message";
-import { ErrorParser } from "../../../utils/ErrorParser";
-import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { mock } from "jest-mock-extended";
+
+import { ILineaRollupClient } from "../../../core/clients/blockchain/ethereum/ILineaRollupClient";
+import { IProvider } from "../../../core/clients/blockchain/IProvider";
 import {
   DEFAULT_ENABLE_POSTMAN_SPONSORING,
   DEFAULT_GAS_ESTIMATION_PERCENTILE,
@@ -40,9 +25,25 @@ import {
   DEFAULT_PROFIT_MARGIN,
   DEFAULT_RETRY_DELAY_IN_SECONDS,
 } from "../../../core/constants";
+import { Message } from "../../../core/entities/Message";
+import { MessageStatus } from "../../../core/enums";
+import { IMessageRepository } from "../../../core/persistence/IMessageRepository";
+import { IMessageClaimingProcessor } from "../../../core/services/processors/IMessageClaimingProcessor";
+import { ErrorParser } from "../../../utils/ErrorParser";
+import {
+  DEFAULT_MAX_FEE_PER_GAS,
+  TEST_ADDRESS_2,
+  TEST_CONTRACT_ADDRESS_2,
+  testAnchoredMessage,
+  testClaimedMessage,
+  testL2NetworkConfig,
+  testUnderpricedAnchoredMessage,
+  testZeroFeeAnchoredMessage,
+} from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
 import { EthereumTransactionValidationService } from "../../EthereumTransactionValidationService";
-import { ILineaRollupClient } from "../../../core/clients/blockchain/ethereum/ILineaRollupClient";
-import { IProvider } from "../../../core/clients/blockchain/IProvider";
+import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { MessageClaimingProcessor } from "../MessageClaimingProcessor";
 
 describe("TestMessageClaimingProcessor", () => {
   let messageClaimingProcessor: IMessageClaimingProcessor;

--- a/postman/src/services/processors/__tests__/MessageSentEventProcessor.test.ts
+++ b/postman/src/services/processors/__tests__/MessageSentEventProcessor.test.ts
@@ -1,20 +1,6 @@
-import { describe, it, beforeEach } from "@jest/globals";
-import { mock } from "jest-mock-extended";
-import { TestLogger } from "../../../utils/testing/helpers";
 import { Direction, MessageSent } from "@consensys/linea-sdk";
-import { MessageStatus } from "../../../core/enums";
-import {
-  TEST_ADDRESS_1,
-  TEST_ADDRESS_2,
-  testL1NetworkConfig,
-  testMessageSentEvent,
-  testMessageSentEventWithCallData,
-} from "../../../utils/testing/constants";
-import { IProvider } from "../../../core/clients/blockchain/IProvider";
-import { MessageSentEventProcessorConfig } from "../../../core/services/processors/IMessageSentEventProcessor";
-import { MessageSentEventProcessor } from "../MessageSentEventProcessor";
-import { ILineaRollupLogClient } from "../../../core/clients/blockchain/ethereum/ILineaRollupLogClient";
-import { MessageFactory } from "../../../core/entities/MessageFactory";
+import { ILogger } from "@consensys/linea-shared-utils";
+import { describe, it, beforeEach } from "@jest/globals";
 import {
   Block,
   ContractTransactionResponse,
@@ -24,10 +10,25 @@ import {
   TransactionRequest,
   TransactionResponse,
 } from "ethers";
-import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
-import { IMessageDBService } from "../../../core/persistence/IMessageDBService";
-import { ILogger } from "@consensys/linea-shared-utils";
+import { mock } from "jest-mock-extended";
+
+import { ILineaRollupLogClient } from "../../../core/clients/blockchain/ethereum/ILineaRollupLogClient";
+import { IProvider } from "../../../core/clients/blockchain/IProvider";
 import { IL2MessageServiceLogClient } from "../../../core/clients/blockchain/linea/IL2MessageServiceLogClient";
+import { MessageFactory } from "../../../core/entities/MessageFactory";
+import { MessageStatus } from "../../../core/enums";
+import { IMessageDBService } from "../../../core/persistence/IMessageDBService";
+import { MessageSentEventProcessorConfig } from "../../../core/services/processors/IMessageSentEventProcessor";
+import {
+  TEST_ADDRESS_1,
+  TEST_ADDRESS_2,
+  testL1NetworkConfig,
+  testMessageSentEvent,
+  testMessageSentEventWithCallData,
+} from "../../../utils/testing/constants";
+import { TestLogger } from "../../../utils/testing/helpers";
+import { EthereumMessageDBService } from "../../persistence/EthereumMessageDBService";
+import { MessageSentEventProcessor } from "../MessageSentEventProcessor";
 
 class TestMessageSentEventProcessor extends MessageSentEventProcessor {
   constructor(

--- a/postman/src/utils/ErrorParser.ts
+++ b/postman/src/utils/ErrorParser.ts
@@ -1,7 +1,8 @@
-import { EthersError, ErrorCode, isError } from "ethers";
 import { isBaseError } from "@consensys/linea-sdk";
-import { DatabaseAccessError } from "../core/errors/DatabaseErrors";
+import { EthersError, ErrorCode, isError } from "ethers";
+
 import { MessageProps } from "../core/entities/Message";
+import { DatabaseAccessError } from "../core/errors/DatabaseErrors";
 
 export type Mitigation = {
   shouldRetry: boolean;

--- a/postman/src/utils/PostmanWinstonLogger.ts
+++ b/postman/src/utils/PostmanWinstonLogger.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { EthersError } from "ethers";
 import { WinstonLogger } from "@consensys/linea-shared-utils";
+import { EthersError } from "ethers";
+
 import { IPostmanLogger } from "./IPostmanLogger";
 
 export class PostmanWinstonLogger extends WinstonLogger implements IPostmanLogger {

--- a/postman/src/utils/__tests__/ErrorParser.test.ts
+++ b/postman/src/utils/__tests__/ErrorParser.test.ts
@@ -1,9 +1,10 @@
+import { makeBaseError } from "@consensys/linea-sdk";
 import { describe, it, expect } from "@jest/globals";
 import { ErrorCode, makeError } from "ethers";
-import { makeBaseError } from "@consensys/linea-sdk";
-import { ErrorParser } from "../ErrorParser";
-import { DatabaseAccessError } from "../../core/errors";
+
 import { DatabaseErrorType, DatabaseRepoName } from "../../core/enums";
+import { DatabaseAccessError } from "../../core/errors";
+import { ErrorParser } from "../ErrorParser";
 import { generateMessage } from "../testing/helpers";
 
 describe("ErrorParser", () => {

--- a/postman/src/utils/testing/constants.ts
+++ b/postman/src/utils/testing/constants.ts
@@ -1,7 +1,6 @@
 import { Direction, MessageSent } from "@consensys/linea-sdk";
+
 import { L1NetworkConfig, L2NetworkConfig } from "../../application/postman/app/config/config";
-import { Message, MessageProps } from "../../core/entities/Message";
-import { MessageStatus } from "../../core/enums";
 import {
   DEFAULT_ENABLE_POSTMAN_SPONSORING,
   DEFAULT_MAX_POSTMAN_SPONSOR_GAS_LIMIT,
@@ -18,6 +17,8 @@ import {
   ZERO_ADDRESS,
   ZERO_HASH,
 } from "../../core/constants";
+import { Message, MessageProps } from "../../core/entities/Message";
+import { MessageStatus } from "../../core/enums";
 
 export const TEST_L1_SIGNER_PRIVATE_KEY = "0x0000000000000000000000000000000000000000000000000000000000000001";
 export const TEST_L2_SIGNER_PRIVATE_KEY = "0x0000000000000000000000000000000000000000000000000000000000000002";

--- a/postman/src/utils/testing/helpers.ts
+++ b/postman/src/utils/testing/helpers.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Direction } from "@consensys/linea-sdk";
+
 import { TEST_ADDRESS_1, TEST_CONTRACT_ADDRESS_1, TEST_CONTRACT_ADDRESS_2, TEST_MESSAGE_HASH } from "./constants";
-import { MessageStatus } from "../../core/enums";
-import { Message, MessageProps } from "../../core/entities/Message";
 import { MessageEntity } from "../../application/postman/persistence/entities/Message.entity";
+import { Message, MessageProps } from "../../core/entities/Message";
+import { MessageStatus } from "../../core/enums";
 import { IPostmanLogger } from "../IPostmanLogger";
 
 export class TestLogger implements IPostmanLogger {

--- a/sdk/sdk-core/src/merkle-tree/smt.test.ts
+++ b/sdk/sdk-core/src/merkle-tree/smt.test.ts
@@ -1,6 +1,7 @@
-import { Hex } from "../types/misc";
-import { SparseMerkleTree } from "./smt";
 import { encodePacked, keccak256 } from "viem";
+
+import { SparseMerkleTree } from "./smt";
+import { Hex } from "../types/misc";
 
 const hash = (left: Hex, right: Hex): Hex => keccak256(encodePacked(["bytes32", "bytes32"], [left, right]));
 

--- a/sdk/sdk-core/src/types/client/public.ts
+++ b/sdk/sdk-core/src/types/client/public.ts
@@ -1,4 +1,3 @@
-import { BlockTag } from "../block";
 import { GetBlockExtraDataParameters, GetBlockExtraDataReturnType } from "../actions/getBlockExtraData";
 import { GetL1ToL2MessageStatusParameters, GetL1ToL2MessageStatusReturnType } from "../actions/getL1ToL2MessageStatus";
 import { GetL2ToL1MessageStatusParameters, GetL2ToL1MessageStatusReturnType } from "../actions/getL2ToL1MessageStatus";
@@ -15,6 +14,7 @@ import {
   GetTransactionReceiptByMessageHashParameters,
   GetTransactionReceiptByMessageHashReturnType,
 } from "../actions/getTransactionReceiptByMessageHash";
+import { BlockTag } from "../block";
 
 export interface PublicClient {
   getMessageByMessageHash<T = bigint>(

--- a/sdk/sdk-core/src/types/transaction.ts
+++ b/sdk/sdk-core/src/types/transaction.ts
@@ -1,4 +1,5 @@
 import { Address } from "abitype";
+
 import { Hex } from "./misc";
 
 export type Log<TUnit = bigint> = {

--- a/sdk/sdk-core/src/utils/block.ts
+++ b/sdk/sdk-core/src/utils/block.ts
@@ -1,5 +1,5 @@
-import { Hex } from "../types/misc";
 import { hexToNumber, slice } from "./misc";
+import { Hex } from "../types/misc";
 
 export type ParseBlockExtraDataReturnType = {
   version: number;

--- a/sdk/sdk-core/src/utils/contract.ts
+++ b/sdk/sdk-core/src/utils/contract.ts
@@ -1,3 +1,4 @@
+import { isLineaMainnet, isLineaSepolia, isMainnet, isSepolia } from "./chain";
 import {
   L2_MESSAGE_SERVICE_MAINNET_ADDRESS,
   L2_MESSAGE_SERVICE_SEPOLIA_ADDRESS,
@@ -9,7 +10,6 @@ import {
   TOKEN_BRIDGE_SEPOLIA_ADDRESS,
 } from "../constants/address";
 import { Address } from "../types/misc";
-import { isLineaMainnet, isLineaSepolia, isMainnet, isSepolia } from "./chain";
 
 export function getContractsAddressesByChainId(chainId: number): {
   messageService: Address;

--- a/sdk/sdk-ethers/src/LineaSDK.test.ts
+++ b/sdk/sdk-ethers/src/LineaSDK.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "@jest/globals";
 import { JsonRpcProvider, Wallet } from "ethers";
-import { LineaSDK } from "./LineaSDK";
+
 import { L1ClaimingService } from "./clients/ethereum";
-import { LineaProvider, Provider } from "./clients/providers";
 import { EthersL2MessageServiceLogClient } from "./clients/linea";
+import { LineaProvider, Provider } from "./clients/providers";
 import { NETWORKS } from "./core/constants";
 import { serialize } from "./core/utils";
+import { LineaSDK } from "./LineaSDK";
 import { TEST_L1_SIGNER_PRIVATE_KEY, TEST_L2_SIGNER_PRIVATE_KEY, TEST_RPC_URL } from "./utils/testing/constants/common";
 import { generateL2MessageServiceClient, generateLineaRollupClient } from "./utils/testing/helpers";
 

--- a/sdk/sdk-ethers/src/LineaSDK.ts
+++ b/sdk/sdk-ethers/src/LineaSDK.ts
@@ -1,4 +1,5 @@
 import { Eip1193Provider, Signer, Wallet } from "ethers";
+
 import {
   LineaRollupClient,
   EthersLineaRollupLogClient,
@@ -6,12 +7,12 @@ import {
   LineaRollupMessageRetriever,
   MerkleTreeService,
 } from "./clients/ethereum";
+import { DefaultGasProvider, GasProvider } from "./clients/gas";
 import {
   L2MessageServiceClient,
   EthersL2MessageServiceLogClient,
   L2MessageServiceMessageRetriever,
 } from "./clients/linea";
-import { DefaultGasProvider, GasProvider } from "./clients/gas";
 import { Provider, LineaProvider, BrowserProvider, LineaBrowserProvider } from "./clients/providers";
 import {
   DEFAULT_ENABLE_LINEA_ESTIMATE_GAS,
@@ -20,11 +21,11 @@ import {
   DEFAULT_L2_MESSAGE_TREE_DEPTH,
   DEFAULT_MAX_FEE_PER_GAS_CAP,
 } from "./core/constants";
-import { L1FeeEstimatorOptions, L2FeeEstimatorOptions, LineaSDKOptions, Network, SDKMode } from "./core/types";
 import { NETWORKS } from "./core/constants";
-import { isString } from "./core/utils";
 import { Direction } from "./core/enums";
 import { makeBaseError } from "./core/errors/utils";
+import { L1FeeEstimatorOptions, L2FeeEstimatorOptions, LineaSDKOptions, Network, SDKMode } from "./core/types";
+import { isString } from "./core/utils";
 
 export class LineaSDK {
   private network: Network;

--- a/sdk/sdk-ethers/src/clients/ethereum/EthersLineaRollupLogClient.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/EthersLineaRollupLogClient.ts
@@ -1,10 +1,3 @@
-import {
-  MessageSentEventFilters,
-  ILineaRollupLogClient,
-  L2MessagingBlockAnchoredFilters,
-  MessageClaimedFilters,
-} from "../../core/clients/ethereum";
-import { L2MessagingBlockAnchored, MessageClaimed, MessageSent } from "../../core/types";
 import { LineaRollup, LineaRollup__factory } from "../../contracts/typechain";
 import { TypedContractEvent, TypedDeferredTopicFilter, TypedEventLog } from "../../contracts/typechain/common";
 import {
@@ -12,6 +5,13 @@ import {
   MessageClaimedEvent,
   MessageSentEvent,
 } from "../../contracts/typechain/LineaRollup";
+import {
+  MessageSentEventFilters,
+  ILineaRollupLogClient,
+  L2MessagingBlockAnchoredFilters,
+  MessageClaimedFilters,
+} from "../../core/clients/ethereum";
+import { L2MessagingBlockAnchored, MessageClaimed, MessageSent } from "../../core/types";
 import { isUndefined } from "../../core/utils";
 import { BrowserProvider, Provider } from "../providers";
 

--- a/sdk/sdk-ethers/src/clients/ethereum/L1ClaimingService.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/L1ClaimingService.ts
@@ -6,13 +6,14 @@ import {
   TransactionResponse,
   ErrorDescription,
 } from "ethers";
-import { OnChainMessageStatus } from "../../core/enums/message";
-import { Cache } from "../../utils/Cache";
+
 import { ILineaRollupClient } from "../../core/clients/ethereum";
-import { IL2MessageServiceClient, IL2MessageServiceLogClient } from "../../core/clients/linea";
-import { MessageSent, Network } from "../../core/types";
 import { FinalizationMessagingInfo, Proof } from "../../core/clients/ethereum/IMerkleTreeService";
+import { IL2MessageServiceClient, IL2MessageServiceLogClient } from "../../core/clients/linea";
+import { OnChainMessageStatus } from "../../core/enums/message";
 import { makeBaseError } from "../../core/errors/utils";
+import { MessageSent, Network } from "../../core/types";
+import { Cache } from "../../utils/Cache";
 
 export class L1ClaimingService {
   private cache: Cache;

--- a/sdk/sdk-ethers/src/clients/ethereum/LineaRollupClient.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/LineaRollupClient.ts
@@ -8,15 +8,8 @@ import {
   Block,
   ErrorDescription,
 } from "ethers";
+
 import { LineaRollup, LineaRollup__factory } from "../../contracts/typechain";
-import { Message, SDKMode, MessageSent } from "../../core/types";
-import { OnChainMessageStatus } from "../../core/enums";
-import {
-  MESSAGE_UNKNOWN_STATUS,
-  MESSAGE_CLAIMED_STATUS,
-  ZERO_ADDRESS,
-  DEFAULT_RATE_LIMIT_MARGIN,
-} from "../../core/constants";
 import {
   ILineaRollupClient,
   ILineaRollupLogClient,
@@ -24,13 +17,21 @@ import {
   IMerkleTreeService,
   Proof,
 } from "../../core/clients/ethereum";
-import { IL2MessageServiceLogClient } from "../../core/clients/linea";
-import { formatMessageStatus, isString } from "../../core/utils";
 import { GasFees, IEthereumGasProvider } from "../../core/clients/IGasProvider";
 import { IMessageRetriever } from "../../core/clients/IMessageRetriever";
 import { IProvider } from "../../core/clients/IProvider";
-import { BrowserProvider, Provider } from "../providers";
+import { IL2MessageServiceLogClient } from "../../core/clients/linea";
+import {
+  MESSAGE_UNKNOWN_STATUS,
+  MESSAGE_CLAIMED_STATUS,
+  ZERO_ADDRESS,
+  DEFAULT_RATE_LIMIT_MARGIN,
+} from "../../core/constants";
+import { OnChainMessageStatus } from "../../core/enums";
 import { makeBaseError } from "../../core/errors/utils";
+import { Message, SDKMode, MessageSent } from "../../core/types";
+import { formatMessageStatus, isString } from "../../core/utils";
+import { BrowserProvider, Provider } from "../providers";
 
 export class LineaRollupClient implements ILineaRollupClient<
   Overrides,

--- a/sdk/sdk-ethers/src/clients/ethereum/LineaRollupMessageRetriever.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/LineaRollupMessageRetriever.ts
@@ -1,11 +1,12 @@
 import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
-import { ILineaRollupLogClient } from "../../core/clients/ethereum";
-import { MessageSent } from "../../core/types";
-import { MESSAGE_SENT_EVENT_SIGNATURE } from "../../core/constants";
-import { isNull } from "../../core/utils";
+
 import { LineaRollup, LineaRollup__factory } from "../../contracts/typechain";
+import { ILineaRollupLogClient } from "../../core/clients/ethereum";
 import { IMessageRetriever } from "../../core/clients/IMessageRetriever";
 import { IProvider } from "../../core/clients/IProvider";
+import { MESSAGE_SENT_EVENT_SIGNATURE } from "../../core/constants";
+import { MessageSent } from "../../core/types";
+import { isNull } from "../../core/utils";
 import { BrowserProvider, Provider } from "../providers";
 
 export class LineaRollupMessageRetriever implements IMessageRetriever<TransactionReceipt> {

--- a/sdk/sdk-ethers/src/clients/ethereum/MerkleTreeService.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/MerkleTreeService.ts
@@ -1,21 +1,22 @@
 import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
-import { SparseMerkleTreeFactory } from "../../utils/merkleTree/MerkleTreeFactory";
+
+import { LineaRollup, LineaRollup__factory } from "../../contracts/typechain";
 import {
   ILineaRollupLogClient,
   FinalizationMessagingInfo,
   IMerkleTreeService,
   Proof,
 } from "../../core/clients/ethereum";
+import { IProvider } from "../../core/clients/IProvider";
 import { IL2MessageServiceLogClient } from "../../core/clients/linea";
 import {
   L2_MERKLE_TREE_ADDED_EVENT_SIGNATURE,
   L2_MESSAGING_BLOCK_ANCHORED_EVENT_SIGNATURE,
   ZERO_HASH,
 } from "../../core/constants";
-import { LineaRollup, LineaRollup__factory } from "../../contracts/typechain";
-import { IProvider } from "../../core/clients/IProvider";
-import { BrowserProvider, Provider } from "../providers";
 import { makeBaseError } from "../../core/errors/utils";
+import { SparseMerkleTreeFactory } from "../../utils/merkleTree/MerkleTreeFactory";
+import { BrowserProvider, Provider } from "../providers";
 
 export class MerkleTreeService implements IMerkleTreeService {
   private readonly contract: LineaRollup;

--- a/sdk/sdk-ethers/src/clients/ethereum/__tests__/EthersLineaRollupLogClient.test.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/__tests__/EthersLineaRollupLogClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, afterEach, it, expect, beforeEach } from "@jest/globals";
 import { MockProxy, mock, mockClear } from "jest-mock-extended";
-import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
+
+import { LineaRollup, LineaRollup__factory } from "../../../contracts/typechain";
 import { TEST_CONTRACT_ADDRESS_1 } from "../../../utils/testing/constants/common";
 import {
   testL2MessagingBlockAnchoredEvent,
@@ -10,9 +11,9 @@ import {
   testMessageSentEvent,
   testMessageSentEventLog,
 } from "../../../utils/testing/constants/events";
-import { LineaRollup, LineaRollup__factory } from "../../../contracts/typechain";
 import { mockProperty } from "../../../utils/testing/helpers";
 import { Provider } from "../../providers";
+import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
 
 describe("TestEthersLineaRollupLogClient", () => {
   let providerMock: MockProxy<Provider>;

--- a/sdk/sdk-ethers/src/clients/ethereum/__tests__/L1ClaimingService.test.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/__tests__/L1ClaimingService.test.ts
@@ -1,19 +1,8 @@
 import { describe, it } from "@jest/globals";
 import { ContractTransactionResponse, ethers } from "ethers";
 import { MockProxy, mock, mockClear } from "jest-mock-extended";
-import { L1ClaimingService } from "../L1ClaimingService";
-import { LineaRollupClient } from "../LineaRollupClient";
-import { L2MessageServiceClient } from "../../linea";
-import {
-  generateHexString,
-  generateL2MerkleTreeAddedLog,
-  generateL2MessageServiceClient,
-  generateL2MessagingBlockAnchoredLog,
-  generateLineaRollupClient,
-  generateMessage,
-  generateTransactionReceipt,
-  generateTransactionResponse,
-} from "../../../utils/testing/helpers";
+
+import { ZERO_ADDRESS } from "../../../core/constants";
 import {
   TEST_CONTRACT_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,
@@ -26,10 +15,22 @@ import {
   testMessageSentEvent,
   testServiceVersionMigratedEvent,
 } from "../../../utils/testing/constants/events";
+import {
+  generateHexString,
+  generateL2MerkleTreeAddedLog,
+  generateL2MessageServiceClient,
+  generateL2MessagingBlockAnchoredLog,
+  generateLineaRollupClient,
+  generateMessage,
+  generateTransactionReceipt,
+  generateTransactionResponse,
+} from "../../../utils/testing/helpers";
+import { L2MessageServiceClient } from "../../linea";
 import { EthersL2MessageServiceLogClient } from "../../linea/EthersL2MessageServiceLogClient";
-import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
-import { ZERO_ADDRESS } from "../../../core/constants";
 import { LineaProvider, Provider } from "../../providers";
+import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
+import { L1ClaimingService } from "../L1ClaimingService";
+import { LineaRollupClient } from "../LineaRollupClient";
 
 describe("L1ClaimingService", () => {
   let l1Provider: MockProxy<Provider>;

--- a/sdk/sdk-ethers/src/clients/ethereum/__tests__/LineaRollupClient.test.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/__tests__/LineaRollupClient.test.ts
@@ -1,6 +1,11 @@
 import { describe, afterEach, it, expect, beforeEach } from "@jest/globals";
-import { MockProxy, mock, mockClear, mockDeep } from "jest-mock-extended";
 import { ContractTransactionResponse, Wallet } from "ethers";
+import { MockProxy, mock, mockClear, mockDeep } from "jest-mock-extended";
+
+import { LineaRollup, LineaRollup__factory } from "../../../contracts/typechain";
+import { ZERO_ADDRESS } from "../../../core/constants";
+import { OnChainMessageStatus } from "../../../core/enums/message";
+import { BaseError, makeBaseError } from "../../../core/errors";
 import {
   TEST_MESSAGE_HASH,
   TEST_CONTRACT_ADDRESS_1,
@@ -16,7 +21,6 @@ import {
   testMessageClaimedEvent,
   testL2MessagingBlockAnchoredEvent,
 } from "../../../utils/testing/constants/events";
-import { LineaRollup, LineaRollup__factory } from "../../../contracts/typechain";
 import {
   generateL2MerkleTreeAddedLog,
   generateL2MessagingBlockAnchoredLog,
@@ -27,14 +31,11 @@ import {
   generateTransactionResponse,
   mockProperty,
 } from "../../../utils/testing/helpers";
-import { LineaRollupClient } from "../LineaRollupClient";
-import { ZERO_ADDRESS } from "../../../core/constants";
-import { OnChainMessageStatus } from "../../../core/enums/message";
-import { BaseError, makeBaseError } from "../../../core/errors";
-import { EthersL2MessageServiceLogClient } from "../../linea/EthersL2MessageServiceLogClient";
-import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
 import { DefaultGasProvider } from "../../gas/DefaultGasProvider";
+import { EthersL2MessageServiceLogClient } from "../../linea/EthersL2MessageServiceLogClient";
 import { LineaProvider, Provider } from "../../providers";
+import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
+import { LineaRollupClient } from "../LineaRollupClient";
 
 describe("TestLineaRollupClient", () => {
   let providerMock: MockProxy<Provider>;

--- a/sdk/sdk-ethers/src/clients/ethereum/__tests__/LineaRollupMessageRetriever.test.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/__tests__/LineaRollupMessageRetriever.test.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach } from "@jest/globals";
 import { Wallet } from "ethers";
 import { MockProxy, mock } from "jest-mock-extended";
+
 import {
   TEST_CONTRACT_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,
@@ -9,9 +10,9 @@ import {
 } from "../../../utils/testing/constants/common";
 import { testMessageSentEvent } from "../../../utils/testing/constants/events";
 import { generateLineaRollupClient, generateTransactionReceipt } from "../../../utils/testing/helpers";
+import { LineaProvider, Provider } from "../../providers";
 import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
 import { LineaRollupMessageRetriever } from "../LineaRollupMessageRetriever";
-import { LineaProvider, Provider } from "../../providers";
 
 describe("LineaRollupMessageRetriever", () => {
   let providerMock: MockProxy<Provider>;

--- a/sdk/sdk-ethers/src/clients/ethereum/__tests__/MerkleTreeService.test.ts
+++ b/sdk/sdk-ethers/src/clients/ethereum/__tests__/MerkleTreeService.test.ts
@@ -1,6 +1,8 @@
 import { describe, beforeEach } from "@jest/globals";
 import { Wallet } from "ethers";
 import { MockProxy, mock } from "jest-mock-extended";
+
+import { LineaRollup, LineaRollup__factory } from "../../../contracts/typechain";
 import {
   TEST_CONTRACT_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,
@@ -15,11 +17,10 @@ import {
   generateLineaRollupClient,
   generateTransactionReceiptWithLogs,
 } from "../../../utils/testing/helpers";
-import { LineaRollup, LineaRollup__factory } from "../../../contracts/typechain";
 import { EthersL2MessageServiceLogClient } from "../../linea/EthersL2MessageServiceLogClient";
+import { LineaProvider, Provider } from "../../providers";
 import { EthersLineaRollupLogClient } from "../EthersLineaRollupLogClient";
 import { MerkleTreeService } from "../MerkleTreeService";
-import { LineaProvider, Provider } from "../../providers";
 
 describe("MerkleTreeService", () => {
   let providerMock: MockProxy<Provider>;

--- a/sdk/sdk-ethers/src/clients/gas/DefaultGasProvider.ts
+++ b/sdk/sdk-ethers/src/clients/gas/DefaultGasProvider.ts
@@ -1,8 +1,9 @@
 import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
+
 import { DefaultGasProviderConfig, FeeHistory, GasFees, IEthereumGasProvider } from "../../core/clients/IGasProvider";
 import { IProvider } from "../../core/clients/IProvider";
-import { BrowserProvider, LineaBrowserProvider, LineaProvider, Provider } from "../providers";
 import { makeBaseError } from "../../core/errors/utils";
+import { BrowserProvider, LineaBrowserProvider, LineaProvider, Provider } from "../providers";
 
 export class DefaultGasProvider implements IEthereumGasProvider<TransactionRequest> {
   private gasFeesCache: GasFees;

--- a/sdk/sdk-ethers/src/clients/gas/GasProvider.ts
+++ b/sdk/sdk-ethers/src/clients/gas/GasProvider.ts
@@ -1,11 +1,12 @@
 import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
+
 import { DefaultGasProvider } from "./DefaultGasProvider";
 import { LineaGasProvider } from "./LineaGasProvider";
-import { IProvider } from "../../core/clients/IProvider";
 import { GasFees, GasProviderConfig, IGasProvider, LineaGasFees } from "../../core/clients/IGasProvider";
+import { IProvider } from "../../core/clients/IProvider";
 import { Direction } from "../../core/enums";
-import { BrowserProvider, LineaBrowserProvider, LineaProvider, Provider } from "../providers";
 import { makeBaseError } from "../../core/errors/utils";
+import { BrowserProvider, LineaBrowserProvider, LineaProvider, Provider } from "../providers";
 
 export class GasProvider implements IGasProvider<TransactionRequest> {
   private defaultGasProvider: DefaultGasProvider;

--- a/sdk/sdk-ethers/src/clients/gas/LineaGasProvider.ts
+++ b/sdk/sdk-ethers/src/clients/gas/LineaGasProvider.ts
@@ -1,4 +1,5 @@
 import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
+
 import {
   LineaEstimateGasResponse,
   LineaGasFees,

--- a/sdk/sdk-ethers/src/clients/gas/__tests__/DefaultGasProvider.test.ts
+++ b/sdk/sdk-ethers/src/clients/gas/__tests__/DefaultGasProvider.test.ts
@@ -1,9 +1,10 @@
 import { describe, afterEach, jest, it, expect, beforeEach } from "@jest/globals";
 import { MockProxy, mock, mockClear } from "jest-mock-extended";
-import { DefaultGasProvider } from "../DefaultGasProvider";
-import { Provider } from "../../providers/provider";
+
 import { DEFAULT_GAS_ESTIMATION_PERCENTILE } from "../../../core/constants";
 import { makeBaseError } from "../../../core/errors";
+import { Provider } from "../../providers/provider";
+import { DefaultGasProvider } from "../DefaultGasProvider";
 
 const MAX_FEE_PER_GAS = 100_000_000n;
 

--- a/sdk/sdk-ethers/src/clients/gas/__tests__/GasProvider.test.ts
+++ b/sdk/sdk-ethers/src/clients/gas/__tests__/GasProvider.test.ts
@@ -1,12 +1,13 @@
 import { describe, afterEach, it, expect, beforeEach } from "@jest/globals";
+import { toBeHex } from "ethers";
 import { MockProxy, mock, mockClear } from "jest-mock-extended";
+
+import { DEFAULT_GAS_ESTIMATION_PERCENTILE, DEFAULT_MAX_FEE_PER_GAS_CAP } from "../../../core/constants";
+import { Direction } from "../../../core/enums/message";
+import { DEFAULT_MAX_FEE_PER_GAS } from "../../../utils/testing/constants/common";
+import { generateTransactionRequest } from "../../../utils/testing/helpers";
 import { Provider } from "../../providers/provider";
 import { GasProvider } from "../GasProvider";
-import { Direction } from "../../../core/enums/message";
-import { DEFAULT_GAS_ESTIMATION_PERCENTILE, DEFAULT_MAX_FEE_PER_GAS_CAP } from "../../../core/constants";
-import { generateTransactionRequest } from "../../../utils/testing/helpers";
-import { toBeHex } from "ethers";
-import { DEFAULT_MAX_FEE_PER_GAS } from "../../../utils/testing/constants/common";
 
 const testFeeHistory = {
   baseFeePerGas: ["0x3da8e7618", "0x3e1ba3b1b", "0x3dfd72b90", "0x3d64eee76", "0x3d4da2da0", "0x3ccbcac6b"],

--- a/sdk/sdk-ethers/src/clients/gas/__tests__/LineaGasProvider.test.ts
+++ b/sdk/sdk-ethers/src/clients/gas/__tests__/LineaGasProvider.test.ts
@@ -1,9 +1,10 @@
 import { describe, afterEach, jest, it, expect, beforeEach } from "@jest/globals";
-import { MockProxy, mock, mockClear } from "jest-mock-extended";
-import { LineaGasProvider } from "../LineaGasProvider";
-import { generateTransactionRequest } from "../../../utils/testing/helpers";
 import { toBeHex } from "ethers";
+import { MockProxy, mock, mockClear } from "jest-mock-extended";
+
+import { generateTransactionRequest } from "../../../utils/testing/helpers";
 import { LineaProvider } from "../../providers";
+import { LineaGasProvider } from "../LineaGasProvider";
 
 const MAX_FEE_PER_GAS = 100_000_000n;
 

--- a/sdk/sdk-ethers/src/clients/linea/EthersL2MessageServiceLogClient.ts
+++ b/sdk/sdk-ethers/src/clients/linea/EthersL2MessageServiceLogClient.ts
@@ -1,8 +1,8 @@
-import { MessageSent, ServiceVersionMigrated } from "../../core/types";
 import { L2MessageService, L2MessageService__factory } from "../../contracts/typechain";
-import { IL2MessageServiceLogClient, MessageSentEventFilters } from "../../core/clients/linea";
 import { TypedContractEvent, TypedDeferredTopicFilter, TypedEventLog } from "../../contracts/typechain/common";
 import { MessageSentEvent, ServiceVersionMigratedEvent } from "../../contracts/typechain/L2MessageService";
+import { IL2MessageServiceLogClient, MessageSentEventFilters } from "../../core/clients/linea";
+import { MessageSent, ServiceVersionMigrated } from "../../core/types";
 import { isUndefined } from "../../core/utils";
 import { LineaBrowserProvider, LineaProvider } from "../providers";
 

--- a/sdk/sdk-ethers/src/clients/linea/L2MessageServiceClient.ts
+++ b/sdk/sdk-ethers/src/clients/linea/L2MessageServiceClient.ts
@@ -8,16 +8,17 @@ import {
   Block,
   ErrorDescription,
 } from "ethers";
+
 import { L2MessageService, L2MessageService__factory } from "../../contracts/typechain";
-import { Message, SDKMode, MessageSent } from "../../core/types";
-import { OnChainMessageStatus } from "../../core/enums";
-import { IL2MessageServiceClient, ILineaProvider } from "../../core/clients/linea";
-import { ZERO_ADDRESS } from "../../core/constants";
-import { formatMessageStatus, isString } from "../../core/utils";
 import { IGasProvider, LineaGasFees } from "../../core/clients/IGasProvider";
 import { IMessageRetriever } from "../../core/clients/IMessageRetriever";
-import { LineaBrowserProvider, LineaProvider } from "../providers";
+import { IL2MessageServiceClient, ILineaProvider } from "../../core/clients/linea";
+import { ZERO_ADDRESS } from "../../core/constants";
+import { OnChainMessageStatus } from "../../core/enums";
 import { makeBaseError } from "../../core/errors/utils";
+import { Message, SDKMode, MessageSent } from "../../core/types";
+import { formatMessageStatus, isString } from "../../core/utils";
+import { LineaBrowserProvider, LineaProvider } from "../providers";
 
 export class L2MessageServiceClient implements IL2MessageServiceClient<
   Overrides,

--- a/sdk/sdk-ethers/src/clients/linea/L2MessageServiceMessageRetriever.ts
+++ b/sdk/sdk-ethers/src/clients/linea/L2MessageServiceMessageRetriever.ts
@@ -1,10 +1,11 @@
 import { Block, TransactionReceipt, TransactionRequest, TransactionResponse } from "ethers";
-import { MessageSent } from "../../core/types";
-import { MESSAGE_SENT_EVENT_SIGNATURE } from "../../core/constants";
-import { isNull } from "../../core/utils";
+
 import { L2MessageService, L2MessageService__factory } from "../../contracts/typechain";
 import { IMessageRetriever } from "../../core/clients/IMessageRetriever";
 import { ILineaProvider, IL2MessageServiceLogClient } from "../../core/clients/linea";
+import { MESSAGE_SENT_EVENT_SIGNATURE } from "../../core/constants";
+import { MessageSent } from "../../core/types";
+import { isNull } from "../../core/utils";
 import { LineaBrowserProvider, LineaProvider } from "../providers";
 
 export class L2MessageServiceMessageRetriever implements IMessageRetriever<TransactionReceipt> {

--- a/sdk/sdk-ethers/src/clients/linea/__tests__/EthersL2MessgaeServiceLogClient.test.ts
+++ b/sdk/sdk-ethers/src/clients/linea/__tests__/EthersL2MessgaeServiceLogClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, afterEach, it, expect, beforeEach } from "@jest/globals";
 import { MockProxy, mock, mockClear } from "jest-mock-extended";
-import { EthersL2MessageServiceLogClient } from "../EthersL2MessageServiceLogClient";
+
+import { L2MessageService, L2MessageService__factory } from "../../../contracts/typechain";
 import { TEST_MESSAGE_HASH, TEST_CONTRACT_ADDRESS_2 } from "../../../utils/testing/constants/common";
 import {
   testMessageSentEvent,
@@ -8,9 +9,9 @@ import {
   testServiceVersionMigratedEvent,
   testServiceVersionMigratedEventLog,
 } from "../../../utils/testing/constants/events";
-import { L2MessageService, L2MessageService__factory } from "../../../contracts/typechain";
 import { mockProperty } from "../../../utils/testing/helpers";
 import { LineaProvider } from "../../providers";
+import { EthersL2MessageServiceLogClient } from "../EthersL2MessageServiceLogClient";
 
 describe("TestEthersL2MessgaeServiceLogClient", () => {
   let providerMock: MockProxy<LineaProvider>;

--- a/sdk/sdk-ethers/src/clients/linea/__tests__/L2MessageServiceClient.test.ts
+++ b/sdk/sdk-ethers/src/clients/linea/__tests__/L2MessageServiceClient.test.ts
@@ -1,6 +1,11 @@
 import { describe, afterEach, it, expect, beforeEach } from "@jest/globals";
-import { MockProxy, mock, mockClear, mockDeep } from "jest-mock-extended";
 import { ContractTransactionResponse, Wallet } from "ethers";
+import { MockProxy, mock, mockClear, mockDeep } from "jest-mock-extended";
+
+import { L2MessageService, L2MessageService__factory } from "../../../contracts/typechain";
+import { ZERO_ADDRESS } from "../../../core/constants";
+import { OnChainMessageStatus } from "../../../core/enums/message";
+import { BaseError, makeBaseError } from "../../../core/errors";
 import {
   TEST_MESSAGE_HASH,
   TEST_CONTRACT_ADDRESS_1,
@@ -9,19 +14,15 @@ import {
   TEST_ADDRESS_1,
   DEFAULT_MAX_FEE_PER_GAS,
 } from "../../../utils/testing/constants/common";
-import { L2MessageService, L2MessageService__factory } from "../../../contracts/typechain";
 import {
   generateL2MessageServiceClient,
   generateMessage,
   generateTransactionResponse,
   mockProperty,
 } from "../../../utils/testing/helpers";
-import { L2MessageServiceClient } from "../L2MessageServiceClient";
-import { ZERO_ADDRESS } from "../../../core/constants";
-import { OnChainMessageStatus } from "../../../core/enums/message";
-import { BaseError, makeBaseError } from "../../../core/errors";
-import { LineaProvider } from "../../providers";
 import { GasProvider } from "../../gas";
+import { LineaProvider } from "../../providers";
+import { L2MessageServiceClient } from "../L2MessageServiceClient";
 
 describe("TestL2MessageServiceClient", () => {
   let providerMock: MockProxy<LineaProvider>;

--- a/sdk/sdk-ethers/src/clients/linea/__tests__/L2MessageServiceMessageRetriever.test.ts
+++ b/sdk/sdk-ethers/src/clients/linea/__tests__/L2MessageServiceMessageRetriever.test.ts
@@ -1,6 +1,7 @@
 import { describe, beforeEach } from "@jest/globals";
 import { Wallet } from "ethers";
 import { MockProxy, mock } from "jest-mock-extended";
+
 import {
   TEST_CONTRACT_ADDRESS_1,
   TEST_MESSAGE_HASH,
@@ -8,9 +9,9 @@ import {
 } from "../../../utils/testing/constants/common";
 import { testMessageSentEvent } from "../../../utils/testing/constants/events";
 import { generateL2MessageServiceClient, generateTransactionReceipt } from "../../../utils/testing/helpers";
-import { L2MessageServiceMessageRetriever } from "../L2MessageServiceMessageRetriever";
-import { EthersL2MessageServiceLogClient } from "../EthersL2MessageServiceLogClient";
 import { LineaProvider } from "../../providers";
+import { EthersL2MessageServiceLogClient } from "../EthersL2MessageServiceLogClient";
+import { L2MessageServiceMessageRetriever } from "../L2MessageServiceMessageRetriever";
 
 describe("L2MessageServiceMessageRetriever", () => {
   let providerMock: MockProxy<LineaProvider>;

--- a/sdk/sdk-ethers/src/clients/providers/__tests__/LineaProvider.test.ts
+++ b/sdk/sdk-ethers/src/clients/providers/__tests__/LineaProvider.test.ts
@@ -1,5 +1,6 @@
-import { Block, FeeData } from "ethers";
 import { describe, afterEach, it, beforeEach } from "@jest/globals";
+import { Block, FeeData } from "ethers";
+
 import { LineaProvider } from "..";
 import { DEFAULT_MAX_FEE_PER_GAS } from "../../../utils/testing/constants/common";
 

--- a/sdk/sdk-ethers/src/clients/providers/__tests__/Provider.test.ts
+++ b/sdk/sdk-ethers/src/clients/providers/__tests__/Provider.test.ts
@@ -1,5 +1,6 @@
-import { FeeData } from "ethers";
 import { describe, afterEach, it, beforeEach } from "@jest/globals";
+import { FeeData } from "ethers";
+
 import { Provider } from "..";
 import { DEFAULT_MAX_FEE_PER_GAS } from "../../../utils/testing/constants/common";
 

--- a/sdk/sdk-ethers/src/clients/providers/lineaProvider.ts
+++ b/sdk/sdk-ethers/src/clients/providers/lineaProvider.ts
@@ -1,6 +1,7 @@
 import { BlockTag, dataSlice, ethers, toNumber } from "ethers";
-import { BlockExtraData } from "../../core/clients/linea";
+
 import { GasFees } from "../../core/clients/IGasProvider";
+import { BlockExtraData } from "../../core/clients/linea";
 import { makeBaseError } from "../../core/errors/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdk/sdk-ethers/src/clients/providers/provider.ts
+++ b/sdk/sdk-ethers/src/clients/providers/provider.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+
 import { GasFees } from "../../core/clients/IGasProvider";
 import { makeBaseError } from "../../core/errors/utils";
 

--- a/sdk/sdk-ethers/src/core/clients/ethereum/ILineaRollupClient.ts
+++ b/sdk/sdk-ethers/src/core/clients/ethereum/ILineaRollupClient.ts
@@ -1,5 +1,5 @@
-import { Message } from "../../types";
 import { OnChainMessageStatus } from "../../enums";
+import { Message } from "../../types";
 import { IMessageServiceContract } from "../IMessageServiceContract";
 import { FinalizationMessagingInfo, Proof } from "./IMerkleTreeService";
 

--- a/sdk/sdk-ethers/src/core/clients/linea/IL2MessageServiceClient.ts
+++ b/sdk/sdk-ethers/src/core/clients/linea/IL2MessageServiceClient.ts
@@ -1,7 +1,7 @@
-import { Message } from "../../types";
-import { IMessageServiceContract } from "../IMessageServiceContract";
-import { LineaGasFees } from "../IGasProvider";
 import { OnChainMessageStatus } from "../../enums";
+import { Message } from "../../types";
+import { LineaGasFees } from "../IGasProvider";
+import { IMessageServiceContract } from "../IMessageServiceContract";
 
 export interface IL2MessageServiceClient<
   Overrides,

--- a/sdk/sdk-ethers/src/core/errors/__tests__/BaseError.test.ts
+++ b/sdk/sdk-ethers/src/core/errors/__tests__/BaseError.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@jest/globals";
+
 import { makeBaseError } from "../utils";
 
 describe("BaseError", () => {

--- a/sdk/sdk-ethers/src/core/errors/utils.ts
+++ b/sdk/sdk-ethers/src/core/errors/utils.ts
@@ -1,4 +1,5 @@
 import { isNativeError } from "util/types";
+
 import { BaseError, InferErrorType } from "./BaseError";
 
 /**

--- a/sdk/sdk-ethers/src/core/utils/__tests__/message.test.ts
+++ b/sdk/sdk-ethers/src/core/utils/__tests__/message.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
-import { formatMessageStatus } from "../message";
+
 import { OnChainMessageStatus } from "../../enums/message";
+import { formatMessageStatus } from "../message";
 
 describe("Message utils", () => {
   describe("formatMessageStatus", () => {

--- a/sdk/sdk-ethers/src/core/utils/__tests__/shared.test.ts
+++ b/sdk/sdk-ethers/src/core/utils/__tests__/shared.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
+
 import { isEmptyBytes, isNull, isString, isUndefined, subtractSeconds } from "../shared";
 
 describe("Shared utils", () => {

--- a/sdk/sdk-ethers/src/utils/Cache.ts
+++ b/sdk/sdk-ethers/src/utils/Cache.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { LRUCache } from "lru-cache";
+
 import { serialize, isUndefined } from "../core/utils";
 
 interface CacheInterface {

--- a/sdk/sdk-ethers/src/utils/merkleTree/SparseMerkleTree.ts
+++ b/sdk/sdk-ethers/src/utils/merkleTree/SparseMerkleTree.ts
@@ -1,7 +1,8 @@
 import { ethers } from "ethers";
-import { makeBaseError } from "../../core/errors";
-import { ZERO_HASH } from "../../core/constants";
+
 import { Proof } from "../../core/clients/ethereum";
+import { ZERO_HASH } from "../../core/constants";
+import { makeBaseError } from "../../core/errors";
 
 class MerkleTreeNode {
   public value: string;

--- a/sdk/sdk-ethers/src/utils/merkleTree/__tests__/SparseMerkleTree.test.ts
+++ b/sdk/sdk-ethers/src/utils/merkleTree/__tests__/SparseMerkleTree.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@jest/globals";
-import { SparseMerkleTree } from "../SparseMerkleTree";
+
 import { generateHexString } from "../../testing/helpers";
+import { SparseMerkleTree } from "../SparseMerkleTree";
 
 describe("TestSparseMerkleTree", () => {
   describe("Initialization", () => {

--- a/sdk/sdk-ethers/src/utils/testing/constants/events.ts
+++ b/sdk/sdk-ethers/src/utils/testing/constants/events.ts
@@ -6,8 +6,8 @@ import {
   TEST_MESSAGE_HASH,
   TEST_TRANSACTION_HASH,
 } from "./common";
-import { L2MessagingBlockAnchoredEvent, MessageSentEvent } from "../../../contracts/typechain/LineaRollup";
 import { MessageClaimedEvent, ServiceVersionMigratedEvent } from "../../../contracts/typechain/L2MessageService";
+import { L2MessagingBlockAnchoredEvent, MessageSentEvent } from "../../../contracts/typechain/LineaRollup";
 import { L2_MESSAGING_BLOCK_ANCHORED_EVENT_SIGNATURE, MESSAGE_SENT_EVENT_SIGNATURE } from "../../../core/constants";
 import { L2MessagingBlockAnchored, MessageClaimed, MessageSent, ServiceVersionMigrated } from "../../../core/types";
 

--- a/sdk/sdk-ethers/src/utils/testing/helpers.ts
+++ b/sdk/sdk-ethers/src/utils/testing/helpers.ts
@@ -8,6 +8,7 @@ import {
   ethers,
   randomBytes,
 } from "ethers";
+
 import {
   TEST_ADDRESS_1,
   TEST_BLOCK_HASH,
@@ -17,6 +18,19 @@ import {
   TEST_TRANSACTION_HASH,
 } from "./constants/common";
 import {
+  LineaRollupClient,
+  EthersLineaRollupLogClient,
+  LineaRollupMessageRetriever,
+  MerkleTreeService,
+} from "../../clients/ethereum";
+import { DefaultGasProvider, GasProvider } from "../../clients/gas";
+import {
+  L2MessageServiceClient,
+  EthersL2MessageServiceLogClient,
+  L2MessageServiceMessageRetriever,
+} from "../../clients/linea";
+import { LineaProvider, Provider } from "../../clients/providers";
+import {
   DEFAULT_ENFORCE_MAX_GAS_FEE,
   DEFAULT_GAS_ESTIMATION_PERCENTILE,
   DEFAULT_L2_MESSAGE_TREE_DEPTH,
@@ -25,21 +39,8 @@ import {
   L2_MESSAGING_BLOCK_ANCHORED_EVENT_SIGNATURE,
   MESSAGE_SENT_EVENT_SIGNATURE,
 } from "../../core/constants";
-import { Message, SDKMode } from "../../core/types";
-import {
-  LineaRollupClient,
-  EthersLineaRollupLogClient,
-  LineaRollupMessageRetriever,
-  MerkleTreeService,
-} from "../../clients/ethereum";
-import {
-  L2MessageServiceClient,
-  EthersL2MessageServiceLogClient,
-  L2MessageServiceMessageRetriever,
-} from "../../clients/linea";
-import { DefaultGasProvider, GasProvider } from "../../clients/gas";
-import { LineaProvider, Provider } from "../../clients/providers";
 import { Direction } from "../../core/enums";
+import { Message, SDKMode } from "../../core/types";
 
 export const getTestProvider = () => {
   return new JsonRpcProvider("http://localhost:8545");

--- a/sdk/sdk-viem/src/actions/claimOnL1.test.ts
+++ b/sdk/sdk-viem/src/actions/claimOnL1.test.ts
@@ -1,4 +1,4 @@
-import { claimOnL1, ClaimOnL1Parameters } from "./claimOnL1";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Client,
   Transport,
@@ -12,8 +12,10 @@ import {
   ClientChainNotConfiguredError,
 } from "viem";
 import { sendTransaction } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import { mainnet } from "viem/chains";
+
+import { claimOnL1, ClaimOnL1Parameters } from "./claimOnL1";
+import { getMessageProof } from "./getMessageProof";
 import {
   TEST_ADDRESS_1,
   TEST_ADDRESS_2,
@@ -23,7 +25,6 @@ import {
   TEST_TRANSACTION_HASH,
 } from "../../tests/constants";
 import { AccountNotFoundError } from "../errors/account";
-import { getMessageProof } from "./getMessageProof";
 import { computeMessageHash } from "../utils/computeMessageHash";
 
 jest.mock("viem/actions", () => ({

--- a/sdk/sdk-viem/src/actions/claimOnL1.ts
+++ b/sdk/sdk-viem/src/actions/claimOnL1.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId, MessageProof, Message } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -18,17 +19,17 @@ import {
   Transport,
   zeroAddress,
 } from "viem";
-import { GetAccountParameter } from "../types/account";
-import { parseAccount } from "viem/utils";
 import { sendTransaction } from "viem/actions";
-import { getContractsAddressesByChainId, MessageProof, Message } from "@consensys/linea-sdk-core";
+import { parseAccount } from "viem/utils";
+
 import { getMessageProof } from "./getMessageProof";
-import { computeMessageHash, ComputeMessageHashErrorType } from "../utils/computeMessageHash";
 import { AccountNotFoundError, AccountNotFoundErrorType } from "../errors/account";
 import {
   MissingMessageProofOrClientForClaimingOnL1Error,
   MissingMessageProofOrClientForClaimingOnL1ErrorType,
 } from "../errors/bridge";
+import { GetAccountParameter } from "../types/account";
+import { computeMessageHash, ComputeMessageHashErrorType } from "../utils/computeMessageHash";
 
 export type ClaimOnL1Parameters<
   chain extends Chain | undefined = Chain | undefined,

--- a/sdk/sdk-viem/src/actions/claimOnL2.test.ts
+++ b/sdk/sdk-viem/src/actions/claimOnL2.test.ts
@@ -1,4 +1,4 @@
-import { claimOnL2 } from "./claimOnL2";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Client,
   Transport,
@@ -11,8 +11,9 @@ import {
   ChainNotFoundError,
 } from "viem";
 import { sendTransaction } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import { linea } from "viem/chains";
+
+import { claimOnL2 } from "./claimOnL2";
 import { TEST_ADDRESS_1, TEST_ADDRESS_2, TEST_TRANSACTION_HASH } from "../../tests/constants";
 import { AccountNotFoundError } from "../errors/account";
 

--- a/sdk/sdk-viem/src/actions/claimOnL2.ts
+++ b/sdk/sdk-viem/src/actions/claimOnL2.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId, Message } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -15,11 +16,11 @@ import {
   Transport,
   zeroAddress,
 } from "viem";
-import { GetAccountParameter } from "../types/account";
-import { parseAccount } from "viem/utils";
 import { sendTransaction } from "viem/actions";
-import { getContractsAddressesByChainId, Message } from "@consensys/linea-sdk-core";
+import { parseAccount } from "viem/utils";
+
 import { AccountNotFoundError, AccountNotFoundErrorType } from "../errors/account";
+import { GetAccountParameter } from "../types/account";
 
 export type ClaimOnL2Parameters<
   chain extends Chain | undefined = Chain | undefined,

--- a/sdk/sdk-viem/src/actions/deposit.test.ts
+++ b/sdk/sdk-viem/src/actions/deposit.test.ts
@@ -1,4 +1,4 @@
-import { deposit, computeMessageStorageSlot, createStateOverride } from "./deposit";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Client,
   Transport,
@@ -23,12 +23,13 @@ import {
   waitForTransactionReceipt,
   getBlock,
 } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import { linea, mainnet } from "viem/chains";
+
+import { deposit, computeMessageStorageSlot, createStateOverride } from "./deposit";
 import { TEST_ADDRESS_1, TEST_ADDRESS_2, TEST_TRANSACTION_HASH } from "../../tests/constants";
 import { generateBlock, generateTransactionReceipt } from "../../tests/utils";
-import { computeMessageHash } from "../utils/computeMessageHash";
 import { AccountNotFoundError } from "../errors/account";
+import { computeMessageHash } from "../utils/computeMessageHash";
 
 jest.mock("viem/actions", () => ({
   readContract: jest.fn(),

--- a/sdk/sdk-viem/src/actions/deposit.ts
+++ b/sdk/sdk-viem/src/actions/deposit.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -31,8 +32,6 @@ import {
   WaitForTransactionReceiptErrorType,
   zeroAddress,
 } from "viem";
-import { GetAccountParameter } from "../types/account";
-import { parseAccount } from "viem/utils";
 import {
   estimateContractGas,
   estimateFeesPerGas,
@@ -41,9 +40,11 @@ import {
   sendTransaction,
   waitForTransactionReceipt,
 } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
-import { computeMessageHash } from "../utils/computeMessageHash";
+import { parseAccount } from "viem/utils";
+
 import { AccountNotFoundError, AccountNotFoundErrorType } from "../errors/account";
+import { GetAccountParameter } from "../types/account";
+import { computeMessageHash } from "../utils/computeMessageHash";
 import { getNextMessageNonce, GetNextMessageNonceErrorType } from "../utils/getNextMessageNonce";
 
 export type DepositParameters<

--- a/sdk/sdk-viem/src/actions/getBlockExtraData.test.ts
+++ b/sdk/sdk-viem/src/actions/getBlockExtraData.test.ts
@@ -1,7 +1,8 @@
-import { getBlockExtraData, GetBlockExtraDataParameters } from "./getBlockExtraData";
 import { Client, Transport, Chain, Account } from "viem";
-import { linea } from "viem/chains";
 import { getBlock } from "viem/actions";
+import { linea } from "viem/chains";
+
+import { getBlockExtraData, GetBlockExtraDataParameters } from "./getBlockExtraData";
 import { generateBlock } from "../../tests/utils";
 
 jest.mock("viem/actions", () => ({

--- a/sdk/sdk-viem/src/actions/getL1ToL2MessageStatus.test.ts
+++ b/sdk/sdk-viem/src/actions/getL1ToL2MessageStatus.test.ts
@@ -1,8 +1,9 @@
-import { getL1ToL2MessageStatus } from "./getL1ToL2MessageStatus";
+import { OnChainMessageStatus } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account, Hex } from "viem";
 import { readContract } from "viem/actions";
 import { linea } from "viem/chains";
-import { OnChainMessageStatus } from "@consensys/linea-sdk-core";
+
+import { getL1ToL2MessageStatus } from "./getL1ToL2MessageStatus";
 import { TEST_MESSAGE_HASH } from "../../tests/constants";
 
 jest.mock("viem/actions", () => ({

--- a/sdk/sdk-viem/src/actions/getL1ToL2MessageStatus.ts
+++ b/sdk/sdk-viem/src/actions/getL1ToL2MessageStatus.ts
@@ -1,3 +1,4 @@
+import { formatMessageStatus, getContractsAddressesByChainId, OnChainMessageStatus } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -10,7 +11,6 @@ import {
   Transport,
 } from "viem";
 import { readContract } from "viem/actions";
-import { formatMessageStatus, getContractsAddressesByChainId, OnChainMessageStatus } from "@consensys/linea-sdk-core";
 
 export type GetL1ToL2MessageStatusReturnType = OnChainMessageStatus;
 

--- a/sdk/sdk-viem/src/actions/getL2ToL1MessageStatus.test.ts
+++ b/sdk/sdk-viem/src/actions/getL2ToL1MessageStatus.test.ts
@@ -1,9 +1,10 @@
-import { getL2ToL1MessageStatus } from "./getL2ToL1MessageStatus";
+import { OnChainMessageStatus } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account } from "viem";
 import { getContractEvents, readContract } from "viem/actions";
-import { getMessageSentEvents } from "./getMessageSentEvents";
 import { linea, mainnet } from "viem/chains";
-import { OnChainMessageStatus } from "@consensys/linea-sdk-core";
+
+import { getL2ToL1MessageStatus } from "./getL2ToL1MessageStatus";
+import { getMessageSentEvents } from "./getMessageSentEvents";
 import { TEST_MESSAGE_HASH } from "../../tests/constants";
 import { generateL2MessagingBlockAnchoredLog, generateMessageSentLog } from "../../tests/utils";
 

--- a/sdk/sdk-viem/src/actions/getL2ToL1MessageStatus.ts
+++ b/sdk/sdk-viem/src/actions/getL2ToL1MessageStatus.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId, OnChainMessageStatus } from "@consensys/linea-sdk-core";
 import {
   Abi,
   Account,
@@ -18,7 +19,7 @@ import {
   Transport,
 } from "viem";
 import { getContractEvents, readContract } from "viem/actions";
-import { getContractsAddressesByChainId, OnChainMessageStatus } from "@consensys/linea-sdk-core";
+
 import { getMessageSentEvents, GetMessageSentEventsErrorType } from "./getMessageSentEvents";
 import { MessageNotFoundError, MessageNotFoundErrorType } from "../errors/bridge";
 

--- a/sdk/sdk-viem/src/actions/getMessageByMessageHash.test.ts
+++ b/sdk/sdk-viem/src/actions/getMessageByMessageHash.test.ts
@@ -1,8 +1,9 @@
-import { getMessageByMessageHash } from "./getMessageByMessageHash";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account, Hex, ChainNotFoundError } from "viem";
 import { getContractEvents } from "viem/actions";
 import { linea } from "viem/chains";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+
+import { getMessageByMessageHash } from "./getMessageByMessageHash";
 import { TEST_ADDRESS_1, TEST_ADDRESS_2, TEST_MESSAGE_HASH, TEST_TRANSACTION_HASH } from "../../tests/constants";
 import { generateMessageSentLog } from "../../tests/utils";
 

--- a/sdk/sdk-viem/src/actions/getMessageByMessageHash.ts
+++ b/sdk/sdk-viem/src/actions/getMessageByMessageHash.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -10,7 +11,7 @@ import {
   Transport,
 } from "viem";
 import { getContractEvents } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+
 import { MessageNotFoundError, MessageNotFoundErrorType } from "../errors/bridge";
 
 export type GetMessageByMessageHashParameters = {

--- a/sdk/sdk-viem/src/actions/getMessageProof.test.ts
+++ b/sdk/sdk-viem/src/actions/getMessageProof.test.ts
@@ -1,15 +1,16 @@
-import { getMessageProof } from "./getMessageProof";
-import { Client, Transport, Chain, Account, Hex, ClientChainNotConfiguredError, ChainNotFoundError } from "viem";
-import { getMessageSentEvents } from "./getMessageSentEvents";
-import { getContractEvents, getTransactionReceipt } from "viem/actions";
 import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+import { Client, Transport, Chain, Account, Hex, ClientChainNotConfiguredError, ChainNotFoundError } from "viem";
+import { getContractEvents, getTransactionReceipt } from "viem/actions";
+
+import { getMessageProof } from "./getMessageProof";
+import { getMessageSentEvents } from "./getMessageSentEvents";
+import { TEST_MERKLE_ROOT, TEST_MERKLE_ROOT_2, TEST_MESSAGE_HASH, TEST_TRANSACTION_HASH } from "../../tests/constants";
 import {
   generateL2MerkleTreeAddedLog,
   generateL2MessagingBlockAnchoredLog,
   generateMessageSentLog,
   generateTransactionReceipt,
 } from "../../tests/utils";
-import { TEST_MERKLE_ROOT, TEST_MERKLE_ROOT_2, TEST_MESSAGE_HASH, TEST_TRANSACTION_HASH } from "../../tests/constants";
 
 jest.mock("./getMessageSentEvents");
 jest.mock("viem/actions", () => ({

--- a/sdk/sdk-viem/src/actions/getMessageProof.ts
+++ b/sdk/sdk-viem/src/actions/getMessageProof.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId, MessageProof, SparseMerkleTree } from "@consensys/linea-sdk-core";
 import {
   Abi,
   Account,
@@ -22,9 +23,9 @@ import {
   Transport,
   zeroHash,
 } from "viem";
-import { getContractsAddressesByChainId, MessageProof, SparseMerkleTree } from "@consensys/linea-sdk-core";
-import { getMessageSentEvents, GetMessageSentEventsErrorType } from "./getMessageSentEvents";
 import { getContractEvents, getTransactionReceipt } from "viem/actions";
+
+import { getMessageSentEvents, GetMessageSentEventsErrorType } from "./getMessageSentEvents";
 import {
   EventNotFoundInFinalizationDataError,
   EventNotFoundInFinalizationDataErrorType,

--- a/sdk/sdk-viem/src/actions/getMessageSentEvents.test.ts
+++ b/sdk/sdk-viem/src/actions/getMessageSentEvents.test.ts
@@ -1,7 +1,7 @@
-import { getMessageSentEvents } from "./getMessageSentEvents";
 import { Client, Transport, Chain, Account } from "viem";
 import { getContractEvents } from "viem/actions";
-import { generateMessageSentLog } from "../../tests/utils";
+
+import { getMessageSentEvents } from "./getMessageSentEvents";
 import {
   TEST_ADDRESS_1,
   TEST_ADDRESS_2,
@@ -9,6 +9,7 @@ import {
   TEST_MESSAGE_HASH,
   TEST_TRANSACTION_HASH,
 } from "../../tests/constants";
+import { generateMessageSentLog } from "../../tests/utils";
 
 jest.mock("viem/actions", () => ({
   getContractEvents: jest.fn(),

--- a/sdk/sdk-viem/src/actions/getMessagesByTransactionHash.test.ts
+++ b/sdk/sdk-viem/src/actions/getMessagesByTransactionHash.test.ts
@@ -1,8 +1,9 @@
-import { getMessagesByTransactionHash } from "./getMessagesByTransactionHash";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account, Hex, ChainNotFoundError } from "viem";
 import { getTransactionReceipt } from "viem/actions";
 import { linea } from "viem/chains";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+
+import { getMessagesByTransactionHash } from "./getMessagesByTransactionHash";
 import {
   TEST_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,

--- a/sdk/sdk-viem/src/actions/getMessagesByTransactionHash.ts
+++ b/sdk/sdk-viem/src/actions/getMessagesByTransactionHash.ts
@@ -1,3 +1,4 @@
+import { ExtendedMessage, getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -13,7 +14,6 @@ import {
   Transport,
 } from "viem";
 import { getTransactionReceipt } from "viem/actions";
-import { ExtendedMessage, getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 
 export type GetMessagesByTransactionHashParameters = {
   transactionHash: Hex;

--- a/sdk/sdk-viem/src/actions/getTransactionReceiptByMessageHash.test.ts
+++ b/sdk/sdk-viem/src/actions/getTransactionReceiptByMessageHash.test.ts
@@ -1,8 +1,9 @@
-import { getTransactionReceiptByMessageHash } from "./getTransactionReceiptByMessageHash";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account, ChainNotFoundError } from "viem";
 import { getContractEvents, getTransactionReceipt } from "viem/actions";
 import { linea } from "viem/chains";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+
+import { getTransactionReceiptByMessageHash } from "./getTransactionReceiptByMessageHash";
 import { TEST_MESSAGE_HASH } from "../../tests/constants";
 import { generateMessageSentLog, generateTransactionReceipt } from "../../tests/utils";
 

--- a/sdk/sdk-viem/src/actions/getTransactionReceiptByMessageHash.ts
+++ b/sdk/sdk-viem/src/actions/getTransactionReceiptByMessageHash.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -12,7 +13,7 @@ import {
   Transport,
 } from "viem";
 import { getContractEvents, getTransactionReceipt } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+
 import { MessageNotFoundError, MessageNotFoundErrorType } from "../errors/bridge";
 
 export type GetTransactionReceiptByMessageHashParameters = {

--- a/sdk/sdk-viem/src/actions/withdraw.test.ts
+++ b/sdk/sdk-viem/src/actions/withdraw.test.ts
@@ -1,4 +1,4 @@
-import { withdraw } from "./withdraw";
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Client,
   Transport,
@@ -12,7 +12,8 @@ import {
 } from "viem";
 import { readContract, sendTransaction } from "viem/actions";
 import { linea } from "viem/chains";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+
+import { withdraw } from "./withdraw";
 import { TEST_TRANSACTION_HASH } from "../../tests/constants";
 import { AccountNotFoundError } from "../errors/account";
 

--- a/sdk/sdk-viem/src/actions/withdraw.ts
+++ b/sdk/sdk-viem/src/actions/withdraw.ts
@@ -1,3 +1,4 @@
+import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
 import {
   Account,
   Address,
@@ -18,11 +19,11 @@ import {
   Transport,
   zeroAddress,
 } from "viem";
-import { GetAccountParameter } from "../types/account";
-import { parseAccount } from "viem/utils";
 import { readContract, sendTransaction } from "viem/actions";
-import { getContractsAddressesByChainId } from "@consensys/linea-sdk-core";
+import { parseAccount } from "viem/utils";
+
 import { AccountNotFoundError, AccountNotFoundErrorType } from "../errors/account";
+import { GetAccountParameter } from "../types/account";
 
 export type WithdrawParameters<
   chain extends Chain | undefined = Chain | undefined,

--- a/sdk/sdk-viem/src/decorators/publicL1.test.ts
+++ b/sdk/sdk-viem/src/decorators/publicL1.test.ts
@@ -1,12 +1,13 @@
-import { publicActionsL1 } from "./publicL1";
+import { ExtendedMessage, MessageProof, OnChainMessageStatus } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account, Hex, TransactionReceipt } from "viem";
-import { getMessageProof } from "../actions/getMessageProof";
+
+import { publicActionsL1 } from "./publicL1";
+import { TEST_CONTRACT_ADDRESS_1, TEST_CONTRACT_ADDRESS_2 } from "../../tests/constants";
 import { getL2ToL1MessageStatus } from "../actions/getL2ToL1MessageStatus";
 import { getMessageByMessageHash } from "../actions/getMessageByMessageHash";
+import { getMessageProof } from "../actions/getMessageProof";
 import { getMessagesByTransactionHash } from "../actions/getMessagesByTransactionHash";
 import { getTransactionReceiptByMessageHash } from "../actions/getTransactionReceiptByMessageHash";
-import { ExtendedMessage, MessageProof, OnChainMessageStatus } from "@consensys/linea-sdk-core";
-import { TEST_CONTRACT_ADDRESS_1, TEST_CONTRACT_ADDRESS_2 } from "../../tests/constants";
 
 jest.mock("../actions/getMessageProof", () => ({ getMessageProof: jest.fn() }));
 jest.mock("../actions/getL2ToL1MessageStatus", () => ({ getL2ToL1MessageStatus: jest.fn() }));

--- a/sdk/sdk-viem/src/decorators/publicL1.ts
+++ b/sdk/sdk-viem/src/decorators/publicL1.ts
@@ -1,5 +1,6 @@
+import { L1PublicClient } from "@consensys/linea-sdk-core";
 import { Abi, Account, Address, BlockNumber, BlockTag, Chain, Client, ContractEventName, Transport } from "viem";
-import { getMessageProof, GetMessageProofParameters, GetMessageProofReturnType } from "../actions/getMessageProof";
+
 import {
   getL2ToL1MessageStatus,
   GetL2ToL1MessageStatusParameters,
@@ -10,6 +11,7 @@ import {
   GetMessageByMessageHashParameters,
   GetMessageByMessageHashReturnType,
 } from "../actions/getMessageByMessageHash";
+import { getMessageProof, GetMessageProofParameters, GetMessageProofReturnType } from "../actions/getMessageProof";
 import {
   getMessagesByTransactionHash,
   GetMessagesByTransactionHashParameters,
@@ -20,7 +22,6 @@ import {
   GetTransactionReceiptByMessageHashParameters,
   GetTransactionReceiptByMessageHashReturnType,
 } from "../actions/getTransactionReceiptByMessageHash";
-import { L1PublicClient } from "@consensys/linea-sdk-core";
 import { StrictFunctionOnly } from "../types/misc";
 
 export type PublicActionsL1<

--- a/sdk/sdk-viem/src/decorators/publicL2.test.ts
+++ b/sdk/sdk-viem/src/decorators/publicL2.test.ts
@@ -1,12 +1,13 @@
-import { publicActionsL2 } from "./publicL2";
+import { ExtendedMessage, OnChainMessageStatus } from "@consensys/linea-sdk-core";
 import { Client, Transport, Chain, Account, Hex, TransactionReceipt } from "viem";
+
+import { publicActionsL2 } from "./publicL2";
+import { TEST_CONTRACT_ADDRESS_2 } from "../../tests/constants";
 import { getBlockExtraData } from "../actions/getBlockExtraData";
 import { getL1ToL2MessageStatus } from "../actions/getL1ToL2MessageStatus";
 import { getMessageByMessageHash } from "../actions/getMessageByMessageHash";
 import { getMessagesByTransactionHash } from "../actions/getMessagesByTransactionHash";
 import { getTransactionReceiptByMessageHash } from "../actions/getTransactionReceiptByMessageHash";
-import { ExtendedMessage, OnChainMessageStatus } from "@consensys/linea-sdk-core";
-import { TEST_CONTRACT_ADDRESS_2 } from "../../tests/constants";
 
 jest.mock("../actions/getBlockExtraData", () => ({ getBlockExtraData: jest.fn() }));
 jest.mock("../actions/getL1ToL2MessageStatus", () => ({ getL1ToL2MessageStatus: jest.fn() }));

--- a/sdk/sdk-viem/src/decorators/publicL2.ts
+++ b/sdk/sdk-viem/src/decorators/publicL2.ts
@@ -1,5 +1,6 @@
-import { Account, Address, BlockTag, Chain, Client, Transport } from "viem";
 import { L2PublicClient } from "@consensys/linea-sdk-core";
+import { Account, Address, BlockTag, Chain, Client, Transport } from "viem";
+
 import {
   getBlockExtraData,
   GetBlockExtraDataParameters,

--- a/sdk/sdk-viem/src/decorators/walletL1.test.ts
+++ b/sdk/sdk-viem/src/decorators/walletL1.test.ts
@@ -1,13 +1,14 @@
-import { walletActionsL1 } from "./walletL1";
 import { Client, Transport, Chain, Account, Address, Hex } from "viem";
-import { deposit } from "../actions/deposit";
-import { claimOnL1 } from "../actions/claimOnL1";
+
+import { walletActionsL1 } from "./walletL1";
 import {
   TEST_ADDRESS_1,
   TEST_ADDRESS_2,
   TEST_CONTRACT_ADDRESS_1,
   TEST_CONTRACT_ADDRESS_2,
 } from "../../tests/constants";
+import { claimOnL1 } from "../actions/claimOnL1";
+import { deposit } from "../actions/deposit";
 
 jest.mock("../actions/deposit", () => ({ deposit: jest.fn() }));
 jest.mock("../actions/claimOnL1", () => ({ claimOnL1: jest.fn() }));

--- a/sdk/sdk-viem/src/decorators/walletL1.ts
+++ b/sdk/sdk-viem/src/decorators/walletL1.ts
@@ -1,8 +1,9 @@
-import { Account, Address, Chain, Client, DeriveChain, Transport } from "viem";
 import { L1WalletClient } from "@consensys/linea-sdk-core";
+import { Account, Address, Chain, Client, DeriveChain, Transport } from "viem";
+
+import { claimOnL1, ClaimOnL1Parameters, ClaimOnL1ReturnType } from "../actions/claimOnL1";
 import { deposit, DepositParameters, DepositReturnType } from "../actions/deposit";
 import { StrictFunctionOnly } from "../types/misc";
-import { claimOnL1, ClaimOnL1Parameters, ClaimOnL1ReturnType } from "../actions/claimOnL1";
 
 export type WalletActionsL1<
   chain extends Chain | undefined = Chain | undefined,

--- a/sdk/sdk-viem/src/decorators/walletL2.test.ts
+++ b/sdk/sdk-viem/src/decorators/walletL2.test.ts
@@ -1,8 +1,9 @@
-import { walletActionsL2 } from "./walletL2";
 import { Client, Transport, Chain, Account, Address, Hex } from "viem";
-import { withdraw } from "../actions/withdraw";
-import { claimOnL2 } from "../actions/claimOnL2";
+
+import { walletActionsL2 } from "./walletL2";
 import { TEST_ADDRESS_2, TEST_CONTRACT_ADDRESS_2 } from "../../tests/constants";
+import { claimOnL2 } from "../actions/claimOnL2";
+import { withdraw } from "../actions/withdraw";
 
 jest.mock("../actions/withdraw", () => ({ withdraw: jest.fn() }));
 jest.mock("../actions/claimOnL2", () => ({ claimOnL2: jest.fn() }));

--- a/sdk/sdk-viem/src/decorators/walletL2.ts
+++ b/sdk/sdk-viem/src/decorators/walletL2.ts
@@ -1,8 +1,9 @@
+import { L2WalletClient } from "@consensys/linea-sdk-core";
 import { Account, Address, Chain, Client, DeriveChain, Transport } from "viem";
+
+import { claimOnL2, ClaimOnL2Parameters, ClaimOnL2ReturnType } from "../actions/claimOnL2";
 import { withdraw, WithdrawParameters, WithdrawReturnType } from "../actions/withdraw";
 import { StrictFunctionOnly } from "../types/misc";
-import { L2WalletClient } from "@consensys/linea-sdk-core";
-import { claimOnL2, ClaimOnL2Parameters, ClaimOnL2ReturnType } from "../actions/claimOnL2";
 
 export type WalletActionsL2<
   chain extends Chain | undefined = Chain | undefined,

--- a/sdk/sdk-viem/src/errors/account.test.ts
+++ b/sdk/sdk-viem/src/errors/account.test.ts
@@ -1,4 +1,5 @@
 import { setErrorConfig } from "viem";
+
 import { AccountNotFoundError } from "./account";
 
 describe("Account Errors", () => {

--- a/sdk/sdk-viem/src/errors/bridge.test.ts
+++ b/sdk/sdk-viem/src/errors/bridge.test.ts
@@ -1,5 +1,5 @@
 import { setErrorConfig } from "viem";
-import { TEST_MERKLE_ROOT, TEST_MESSAGE_HASH, TEST_TRANSACTION_HASH } from "../../tests/constants";
+
 import {
   EventNotFoundInFinalizationDataError,
   L2BlockNotFinalizedError,
@@ -8,6 +8,7 @@ import {
   MessagesNotFoundInBlockRangeError,
   MissingMessageProofOrClientForClaimingOnL1Error,
 } from "./bridge";
+import { TEST_MERKLE_ROOT, TEST_MESSAGE_HASH, TEST_TRANSACTION_HASH } from "../../tests/constants";
 
 describe("Bridge Errors", () => {
   beforeAll(() => {

--- a/sdk/sdk-viem/tests/utils.ts
+++ b/sdk/sdk-viem/tests/utils.ts
@@ -1,5 +1,6 @@
-import { Block, Hex, Log, padHex, toHex, TransactionReceipt } from "viem";
 import { Message } from "@consensys/linea-sdk-core";
+import { Block, Hex, Log, padHex, toHex, TransactionReceipt } from "viem";
+
 import {
   L2_MERKLE_TREE_ADDED_EVENT_SIGNATURE,
   L2_MESSAGING_BLOCK_ANCHORED_EVENT_SIGNATURE,

--- a/ts-libs/eslint-config/base.js
+++ b/ts-libs/eslint-config/base.js
@@ -3,7 +3,7 @@ import { defineConfig } from "eslint/config";
 
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
-// import importPlugin from "eslint-plugin-import";
+import importPlugin from "eslint-plugin-import";
 import prettierPlugin from "eslint-plugin-prettier";
 
 /**
@@ -19,37 +19,36 @@ export const base = defineConfig(
       sourceType: "module",
     },
     plugins: {
-        // TODO: this plugin is disabled for now to avoid a lot of files changes
-        // import: importPlugin,
-        prettier: prettierPlugin
+      import: importPlugin,
+      prettier: prettierPlugin
     },
     rules: {
         "prettier/prettier": "error",
-        // "import/order": [
-        //     "error",
-        //     {
-        //         groups: [
-        //             ["builtin", "external"],
-        //             ["internal"],
-        //             ["parent", "sibling", "index"],
-        //             ["type"],
-        //         ],
-        //         pathGroups: [
-        //             {
-        //                 pattern: "react",
-        //                 group: "external",
-        //                 position: "before", 
-        //             },
-        //             {
-        //                 pattern: "@/**",
-        //                 group: "internal",
-        //             },
-        //         ],
-        //         pathGroupsExcludedImportTypes: ["react"],
-        //         "newlines-between": "always",
-        //         alphabetize: { order: "asc", caseInsensitive: true },
-        //     },
-        // ]
+        "import/order": [
+          "error",
+          {
+            groups: [
+              ["builtin", "external"],
+              ["internal"],
+              ["parent", "sibling", "index"],
+              ["type"],
+            ],
+            pathGroups: [
+              {
+                pattern: "react",
+                group: "external",
+                position: "before", 
+              },
+              {
+                pattern: "@/**",
+                group: "internal",
+              },
+            ],
+            pathGroupsExcludedImportTypes: ["react"],
+            "newlines-between": "always",
+            alphabetize: { order: "asc", caseInsensitive: true },
+          },
+        ]
     },
   },
 );

--- a/ts-libs/linea-shared-utils/scripts/test-ethereum-mainnet-client-library-viem-signer.ts
+++ b/ts-libs/linea-shared-utils/scripts/test-ethereum-mainnet-client-library-viem-signer.ts
@@ -5,11 +5,12 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
 pnpm --filter @consensys/linea-shared-utils exec tsx scripts/test-ethereum-mainnet-client-library-viem-signer.ts
 
  */
+import { Hex } from "viem";
+import { anvil } from "viem/chains";
+
 import { ViemBlockchainClientAdapter } from "../src/clients/ViemBlockchainClientAdapter";
 import { ViemWalletSignerClientAdapter } from "../src/clients/ViemWalletSignerClientAdapter";
 import { WinstonLogger } from "../src/logging/WinstonLogger";
-import { Hex } from "viem";
-import { anvil } from "viem/chains";
 
 async function main() {
   const requiredEnvVars = ["RPC_URL", "PRIVATE_KEY"];

--- a/ts-libs/linea-shared-utils/scripts/test-ethereum-mainnet-client-library-web3-signer.ts
+++ b/ts-libs/linea-shared-utils/scripts/test-ethereum-mainnet-client-library-web3-signer.ts
@@ -34,11 +34,12 @@ WEB3_SIGNER_TRUST_STORE_PASSPHRASE=changeit \
 pnpm --filter @consensys/linea-shared-utils exec tsx scripts/test-ethereum-mainnet-client-library-web3-signer.ts
 
  */
+import { Hex } from "viem";
+import { anvil } from "viem/chains";
+
 import { Web3SignerClientAdapter } from "../src";
 import { ViemBlockchainClientAdapter } from "../src/clients/ViemBlockchainClientAdapter";
 import { WinstonLogger } from "../src/logging/WinstonLogger";
-import { Hex } from "viem";
-import { anvil } from "viem/chains";
 
 async function main() {
   const requiredEnvVars = [

--- a/ts-libs/linea-shared-utils/scripts/test-web3-signer-client-adapter.ts
+++ b/ts-libs/linea-shared-utils/scripts/test-web3-signer-client-adapter.ts
@@ -38,9 +38,10 @@ pnpm --filter @consensys/linea-shared-utils exec tsx scripts/test-web3-signer-cl
 //   TX_DATA=0x
  */
 
+import { Address, Hex, TransactionSerializableEIP1559, serializeTransaction } from "viem";
+
 import { Web3SignerClientAdapter } from "../src/clients/Web3SignerClientAdapter";
 import { WinstonLogger } from "../src/logging/WinstonLogger";
-import { Address, Hex, TransactionSerializableEIP1559, serializeTransaction } from "viem";
 
 const REQUIRED_ENV_VARS = [
   "WEB3_SIGNER_URL",

--- a/ts-libs/linea-shared-utils/src/applications/ExpressApiApplication.ts
+++ b/ts-libs/linea-shared-utils/src/applications/ExpressApiApplication.ts
@@ -1,7 +1,8 @@
 import express, { Express, Request, Response } from "express";
+
+import { IApplication } from "../core/applications/IApplication";
 import { IMetricsService } from "../core/services/IMetricsService";
 import { ILogger } from "../logging/ILogger";
-import { IApplication } from "../core/applications/IApplication";
 
 /**
  * Express-based API application that provides HTTP server functionality with metrics endpoint.

--- a/ts-libs/linea-shared-utils/src/applications/__tests__/ExpressApiApplication.test.ts
+++ b/ts-libs/linea-shared-utils/src/applications/__tests__/ExpressApiApplication.test.ts
@@ -1,8 +1,9 @@
-import { mock, MockProxy } from "jest-mock-extended";
-import { ExpressApiApplication } from "../ExpressApiApplication";
-import { Request, Response } from "express";
 import { ILogger, IMetricsService } from "@consensys/linea-shared-utils";
+import { Request, Response } from "express";
+import { mock, MockProxy } from "jest-mock-extended";
 import { Registry } from "prom-client";
+
+import { ExpressApiApplication } from "../ExpressApiApplication";
 
 enum ExampleMetrics {
   ExampleMetrics = "ExampleMetrics",

--- a/ts-libs/linea-shared-utils/src/clients/BeaconNodeApiClient.ts
+++ b/ts-libs/linea-shared-utils/src/clients/BeaconNodeApiClient.ts
@@ -1,11 +1,12 @@
+import axios from "axios";
+
 import {
   IBeaconNodeAPIClient,
   PendingPartialWithdrawal,
   PendingPartialWithdrawalResponse,
 } from "../core/client/IBeaconNodeApiClient";
-import axios from "axios";
-import { ILogger } from "../logging/ILogger";
 import { IRetryService } from "../core/services/IRetryService";
+import { ILogger } from "../logging/ILogger";
 
 /**
  * Client for interacting with a Beacon Node API.

--- a/ts-libs/linea-shared-utils/src/clients/OAuth2TokenClient.ts
+++ b/ts-libs/linea-shared-utils/src/clients/OAuth2TokenClient.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
-import { ILogger } from "../logging/ILogger";
-import { getCurrentUnixTimestampSeconds } from "../utils/time";
+
 import { IOAuth2TokenClient, OAuth2TokenResponse } from "../core/client/IOAuth2TokenClient";
 import { IRetryService } from "../core/services/IRetryService";
+import { ILogger } from "../logging/ILogger";
+import { getCurrentUnixTimestampSeconds } from "../utils/time";
 
 /**
  * Client for obtaining and managing OAuth2 bearer tokens.

--- a/ts-libs/linea-shared-utils/src/clients/ViemBlockchainClientAdapter.ts
+++ b/ts-libs/linea-shared-utils/src/clients/ViemBlockchainClientAdapter.ts
@@ -1,4 +1,3 @@
-import { IBlockchainClient } from "../core/client/IBlockchainClient";
 import {
   Hex,
   createPublicClient,
@@ -15,9 +14,11 @@ import {
   BaseError,
 } from "viem";
 import { sendRawTransaction, waitForTransactionReceipt } from "viem/actions";
+
+import { IBlockchainClient } from "../core/client/IBlockchainClient";
 import { IContractSignerClient } from "../core/client/IContractSignerClient";
-import { ILogger } from "../logging/ILogger";
 import { MAX_BPS } from "../core/constants/maths";
+import { ILogger } from "../logging/ILogger";
 
 /**
  * Adapter that wraps viem's PublicClient to provide blockchain interaction functionality.

--- a/ts-libs/linea-shared-utils/src/clients/ViemWalletSignerClientAdapter.ts
+++ b/ts-libs/linea-shared-utils/src/clients/ViemWalletSignerClientAdapter.ts
@@ -10,8 +10,9 @@ import {
   TransactionSerializable,
   WalletClient,
 } from "viem";
-import { IContractSignerClient } from "../core/client/IContractSignerClient";
 import { privateKeyToAccount, privateKeyToAddress } from "viem/accounts";
+
+import { IContractSignerClient } from "../core/client/IContractSignerClient";
 import { ILogger } from "../logging/ILogger";
 
 /**

--- a/ts-libs/linea-shared-utils/src/clients/Web3SignerClientAdapter.ts
+++ b/ts-libs/linea-shared-utils/src/clients/Web3SignerClientAdapter.ts
@@ -1,11 +1,12 @@
 import axios from "axios";
-import { Agent } from "https";
-import { Address, Hex, serializeTransaction, TransactionSerializable } from "viem";
-import { IContractSignerClient } from "../core/client/IContractSignerClient";
-import { publicKeyToAddress } from "viem/accounts";
-import forge from "node-forge";
 import { readFileSync } from "fs";
+import { Agent } from "https";
+import forge from "node-forge";
 import path from "path";
+import { Address, Hex, serializeTransaction, TransactionSerializable } from "viem";
+import { publicKeyToAddress } from "viem/accounts";
+
+import { IContractSignerClient } from "../core/client/IContractSignerClient";
 import { ILogger } from "../logging/ILogger";
 import { getModuleDir } from "../utils/file";
 

--- a/ts-libs/linea-shared-utils/src/clients/__tests__/BeaconNodeApiClient.test.ts
+++ b/ts-libs/linea-shared-utils/src/clients/__tests__/BeaconNodeApiClient.test.ts
@@ -1,9 +1,10 @@
 import axios from "axios";
 import { mock } from "jest-mock-extended";
-import { BeaconNodeApiClient } from "../BeaconNodeApiClient";
-import { ILogger } from "../../logging/ILogger";
-import { IRetryService } from "../../core/services/IRetryService";
+
 import { PendingPartialWithdrawal } from "../../core/client/IBeaconNodeApiClient";
+import { IRetryService } from "../../core/services/IRetryService";
+import { ILogger } from "../../logging/ILogger";
+import { BeaconNodeApiClient } from "../BeaconNodeApiClient";
 
 jest.mock("axios");
 

--- a/ts-libs/linea-shared-utils/src/clients/__tests__/OAuth2TokenClient.test.ts
+++ b/ts-libs/linea-shared-utils/src/clients/__tests__/OAuth2TokenClient.test.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
-import { OAuth2TokenClient } from "../OAuth2TokenClient";
-import { ILogger } from "../../logging/ILogger";
+
 import { IRetryService } from "../../core/services/IRetryService";
+import { ILogger } from "../../logging/ILogger";
 import { getCurrentUnixTimestampSeconds } from "../../utils/time";
+import { OAuth2TokenClient } from "../OAuth2TokenClient";
 
 jest.mock("axios");
 jest.mock("../../utils/time", () => ({

--- a/ts-libs/linea-shared-utils/src/clients/__tests__/ViemBlockchainClientAdapter.test.ts
+++ b/ts-libs/linea-shared-utils/src/clients/__tests__/ViemBlockchainClientAdapter.test.ts
@@ -13,9 +13,10 @@ import {
   withTimeout,
 } from "viem";
 import { sendRawTransaction, waitForTransactionReceipt } from "viem/actions";
-import { ViemBlockchainClientAdapter } from "../ViemBlockchainClientAdapter";
-import { ILogger } from "../../logging/ILogger";
+
 import { IContractSignerClient } from "../../core/client/IContractSignerClient";
+import { ILogger } from "../../logging/ILogger";
+import { ViemBlockchainClientAdapter } from "../ViemBlockchainClientAdapter";
 
 jest.mock("viem", () => {
   const actual = jest.requireActual("viem");

--- a/ts-libs/linea-shared-utils/src/clients/__tests__/ViemWalletSignerClientAdapter.test.ts
+++ b/ts-libs/linea-shared-utils/src/clients/__tests__/ViemWalletSignerClientAdapter.test.ts
@@ -1,7 +1,8 @@
 import { createWalletClient, http, parseTransaction, serializeSignature } from "viem";
 import { privateKeyToAccount, privateKeyToAddress } from "viem/accounts";
-import { ViemWalletSignerClientAdapter } from "../ViemWalletSignerClientAdapter";
+
 import { ILogger } from "../../logging/ILogger";
+import { ViemWalletSignerClientAdapter } from "../ViemWalletSignerClientAdapter";
 
 jest.mock("viem", () => {
   const actual = jest.requireActual("viem");

--- a/ts-libs/linea-shared-utils/src/clients/__tests__/Web3SignerClientAdapter.test.ts
+++ b/ts-libs/linea-shared-utils/src/clients/__tests__/Web3SignerClientAdapter.test.ts
@@ -1,11 +1,12 @@
-import path from "path";
 import axios from "axios";
-import { Agent } from "https";
-import { Hex, serializeTransaction } from "viem";
 import { readFileSync } from "fs";
+import { Agent } from "https";
 import forge from "node-forge";
-import { Web3SignerClientAdapter } from "../Web3SignerClientAdapter";
+import path from "path";
+import { Hex, serializeTransaction } from "viem";
+
 import { ILogger } from "../../logging/ILogger";
+import { Web3SignerClientAdapter } from "../Web3SignerClientAdapter";
 
 // Mock getModuleDir to avoid Jest parsing issues with import.meta.url in file.ts
 jest.mock("../../utils/file", () => ({

--- a/ts-libs/linea-shared-utils/src/logging/WinstonLogger.ts
+++ b/ts-libs/linea-shared-utils/src/logging/WinstonLogger.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Logger as LoggerClass, LoggerOptions, createLogger, format, transports } from "winston";
+
 import { ILogger } from "./ILogger";
 import { isString, serialize } from "../utils/string";
 

--- a/ts-libs/linea-shared-utils/src/services/SingletonMetricsService.ts
+++ b/ts-libs/linea-shared-utils/src/services/SingletonMetricsService.ts
@@ -7,6 +7,7 @@ import {
   MetricValueWithName,
   Registry,
 } from "prom-client";
+
 import { IMetricsService } from "../core/services/IMetricsService";
 
 /**

--- a/ts-libs/linea-shared-utils/src/services/__tests__/ExponentialBackoffRetryService.test.ts
+++ b/ts-libs/linea-shared-utils/src/services/__tests__/ExponentialBackoffRetryService.test.ts
@@ -2,8 +2,8 @@ jest.mock("../../utils/time", () => ({
   wait: jest.fn(() => Promise.resolve()),
 }));
 
-import { wait } from "../../utils/time";
 import { ILogger } from "../../logging/ILogger";
+import { wait } from "../../utils/time";
 import { ExponentialBackoffRetryService } from "../ExponentialBackoffRetryService";
 
 const waitMock = wait as jest.MockedFunction<typeof wait>;

--- a/ts-libs/linea-shared-utils/src/services/__tests__/SingletonMetricsService.test.ts
+++ b/ts-libs/linea-shared-utils/src/services/__tests__/SingletonMetricsService.test.ts
@@ -1,4 +1,5 @@
 import { Counter, Gauge, Histogram, Registry } from "prom-client";
+
 import { IMetricsService } from "../../core/services/IMetricsService";
 import { SingletonMetricsService } from "../SingletonMetricsService";
 

--- a/ts-libs/linea-shared-utils/src/utils/__tests__/blockchain.test.ts
+++ b/ts-libs/linea-shared-utils/src/utils/__tests__/blockchain.test.ts
@@ -1,5 +1,5 @@
-import { gweiToWei, weiToGwei, weiToGweiNumber } from "../blockchain";
 import { WEI_PER_GWEI } from "../../core/constants/blockchain";
+import { gweiToWei, weiToGwei, weiToGweiNumber } from "../blockchain";
 
 describe("weiToGwei", () => {
   it("returns zero when converting zero wei", () => {

--- a/ts-libs/linea-shared-utils/src/utils/errors.ts
+++ b/ts-libs/linea-shared-utils/src/utils/errors.ts
@@ -1,4 +1,5 @@
 import { ResultAsync } from "neverthrow";
+
 import { ILogger } from "../logging/ILogger";
 
 /**


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes import order across the codebase to satisfy linting, touching many files in `bridge-ui`, `postman`, `operations`, and verifier packages.
> 
> - Reorders and groups imports (third‑party, internal, styles) with no functional changes
> - Updates ESLint configs to adjust/disable `import/order` in several packages
> - Minor cosmetic moves of style and icon imports for consistency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47e615ee33ab0b089c3d1b1aea7b5e19dbdffe9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->