### PR TITLE
coordinator: fix request retries inconsistencies

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/L1FinalizationMonitorConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/L1FinalizationMonitorConfig.kt
@@ -1,6 +1,7 @@
 package linea.coordinator.config.v2
 
 import linea.domain.BlockParameter
+import linea.domain.RetryConfig
 import java.net.URL
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -10,4 +11,6 @@ data class L1FinalizationMonitorConfig(
   val l2Endpoint: URL,
   val l1PollingInterval: Duration = 6.seconds,
   val l1QueryBlockTag: BlockParameter.Tag = BlockParameter.Tag.FINALIZED,
+  val l1RequestRetries: RetryConfig,
+  val l2RequestRetries: RetryConfig,
 )

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/L1SubmissionConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/L1SubmissionConfig.kt
@@ -1,5 +1,6 @@
 package linea.coordinator.config.v2
 
+import linea.domain.RetryConfig
 import net.consensys.linea.ethereum.gaspricing.dynamiccap.TimeOfDayMultipliers
 import java.net.URL
 import kotlin.time.Duration
@@ -40,6 +41,7 @@ data class L1SubmissionConfig(
 
     data class FeeHistoryFetcherConfig(
       val l1Endpoint: URL,
+      val l1RequestRetries: RetryConfig,
       val fetchInterval: Duration,
       val maxBlockCount: UInt,
       val rewardPercentiles: List<UInt>,
@@ -69,6 +71,7 @@ data class L1SubmissionConfig(
   data class BlobSubmissionConfig(
     override val disabled: Boolean,
     val l1Endpoint: URL,
+    val l1RequestRetries: RetryConfig,
     val submissionDelay: Duration,
     val submissionTickInterval: Duration,
     val maxSubmissionTransactionsPerTick: UInt,
@@ -81,6 +84,7 @@ data class L1SubmissionConfig(
   data class AggregationSubmissionConfig(
     override val disabled: Boolean,
     val l1Endpoint: URL,
+    val l1RequestRetries: RetryConfig,
     val submissionDelay: Duration,
     val submissionTickInterval: Duration,
     val maxSubmissionsPerTick: UInt,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/L2NetworkGasPricingConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/L2NetworkGasPricingConfig.kt
@@ -15,7 +15,9 @@ data class L2NetworkGasPricingConfig(
   val extraDataUpdateEndpoint: URL,
   val extraDataUpdateRequestRetries: RetryConfig,
   val l1Endpoint: URL,
+  val l1RequestRetries: RetryConfig,
   val l2Endpoint: URL,
+  val l2RequestRetries: RetryConfig,
 ) : FeatureToggle {
   data class DynamicGasPricing(
     val l1BlobGas: ULong,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/CoordinatorConfigFilesToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/CoordinatorConfigFilesToml.kt
@@ -65,6 +65,7 @@ data class CoordinatorConfigToml(
       l1Submission =
       this.configs.l1Submission.reified(
         l1DefaultEndpoint = this.configs.defaults.l1Endpoint,
+        l1DefaultRequestRetries = this.configs.defaults.l1RequestRetries,
         timeOfDayMultipliers =
         l1DynamicGasPriceCapTimeOfDayMultipliers
           ?.gasPriceCapTimeOfDayMultipliers
@@ -76,10 +77,7 @@ data class CoordinatorConfigToml(
         l2DefaultEndpoint = this.configs.defaults.l2Endpoint,
       ),
       l2NetworkGasPricing =
-      this.configs.l2NetworkGasPricing.reified(
-        l1DefaultEndpoint = this.configs.defaults.l1Endpoint,
-        l2DefaultEndpoint = this.configs.defaults.l2Endpoint,
-      ),
+      this.configs.l2NetworkGasPricing.reified(defaults = this.configs.defaults),
       database = this.configs.database.reified(),
       api = this.configs.api.reified(),
       smartContractErrors = smartContractErrors?.smartContractErrors ?: emptyMap(),

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/L1FinalizationMonitorConfigToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/L1FinalizationMonitorConfigToml.kt
@@ -11,6 +11,8 @@ data class L1FinalizationMonitorConfigToml(
   val l2Endpoint: URL?,
   val l1PollingInterval: Duration = 6.seconds,
   val l1QueryBlockTag: BlockParameter.Tag = BlockParameter.Tag.FINALIZED,
+  val l1RequestRetries: RequestRetriesToml? = null,
+  val l2RequestRetries: RequestRetriesToml? = null,
 ) {
   fun reified(defaults: DefaultsToml): L1FinalizationMonitorConfig {
     return L1FinalizationMonitorConfig(
@@ -18,6 +20,8 @@ data class L1FinalizationMonitorConfigToml(
       l2Endpoint = this.l2Endpoint ?: defaults.l2Endpoint ?: throw AssertionError("l2Endpoint missing"),
       l1PollingInterval = this.l1PollingInterval,
       l1QueryBlockTag = this.l1QueryBlockTag,
+      l1RequestRetries = this.l1RequestRetries?.asDomain ?: defaults.l1RequestRetries.asDomain,
+      l2RequestRetries = this.l2RequestRetries?.asDomain ?: defaults.l2RequestRetries.asDomain,
     )
   }
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/L2NetworkGasPricingConfigToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/L2NetworkGasPricingConfigToml.kt
@@ -8,7 +8,9 @@ import kotlin.time.Duration.Companion.seconds
 data class L2NetworkGasPricingConfigToml(
   val disabled: Boolean = false,
   val l1Endpoint: URL? = null,
+  val l1RequestRetries: RequestRetriesToml? = null,
   val l2Endpoint: URL? = null,
+  val l2RequestRetries: RequestRetriesToml? = null,
   val priceUpdateInterval: Duration = 12.seconds,
   val feeHistoryBlockCount: UInt = 1000u,
   val feeHistoryRewardPercentile: UInt = 15u,
@@ -84,7 +86,9 @@ data class L2NetworkGasPricingConfigToml(
     }
   }
 
-  fun reified(l1DefaultEndpoint: URL?, l2DefaultEndpoint: URL?): L2NetworkGasPricingConfig {
+  fun reified(
+    defaults: DefaultsToml,
+  ): L2NetworkGasPricingConfig {
     return L2NetworkGasPricingConfig(
       disabled = disabled,
       priceUpdateInterval = this.priceUpdateInterval,
@@ -95,8 +99,10 @@ data class L2NetworkGasPricingConfigToml(
       flatRateGasPricing = this.flatRateGasPricing.reified(),
       extraDataUpdateEndpoint = this.extraDataUpdateEndpoint,
       extraDataUpdateRequestRetries = this.extraDataUpdateRequestRetries.asDomain,
-      l1Endpoint = this.l1Endpoint ?: l1DefaultEndpoint ?: throw AssertionError("l1Endpoint must be set"),
-      l2Endpoint = this.l2Endpoint ?: l2DefaultEndpoint ?: throw AssertionError("l2Endpoint must be set"),
+      l1Endpoint = this.l1Endpoint ?: defaults.l1Endpoint ?: throw AssertionError("l1Endpoint must be set"),
+      l2Endpoint = this.l2Endpoint ?: defaults.l2Endpoint ?: throw AssertionError("l2Endpoint must be set"),
+      l1RequestRetries = this.l1RequestRetries?.asDomain ?: defaults.l1RequestRetries.asDomain,
+      l2RequestRetries = this.l2RequestRetries?.asDomain ?: defaults.l2RequestRetries.asDomain,
     )
   }
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/RequestRetriesToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/RequestRetriesToml.kt
@@ -50,7 +50,10 @@ data class RequestRetriesToml(
     )
 
   companion object {
-    fun endlessRetry(backoffDelay: Duration, failuresWarningThreshold: UInt) = RequestRetriesToml(
+    fun endlessRetry(
+      backoffDelay: Duration = 1.seconds,
+      failuresWarningThreshold: UInt = 3u,
+    ) = RequestRetriesToml(
       maxRetries = null,
       timeout = null,
       backoffDelay = backoffDelay,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -150,6 +150,8 @@ class L1DependentApp(
     val l1EthApiClient = createEthApiClient(
       rpcUrl = configs.l1Submission!!.dynamicGasPriceCap.feeHistoryFetcher.l1Endpoint.toString(),
       log = LogManager.getLogger("clients.l1.eth.fees-fetcher"),
+      vertx = vertx,
+      requestRetryConfig = configs.l1Submission.dynamicGasPriceCap.feeHistoryFetcher.l1RequestRetries,
     )
 
     FeeHistoryFetcherImpl(
@@ -181,6 +183,8 @@ class L1DependentApp(
       l2EthApiClient = createEthApiClient(
         rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
         log = LogManager.getLogger("clients.l2.eth.finalization-monitor"),
+        requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
+        vertx = vertx,
       ),
       vertx = vertx,
     )
@@ -190,6 +194,8 @@ class L1DependentApp(
     val l2EthApiClient: EthApiClient = createEthApiClient(
       rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
       log = LogManager.getLogger("clients.l2.eth.shomei-frontend"),
+      requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
+      vertx = vertx,
     )
     setupL1FinalizationMonitorForShomeiFrontend(
       type2StateProofProviderConfig = configs.type2StateProofProvider,
@@ -229,6 +235,8 @@ class L1DependentApp(
         createEthApiClient(
           rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
           log = LogManager.getLogger("clients.l2.eth.gascap-provider"),
+          vertx = vertx,
+          requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
         )
 
       GasPriceCapProviderImpl(
@@ -566,10 +574,14 @@ class L1DependentApp(
       val l2EthApiClient = createEthApiClient(
         rpcUrl = configs.l2NetworkGasPricing.l2Endpoint.toString(),
         log = LogManager.getLogger("clients.l2.eth.l2pricing"),
+        vertx = vertx,
+        requestRetryConfig = configs.l2NetworkGasPricing.l2RequestRetries,
       )
       val l1EthApiClient = createEthApiClient(
         rpcUrl = configs.l2NetworkGasPricing.l1Endpoint.toString(),
         log = LogManager.getLogger("clients.l1.eth.l1pricing"),
+        vertx = vertx,
+        requestRetryConfig = configs.l2NetworkGasPricing.l1RequestRetries,
       )
       L2NetworkGasPricingService(
         vertx = vertx,
@@ -595,6 +607,8 @@ class L1DependentApp(
       val l1EthApiClient = createEthApiClient(
         rpcUrl = configs.l1Submission.dynamicGasPriceCap.feeHistoryFetcher.l1Endpoint.toString(),
         log = LogManager.getLogger("clients.l1.eth.feehistory-cache"),
+        vertx = vertx,
+        requestRetryConfig = configs.l1Submission.dynamicGasPriceCap.feeHistoryFetcher.l1RequestRetries,
       )
 
       val l1FeeHistoryFetcher: GasPriceCapFeeHistoryFetcher = GasPriceCapFeeHistoryFetcherImpl(


### PR DESCRIPTION
This PR implements issue(s) #1997

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config schemas and how retry policies are applied to core L1/L2 JSON-RPC clients; misconfiguration or incorrect defaults could change runtime retry/timeout behavior and impact liveness.
> 
> **Overview**
> Standardizes RPC retry handling by adding explicit `RetryConfig` fields for L1/L2 endpoints across `L1FinalizationMonitorConfig`, `L1SubmissionConfig` (fee history fetcher, blob, aggregation), and `L2NetworkGasPricingConfig`.
> 
> Updates TOML reification to accept optional per-section `RequestRetriesToml` with fallbacks to `defaults`, adjusts coordinator config assembly accordingly, and wires these retry configs into `createEthApiClient` calls in `L1DependentApp` so each client uses the intended retry policy. Also tweaks `RequestRetriesToml.endlessRetry` to provide sensible default arguments (1s backoff, threshold 3).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c895d41bb3f28c28767f14be419a15410dfbf56d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->