### PR TITLE
fix: add ESLint 9 to bridge-ui devDependencies

### DIFF
--- a/bridge-ui/eslint.config.mjs
+++ b/bridge-ui/eslint.config.mjs
@@ -3,7 +3,7 @@ import { nextjs } from "@consensys/eslint-config/nextjs";
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   {
-    ignores: ["test/advancedFixtures.ts"]
+    ignores: ["test/advancedFixtures.ts", "playwright-report/**"]
   },
   ...nextjs,
   {

--- a/bridge-ui/package.json
+++ b/bridge-ui/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@consensys/eslint-config": "workspace:*",
     "@playwright/test": "1.53.2",
+    "eslint": "catalog:",
     "@svgr/webpack": "8.1.0",
     "@synthetixio/synpress": "4.1.0",
     "@types/fs-extra": "11.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       dotenv:
         specifier: 'catalog:'
         version: 16.5.0
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.2(jiti@2.3.3)
       nock:
         specifier: 14.0.1
         version: 14.0.1


### PR DESCRIPTION
- Add eslint@catalog to bridge-ui package.json devDependencies to ensure ESLint 9.39.2 is installed
- Add playwright-report/** to ESLint ignores to prevent linting generated files
- Update pnpm-lock.yaml with ESLint 9 dependency

This fixes the ESLint configuration error where ESLint 8 was being used but the config requires ESLint 9+ for the checkLoops: 'all' option in no-constant-condition rule.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures ESLint v9 is used and prevents linting of generated reports.
> 
> - Adds `eslint@catalog` to `bridge-ui/package.json` devDependencies (locks to ESLint 9.39.2)
> - Updates `eslint.config.mjs` to ignore `playwright-report/**`
> - Refreshes `pnpm-lock.yaml` to include ESLint 9
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 071eea23e4f347659efd775855356bd5a82ce8a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->