### PR TITLE
fix: update natspecs for Poseidon2 and SparseMerkleProof contracts

### DIFF
--- a/contracts/src/libraries/Poseidon2.sol
+++ b/contracts/src/libraries/Poseidon2.sol
@@ -83,7 +83,7 @@ library Poseidon2 {
       }
 
       /**
-       * @dev Poseidon2 permutation over a 2-element state (ra, rb).
+       * @dev Poseidon2 permutation over a 16-element state (ra, rb).
        *
        * The permutation consists of:
        *  1. Initial external MDS mixing
@@ -91,7 +91,7 @@ library Poseidon2 {
        *  3. 21 partial rounds
        *  4. 3 final full rounds
        *
-       * Each round follows the Poseidon2 specification for t = 2.
+       * Each round follows the Poseidon2 specification for t = 16.
        *
        * @param a First state element (capacity/output lane)
        * @param b Second state element (rate/input lane)

--- a/contracts/src/libraries/SparseMerkleProof.sol
+++ b/contracts/src/libraries/SparseMerkleProof.sol
@@ -103,7 +103,7 @@ library SparseMerkleProof {
 
   /**
    * @notice Get account.
-   * @param _encodedAccountValue Encoded account value bytes (nonce, balance, storageRoot, mimcCodeHash, keccakCodeHash, codeSize).
+   * @param _encodedAccountValue Encoded account value bytes (nonce, balance, storageRoot, snarkCodeHash, keccakCodeHash, codeSize).
    * @return Account Formatted account struct.
    */
   function getAccount(bytes calldata _encodedAccountValue) external pure returns (Account memory) {
@@ -112,7 +112,7 @@ library SparseMerkleProof {
 
   /**
    * @notice Hash account value.
-   * @param _value Encoded account value bytes (nonce, balance, storageRoot, mimcCodeHash, keccakCodeHash, codeSize).
+   * @param _value Encoded account value bytes (nonce, balance, storageRoot, snarkCodeHash, keccakCodeHash, codeSize).
    * @return bytes32 Account value hash.
    */
   function hashAccountValue(bytes calldata _value) external pure returns (bytes32) {
@@ -154,7 +154,7 @@ library SparseMerkleProof {
 
   /**
    * @notice Parse account value.
-   * @param _value Encoded account value bytes (nonce, balance, storageRoot, mimcCodeHash, keccakCodeHash, codeSize).
+   * @param _value Encoded account value bytes (nonce, balance, storageRoot, snarkCodeHash, keccakCodeHash, codeSize).
    * @return Account Formatted account struct.
    */
   function _parseAccount(bytes calldata _value) private pure returns (Account memory) {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates to NatSpec docs; no functional or bytecode-changing logic is modified, so runtime risk is minimal.
> 
> **Overview**
> Updates NatSpec comments in `Poseidon2.sol` to reference the correct Poseidon2 parameterization (`t = 16` / 16-element state) for the `permutation` description.
> 
> Adjusts NatSpec in `SparseMerkleProof.sol` to rename the documented account field from `mimcCodeHash` to `snarkCodeHash` in account parsing/hashing documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec0deddbb46c8062fb1261f9c938833f5664bf8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->