### PR TITLE
fix: prover static check issue

### DIFF
--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -25,7 +25,7 @@ jobs:
     - name: install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24.x
+        go-version: 1.24.6
         cache-dependency-path: |
               prover/go.sum
     - uses: actions/cache@v4.2.0


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that just pins a toolchain version; low risk beyond potentially surfacing Go-version-specific lint differences.
> 
> **Overview**
> Pins the Go toolchain used by the `staticcheck` GitHub Actions job in `prover-testing.yml` from `1.24.x` to `1.24.6` to make CI runs deterministic and avoid version-resolution issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e76360ed6f5a6a4b31323f92bef93b10e31da18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->