### PR TITLE
fix: replace require with if statement in SparseMerkleProof contract

### DIFF
--- a/contracts/src/libraries/SparseMerkleProof.sol
+++ b/contracts/src/libraries/SparseMerkleProof.sol
@@ -263,7 +263,9 @@ library SparseMerkleProof {
       else computedHash = Poseidon2.hash(abi.encodePacked(computedHash, _proof[height]));
     }
 
-    require(computedHash == _subSmtRoot, SubSmtRootMismatch(_subSmtRoot, computedHash));
+    if (computedHash != _subSmtRoot) {
+      revert SubSmtRootMismatch(_subSmtRoot, computedHash);
+    }
 
     return Poseidon2.hash(abi.encodePacked(_nextFreeNode, computedHash)) == _root;
   }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is effectively unchanged; it just switches from `require` to an explicit `if` + `revert` for the subtree root check in proof verification.
> 
> **Overview**
> Updates `SparseMerkleProof._verify` to replace the `require(computedHash == _subSmtRoot, ...)` check with an explicit `if` condition that `revert`s `SubSmtRootMismatch` when the computed subtree root doesn’t match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa26b5e79ed557bffef64bbf46e17f51d17c537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->