### PR TITLE
Revert "[ZkTracer] EIP-7702 in STP"

### DIFF
--- a/tracer-constraints/hub/osaka/columns/miscellaneous.lisp
+++ b/tracer-constraints/hub/osaka/columns/miscellaneous.lisp
@@ -35,8 +35,8 @@
 
 		 ;; MXP colummns
 		 ( MXP_INST                     :byte   )
-		 ( MXP_MXPX                     :binary )
-		 ( MXP_DEPLOYS                  :binary )
+		 ( MXP_MXPX                     :binary ) 
+		 ( MXP_DEPLOYS                  :binary ) 
 		 ( MXP_OFFSET_1_HI              :i128 )
 		 ( MXP_OFFSET_1_LO              :i128 )
 		 ( MXP_OFFSET_2_HI              :i128 )
@@ -60,19 +60,15 @@
 		 ( STP_GAS_LO                    :i128 )
 		 ( STP_VALUE_HI                  :i128 )
 		 ( STP_VALUE_LO                  :i128 )
-		 ( STP_EXISTS                    :binary)
-		 ( STP_WARMTH                    :binary)
-		 ( STP_OOGX                      :binary)
+		 ( STP_EXISTS                    :binary)  
+		 ( STP_WARMTH                    :binary)  
+		 ( STP_OOGX                      :binary)  
 		 ( STP_GAS_MXP                   :i64 )
 		 ( STP_GAS_UPFRONT_GAS_COST      :i64 )
 		 ( STP_GAS_PAID_OUT_OF_POCKET    :i64 )
-		 ( STP_GAS_STIPEND               :i12 )
-		 ( STP_CALLEE_IS_DELEGATED       :binary )
-		 ( STP_CALLEE_IS_DELEGATED_TO_SELF  :binary )
-		 ( STP_DELEGATE_WARMTH       :binary )
-
+		 ( STP_GAS_STIPEND               :i12 )   
 
 		 ;; ``truly'' miscellaneous columns
-		 ( CCSR_FLAG                           :binary)  ;; Child Context Self Reverts Flag;
+		 ( CCSR_FLAG                           :binary)  ;; Child Context Self Reverts Flag; 
 		 ( CCRS_STAMP                          :i32 )    ;; Child Context Revert Stamp
 		 ))

--- a/tracer-constraints/hub/osaka/lookups/hub_into_stp.lisp
+++ b/tracer-constraints/hub/osaka/lookups/hub_into_stp.lisp
@@ -16,9 +16,6 @@
     stp.GAS_MXP
     stp.GAS_OOP
     stp.GAS_STIPEND
-    stp.CALLEE_IS_DELEGATED
-    stp.CALLEE_IS_DELEGATED_TO_SELF
-    stp.DELEGATE_WARMTH
   )
   ;; source selector
   (hub-into-stp-trigger)
@@ -35,9 +32,6 @@
     hub.misc/STP_GAS_MXP
     hub.misc/STP_GAS_PAID_OUT_OF_POCKET
     hub.misc/STP_GAS_STIPEND
-    hub.misc/STP_CALLEE_IS_DELEGATED
-    hub.misc/STP_CALLEE_IS_DELEGATED_TO_SELF
-    hub.misc/STP_DELEGATE_WARMTH
   )
   )
 

--- a/tracer-constraints/stp/stp.zkasm
+++ b/tracer-constraints/stp/stp.zkasm
@@ -22,9 +22,7 @@ include "../constants/evm.zkasm"
 ;; Finally, EXISTS indicates for a CALL instruction whether target
 ;; account exists already, and WARM indicates whether the target
 ;; account for a call instruction is warm (or not).
-pub fn stp(INST=0xf0 u8, GAS_ACTUAL u64, GAS_MXP u64, GAS u256, VALUE u256, EXISTS u1, WARM u1,
-CALLEE_IS_DELEGATED u1, CALLEE_IS_DELEGATED_TO_SELF u1, DELEGATE_WARMTH u1)
--> (OOGX=1 u1, GAS_UPFRONT=32000 u64, GAS_OOP u64, GAS_STIPEND u64)
+pub fn stp(INST=0xf0 u8, GAS_ACTUAL u64, GAS_MXP u64, GAS u256, VALUE u256, EXISTS u1, WARM u1) -> (OOGX=1 u1, GAS_UPFRONT=32000 u64, GAS_OOP u64, GAS_STIPEND u64)
 ;; PRE: GAS_UPFRONT calculation does not overflow.
 {
   var L_gas_diff u64
@@ -36,7 +34,7 @@ CALLEE_IS_DELEGATED u1, CALLEE_IS_DELEGATED_TO_SELF u1, DELEGATE_WARMTH u1)
   ;; ===========================================================================
   ;; CALL / CALLCODE / DELEGATECALL / STATICCALL
   ;; ===========================================================================
