### PR TITLE
[ZkTracer] feat: EIP-7702: fix and missing lookup in romlex

### DIFF
--- a/tracer-constraints/romlex/lookups/romLex_into_rom_for_CFI.lisp
+++ b/tracer-constraints/romlex/lookups/romLex_into_rom_for_CFI.lisp
@@ -1,5 +1,5 @@
 (deflookup
-  romlex-into-rom
+  romlex-into-rom-for-CFI
   ;; target columns
   (
     rom.CODE_FRAGMENT_INDEX

--- a/tracer-constraints/romlex/lookups/romLex_into_rom_for_delegation.lisp
+++ b/tracer-constraints/romlex/lookups/romLex_into_rom_for_delegation.lisp
@@ -1,0 +1,46 @@
+(defclookup
+  romlex-into-rom-for-delegation
+  ;; target columns
+  (
+    rom.CODE_FRAGMENT_INDEX
+    (next rom.PROGRAM_COUNTER)
+    (shift rom.ACC 2)
+    (four-bytes-lead-bytes)
+    (sixteen-bytes-tail-bytes)
+  )
+  ;; source selector
+  romlex.COULD_BE_DELEGATION_CODE
+  ;; source columns
+  (
+    romlex.CODE_FRAGMENT_INDEX
+    1
+    romlex.LEADING_THREE_BYTES
+    romlex.LEAD_DELEGATION_BYTES
+    romlex.TAIL_DELEGATION_BYTES
+  ))
+
+  (defun (four-bytes-lead-bytes)
+    (+ (* (^ 256 3) (shift rom.PADDED_BYTECODE_BYTE 3) )
+       (* (^ 256 2) (shift rom.PADDED_BYTECODE_BYTE 4) )
+       (* (^ 256 1) (shift rom.PADDED_BYTECODE_BYTE 5) )
+       (* (^ 256 0) (shift rom.PADDED_BYTECODE_BYTE 6) )
+    ))
+
+ (defun (sixteen-bytes-tail-bytes)
+    (+ (* (^ 256 15) (shift rom.PADDED_BYTECODE_BYTE 7 ) )
+       (* (^ 256 14) (shift rom.PADDED_BYTECODE_BYTE 8 ) )
+       (* (^ 256 13) (shift rom.PADDED_BYTECODE_BYTE 9 ) )
+       (* (^ 256 12) (shift rom.PADDED_BYTECODE_BYTE 10) )
+       (* (^ 256 11) (shift rom.PADDED_BYTECODE_BYTE 11) )
+       (* (^ 256 10) (shift rom.PADDED_BYTECODE_BYTE 12) )
+       (* (^ 256 9 ) (shift rom.PADDED_BYTECODE_BYTE 13) )
+       (* (^ 256 8 ) (shift rom.PADDED_BYTECODE_BYTE 14) )
+       (* (^ 256 7 ) (shift rom.PADDED_BYTECODE_BYTE 15) )
+       (* (^ 256 6 ) (shift rom.PADDED_BYTECODE_BYTE 16) )
+       (* (^ 256 5 ) (shift rom.PADDED_BYTECODE_BYTE 17) )
+       (* (^ 256 4 ) (shift rom.PADDED_BYTECODE_BYTE 18) )
+       (* (^ 256 3 ) (shift rom.PADDED_BYTECODE_BYTE 19) )
+       (* (^ 256 2 ) (shift rom.PADDED_BYTECODE_BYTE 20) )
+       (* (^ 256 1 ) (shift rom.PADDED_BYTECODE_BYTE 21) )
+       (* (^ 256 0 ) (shift rom.PADDED_BYTECODE_BYTE 22) )
+    ))

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -253,7 +253,7 @@ public class ZkCounter implements LineCountingTracer {
         trm, // not trivial
         wcp, // need MMU/TxnData/Oob etc ... to be counted
         // traceless modules
-        blakeRounds// blakeEffectiveCall is counted and already rejects all BLAKE calls
+        blakeRounds // blakeEffectiveCall is counted and already rejects all BLAKE calls
         );
   }
 

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/blake2fmodexpdata/BlakeModexpData.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static net.consensys.linea.zktracer.module.ModuleName.BLAKE_MODEXP_DATA;
 
 import java.util.List;
-import java.util.Optional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/BlakeSubsection.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/hub/section/call/precompileSubsection/BlakeSubsection.java
@@ -125,8 +125,7 @@ public class BlakeSubsection extends PrecompileSubsection {
             callData.slice(212, 1),
             extractReturnData());
     hub.blakeModexpData()
-        .callBlake(
-            new BlakeModexpDataOperation(blake2f, this.exoModuleOperationId()));
+        .callBlake(new BlakeModexpDataOperation(blake2f, this.exoModuleOperationId()));
   }
 
   @Override

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
@@ -67,15 +67,6 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
     return ROM_LEX;
   }
 
-  public int getCodeFragmentIndexByMetadata(
-      final Address address,
-      final int deploymentNumber,
-      final boolean depStatus,
-      final int delegationNumber) {
-    return getCodeFragmentIndexByMetadata(
-        ContractMetadata.make(address, deploymentNumber, depStatus, delegationNumber));
-  }
-
   public int getCodeFragmentIndexByMetadata(final ContractMetadata metadata) {
     if (sortedOperations.isEmpty()) {
       throw new RuntimeException("Chunks have not been sorted yet");
@@ -277,7 +268,8 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
     final Hash codeHash =
         operation.metadata().underDeployment() ? Hash.EMPTY : Hash.hash(operation.byteCode());
     final boolean couldBeDelegationCode =
-        operation.byteCode().size() == EIP_7702_DELEGATED_ACCOUNT_CODE_SIZE;
+        operation.byteCode().size() == EIP_7702_DELEGATED_ACCOUNT_CODE_SIZE
+            && !operation.metadata().underDeployment();
     final int leadingThreeBytes =
         couldBeDelegationCode ? bytesToInt(operation.byteCode().slice(0, 3)) : 0;
     final boolean actuallyDelegationCode = leadingThreeBytes == EIP_7702_DELEGATION_INDICATOR;

--- a/tracer/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/tracer/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -104,7 +104,7 @@ public class ExecutionEnvironment {
           boolean traceFileDeleted = traceFilePath.toFile().delete();
           final Path finalTraceFilePath = traceFilePath;
           logger.ifPresent(
-            log -> log.debug("trace file {} deleted {}", finalTraceFilePath, traceFileDeleted));
+              log -> log.debug("trace file {} deleted {}", finalTraceFilePath, traceFileDeleted));
         }
       }
     }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ROMLEX tracing and constraint lookups used to validate traces; a mistake could cause incorrect proof constraints or misclassification of delegation bytecode, but the change is narrow and targeted.
> 
> **Overview**
> Fixes ROMLEX↔ROM constraint wiring by renaming the existing CFI lookup to `romlex-into-rom-for-CFI` and adding a new `romlex-into-rom-for-delegation` conditional lookup that ties potential EIP-7702 delegation byte patterns in `romlex` to the corresponding ROM bytes/PC.
> 
> Updates `RomLex.traceOperation` so `couldBeDelegationCode` is only set for non-deployment code, preventing deployment bytecode from being misclassified as delegation code. Remaining Java changes are formatting/cleanup (minor whitespace and an unused import removal).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1edc78674cd57eda5d3e4f4c500cd784f4a65da4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->