### PR TITLE
ci: try to speed up nodejs setup

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -26,13 +26,26 @@ runs:
       with:
         node-version-file: .nvmrc
         cache: 'pnpm'
-    
+
     - id: versions
       name: Capture versions
       shell: bash
       run: |
         echo "node=$(node -v | sed 's/^v//')" >> "$GITHUB_OUTPUT"
         echo "pnpm=$(pnpm -v)" >> "$GITHUB_OUTPUT"
+
+    # Configure pnpm for better caching
+    - name: Configure pnpm
+      shell: bash
+      run: |
+        pnpm config set store-dir ~/.pnpm-store
+        pnpm config set side-effects-cache true
+        pnpm config set side-effects-cache-readonly ${{ github.ref != 'refs/heads/main' && 'true' || 'false' }}
+
+    # Parallel fetch all dependencies before install
+    - name: Fetch dependencies
+      shell: bash
+      run: pnpm fetch ${{ inputs.pnpm-install-options }}
 
     - name: pnpm install
       run: pnpm i ${{ inputs.pnpm-install-options }}


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared CI setup used across multiple workflows; changes pnpm cache/store behavior and adds `pnpm fetch`, which could cause unexpected cache misses or install differences if misconfigured.
> 
> **Overview**
> Speeds up the shared `.github/actions/setup-nodejs` composite action by **tuning pnpm caching** (sets a fixed `store-dir`, enables `side-effects-cache`, and makes the side-effects cache read-only on non-`main` refs).
> 
> Adds a new **prefetch step** (`pnpm fetch`) before `pnpm install` to parallelize dependency download and improve subsequent install time, while still capturing Node/pnpm versions as action outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d29b3eb51442edebd3ce7780a13fed61931657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->