### PR TITLE
[Coordinator] Refactor ProofIndex

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -24,7 +24,7 @@ import net.consensys.zkevm.coordinator.blockcreation.LastProvenBlockNumberProvid
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.coordinator.clients.prover.ProverClientFactory
 import net.consensys.zkevm.coordinator.clients.prover.ProverConfig
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobShnarfMetaData
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
@@ -77,7 +77,7 @@ class ConflationBacktestingApp(
   fun isConflationBacktestingComplete(): Boolean = conflationBacktestingComplete.load()
 
   fun onConflationProgress(
-    proofIndex: ProofIndex,
+    proofIndex: CompressionProofIndex,
   ): SafeFuture<*> {
     return if (proofIndex.endBlockNumber == conflationBacktestingAppConfig.endBlockNumber) {
       conflationBacktestingComplete.store(true)

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ABProverClientRouter.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ABProverClientRouter.kt
@@ -1,38 +1,60 @@
 package net.consensys.zkevm.coordinator.clients.prover
 
-import linea.domain.BlockInterval
+import net.consensys.zkevm.coordinator.clients.BatchExecutionProofRequestV1
+import net.consensys.zkevm.coordinator.clients.BlobCompressionProofRequest
+import net.consensys.zkevm.coordinator.clients.InvalidityProofRequest
 import net.consensys.zkevm.coordinator.clients.ProverClient
+import net.consensys.zkevm.domain.AggregationProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
+import net.consensys.zkevm.domain.InvalidityProofIndex
 import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.ProofsToAggregate
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 class StartBlockNumberBasedSwitchPredicate(
   private val switchStartBlockNumberInclusive: ULong,
 ) {
-  fun invoke(proofRequest: BlockInterval): Boolean = proofRequest.startBlockNumber >= switchStartBlockNumberInclusive
+  fun invoke(proofRequestOrIndex: Any): Boolean {
+    val startBlockNumber = when (proofRequestOrIndex) {
+      is BatchExecutionProofRequestV1 -> proofRequestOrIndex.startBlockNumber
+      is BlobCompressionProofRequest -> proofRequestOrIndex.startBlockNumber
+      is ProofsToAggregate -> proofRequestOrIndex.startBlockNumber
+      is InvalidityProofRequest -> proofRequestOrIndex.simulatedExecutionBlockNumber
+      is ExecutionProofIndex -> proofRequestOrIndex.startBlockNumber
+      is CompressionProofIndex -> proofRequestOrIndex.startBlockNumber
+      is AggregationProofIndex -> proofRequestOrIndex.startBlockNumber
+      is InvalidityProofIndex -> proofRequestOrIndex.simulatedExecutionBlockNumber
+      else ->
+        throw IllegalArgumentException("Unsupported proof request or index type: ${proofRequestOrIndex::class}")
+    }
+    return startBlockNumber >= switchStartBlockNumberInclusive
+  }
 }
 
-class ABProverClientRouter<ProofRequest, ProofResponse>(
-  private val proverA: ProverClient<ProofRequest, ProofResponse>,
-  private val proverB: ProverClient<ProofRequest, ProofResponse>,
-  private val switchToProverBPredicate: (BlockInterval) -> Boolean,
-) : ProverClient<ProofRequest, ProofResponse> where ProofRequest : BlockInterval {
+class ABProverClientRouter<ProofRequest : Any, ProofResponse, TProofIndex : ProofIndex>(
+  private val proverA: ProverClient<ProofRequest, ProofResponse, TProofIndex>,
+  private val proverB: ProverClient<ProofRequest, ProofResponse, TProofIndex>,
+  private val switchToProverBPredicate: (Any) -> Boolean,
+) : ProverClient<ProofRequest, ProofResponse, TProofIndex> {
 
-  private fun getProver(blockInterval: BlockInterval): ProverClient<ProofRequest, ProofResponse> {
-    if (switchToProverBPredicate(blockInterval)) {
-      return proverB
+  private fun getProver(proofRequest: Any): ProverClient<ProofRequest, ProofResponse, TProofIndex> {
+    return if (switchToProverBPredicate(proofRequest)) {
+      proverB
     } else {
-      return proverA
+      proverA
     }
   }
-  override fun findProofResponse(proofRequestId: ProofIndex): SafeFuture<ProofResponse?> {
-    return getProver(proofRequestId).findProofResponse(proofRequestId)
+
+  override fun findProofResponse(proofIndex: TProofIndex): SafeFuture<ProofResponse?> {
+    return getProver(proofIndex).findProofResponse(proofIndex)
   }
 
   override fun requestProof(proofRequest: ProofRequest): SafeFuture<ProofResponse> {
     return getProver(proofRequest).requestProof(proofRequest)
   }
 
-  override fun createProofRequest(proofRequest: ProofRequest): SafeFuture<ProofIndex> {
+  override fun createProofRequest(proofRequest: ProofRequest): SafeFuture<TProofIndex> {
     return getProver(proofRequest).createProofRequest(proofRequest)
   }
 }

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedBlobCompressionProverClientV2.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedBlobCompressionProverClientV2.kt
@@ -8,7 +8,7 @@ import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
 import net.consensys.zkevm.coordinator.clients.prover.serialization.BlobCompressionProofJsonRequest
 import net.consensys.zkevm.coordinator.clients.prover.serialization.BlobCompressionProofJsonResponse
 import net.consensys.zkevm.coordinator.clients.prover.serialization.JsonSerialization
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.fileio.FileReader
 import net.consensys.zkevm.fileio.FileWriter
 import org.apache.logging.log4j.LogManager
@@ -37,6 +37,7 @@ class FileBasedBlobCompressionProverClientV2(
     BlobCompressionProof,
     BlobCompressionProofJsonRequest,
     BlobCompressionProofJsonResponse,
+    CompressionProofIndex,
     >(
     config = config,
     vertx = vertx,
@@ -59,8 +60,8 @@ class FileBasedBlobCompressionProverClientV2(
   companion object {
     val LOG: Logger = LogManager.getLogger(FileBasedBlobCompressionProverClientV2::class.java)
 
-    fun blobFileIndex(request: BlobCompressionProofRequest): ProofIndex {
-      return ProofIndex(
+    fun blobFileIndex(request: BlobCompressionProofRequest): CompressionProofIndex {
+      return CompressionProofIndex(
         startBlockNumber = request.startBlockNumber,
         endBlockNumber = request.endBlockNumber,
         hash = request.expectedShnarfResult.expectedShnarf,

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
@@ -9,7 +9,7 @@ import net.consensys.zkevm.coordinator.clients.InvalidityProofRequest
 import net.consensys.zkevm.coordinator.clients.InvalidityProofResponse
 import net.consensys.zkevm.coordinator.clients.InvalidityProverClientV1
 import net.consensys.zkevm.coordinator.clients.prover.serialization.JsonSerialization
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.InvalidityProofIndex
 import net.consensys.zkevm.fileio.FileReader
 import net.consensys.zkevm.fileio.FileWriter
 import org.apache.logging.log4j.LogManager
@@ -70,6 +70,7 @@ class FileBasedInvalidityProverClient(
     InvalidityProofResponse,
     InvalidityProofRequestDto,
     InvalidityProofResponse,
+    InvalidityProofIndex,
     >(
     config = config,
     vertx = vertx,
@@ -93,20 +94,22 @@ class FileBasedInvalidityProverClient(
     log = LogManager.getLogger(FileBasedInvalidityProverClient::class.java),
   ),
   InvalidityProverClientV1 {
-  override fun parseResponse(responseFilePath: Path, proofIndex: ProofIndex): SafeFuture<InvalidityProofResponse> {
+  override fun parseResponse(
+    responseFilePath: Path,
+    proofIndex: InvalidityProofIndex,
+  ): SafeFuture<InvalidityProofResponse> {
     return SafeFuture.completedFuture(
       InvalidityProofResponse(
-        ftxNumber = proofIndex.endBlockNumber,
+        ftxNumber = proofIndex.ftxNumber,
       ),
     )
   }
 
   companion object {
-    fun invalidityProofIndex(request: InvalidityProofRequest): ProofIndex {
-      return ProofIndex(
-        startBlockNumber = request.simulatedExecutionBlockNumber,
-        endBlockNumber = request.ftxNumber,
-        hash = request.ftxHash,
+    fun invalidityProofIndex(request: InvalidityProofRequest): InvalidityProofIndex {
+      return InvalidityProofIndex(
+        simulatedExecutionBlockNumber = request.simulatedExecutionBlockNumber,
+        ftxNumber = request.ftxNumber,
       )
     }
   }

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
@@ -20,27 +20,24 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.function.Supplier
 import kotlin.io.path.notExists
 
-open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseDto>(
+open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseDto, TProofIndex>(
   private val config: FileBasedProverConfig,
   private val vertx: Vertx,
   private val fileWriter: FileWriter,
   private val fileReader: FileReader<ResponseDto>,
-  private val requestFileNameProvider: ProverFileNameProvider,
-  private val responseFileNameProvider: ProverFileNameProvider,
+  private val requestFileNameProvider: ProverFileNameProvider<TProofIndex>,
+  private val responseFileNameProvider: ProverFileNameProvider<TProofIndex>,
   private val fileMonitor: FileMonitor = FileMonitor(
     vertx,
     FileMonitor.Config(config.pollingInterval, config.pollingTimeout),
   ),
-  private val proofIndexProvider: (Request) -> ProofIndex,
+  private val proofIndexProvider: (Request) -> TProofIndex,
   private val requestMapper: (Request) -> SafeFuture<RequestDto>,
   private val responseMapper: (ResponseDto) -> Response,
   private val proofTypeLabel: String,
   private val log: Logger = LogManager.getLogger(GenericFileBasedProverClient::class.java),
-) : ProverProofResponseChecker<Response>, Supplier<Number>, ProverProofRequestCreator<Request>
-  where Request : Any,
-        Response : Any,
-        RequestDto : Any,
-        ResponseDto : Any {
+) : ProverProofResponseChecker<Response, TProofIndex>, Supplier<Number>, ProverProofRequestCreator<Request, TProofIndex>
+  where TProofIndex : ProofIndex, Request : Any, RequestDto : Any {
 
   init {
     createDirectoryIfNotExists(config.requestsDirectory, log)
@@ -50,7 +47,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
   private val responsesWaiting = AtomicLong(0)
   override fun get(): Long = responsesWaiting.get()
 
-  fun isResponseAlreadyDone(proofIndex: ProofIndex): SafeFuture<Path?> {
+  fun isResponseAlreadyDone(proofIndex: TProofIndex): SafeFuture<Path?> {
     val responseFilePath = config.responsesDirectory.resolve(responseFileNameProvider.getFileName(proofIndex))
     return fileMonitor
       .fileExists(responseFilePath)
@@ -59,7 +56,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
           log.debug(
             "request already proven: {}={} reusedResponse={}",
             proofTypeLabel,
-            proofIndex.intervalString(),
+            proofIndex,
             responseFilePath,
           )
           responseFilePath
@@ -69,16 +66,16 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
       }
   }
 
-  override fun findProofResponse(proofRequestId: ProofIndex): SafeFuture<Response?> {
-    return isResponseAlreadyDone(proofRequestId)
+  override fun findProofResponse(proofIndex: TProofIndex): SafeFuture<Response?> {
+    return isResponseAlreadyDone(proofIndex)
       .thenCompose { responseFilePath ->
         responseFilePath
-          ?.let { parseResponse(it, proofRequestId) }
+          ?.let { parseResponse(it, proofIndex) }
           ?: SafeFuture.completedFuture(null)
       }
   }
 
-  override fun createProofRequest(proofRequest: Request): SafeFuture<ProofIndex> {
+  override fun createProofRequest(proofRequest: Request): SafeFuture<TProofIndex> {
     val proofIndex = proofIndexProvider(proofRequest)
     val requestFileName = requestFileNameProvider.getFileName(proofIndex)
     val requestFilePath = config.requestsDirectory.resolve(requestFileName)
@@ -89,7 +86,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
           log.debug(
             "request already in file system: {}={} reusedRequest={}",
             proofTypeLabel,
-            proofIndex.intervalString(),
+            proofIndex,
             requestFileFound,
           )
           SafeFuture.completedFuture(proofIndex)
@@ -130,7 +127,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
         log.error(
           "Failed to get proof: {}={} errorMessage={}",
           proofTypeLabel,
-          proofIndex.intervalString(),
+          proofIndex,
           it.message,
           it,
         )
@@ -161,7 +158,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
     )
   }
 
-  protected open fun parseResponse(responseFilePath: Path, proofIndex: ProofIndex): SafeFuture<Response> {
+  protected open fun parseResponse(responseFilePath: Path, proofIndex: TProofIndex): SafeFuture<Response> {
     return fileReader.read(responseFilePath)
       .thenCompose { result ->
         result

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactory.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactory.kt
@@ -1,7 +1,6 @@
 package net.consensys.zkevm.coordinator.clients.prover
 
 import io.vertx.core.Vertx
-import linea.domain.BlockInterval
 import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.micrometer.GaugeAggregator
@@ -9,6 +8,7 @@ import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.coordinator.clients.ProofAggregationProverClientV2
 import net.consensys.zkevm.coordinator.clients.ProverClient
+import net.consensys.zkevm.domain.ProofIndex
 import org.apache.logging.log4j.Logger
 
 class ProverClientFactory(
@@ -96,13 +96,13 @@ class ProverClientFactory(
     }
   }
 
-  private fun <ProofRequest, ProofResponse> createClient(
+  private fun <ProofRequest, ProofResponse, TProofIndex> createClient(
     proverAConfig: FileBasedProverConfig,
     proverBConfig: FileBasedProverConfig?,
     switchBlockNumberInclusive: ULong?,
-    clientBuilder: (FileBasedProverConfig) -> ProverClient<ProofRequest, ProofResponse>,
-  ): ProverClient<ProofRequest, ProofResponse>
-    where ProofRequest : BlockInterval {
+    clientBuilder: (FileBasedProverConfig) -> ProverClient<ProofRequest, ProofResponse, TProofIndex>,
+  ): ProverClient<ProofRequest, ProofResponse, TProofIndex>
+    where ProofRequest : Any, TProofIndex : ProofIndex {
     return if (switchBlockNumberInclusive != null) {
       val switchPredicate = StartBlockNumberBasedSwitchPredicate(switchBlockNumberInclusive)
       ABProverClientRouter(

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvider.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvider.kt
@@ -1,25 +1,14 @@
 package net.consensys.zkevm.coordinator.clients.prover
 
 import linea.kotlin.encodeHex
+import net.consensys.zkevm.domain.AggregationProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
+import net.consensys.zkevm.domain.InvalidityProofIndex
 import net.consensys.zkevm.domain.ProofIndex
 
-open class ProverFileNameProvider(protected val fileNameSuffix: String) {
-  protected fun encodeHash(hash: ByteArray): String = hash.encodeHex(prefix = false)
-  private fun fileName(startBlockNumber: ULong, endBlockNumber: ULong, fileNameSuffix: String, hash: ByteArray?) =
-    if (hash == null || hash.isEmpty()) {
-      "$startBlockNumber-$endBlockNumber-$fileNameSuffix"
-    } else {
-      val hashString = encodeHash(hash)
-      "$startBlockNumber-$endBlockNumber-$hashString-$fileNameSuffix"
-    }
-  open fun getFileName(proofIndex: ProofIndex): String {
-    return fileName(
-      startBlockNumber = proofIndex.startBlockNumber,
-      endBlockNumber = proofIndex.endBlockNumber,
-      hash = proofIndex.hash,
-      fileNameSuffix = fileNameSuffix,
-    )
-  }
+interface ProverFileNameProvider<T : ProofIndex> {
+  fun getFileName(proofIndex: T): String
 }
 
 object FileNameSuffixes {
@@ -32,32 +21,57 @@ object FileNameSuffixes {
 class ExecutionProofRequestFileNameProvider(
   private val tracesVersion: String,
   private val stateManagerVersion: String,
-) : ProverFileNameProvider(FileNameSuffixes.EXECUTION_PROOF_SUFFIX) {
-  override fun getFileName(proofIndex: ProofIndex): String {
+) : ProverFileNameProvider<ExecutionProofIndex> {
+  override fun getFileName(proofIndex: ExecutionProofIndex): String {
     return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}" +
       "-etv$tracesVersion-stv$stateManagerVersion" +
-      "-$fileNameSuffix"
+      "-${FileNameSuffixes.EXECUTION_PROOF_SUFFIX}"
   }
 }
-object ExecutionProofResponseFileNameProvider : ProverFileNameProvider(FileNameSuffixes.EXECUTION_PROOF_SUFFIX)
+object ExecutionProofResponseFileNameProvider : ProverFileNameProvider<ExecutionProofIndex> {
+  override fun getFileName(proofIndex: ExecutionProofIndex): String {
+    return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}-${FileNameSuffixes.EXECUTION_PROOF_SUFFIX}"
+  }
+}
 
-object CompressionProofRequestFileNameProvider : ProverFileNameProvider(FileNameSuffixes.COMPRESSION_PROOF_SUFFIX) {
+object CompressionProofRequestFileNameProvider : ProverFileNameProvider<CompressionProofIndex> {
+  private fun encodeHash(hash: ByteArray): String = hash.encodeHex(prefix = false)
   private const val HARD_CODED_VERSION = "0.0"
-  override fun getFileName(proofIndex: ProofIndex): String {
-    val requestHashString = encodeHash(proofIndex.hash!!)
+
+  override fun getFileName(proofIndex: CompressionProofIndex): String {
+    val requestHashString = encodeHash(proofIndex.hash)
     return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}-" +
       "bcv$HARD_CODED_VERSION-" +
       "ccv$HARD_CODED_VERSION-" +
       requestHashString + "-" +
-      fileNameSuffix
+      FileNameSuffixes.COMPRESSION_PROOF_SUFFIX
   }
 }
-object CompressionProofResponseFileNameProvider : ProverFileNameProvider(FileNameSuffixes.COMPRESSION_PROOF_SUFFIX)
+object CompressionProofResponseFileNameProvider : ProverFileNameProvider<CompressionProofIndex> {
+  private fun encodeHash(hash: ByteArray): String = hash.encodeHex(prefix = false)
 
-object AggregationProofFileNameProvider : ProverFileNameProvider(FileNameSuffixes.AGGREGATION_PROOF_SUFFIX)
+  override fun getFileName(proofIndex: CompressionProofIndex): String {
+    val requestHashString = encodeHash(proofIndex.hash)
+    return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}-" +
+      requestHashString + "-" +
+      FileNameSuffixes.COMPRESSION_PROOF_SUFFIX
+  }
+}
 
-object InvalidityProofFileNameProvider : ProverFileNameProvider(FileNameSuffixes.INVALIDITY_PROOF_SUFFIX) {
-  override fun getFileName(proofIndex: ProofIndex): String {
-    return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}-$fileNameSuffix"
+object AggregationProofFileNameProvider : ProverFileNameProvider<AggregationProofIndex> {
+  private fun encodeHash(hash: ByteArray): String = hash.encodeHex(prefix = false)
+
+  override fun getFileName(proofIndex: AggregationProofIndex): String {
+    val requestHashString = encodeHash(proofIndex.hash)
+
+    return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}" +
+      "-$requestHashString-${FileNameSuffixes.AGGREGATION_PROOF_SUFFIX}"
+  }
+}
+
+object InvalidityProofFileNameProvider : ProverFileNameProvider<InvalidityProofIndex> {
+  override fun getFileName(proofIndex: InvalidityProofIndex): String {
+    return "${proofIndex.simulatedExecutionBlockNumber}-${proofIndex.ftxNumber}" +
+      "-${FileNameSuffixes.INVALIDITY_PROOF_SUFFIX}"
   }
 }

--- a/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactoryTest.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactoryTest.kt
@@ -9,7 +9,7 @@ import linea.domain.BlockIntervals
 import linea.kotlin.ByteArrayExt
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.domain.ProofsToAggregate
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -72,21 +73,39 @@ class ProverClientFactoryTest {
   private lateinit var testTmpDir: Path
 
   private val request1 = ProofsToAggregate(
-    compressionProofIndexes = listOf(ProofIndex(startBlockNumber = 1uL, endBlockNumber = 9uL)),
+    compressionProofIndexes = listOf(
+      CompressionProofIndex(
+        startBlockNumber = 1uL,
+        endBlockNumber = 9uL,
+        hash = Random.nextBytes(32),
+      ),
+    ),
     executionProofs = BlockIntervals(startingBlockNumber = 1uL, listOf(9uL)),
     parentAggregationLastBlockTimestamp = Clock.System.now(),
     parentAggregationLastL1RollingHashMessageNumber = 0uL,
     parentAggregationLastL1RollingHash = ByteArrayExt.random32(),
   )
   private val request2 = ProofsToAggregate(
-    compressionProofIndexes = listOf(ProofIndex(startBlockNumber = 10uL, endBlockNumber = 19uL)),
+    compressionProofIndexes = listOf(
+      CompressionProofIndex(
+        startBlockNumber = 10uL,
+        endBlockNumber = 19uL,
+        hash = Random.nextBytes(32),
+      ),
+    ),
     executionProofs = BlockIntervals(startingBlockNumber = 10uL, listOf(19uL)),
     parentAggregationLastBlockTimestamp = Clock.System.now(),
     parentAggregationLastL1RollingHashMessageNumber = 9uL,
     parentAggregationLastL1RollingHash = ByteArrayExt.random32(),
   )
   private val request3 = ProofsToAggregate(
-    compressionProofIndexes = listOf(ProofIndex(startBlockNumber = 300uL, endBlockNumber = 319uL)),
+    compressionProofIndexes = listOf(
+      CompressionProofIndex(
+        startBlockNumber = 300uL,
+        endBlockNumber = 319uL,
+        hash = Random.nextBytes(32),
+      ),
+    ),
     executionProofs = BlockIntervals(startingBlockNumber = 300uL, listOf(319uL)),
     parentAggregationLastBlockTimestamp = Clock.System.now(),
     parentAggregationLastL1RollingHashMessageNumber = 299uL,

--- a/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvidersTest.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvidersTest.kt
@@ -1,7 +1,9 @@
 package net.consensys.zkevm.coordinator.clients.prover
 
 import linea.kotlin.decodeHex
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.AggregationProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -16,7 +18,7 @@ class ProverFileNameProvidersTest {
     Assertions.assertEquals(
       "11-17-etv0.1-stv0.2-getZkProof.json",
       executionProofRequestFileNameProvider.getFileName(
-        ProofIndex(
+        ExecutionProofIndex(
           startBlockNumber = 11u,
           endBlockNumber = 17u,
         ),
@@ -29,7 +31,7 @@ class ProverFileNameProvidersTest {
     Assertions.assertEquals(
       "11-17-getZkProof.json",
       ExecutionProofResponseFileNameProvider.getFileName(
-        ProofIndex(
+        ExecutionProofIndex(
           startBlockNumber = 11u,
           endBlockNumber = 17u,
         ),
@@ -44,7 +46,7 @@ class ProverFileNameProvidersTest {
     Assertions.assertEquals(
       "11-17-0abcd123-getZkBlobCompressionProof.json",
       fileNameProvider.getFileName(
-        ProofIndex(
+        CompressionProofIndex(
           startBlockNumber = 11u,
           endBlockNumber = 17u,
           hash = hash,
@@ -57,7 +59,7 @@ class ProverFileNameProvidersTest {
   fun test_compressionProof_requestFileName() {
     val requestHash = "0abcd123".decodeHex()
     val requestFileName = CompressionProofRequestFileNameProvider.getFileName(
-      ProofIndex(
+      CompressionProofIndex(
         startBlockNumber = 1uL,
         endBlockNumber = 11uL,
         hash = requestHash,
@@ -76,7 +78,7 @@ class ProverFileNameProvidersTest {
     Assertions.assertEquals(
       "11-27-abcd-getZkAggregatedProof.json",
       AggregationProofFileNameProvider.getFileName(
-        ProofIndex(
+        AggregationProofIndex(
           startBlockNumber = 11u,
           endBlockNumber = 27u,
           hash = hash,

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/ProverClient.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/ProverClient.kt
@@ -1,28 +1,34 @@
 package net.consensys.zkevm.coordinator.clients
 
+import net.consensys.zkevm.domain.AggregationProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
+import net.consensys.zkevm.domain.InvalidityProofIndex
 import net.consensys.zkevm.domain.ProofIndex
 import net.consensys.zkevm.domain.ProofToFinalize
 import net.consensys.zkevm.domain.ProofsToAggregate
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
-interface ProverProofResponseChecker<ProofResponse> {
-  fun findProofResponse(proofRequestId: ProofIndex): SafeFuture<ProofResponse?>
+interface ProverProofResponseChecker<ProofResponse, TProofIndex : ProofIndex> {
+  fun findProofResponse(proofIndex: TProofIndex): SafeFuture<ProofResponse?>
 
-  fun isProofAlreadyDone(proofRequestId: ProofIndex): SafeFuture<Boolean> =
-    findProofResponse(proofRequestId).thenApply { it != null }
+  fun isProofAlreadyDone(proofIndex: TProofIndex): SafeFuture<Boolean> =
+    findProofResponse(proofIndex).thenApply { it != null }
 }
 
-interface ProverProofRequestCreator<ProofRequest> {
-  fun createProofRequest(proofRequest: ProofRequest): SafeFuture<ProofIndex>
+interface ProverProofRequestCreator<ProofRequest : Any, T : ProofIndex> {
+  fun createProofRequest(proofRequest: ProofRequest): SafeFuture<T>
 }
 
-interface ProverClient<ProofRequest, ProofResponse> :
-  ProverProofResponseChecker<ProofResponse>,
-  ProverProofRequestCreator<ProofRequest> {
+interface ProverClient<ProofRequest : Any, ProofResponse, T : ProofIndex> :
+  ProverProofResponseChecker<ProofResponse, T>,
+  ProverProofRequestCreator<ProofRequest, T> {
   fun requestProof(proofRequest: ProofRequest): SafeFuture<ProofResponse>
 }
 
-typealias BlobCompressionProverClientV2 = ProverClient<BlobCompressionProofRequest, BlobCompressionProof>
-typealias ProofAggregationProverClientV2 = ProverClient<ProofsToAggregate, ProofToFinalize>
-typealias ExecutionProverClientV2 = ProverClient<BatchExecutionProofRequestV1, BatchExecutionProofResponse>
-typealias InvalidityProverClientV1 = ProverClient<InvalidityProofRequest, InvalidityProofResponse>
+typealias BlobCompressionProverClientV2 =
+  ProverClient<BlobCompressionProofRequest, BlobCompressionProof, CompressionProofIndex>
+typealias ProofAggregationProverClientV2 = ProverClient<ProofsToAggregate, ProofToFinalize, AggregationProofIndex>
+typealias ExecutionProverClientV2 =
+  ProverClient<BatchExecutionProofRequestV1, BatchExecutionProofResponse, ExecutionProofIndex>
+typealias InvalidityProverClientV1 = ProverClient<InvalidityProofRequest, InvalidityProofResponse, InvalidityProofIndex>

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/domain/Aggregation.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/domain/Aggregation.kt
@@ -11,9 +11,9 @@ typealias BlobsToAggregate = BlockInterval
  * @property parentAggregationLastBlockTimestamp The timestamp of the last block of the previous aggregation.
  */
 data class ProofsToAggregate(
-  val compressionProofIndexes: List<ProofIndex>,
+  val compressionProofIndexes: List<CompressionProofIndex>,
   val executionProofs: BlockIntervals,
-  val invalidityProofs: List<ProofIndex> = emptyList(),
+  val invalidityProofs: List<InvalidityProofIndex> = emptyList(),
   val parentAggregationLastBlockTimestamp: Instant,
   val parentAggregationLastL1RollingHashMessageNumber: ULong,
   val parentAggregationLastL1RollingHash: ByteArray,

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/domain/ProofIndex.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/domain/ProofIndex.kt
@@ -1,26 +1,26 @@
 package net.consensys.zkevm.domain
 
-import linea.domain.BlockInterval
+interface ProofIndex
 
-data class ProofIndex(
-  override val startBlockNumber: ULong,
-  override val endBlockNumber: ULong,
-  val hash: ByteArray? = null,
-) : BlockInterval {
+data class ExecutionProofIndex(
+  val startBlockNumber: ULong,
+  val endBlockNumber: ULong,
+) : ProofIndex
+
+data class CompressionProofIndex(
+  val startBlockNumber: ULong,
+  val endBlockNumber: ULong,
+  val hash: ByteArray,
+) : ProofIndex {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
 
-    other as ProofIndex
+    other as CompressionProofIndex
 
     if (startBlockNumber != other.startBlockNumber) return false
     if (endBlockNumber != other.endBlockNumber) return false
-    if (hash != null) {
-      if (other.hash == null) return false
-      if (!hash.contentEquals(other.hash)) return false
-    } else if (other.hash != null) {
-      return false
-    }
+    if (!hash.contentEquals(other.hash)) return false
 
     return true
   }
@@ -28,7 +28,38 @@ data class ProofIndex(
   override fun hashCode(): Int {
     var result = startBlockNumber.hashCode()
     result = 31 * result + endBlockNumber.hashCode()
-    result = 31 * result + (hash?.contentHashCode() ?: 0)
+    result = 31 * result + hash.contentHashCode()
     return result
   }
 }
+
+data class AggregationProofIndex(
+  val startBlockNumber: ULong,
+  val endBlockNumber: ULong,
+  val hash: ByteArray,
+) : ProofIndex {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as AggregationProofIndex
+
+    if (startBlockNumber != other.startBlockNumber) return false
+    if (endBlockNumber != other.endBlockNumber) return false
+    if (!hash.contentEquals(other.hash)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = startBlockNumber.hashCode()
+    result = 31 * result + endBlockNumber.hashCode()
+    result = 31 * result + hash.contentHashCode()
+    return result
+  }
+}
+
+data class InvalidityProofIndex(
+  val simulatedExecutionBlockNumber: ULong,
+  val ftxNumber: ULong,
+) : ProofIndex

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
@@ -17,7 +17,7 @@ import net.consensys.zkevm.coordinator.clients.ProofAggregationProverClientV2
 import net.consensys.zkevm.domain.Aggregation
 import net.consensys.zkevm.domain.BlobAndBatchCounters
 import net.consensys.zkevm.domain.BlobsToAggregate
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.domain.ProofToFinalize
 import net.consensys.zkevm.domain.ProofsToAggregate
 import net.consensys.zkevm.ethereum.coordination.blockcreation.SafeBlockProvider
@@ -170,7 +170,7 @@ class ProofAggregationCoordinatorService(
 
     val compressionProofIndexes =
       compressionBlobs.map {
-        ProofIndex(
+        CompressionProofIndex(
           startBlockNumber = it.blobCounters.startBlockNumber,
           endBlockNumber = it.blobCounters.endBlockNumber,
           hash = it.blobCounters.expectedShnarf,
@@ -247,7 +247,7 @@ class ProofAggregationCoordinatorService(
 
   private fun aggregationProofCreation(
     batchIntervals: BlockIntervals,
-    compressionProofIndexes: List<ProofIndex>,
+    compressionProofIndexes: List<CompressionProofIndex>,
   ): SafeFuture<ProofToFinalize> {
     val blobsToAggregate = batchIntervals.toBlockInterval()
     return aggregationL2StateProvider

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofHandler.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofHandler.kt
@@ -1,7 +1,7 @@
 package net.consensys.zkevm.ethereum.coordination.blob
 
 import net.consensys.zkevm.domain.BlobRecord
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 fun interface BlobCompressionProofHandler {
@@ -9,5 +9,8 @@ fun interface BlobCompressionProofHandler {
 }
 
 fun interface BlobCompressionProofRequestHandler {
-  fun acceptNewBlobCompressionProofRequest(proofIndex: ProofIndex, unProvenBlobRecord: BlobRecord): SafeFuture<*>
+  fun acceptNewBlobCompressionProofRequest(
+    proofIndex: CompressionProofIndex,
+    unProvenBlobRecord: BlobRecord,
+  ): SafeFuture<*>
 }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofPoller.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofPoller.kt
@@ -7,7 +7,7 @@ import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
 import net.consensys.zkevm.domain.BlobRecord
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.concurrent.ConcurrentLinkedDeque
@@ -30,7 +30,7 @@ class BlobCompressionProofPoller(
   timerSchedule = timerSchedule,
 ) {
   data class ProofInProgress(
-    val proofIndex: ProofIndex,
+    val proofIndex: CompressionProofIndex,
     val unProvenBlobRecord: BlobRecord,
   )
 
@@ -46,7 +46,7 @@ class BlobCompressionProofPoller(
   }
 
   @Synchronized
-  fun addProofRequestsInProgressForPolling(proofIndex: ProofIndex, unProvenBlobRecord: BlobRecord) {
+  fun addProofRequestsInProgressForPolling(proofIndex: CompressionProofIndex, unProvenBlobRecord: BlobRecord) {
     proofRequestsInProgress.add(ProofInProgress(proofIndex, unProvenBlobRecord))
   }
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -15,7 +15,7 @@ import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.domain.Batch
 import net.consensys.zkevm.domain.BlocksConflation
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
 import net.consensys.zkevm.ethereum.coordination.proofcreation.BatchProofHandler
 import net.consensys.zkevm.ethereum.coordination.proofcreation.ZkProofCreationCoordinator
 import org.apache.logging.log4j.LogManager
@@ -46,7 +46,7 @@ class ProofGeneratingConflationHandlerImpl(
     val executionProofPollingInterval: Duration,
   )
 
-  private val proofRequestsInProgress = ConcurrentLinkedDeque<ProofIndex>()
+  private val proofRequestsInProgress = ConcurrentLinkedDeque<ExecutionProofIndex>()
 
   init {
     metricsFacade.createGauge(
@@ -120,7 +120,7 @@ class ProofGeneratingConflationHandlerImpl(
       .getOrThrow().let { blocksRange ->
         val batch = Batch(conflation.startBlockNumber, conflation.endBlockNumber)
         zkProofProductionCoordinator.isZkProofRequestProven(
-          ProofIndex(
+          ExecutionProofIndex(
             startBlockNumber = batch.startBlockNumber,
             endBlockNumber = batch.endBlockNumber,
           ),

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinator.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinator.kt
@@ -1,11 +1,14 @@
 package net.consensys.zkevm.ethereum.coordination.proofcreation
 
 import net.consensys.zkevm.domain.BlocksConflation
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
 import net.consensys.zkevm.ethereum.coordination.conflation.BlocksTracesConflated
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 interface ZkProofCreationCoordinator {
-  fun createZkProofRequest(blocksConflation: BlocksConflation, traces: BlocksTracesConflated): SafeFuture<ProofIndex>
-  fun isZkProofRequestProven(proofIndex: ProofIndex): SafeFuture<Boolean>
+  fun createZkProofRequest(
+    blocksConflation: BlocksConflation,
+    traces: BlocksTracesConflated,
+  ): SafeFuture<ExecutionProofIndex>
+  fun isZkProofRequestProven(proofIndex: ExecutionProofIndex): SafeFuture<Boolean>
 }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinatorImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinatorImpl.kt
@@ -9,7 +9,7 @@ import linea.ethapi.EthApiClient
 import net.consensys.zkevm.coordinator.clients.BatchExecutionProofRequestV1
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.domain.BlocksConflation
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
 import net.consensys.zkevm.ethereum.coordination.conflation.BlocksTracesConflated
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -51,7 +51,7 @@ class ZkProofCreationCoordinatorImpl(
   override fun createZkProofRequest(
     blocksConflation: BlocksConflation,
     traces: BlocksTracesConflated,
-  ): SafeFuture<ProofIndex> {
+  ): SafeFuture<ExecutionProofIndex> {
     val startBlockNumber = blocksConflation.blocks.first().number
     val endBlockNumber = blocksConflation.blocks.last().number
     val blocksConflationInterval = blocksConflation.intervalString()
@@ -84,6 +84,6 @@ class ZkProofCreationCoordinatorImpl(
       }
   }
 
-  override fun isZkProofRequestProven(proofIndex: ProofIndex): SafeFuture<Boolean> =
+  override fun isZkProofRequestProven(proofIndex: ExecutionProofIndex): SafeFuture<Boolean> =
     executionProverClient.isProofAlreadyDone(proofIndex)
 }

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorServiceTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorServiceTest.kt
@@ -14,7 +14,7 @@ import net.consensys.zkevm.domain.Aggregation
 import net.consensys.zkevm.domain.BlobAndBatchCounters
 import net.consensys.zkevm.domain.BlobCounters
 import net.consensys.zkevm.domain.BlobsToAggregate
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.domain.ProofToFinalize
 import net.consensys.zkevm.domain.ProofsToAggregate
 import net.consensys.zkevm.persistence.AggregationsRepository
@@ -202,7 +202,7 @@ class ProofAggregationCoordinatorServiceTest {
       ProofsToAggregate(
         compressionProofIndexes =
         compressionBlobs1.map {
-          ProofIndex(
+          CompressionProofIndex(
             it.blobCounters.startBlockNumber,
             it.blobCounters.endBlockNumber,
             it.blobCounters.expectedShnarf,
@@ -218,7 +218,7 @@ class ProofAggregationCoordinatorServiceTest {
       ProofsToAggregate(
         compressionProofIndexes =
         compressionBlobs2.map {
-          ProofIndex(
+          CompressionProofIndex(
             it.blobCounters.startBlockNumber,
             it.blobCounters.endBlockNumber,
             it.blobCounters.expectedShnarf,

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinatorImplTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinatorImplTest.kt
@@ -16,7 +16,7 @@ import net.consensys.zkevm.coordinator.clients.GenerateTracesResponse
 import net.consensys.zkevm.domain.BlocksConflation
 import net.consensys.zkevm.domain.ConflationCalculationResult
 import net.consensys.zkevm.domain.ConflationTrigger
-import net.consensys.zkevm.domain.ProofIndex
+import net.consensys.zkevm.domain.ExecutionProofIndex
 import net.consensys.zkevm.ethereum.coordination.conflation.BlocksTracesConflated
 import org.apache.logging.log4j.Level
 import org.assertj.core.api.Assertions.assertThat
@@ -86,7 +86,7 @@ class ZkProofCreationCoordinatorImplTest {
     whenever(executionProverClient.createProofRequest(any()))
       .thenReturn(
         SafeFuture.completedFuture(
-          ProofIndex(
+          ExecutionProofIndex(
             startBlockNumber = 123UL,
             endBlockNumber = 124UL,
           ),

--- a/coordinator/persistence/blob/src/integrationTest/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofCoordinatorIntTest.kt
+++ b/coordinator/persistence/blob/src/integrationTest/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofCoordinatorIntTest.kt
@@ -17,6 +17,7 @@ import net.consensys.zkevm.coordinator.clients.BlobCompressionProof
 import net.consensys.zkevm.coordinator.clients.BlobCompressionProofRequest
 import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
 import net.consensys.zkevm.domain.Blob
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.domain.ConflationCalculationResult
 import net.consensys.zkevm.domain.ConflationTrigger
 import net.consensys.zkevm.domain.ProofIndex
@@ -146,7 +147,7 @@ class BlobCompressionProofCoordinatorIntTest : CleanDbTestSuiteParallel() {
           kzgProofContract = Random.nextBytes(48),
           kzgProofSidecar = Random.nextBytes(48),
         )
-        val proofIndex = ProofIndex(
+        val proofIndex = CompressionProofIndex(
           startBlockNumber = proofReq.startBlockNumber,
           endBlockNumber = proofReq.conflations.last().endBlockNumber,
           hash = proofReq.expectedShnarfResult.dataHash,

--- a/coordinator/persistence/blob/src/test/kotlin/net/consensys/zkevm/ethereum/coordinator/blob/BlobCompressionProofCoordinatorTest.kt
+++ b/coordinator/persistence/blob/src/test/kotlin/net/consensys/zkevm/ethereum/coordinator/blob/BlobCompressionProofCoordinatorTest.kt
@@ -9,9 +9,9 @@ import net.consensys.zkevm.coordinator.clients.BlobCompressionProof
 import net.consensys.zkevm.coordinator.clients.BlobCompressionProofRequest
 import net.consensys.zkevm.coordinator.clients.BlobCompressionProverClientV2
 import net.consensys.zkevm.domain.Blob
+import net.consensys.zkevm.domain.CompressionProofIndex
 import net.consensys.zkevm.domain.ConflationCalculationResult
 import net.consensys.zkevm.domain.ConflationTrigger
-import net.consensys.zkevm.domain.ProofIndex
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkState
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProvider
@@ -75,9 +75,10 @@ class BlobCompressionProofCoordinatorTest {
       .thenAnswer { invocationOnMock ->
         val request = invocationOnMock.getArgument<BlobCompressionProofRequest>(0)
         SafeFuture.completedFuture(
-          ProofIndex(
+          CompressionProofIndex(
             startBlockNumber = request.conflations.first().startBlockNumber,
             endBlockNumber = request.conflations.last().endBlockNumber,
+            hash = request.expectedShnarfResult.expectedShnarf,
           ),
         )
       }
@@ -176,7 +177,13 @@ class BlobCompressionProofCoordinatorTest {
             ),
           )
         verify(blobCompressionProverClient, times(1))
-          .findProofResponse(ProofIndex(expectedStartBlock, expectedEndBlock))
+          .findProofResponse(
+            CompressionProofIndex(
+              expectedStartBlock,
+              expectedEndBlock,
+              shnarfResult.expectedShnarf,
+            ),
+          )
       }
   }
 
@@ -292,9 +299,21 @@ class BlobCompressionProofCoordinatorTest {
           )
 
         verify(blobCompressionProverClient, times(1))
-          .findProofResponse(ProofIndex(blob1.startBlockNumber, blob1.endBlockNumber))
+          .findProofResponse(
+            CompressionProofIndex(
+              blob1.startBlockNumber,
+              blob1.endBlockNumber,
+              shnarfResult.expectedShnarf,
+            ),
+          )
         verify(blobCompressionProverClient, times(1))
-          .findProofResponse(ProofIndex(blob2.startBlockNumber, blob2.endBlockNumber))
+          .findProofResponse(
+            CompressionProofIndex(
+              blob2.startBlockNumber,
+              blob2.endBlockNumber,
+              shnarfResult.expectedShnarf,
+            ),
+          )
       }
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #2102 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a broad API refactor across prover clients and coordination flow; mistakes could break prover routing or file name/path matching for proofs.
> 
> **Overview**
> Refactors `ProofIndex` from a single data class into a marker interface with dedicated types (`ExecutionProofIndex`, `CompressionProofIndex`, `AggregationProofIndex`, `InvalidityProofIndex`) and updates all call sites to use the correct index type.
> 
> Updates the prover client API and file-based prover implementations to be generic over the proof-index type, including `ABProverClientRouter` switching logic and `ProverFileNameProvider` becoming a typed interface with explicit request/response filename generation per proof type.
> 
> Adjusts aggregation, blob compression polling/handlers, backtesting progress reporting, and unit/integration tests to pass/compare the new typed indexes (notably fixing invalidity indexing to use `ftxNumber` and ensuring compression indexes always include a hash).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37c350836fd035371e4064fa73ccaeafb3e78c2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->