### PR TITLE
fix: upgrade Go version to 1.24.12 in Dockerfile and go.mod

### DIFF
--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -6,7 +6,7 @@
 # G O + R U S T   B U I L D E R
 #
 ###############################
-FROM golang:1.24.6-alpine AS go-builder
+FROM golang:1.24.12-alpine AS go-builder
 
 RUN apk add --no-cache rust cargo bash make
 

--- a/prover/README.md
+++ b/prover/README.md
@@ -9,7 +9,7 @@ the server implementation.
 
 The prover has the following build dependencies
 * `rust@1.74.0` and `cargo`
-* `go@1.21.5`
+* `go@1.24.12`
 * `make`
 
 The repository counts 2 main binaries:

--- a/prover/go.mod
+++ b/prover/go.mod
@@ -1,6 +1,6 @@
 module github.com/consensys/linea-monorepo/prover
 
-go 1.24.6
+go 1.24.12
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.0


### PR DESCRIPTION
This PR upgraded the Go version in use from `1.24.6` to `1.24.12`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump affecting only the Go toolchain/build environment; primary risk is CI/build breakage if any code or dependencies behave differently under the newer patch release.
> 
> **Overview**
> Updates the prover build to use Go `1.24.12` by bumping the base image in `prover/Dockerfile` and the language version in `prover/go.mod`.
> 
> Refreshes `prover/README.md` to reflect the new Go build dependency version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e561f6842aef96de5520d5adc662bb1cdefa5e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->