-  gas_extra, stipend = call_gas_extra(INST, VALUE, WARM, EXISTS, CALLEE_IS_DELEGATED, CALLEE_IS_DELEGATED_TO_SELF, DELEGATE_WARMTH)
+  gas_extra, stipend = call_gas_extra(INST, VALUE, WARM, EXISTS)
   ;; determine upfront cost for call
   c, GAS_UPFRONT = GAS_MXP + gas_extra
   ;; sanity check precondition
@@ -73,9 +71,7 @@ failed_pre:
 ;; transfering value) and computes the gas stipend for the caller
 ;; context.  The logic of this function is essentially determined by
 ;; the yellow paper.
-fn call_gas_extra(inst=0xf1 u8, value u256, warm u1, exists u1,
-callee_is_delegated u1, callee_is_delegated_to_self u1, delegate_warmth u1)
- -> (gas_extra=2600 u64, stipend u64)
+fn call_gas_extra(inst=0xf1 u8, value u256, warm u1, exists u1) -> (gas_extra=2600 u64, stipend u64)
 ;; PRE: inst in {0xf1,0xf2,0xf4,0xf5]
 {
   var gas_access u16
@@ -83,22 +79,8 @@ callee_is_delegated u1, callee_is_delegated_to_self u1, delegate_warmth u1)
   ;; inversions
   notWarm = 1 - warm
   notExists = 1 - exists
-
-  ;; delegate access bit
-  ;; extra_delegation_warming_cost := if CALLEE_IS_DELEGATED then:
-  ;;       CALLEE_IS_DELEGATED_TO_SELF  ? G_WARM_ACCESS
-  ;;                                    : (DELEGATE_WARMTH ? G_WARM_ACCESS : G_COLD_ACCESS)
-  ;;       else: 0;
-
-;; TODO: TMP check to remove once 7702 is fully implemented:
-if callee_is_delegated != 0 goto exit_fail
-
-  var delegate_to_other, delegate_hot_access, delegate_cold_access, tmp u1
-  delegate_to_other = callee_is_delegated * (1 - callee_is_delegated_to_self)
-  delegate_cold_access = delegate_to_other * (1 - delegate_warmth)
-  tmp, delegate_hot_access = callee_is_delegated - delegate_cold_access ;; can't overflow
   ;; calculate gas access cost
-  gas_access = ((warm + delegate_hot_access) * G_WARMACCESS) + ((notWarm + delegate_cold_access)  * G_COLDACCOUNTACCESS)
+  gas_access = (warm * G_WARMACCESS) + (notWarm * G_COLDACCOUNTACCESS)
   ;;
   if value == 0 goto call_no_transfer
   if inst == EVM_INST_CALL goto call
@@ -117,8 +99,6 @@ call_no_transfer:
   stipend=0
   gas_extra = gas_access
   return
- exit_fail:
- fail
 }
 
 ;; Determine either: (a) the gas taken immediately when a call /


### PR DESCRIPTION
Reverts Consensys/linea-monorepo#2122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CALL gas accounting by removing delegation-related flags and reverting to warm/cold access-only costs, which can affect trace validity if any 7702 paths are still expected. Scope is limited to STP wiring and gas-extra computation, with no broader system changes.
> 
> **Overview**
> This PR **reverts the STP EIP-7702 delegation wiring** by removing delegation-related fields from the hub→STP lookup and from the `stp`/`call_gas_extra` function signatures.
> 
> `call_gas_extra` is simplified back to using only `WARM`/`EXISTS` for access gas, dropping the delegation-warmth cost branch (and its fail-fast check). Minor whitespace-only formatting changes are also included in `miscellaneous.lisp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88356ccee1284b0b958427616a88b566f9a2314c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->