### PR TITLE
feat: re-enable slack notification on tracer test failures

### DIFF
--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -122,12 +122,12 @@ jobs:
         env:
           JSON_REPORT: ${{ github.workspace }}/tmp/${{ steps.extract_branch.outputs.branch }}/BlockchainReferenceTestOutcome.json
 
-      # - name: Failure Notification
-      #   if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: webhook-trigger
-      #     payload: |
-      #       name: "Daily Blockchain"
-      #       status: "${{ env.SUCCESS }} successful, ${{ env.FAILED }} failed, ${{ env.ABORTED }} aborted, ${{ env.DISABLED }} disabled"
+      - name: Failure Notification
+        if: github.ref == 'refs/heads/main' && (failure() || cancelled())
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            name: "Daily Blockchain"
+            status: "${{ env.SUCCESS }} successful, ${{ env.FAILED }} failed, ${{ env.ABORTED }} aborted, ${{ env.DISABLED }} disabled"

--- a/.github/workflows/reusable-tracer-nightly-tests.yml
+++ b/.github/workflows/reusable-tracer-nightly-tests.yml
@@ -57,12 +57,12 @@ jobs:
           name: jacoco-nightly-tests-exec-file-${{ inputs.zkevm_fork }}
           path: tracer/arithmetization/build/jacoco/nightlyTests.exec
 
-      # - name: Failure Notification
-      #   if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: webhook-trigger
-      #     payload: |
-      #       name: "Nightly"
-      #       status: "${{ job.status }}"
+      - name: Failure Notification
+        if: github.ref == 'refs/heads/main' && (failure() || cancelled())
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            name: "Nightly"
+            status: "${{ job.status }}"

--- a/.github/workflows/reusable-tracer-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-prc-tests.yml
@@ -54,12 +54,12 @@ jobs:
           name: jacoco-prc-call-tests-exec-file-${{ inputs.zkevm_fork }}
           path: tracer/arithmetization/build/jacoco/prcCallTests.exec
 
-      # - name: Failure Notification
-      #   if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: webhook-trigger
-      #     payload: |
-      #       name: "Weekly Precompile call"
-      #       status: "${{ job.status }}"
+      - name: Failure Notification
+        if: github.ref == 'refs/heads/main' && (failure() || cancelled())
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            name: "Weekly Precompile call"
+            status: "${{ job.status }}"

--- a/.github/workflows/reusable-tracer-weekly-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-tests.yml
@@ -53,12 +53,12 @@ jobs:
           name: jacoco-weekly-tests-exec-file-${{ inputs.zkevm_fork }}
           path: tracer/arithmetization/build/jacoco/weeklyTests.exec
 
-      # - name: Failure Notification
-      #   if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: webhook-trigger
-      #     payload: |
-      #       name: "Weekly Unit"
-      #       status: "${{ job.status }}"
+      - name: Failure Notification
+        if: github.ref == 'refs/heads/main' && (failure() || cancelled())
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            name: "Weekly Unit"
+            status: "${{ job.status }}"

--- a/.github/workflows/tracer-gradle-nightly-tests.yml
+++ b/.github/workflows/tracer-gradle-nightly-tests.yml
@@ -47,12 +47,12 @@ jobs:
           name: nightly-replay-tests-report
           path: tracer/arithmetization/build/reports/tests/**/*
 
-      # - name: Failure Notification
-      #   if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: webhook-trigger
-      #     payload: |
-      #       name: "NightlyReplay"
-      #       status: "${{ job.status }}"
+      - name: Failure Notification
+        if: github.ref == 'refs/heads/main' && (failure() || cancelled())
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            name: "NightlyReplay"
+            status: "${{ job.status }}"

--- a/.github/workflows/tracer-gradle-weekly-tests.yml
+++ b/.github/workflows/tracer-gradle-weekly-tests.yml
@@ -49,12 +49,12 @@ jobs:
           name: weekly-replay-tests-report
           path: tracer/arithmetization/build/reports/tests/**/*
 
-      # - name: Failure Notification
-      #   if: github.ref == 'refs/heads/arith-dev' && (failure() || cancelled())
-      #   uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-      #   with:
-      #     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #     webhook-type: webhook-trigger
-      #     payload: |
-      #       name: "WeeklyReplay"
-      #       status: "${{ job.status }}"
+      - name: Failure Notification
+        if: github.ref == 'refs/heads/main' && (failure() || cancelled())
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            name: "WeeklyReplay"
+            status: "${{ job.status }}"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that restores Slack notifications when scheduled tracer test jobs fail or are cancelled; impact is limited to CI messaging volume and conditions.
> 
> **Overview**
> Re-enables **Slack failure notifications** across tracer test GitHub Actions workflows (nightly, weekly, PRC-call, replay, and blockchain reference tests).
> 
> Notifications now trigger on `refs/heads/main` when jobs *fail or are cancelled*, posting status summaries (including pass/fail counts for blockchain reference tests) to the configured Slack webhook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59ab3c506290a78fb1d4ab1c5f5b13ba63a46540. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->