### PR TITLE
[Coordinator] Invalidity proof client

### DIFF
--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedExecutionProverClientV2.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedExecutionProverClientV2.kt
@@ -123,6 +123,12 @@ class FileBasedExecutionProverClientV2(
     requestFileNameProvider = executionProofRequestFileNameProvider,
     responseFileNameProvider = executionProofResponseFileNameProvider,
     requestMapper = ExecutionProofRequestDtoMapper(),
+    proofIndexProvider = { request ->
+      ProofIndex(
+        startBlockNumber = request.startBlockNumber,
+        endBlockNumber = request.endBlockNumber,
+      )
+    },
     responseMapper = { throw UnsupportedOperationException("Batch execution proof response shall not be parsed!") },
     proofTypeLabel = "batch",
     log = LogManager.getLogger(FileBasedExecutionProverClientV2::class.java),

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
@@ -1,0 +1,113 @@
+package net.consensys.zkevm.coordinator.clients.prover
+
+import build.linea.clients.LineaAccountProof
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import io.vertx.core.Vertx
+import linea.kotlin.encodeHex
+import net.consensys.zkevm.coordinator.clients.InvalidityProofRequest
+import net.consensys.zkevm.coordinator.clients.InvalidityProofResponse
+import net.consensys.zkevm.coordinator.clients.InvalidityProverClientV1
+import net.consensys.zkevm.coordinator.clients.prover.serialization.JsonSerialization
+import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.fileio.FileReader
+import net.consensys.zkevm.fileio.FileWriter
+import org.apache.logging.log4j.LogManager
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.nio.file.Path
+
+data class InvalidityProofRequestDto(
+  val ftxRLP: String,
+  val ftxNumber: Long,
+  val prevFtxRollingHash: String,
+  val ftxBlockNumberDeadline: Long,
+  val invalidityType: String,
+  val zkParentStateRootHash: String,
+  val conflatedExecutionTracesFile: String,
+  val accountProof: AccountProofDto?,
+  val zkStateMerkleProof: ArrayNode?,
+  val simulatedExecutionBlockNumber: Long,
+  val simulatedExecutionBlockTimestamp: Long,
+) {
+  companion object {
+    fun fromDomainObject(invalidityProofRequest: InvalidityProofRequest): InvalidityProofRequestDto {
+      return InvalidityProofRequestDto(
+        ftxRLP = invalidityProofRequest.ftxRlp.encodeHex(),
+        ftxNumber = invalidityProofRequest.ftxNumber.toLong(),
+        prevFtxRollingHash = invalidityProofRequest.prevFtxRollingHash.encodeHex(),
+        ftxBlockNumberDeadline = invalidityProofRequest.ftxBlockNumberDeadline.toLong(),
+        invalidityType = invalidityProofRequest.invalidityReason.name,
+        zkParentStateRootHash = invalidityProofRequest.zkParentStateRootHash.encodeHex(),
+        conflatedExecutionTracesFile = invalidityProofRequest.tracesResponse.tracesFileName,
+        accountProof = invalidityProofRequest.accountProof?.let {
+          AccountProofDto.fromDomainObject(it)
+        },
+        zkStateMerkleProof = invalidityProofRequest.zkStateMerkleProof?.zkStateMerkleProof,
+        simulatedExecutionBlockNumber = invalidityProofRequest.simulatedExecutionBlockNumber.toLong(),
+        simulatedExecutionBlockTimestamp = invalidityProofRequest.simulatedExecutionBlockTimestamp.epochSeconds,
+      )
+    }
+  }
+}
+
+data class AccountProofDto(val accountProof: String) {
+  companion object {
+    fun fromDomainObject(lineaAccountProof: LineaAccountProof): AccountProofDto {
+      return AccountProofDto(
+        accountProof = lineaAccountProof.accountProof.encodeHex(),
+      )
+    }
+  }
+}
+
+class FileBasedInvalidityProverClient(
+  val config: FileBasedProverConfig,
+  val vertx: Vertx,
+  jsonObjectMapper: ObjectMapper = JsonSerialization.proofResponseMapperV1,
+) :
+  GenericFileBasedProverClient<
+    InvalidityProofRequest,
+    InvalidityProofResponse,
+    InvalidityProofRequestDto,
+    InvalidityProofResponse,
+    >(
+    config = config,
+    vertx = vertx,
+    fileWriter = FileWriter(vertx, jsonObjectMapper),
+    fileReader = FileReader(
+      vertx,
+      jsonObjectMapper,
+      InvalidityProofResponse::class.java,
+    ),
+    requestFileNameProvider = InvalidityProofFileNameProvider,
+    responseFileNameProvider = InvalidityProofFileNameProvider,
+    proofIndexProvider = FileBasedInvalidityProverClient::invalidityProofIndex,
+    requestMapper = {
+        invalidityProofRequest ->
+      SafeFuture.completedFuture(
+        InvalidityProofRequestDto.fromDomainObject(invalidityProofRequest),
+      )
+    },
+    responseMapper = { throw UnsupportedOperationException("Invalidity proof response will not be parsed!") },
+    proofTypeLabel = "invalidity",
+    log = LogManager.getLogger(FileBasedInvalidityProverClient::class.java),
+  ),
+  InvalidityProverClientV1 {
+  override fun parseResponse(responseFilePath: Path, proofIndex: ProofIndex): SafeFuture<InvalidityProofResponse> {
+    return SafeFuture.completedFuture(
+      InvalidityProofResponse(
+        ftxNumber = proofIndex.endBlockNumber,
+      ),
+    )
+  }
+
+  companion object {
+    fun invalidityProofIndex(request: InvalidityProofRequest): ProofIndex {
+      return ProofIndex(
+        startBlockNumber = request.simulatedExecutionBlockNumber,
+        endBlockNumber = request.ftxNumber,
+        hash = request.ftxHash,
+      )
+    }
+  }
+}

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
@@ -4,7 +4,6 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import io.vertx.core.Vertx
-import linea.domain.BlockInterval
 import net.consensys.linea.errors.ErrorResponse
 import net.consensys.zkevm.coordinator.clients.ProverProofRequestCreator
 import net.consensys.zkevm.coordinator.clients.ProverProofResponseChecker
@@ -32,13 +31,13 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
     vertx,
     FileMonitor.Config(config.pollingInterval, config.pollingTimeout),
   ),
