### PR TITLE
[Tracer] Add CodeDelegation list to ToyTransaction

### DIFF
--- a/tracer/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
+++ b/tracer/testing/src/main/java/net/consensys/linea/testing/ToyTransaction.java
@@ -84,13 +84,17 @@ public class ToyTransaction {
               .gasLimit(Optional.ofNullable(gasLimit).orElse(DEFAULT_GAS_LIMIT))
               .value(Optional.ofNullable(value).orElse(DEFAULT_VALUE))
               .payload(Optional.ofNullable(payload).orElse(DEFAULT_INPUT_DATA))
-              .chainId(Optional.ofNullable(chainId).orElse(BigInteger.valueOf(LINEA_CHAIN_ID)))
-              .codeDelegations(codeDelegations);
+              .chainId(Optional.ofNullable(chainId).orElse(BigInteger.valueOf(LINEA_CHAIN_ID)));
 
       if (transactionType == TransactionType.EIP1559) {
         builder.maxPriorityFeePerGas(
             Optional.ofNullable(maxPriorityFeePerGas).orElse(DEFAULT_MAX_PRIORITY_FEE_PER_GAS));
         builder.maxFeePerGas(Optional.ofNullable(maxFeePerGas).orElse(DEFAULT_MAX_FEE_PER_GAS));
+      }
+
+      if (transactionType == TransactionType.DELEGATE_CODE) {
+         checkArgument(codeDelegations != null && !codeDelegations.isEmpty(), "Code delegations must be provided for DELEGATE_CODE transactions");
+         builder.codeDelegations(codeDelegations);
       }
 
       if (signature != null) {


### PR DESCRIPTION
This PR implements issue(s) #2243 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test helper change only; main risk is new argument validation potentially breaking existing tests that start using `DELEGATE_CODE` without delegations.
> 
> **Overview**
> `ToyTransaction` now supports constructing `DELEGATE_CODE` transactions by accepting a `codeDelegations` list and wiring it into `Transaction.Builder`.
> 
> The builder enforces that `codeDelegations` are provided for `DELEGATE_CODE` txs and adds convenience `addCodeDelegation(...)` helpers to append signed delegations via `KeyPair`, `SECPSignature`, or `(r,s,yParity)` inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff6162fcfcc6fcb5233a1759c29574b5cf88e78f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->