### PR TITLE
[Coordinator] Add logs to debug missing aggregation

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -263,6 +263,7 @@ class ConflationApp(
       description = "Highest consecutive proven aggregation block number",
       measurementSupplier = highestConsecutiveAggregationTracker,
     )
+    log.info("Resuming aggregation from block={} inclusive", lastConsecutiveAggregatedBlockNumber + 1u)
     ProofAggregationCoordinatorService.Companion
       .create(
         vertx = vertx,

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/GenericFileBasedProverClient.kt
@@ -49,6 +49,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
 
   fun isResponseAlreadyDone(proofIndex: TProofIndex): SafeFuture<Path?> {
     val responseFilePath = config.responsesDirectory.resolve(responseFileNameProvider.getFileName(proofIndex))
+    log.trace("Checking if response file exists. file={}", responseFilePath)
     return fileMonitor
       .fileExists(responseFilePath)
       .thenApply { responseFileExists ->
@@ -61,6 +62,7 @@ open class GenericFileBasedProverClient<Request, Response, RequestDto, ResponseD
           )
           responseFilePath
         } else {
+          log.trace("Response file not found file={}", responseFilePath)
           null
         }
       }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes (one `info`, two `trace`) with no behavioral changes to aggregation or prover workflows; low risk aside from potential log volume if `trace` is enabled.
> 
> **Overview**
> Adds a startup log in `ConflationApp` to explicitly report the block number the aggregation coordinator will resume from.
> 
> Adds `trace`-level logging in `GenericFileBasedProverClient.isResponseAlreadyDone` to record the response file path being checked and when it is missing, helping diagnose “missing” aggregation/proof responses in file-based prover setups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2f3ceef675aec5a23cd2d2093aff04a26c9d210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->