-  private val proofIndexProvider: (Request) -> ProofIndex = ::blockIntervalProofIndex,
+  private val proofIndexProvider: (Request) -> ProofIndex,
   private val requestMapper: (Request) -> SafeFuture<RequestDto>,
   private val responseMapper: (ResponseDto) -> Response,
   private val proofTypeLabel: String,
   private val log: Logger = LogManager.getLogger(GenericFileBasedProverClient::class.java),
 ) : ProverProofResponseChecker<Response>, Supplier<Number>, ProverProofRequestCreator<Request>
-  where Request : BlockInterval,
+  where Request : Any,
         Response : Any,
         RequestDto : Any,
         ResponseDto : Any {
@@ -183,13 +182,6 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
   }
 
   companion object {
-    fun <R : BlockInterval> blockIntervalProofIndex(request: R): ProofIndex {
-      return ProofIndex(
-        startBlockNumber = request.startBlockNumber,
-        endBlockNumber = request.endBlockNumber,
-      )
-    }
-
     fun createDirectoryIfNotExists(
       directory: Path,
       log: Logger = LogManager.getLogger(GenericFileBasedProverClient::class.java),

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvider.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvider.kt
@@ -26,6 +26,7 @@ object FileNameSuffixes {
   const val EXECUTION_PROOF_SUFFIX = "getZkProof.json"
   const val COMPRESSION_PROOF_SUFFIX = "getZkBlobCompressionProof.json"
   const val AGGREGATION_PROOF_SUFFIX = "getZkAggregatedProof.json"
+  const val INVALIDITY_PROOF_SUFFIX = "getZkInvalidityProof.json"
 }
 
 class ExecutionProofRequestFileNameProvider(
@@ -54,3 +55,9 @@ object CompressionProofRequestFileNameProvider : ProverFileNameProvider(FileName
 object CompressionProofResponseFileNameProvider : ProverFileNameProvider(FileNameSuffixes.COMPRESSION_PROOF_SUFFIX)
 
 object AggregationProofFileNameProvider : ProverFileNameProvider(FileNameSuffixes.AGGREGATION_PROOF_SUFFIX)
+
+object InvalidityProofFileNameProvider : ProverFileNameProvider(FileNameSuffixes.INVALIDITY_PROOF_SUFFIX) {
+  override fun getFileName(proofIndex: ProofIndex): String {
+    return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}-$fileNameSuffix"
+  }
+}

--- a/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClientTest.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClientTest.kt
@@ -76,6 +76,12 @@ class GenericFileBasedProverClientTest {
       requestMapper = { SafeFuture.completedFuture(ProofRequestDto.fromDomain(it)) },
       proofTypeLabel = "batch",
       responseMapper = ProofResponseDto::toDomain,
+      proofIndexProvider = { request ->
+        ProofIndex(
+          startBlockNumber = request.startBlockNumber,
+          endBlockNumber = request.endBlockNumber,
+        )
+      },
     )
   }
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/InvalidtyProofRequestResponse.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/InvalidtyProofRequestResponse.kt
@@ -18,7 +18,7 @@ data class InvalidityProofRequest(
   val simulatedExecutionBlockTimestamp: Instant,
   val ftxNumber: ULong,
   val ftxBlockNumberDeadline: ULong,
-  val ftxHash: ByteArray, // necessary for file name
+  val ftxHash: ByteArray,
   val ftxRlp: ByteArray,
   val prevFtxRollingHash: ByteArray,
   val parentBlockHash: ByteArray,


### PR DESCRIPTION
This PR implements issue(s) #2102 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the generic file-based prover client contract (removing `BlockInterval` constraint and requiring a `proofIndexProvider`), which can affect all file-based prover integrations and file naming consistency.
> 
> **Overview**
> Adds a new file-based `InvalidityProverClientV1` that writes `InvalidityProofRequest` payloads to disk (including optional account/state proofs) and waits for `getZkInvalidityProof.json` responses, using an `InvalidityProofFileNameProvider`.
> 
> Refactors `GenericFileBasedProverClient` to accept any request type and require an explicit `proofIndexProvider` instead of assuming `BlockInterval`; updates the execution prover client and `GenericFileBasedProverClientTest` to supply this provider, and introduces the invalidity proof filename suffix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5945cf2fcd15836d7e2432236fb16ea65562555f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->