### PR TITLE
feat: add fallback RPC URL support for blockchain client

### DIFF
--- a/native-yield-operations/automation-service/src/application/main/NativeYieldAutomationServiceBootstrap.ts
+++ b/native-yield-operations/automation-service/src/application/main/NativeYieldAutomationServiceBootstrap.ts
@@ -143,6 +143,11 @@ export class NativeYieldAutomationServiceBootstrap {
       getChain(config.dataSources.chainId),
       this.web3SignerClient,
       estimateGasErrorReporter,
+      undefined, // sendTransactionsMaxRetries - use default
+      undefined, // gasRetryBumpBps - use default
+      undefined, // sendTransactionAttemptTimeoutMs - use default
+      undefined, // gasLimitBufferBps - use default
+      config.dataSources.l1RpcUrlFallback,
     );
     DashboardContractClient.initialize(
       this.viemBlockchainClientAdapter,

--- a/native-yield-operations/automation-service/src/application/main/__tests__/NativeYieldAutomationServiceBootstrap.test.ts
+++ b/native-yield-operations/automation-service/src/application/main/__tests__/NativeYieldAutomationServiceBootstrap.test.ts
@@ -204,6 +204,7 @@ const createBootstrapConfig = () => ({
   dataSources: {
     chainId: CHAIN_ID_MAINNET,
     l1RpcUrl: "https://rpc.example.com",
+    l1RpcUrlFallback: undefined,
     beaconChainRpcUrl: "https://beacon.example.com",
     stakingGraphQLUrl: "https://staking.example.com/graphql",
     ipfsBaseUrl: "https://ipfs.example.com",
@@ -378,6 +379,11 @@ describe("NativeYieldAutomationServiceBootstrap", () => {
         hoodi,
         expect.anything(), // contractSignerClient
         expect.anything(), // errorReporter
+        undefined, // sendTransactionsMaxRetries - use default
+        undefined, // gasRetryBumpBps - use default
+        undefined, // sendTransactionAttemptTimeoutMs - use default
+        undefined, // gasLimitBufferBps - use default
+        config.dataSources.l1RpcUrlFallback, // fallbackRpcUrl
       );
     });
 

--- a/native-yield-operations/automation-service/src/application/main/config/config.schema.ts
+++ b/native-yield-operations/automation-service/src/application/main/config/config.schema.ts
@@ -32,6 +32,8 @@ export const configSchema = z
     CHAIN_ID: z.coerce.number().int().positive(),
     // RPC endpoint URL for the L1 Ethereum blockchain. Must be a valid HTTP/HTTPS URL.
     L1_RPC_URL: z.string().url(),
+    // Optional fallback RPC endpoint URL for the L1 Ethereum blockchain. Used when primary RPC fails.
+    L1_RPC_URL_FALLBACK: z.string().url().optional(),
     // Beacon chain API endpoint URL for Ethereum 2.0 consensus layer.
     // See API documentation - https://ethereum.github.io/beacon-APIs/
     BEACON_CHAIN_RPC_URL: z.string().url(),

--- a/native-yield-operations/automation-service/src/application/main/config/config.ts
+++ b/native-yield-operations/automation-service/src/application/main/config/config.ts
@@ -23,6 +23,7 @@ export const toClientConfig = (env: FlattenedConfigSchema) => ({
   dataSources: {
     chainId: env.CHAIN_ID,
     l1RpcUrl: env.L1_RPC_URL,
+    l1RpcUrlFallback: env.L1_RPC_URL_FALLBACK,
     beaconChainRpcUrl: env.BEACON_CHAIN_RPC_URL,
     stakingGraphQLUrl: env.STAKING_GRAPHQL_URL,
     ipfsBaseUrl: env.IPFS_BASE_URL,

--- a/ts-libs/linea-shared-utils/src/clients/ViemBlockchainClientAdapter.ts
+++ b/ts-libs/linea-shared-utils/src/clients/ViemBlockchainClientAdapter.ts
@@ -2,6 +2,7 @@ import {
   Hex,
   createPublicClient,
   http,
+  fallback,
   PublicClient,
   TransactionReceipt,
   Address,
@@ -18,6 +19,7 @@ import {
   RpcRequestError,
   Abi,
   decodeErrorResult,
+  HttpTransport,
 } from "viem";
 import { sendRawTransaction, waitForTransactionReceipt } from "viem/actions";
 
@@ -47,6 +49,7 @@ export class ViemBlockchainClientAdapter implements IBlockchainClient<PublicClie
    * @param {bigint} [gasRetryBumpBps=1000n] - Gas price bump in basis points per retry (e.g., 1000n = +10% per retry).
    * @param {number} [sendTransactionAttemptTimeoutMs=300000] - Timeout in milliseconds for each transaction attempt (default: 5 minutes).
    * @param {bigint} [gasLimitBufferBps=1500n] - Gas limit buffer in basis points applied to estimated gas (e.g., 1500n = +15% buffer). This prevents transactions from being included in blocks but failing to complete execution due to running out of gas, which can leave contract state partially updated.
+   * @param {string} [fallbackRpcUrl] - Optional fallback RPC URL. When provided, creates a fallback transport that tries the primary RPC first and falls back to this URL on failure.
    * @throws {Error} If sendTransactionsMaxRetries is less than 1.
    */
   constructor(
@@ -59,10 +62,22 @@ export class ViemBlockchainClientAdapter implements IBlockchainClient<PublicClie
     private readonly gasRetryBumpBps: bigint = 1000n, // +10% per retry
     private readonly sendTransactionAttemptTimeoutMs = 300_000, // 5m
     private readonly gasLimitBufferBps: bigint = 1500n, // +15% buffer to prevent partial execution
+    fallbackRpcUrl?: string,
   ) {
     if (sendTransactionsMaxRetries < 1) {
       throw new Error("sendTransactionsMaxRetries must be at least 1");
     }
+
+    // Create primary transport
+    const primaryTransport = this._createHttpTransport(rpcUrl, "primary");
+
+    // Create transport - either fallback (if fallbackRpcUrl provided) or single
+    const transport = fallbackRpcUrl
+      ? fallback([primaryTransport, this._createHttpTransport(fallbackRpcUrl, "secondary")], {
+          rank: false, // Always try primary first, no ranking
+        })
+      : primaryTransport;
+
     // Aim re-use single blockchain client for
     // i.) Better connection pooling
     // ii.) Memory efficient
@@ -72,41 +87,56 @@ export class ViemBlockchainClientAdapter implements IBlockchainClient<PublicClie
         ...chain,
         id: chain.id, // Explicitly set chainId to prevent redundant eth_chainId validation calls
       },
-      transport: http(rpcUrl, {
-        batch: true,
-        // TODO - How does this interact with our custom retry logic in sendSignedTransaction?
-        // Hypothesis - Default Viem timeout of 10s will kick in first. It should still retry because we are using the native Viem Timeout error.
-        retryCount: 3,
-        onFetchRequest: async (request) => {
-          const cloned = request.clone(); // clone before reading body
-          try {
-            const bodyText = await cloned.text();
-            this.logger.debug("onFetchRequest", {
-              method: request.method,
-              url: request.url,
-              body: bodyText,
-            });
-          } catch (err) {
-            this.logger.warn("Failed to read request body", { err });
-          }
-        },
-        onFetchResponse: async (resp) => {
-          const cloned = resp.clone(); // clone before reading body
-          try {
-            const bodyText = await cloned.text();
-            this.logger.debug("onFetchResponse", {
-              status: resp.status,
-              statusText: resp.statusText,
-              body: bodyText,
-            });
-          } catch (err) {
-            this.logger.warn("Failed to read response body", { err });
-          }
-        },
-      }),
+      transport,
       batch: {
         // Not sure if this will help or not, need to experiment in testnet
         multicall: true,
+      },
+    });
+  }
+
+  /**
+   * Creates an HTTP transport with logging hooks.
+   * Secondary transport logs at warn level to make failover events visible.
+   *
+   * @param {string} rpcUrl - The RPC URL for the transport.
+   * @param {"primary" | "secondary"} label - Label for the transport, used in log messages.
+   * @returns {HttpTransport} The configured HTTP transport.
+   */
+  private _createHttpTransport(rpcUrl: string, label: "primary" | "secondary"): HttpTransport {
+    // Secondary transport logs at warn level to make failover events visible
+    const logMethod = label === "secondary" ? this.logger.warn.bind(this.logger) : this.logger.debug.bind(this.logger);
+
+    return http(rpcUrl, {
+      batch: true,
+      retryCount: 1, // Reduced from 3 for faster failover to secondary transport
+      onFetchRequest: async (request) => {
+        const cloned = request.clone(); // clone before reading body
+        try {
+          const bodyText = await cloned.text();
+          logMethod(`onFetchRequest [${label}]`, {
+            transport: label,
+            method: request.method,
+            url: request.url,
+            body: bodyText,
+          });
+        } catch (err) {
+          this.logger.warn(`Failed to read request body [${label}]`, { err });
+        }
+      },
+      onFetchResponse: async (resp) => {
+        const cloned = resp.clone(); // clone before reading body
+        try {
+          const bodyText = await cloned.text();
+          logMethod(`onFetchResponse [${label}]`, {
+            transport: label,
+            status: resp.status,
+            statusText: resp.statusText,
+            body: bodyText,
+          });
+        } catch (err) {
+          this.logger.warn(`Failed to read response body [${label}]`, { err });
+        }
       },
     });
   }


### PR DESCRIPTION
- Add optional L1_RPC_URL_FALLBACK config parameter
- Implement fallback transport in ViemBlockchainClientAdapter using viem's fallback function
- Configure primary transport with retryCount:1 for faster failover
- Log secondary transport requests at warn level for visibility
- Update bootstrap service to pass fallback RPC URL to client adapter
- Add comprehensive tests for fallback transport behavior

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RPC transport and retry behavior for all blockchain reads/writes, which could affect reliability and observability under degraded RPC conditions despite good test coverage.
> 
> **Overview**
> Adds an optional `L1_RPC_URL_FALLBACK` configuration and wires it through the native yield automation bootstrap into `ViemBlockchainClientAdapter`.
> 
> `ViemBlockchainClientAdapter` now builds a `viem` `fallback()` transport (primary + secondary) when a fallback URL is provided, reduces per-transport `http` `retryCount` to `1` for quicker failover, and annotates request/response logs with `[primary|secondary]` while logging secondary traffic at `warn` for visibility. Tests are updated/added to cover the new config plumb-through, transport construction, retryCount behavior, and logging expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c833ec8079f2b0c8304da57bbc5bfa49d4bdeb12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->