### PR TITLE
Enabling trace logs for the engine api requests from Maru

### DIFF
--- a/docker/config/maru/log4j.xml
+++ b/docker/config/maru/log4j.xml
@@ -26,6 +26,9 @@
     <Logger name="maru.clients" level="DEBUG" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
+    <Logger name="maru.clients.el.engineapi" level="TRACE" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
     <Root level="${sys:root.log.level}">
       <AppenderRef ref="Console"/>
     </Root>


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that increases log verbosity for `maru.clients.el.engineapi`, which may impact log volume/performance but does not change runtime behavior.
> 
> **Overview**
> Enables **TRACE-level logging** specifically for the `maru.clients.el.engineapi` logger in `docker/config/maru/log4j.xml`, allowing detailed Engine API request/response logging from Maru without changing other logger levels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532dd429a52c2a59a3cdb3efbbfab1b929a68151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->