### PR TITLE
feat(bridge-ui): add feature flag for social login

### DIFF
--- a/bridge-ui/.env.template
+++ b/bridge-ui/.env.template
@@ -46,3 +46,5 @@ E2E_TEST_SEED_PHRASE="test test test test test test test test test test test jun
 E2E_TEST_WALLET_PASSWORD="TestPassword!"
 
 CONTENTFUL_SPACE_ID=132465789
+
+NEXT_PUBLIC_SOCIAL_LOGIN_ENABLED=false

--- a/bridge-ui/src/contexts/Web3Provider.tsx
+++ b/bridge-ui/src/contexts/Web3Provider.tsx
@@ -26,14 +26,17 @@ const googleAuthConnectionId = process.env.NEXT_PUBLIC_CONNECTOR_GOOGLE_ID || ""
 const passwordlessAuthConnectionId = process.env.NEXT_PUBLIC_CONNECTOR_PASSWORDLESS_ID || "";
 const groupedAuthConnectionId = process.env.NEXT_PUBLIC_CONNECTOR_GROUPED_ID || "";
 
+const isSocialLoginEnabled =
+  process.env.NEXT_PUBLIC_SOCIAL_LOGIN_ENABLED === 'true';
+
 const connectorLabel = "Web3Auth";
 
-const connectorConfigProduction = {
+const socialLoginDisabledConfig = {
   label: connectorLabel,
   showOnModal: false,
 };
 
-const connectorConfigStaging = {
+const socialLoginEnabledConfig = {
   label: connectorLabel,
   loginMethods: {
     google: {
@@ -92,7 +95,9 @@ const web3AuthContextConfig: Web3AuthContextConfig = {
     connectors: [coinbaseConnector({ options: "eoaOnly" })],
     modalConfig: {
       connectors: {
-        [WALLET_CONNECTORS.AUTH]: isProd ? connectorConfigProduction : connectorConfigStaging,
+        [WALLET_CONNECTORS.AUTH]: isSocialLoginEnabled
+          ? socialLoginEnabledConfig
+          : socialLoginDisabledConfig,
       },
     },
   },


### PR DESCRIPTION
This PR implements issue(s) #2300

## Summary

- Add `NEXT_PUBLIC_SOCIAL_LOGIN_ENABLED` feature flag to control social login visibility
- Decouple social login from production environment check
- Default: disabled when variable is absent

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI/config toggle that only changes which Web3Auth connector options are displayed; minimal impact unless misconfigured env values hide or expose social login unexpectedly.
> 
> **Overview**
> Adds a new `NEXT_PUBLIC_SOCIAL_LOGIN_ENABLED` environment flag (documented in `.env.template`) to explicitly control whether Web3Auth social login options (Google/passwordless) are shown.
> 
> Updates `Web3Provider` to **decouple social login visibility from the production/staging environment check**, selecting either a hidden connector config or the full `loginMethods` config based solely on the flag (defaulting to disabled unless set to `true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e16b6f565240a78c11f46fc7e6b76397a2773549. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->