### PR TITLE
Prover cosmetic CI test

### DIFF
--- a/prover/cmd/prover/main.go
+++ b/prover/cmd/prover/main.go
@@ -46,6 +46,7 @@ var (
 	logStatsArgs cmd.LogStatsArgs
 )
 
+// main executes the root command.
 func main() {
 	err := rootCmd.Execute()
 	if err != nil {
@@ -59,7 +60,7 @@ func init() {
 	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: "15:04:05", NoColor: true}
 	l := zerolog.New(output).With().Timestamp().Logger()
 
-	// Set global log level for gnark logger
+	// Set global log level for gnark
 	logger.Set(l)
 
 	rootCmd.AddCommand(setupCmd)


### PR DESCRIPTION
This PR implements issue(s) # (CI testing)

This PR introduces a minor cosmetic change to `prover/cmd/prover/main.go` by adding a comment. The primary purpose of this PR is to trigger and test the CI pipeline.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

---
[Slack Thread](https://consensys.slack.com/archives/D0A9RNJ0RBR/p1770297546150309?thread_ts=1770297546.150309&cid=D0A9RNJ0RBR)

<p><a href="https://cursor.com/background-agent?bcId=bc-a1355400-0226-5c90-9ce0-55583670da41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1355400-0226-5c90-9ce0-55583670da41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no behavioral impact or data/security implications.
> 
> **Overview**
> Adds a single top-level comment to `prover/cmd/prover/main.go` describing the prover CLI for Linea circuits; no functional code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b87e80a45e14f2f28f38904874e2c8d582e6ca85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->