### PR TITLE
feat: only build components if they have changed or merging into main…

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -65,7 +65,7 @@ on:
 jobs:
   coordinator:
     uses: ./.github/workflows/coordinator-build-and-publish.yml
-    if: ${{ always() && (inputs.coordinator_changed == 'true' || inputs.coordinator_image_tagged != 'true') }}
+    if: ${{ always() && (inputs.coordinator_changed == 'true' || (inputs.push_image == 'true' && inputs.coordinator_image_tagged != 'true')) }}
     with:
       commit_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}
@@ -77,7 +77,7 @@ jobs:
     uses: ./.github/workflows/native-yield-automation-service-build-and-publish.yml
     if: ${{ inputs.native_yield_automation_service_changed == 'true' }}
     # Uncomment below later when E2E test cases include native yield functionality.
-    # if: ${{ always() && (inputs.native_yield_automation_service_changed == 'true' || inputs.native_yield_automation_service_image_tagged != 'true') }}
+    # if: ${{ always() && (inputs.native_yield_automation_service_changed == 'true' || (inputs.push_image == 'true' && inputs.native_yield_automation_service_image_tagged != 'true')) }}
     with:
       commit_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}
@@ -87,7 +87,7 @@ jobs:
 
   prover:
     uses: ./.github/workflows/prover-build-and-publish.yml
-    if: ${{ always() && (inputs.prover_changed == 'true' || inputs.prover_image_tagged != 'true') }}
+    if: ${{ always() && (inputs.prover_changed == 'true' || (inputs.push_image == 'true' && inputs.prover_image_tagged != 'true')) }}
     with:
       commit_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}
@@ -97,7 +97,7 @@ jobs:
 
   postman:
     uses: ./.github/workflows/postman-build-and-publish.yml
-    if: ${{ always() && (inputs.postman_changed == 'true' || inputs.postman_image_tagged != 'true') }}
+    if: ${{ always() && (inputs.postman_changed == 'true' || (inputs.push_image == 'true' && inputs.postman_image_tagged != 'true')) }}
     with:
       commit_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}
@@ -107,7 +107,7 @@ jobs:
 
   transaction_exclusion_api:
     uses: ./.github/workflows/transaction-exclusion-api-build-and-publish.yml
-    if: ${{ always() && (inputs.transaction_exclusion_api_changed == 'true' || inputs.transaction_exclusion_api_image_tagged != 'true') }}
+    if: ${{ always() && (inputs.transaction_exclusion_api_changed == 'true' || (inputs.push_image == 'true' && inputs.transaction_exclusion_api_image_tagged != 'true')) }}
     with:
       commit_tag: ${{ inputs.commit_tag }}
       develop_tag: ${{ inputs.develop_tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,6 +230,7 @@ jobs:
   run-e2e-tests:
     needs:
       [
+        filter-commit-changes,
         check-and-tag-images,
         docker-build,
         get-has-changes-requiring-e2e-testing,
@@ -247,6 +248,10 @@ jobs:
       expected_traces_api_version: ${{ needs.docker-build.outputs.expected_traces_api_version }}
       e2e-tests-logs-dump: true
       has-changes-requiring-e2e-testing: ${{ needs.get-has-changes-requiring-e2e-testing.outputs.has-changes-requiring-e2e-testing }}
+      coordinator_changed: ${{ needs.filter-commit-changes.outputs.coordinator }}
+      postman_changed: ${{ needs.filter-commit-changes.outputs.postman }}
+      prover_changed: ${{ needs.filter-commit-changes.outputs.prover }}
+      transaction_exclusion_api_changed: ${{ needs.filter-commit-changes.outputs.transaction-exclusion-api }}
     secrets: inherit
 
   publish-images-after-run-tests-success-on-main:

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -56,6 +56,18 @@ on:
         default: true
       has-changes-requiring-e2e-testing:
         type: string
+      coordinator_changed:
+        required: true
+        type: string
+      postman_changed:
+        required: true
+        type: string
+      prover_changed:
+        required: true
+        type: string
+      transaction_exclusion_api_changed:
+        required: true
+        type: string
     outputs:
       tests_outcome:
         value: ${{ jobs.run-e2e-tests.outputs.tests_outcome }}
@@ -71,10 +83,10 @@ jobs:
     # We can only use conditionals, and not path filters to 'successfully' skip a required job - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     if: ${{ inputs.has-changes-requiring-e2e-testing == 'true' }}
     env:
-      COORDINATOR_TAG: ${{ inputs.commit_tag }}
-      POSTMAN_TAG: ${{ inputs.commit_tag }}
-      PROVER_TAG: ${{ inputs.commit_tag }}
-      TRANSACTION_EXCLUSION_API_TAG: ${{ inputs.commit_tag }}
+      COORDINATOR_TAG: ${{ inputs.coordinator_changed == 'true' && inputs.commit_tag || '' }}
+      POSTMAN_TAG: ${{ inputs.postman_changed == 'true' && inputs.commit_tag || '' }}
+      PROVER_TAG: ${{ inputs.prover_changed == 'true' && inputs.commit_tag || '' }}
+      TRANSACTION_EXCLUSION_API_TAG: ${{ inputs.transaction_exclusion_api_changed == 'true' && inputs.commit_tag || '' }}
       BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
       EXPECTED_TRACES_API_VERSION: ${{ inputs.expected_traces_api_version }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -119,11 +131,12 @@ jobs:
           pattern: linea-*
       - name: Load Docker images
         run: |
-          pwd && ls -la && echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" &&
-          gunzip -c $GITHUB_WORKSPACE/linea-coordinator/linea-coordinator-docker-image.tar.gz | docker load &&
-          gunzip -c $GITHUB_WORKSPACE/linea-postman/linea-postman-docker-image.tar.gz | docker load &&
-          gunzip -c $GITHUB_WORKSPACE/linea-prover/linea-prover-docker-image.tar.gz | docker load &&
-          gunzip -c $GITHUB_WORKSPACE/linea-transaction-exclusion-api/linea-transaction-exclusion-api-docker-image.tar.gz | docker load
+          pwd && ls -la && echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          gunzip -c $GITHUB_WORKSPACE/linea-coordinator/linea-coordinator-docker-image.tar.gz | docker load || true
+          gunzip -c $GITHUB_WORKSPACE/linea-postman/linea-postman-docker-image.tar.gz | docker load || true
+          gunzip -c $GITHUB_WORKSPACE/linea-prover/linea-prover-docker-image.tar.gz | docker load || true
+          gunzip -c $GITHUB_WORKSPACE/linea-transaction-exclusion-api/linea-transaction-exclusion-api-docker-image.tar.gz | docker load || true
+          echo "Done attempting to load docker images"
         shell: bash
       - name: Load linea-besu-package Docker image
         if: ${{ inputs.linea_besu_package_tag != '' }}


### PR DESCRIPTION
… without able to find the image with last commit tag

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI control flow for when images are built/pushed and which tags E2E uses, so misconfigured conditions could skip needed builds or test the wrong images. No application/runtime code is modified.
> 
> **Overview**
> Optimizes CI to **only build component images when the component changed**, while still allowing main-branch publishing to rebuild *only if pushing* and the image wasn’t previously tagged.
> 
> Updates the E2E reusable workflow to receive per-component `*_changed` flags and set `*_TAG` env vars to the commit tag only when that component changed; Docker image loading now tolerates missing artifacts (`docker load || true`) so E2E can proceed when an image wasn’t built.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28e5da89e0088b9ef5237fc61d797a06696a40b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->