### PR TITLE
Remove unnecessary zkStateRootHash from FinalizationUpdate

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitor.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitor.kt
@@ -6,7 +6,6 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 interface FinalizationMonitor {
   data class FinalizationUpdate(
     val blockNumber: ULong,
-    val zkStateRootHash: Bytes32,
     val blockHash: Bytes32,
   )
 

--- a/coordinator/ethereum/finalization-monitor/src/main/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitorImpl.kt
+++ b/coordinator/ethereum/finalization-monitor/src/main/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitorImpl.kt
@@ -72,15 +72,9 @@ class FinalizationMonitorImpl(
       .thenCompose { lineaFinalizedBlockNumber ->
         l2EthApiClient
           .ethGetBlockByNumberTxHashes(BlockParameter.fromNumber(lineaFinalizedBlockNumber))
-          .thenCombine(
-            contract.blockStateRootHash(
-              blockParameter = config.l1QueryBlockTag,
-              lineaL2BlockNumber = lineaFinalizedBlockNumber,
-            ),
-          ) { finalizedBlock, stateRootHash ->
+          .thenApply { finalizedBlock ->
             FinalizationMonitor.FinalizationUpdate(
               lineaFinalizedBlockNumber,
-              Bytes32.wrap(stateRootHash),
               Bytes32.wrap(finalizedBlock.hash),
             )
           }

--- a/coordinator/ethereum/finalization-monitor/src/test/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitorImplTest.kt
+++ b/coordinator/ethereum/finalization-monitor/src/test/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitorImplTest.kt
@@ -8,8 +8,6 @@ import linea.domain.BlockParameter
 import linea.domain.BlockWithTxHashes
 import linea.ethapi.EthApiBlockClient
 import linea.kotlin.ByteArrayExt
-import org.apache.tuweni.bytes.Bytes
-import org.apache.tuweni.bytes.Bytes32
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
@@ -53,9 +51,6 @@ class FinalizationMonitorImplTest {
   fun start_startsPollingProcess(vertx: Vertx, testContext: VertxTestContext) {
     whenever(contractMock.finalizedL2BlockNumber(eq(BlockParameter.Tag.FINALIZED)))
       .thenReturn(SafeFuture.completedFuture(expectedBlockNumber))
-    val expectedStateRootHash = ByteArrayExt.random32()
-    whenever(contractMock.blockStateRootHash(any(), any()))
-      .thenReturn(SafeFuture.completedFuture(expectedStateRootHash))
 
     val expectedBlockHash = ByteArrayExt.random32()
     val mockBlockByNumberReturn = mock<BlockWithTxHashes>()
@@ -81,7 +76,6 @@ class FinalizationMonitorImplTest {
               atLeastOnce(),
             ).ethGetBlockByNumberTxHashes(eq(BlockParameter.fromNumber(expectedBlockNumber)))
             verify(contractMock, atLeastOnce()).finalizedL2BlockNumber(BlockParameter.Tag.FINALIZED)
-            verify(contractMock, atLeastOnce()).blockStateRootHash(BlockParameter.Tag.FINALIZED, expectedBlockNumber)
           }
       }
       .thenCompose { finalizationMonitorImpl.stop() }
@@ -96,11 +90,8 @@ class FinalizationMonitorImplTest {
       blockNumber += 1
       SafeFuture.completedFuture(blockNumber.toULong())
     }
-    whenever(contractMock.blockStateRootHash(any(), any())).thenAnswer {
-      SafeFuture.completedFuture(intToBytes32(blockNumber).toArray())
-    }
 
-    val expectedBlockHash = intToBytes32(blockNumber).toArray()
+    val expectedBlockHash = ByteArrayExt.random32()
     val mockBlockByNumberReturn = mock<BlockWithTxHashes>()
     whenever(mockBlockByNumberReturn.hash).thenReturn(expectedBlockHash)
     whenever(mockL2Client.ethGetBlockByNumberTxHashes(any())).thenAnswer {
@@ -154,11 +145,8 @@ class FinalizationMonitorImplTest {
       blockNumber += 1
       SafeFuture.completedFuture(blockNumber.toULong())
     }
-    whenever(contractMock.blockStateRootHash(any(), any())).thenAnswer {
-      SafeFuture.completedFuture(intToBytes32(blockNumber).toArray())
-    }
 
-    val expectedBlockHash = intToBytes32(blockNumber).toArray()
+    val expectedBlockHash = ByteArrayExt.random32()
     val mockBlockByNumberReturn = mock<BlockWithTxHashes>()
     whenever(mockBlockByNumberReturn.hash).thenReturn(expectedBlockHash)
     whenever(mockL2Client.ethGetBlockByNumberTxHashes(any())).thenAnswer {
@@ -223,11 +211,8 @@ class FinalizationMonitorImplTest {
       }
       SafeFuture.completedFuture(blockNumber.toULong())
     }
-    whenever(contractMock.blockStateRootHash(any(), any())).thenAnswer {
-      SafeFuture.completedFuture(intToBytes32(blockNumber).toArray())
-    }
 
-    val expectedBlockHash = intToBytes32(blockNumber).toArray()
+    val expectedBlockHash = ByteArrayExt.random32()
     val mockBlockByNumberReturn = mock<BlockWithTxHashes>()
     whenever(mockBlockByNumberReturn.hash).thenReturn(expectedBlockHash)
     whenever(mockL2Client.ethGetBlockByNumberTxHashes(any())).thenAnswer {
@@ -265,11 +250,8 @@ class FinalizationMonitorImplTest {
       blockNumber += 1
       SafeFuture.completedFuture(blockNumber.toULong())
     }
-    whenever(contractMock.blockStateRootHash(any(), any())).thenAnswer {
-      SafeFuture.completedFuture(intToBytes32(blockNumber).toArray())
-    }
 
-    val expectedBlockHash = intToBytes32(blockNumber).toArray()
+    val expectedBlockHash = ByteArrayExt.random32()
     val mockBlockByNumberReturn = mock<BlockWithTxHashes>()
     whenever(mockBlockByNumberReturn.hash).thenReturn(expectedBlockHash)
     whenever(mockL2Client.ethGetBlockByNumberTxHashes(any())).thenAnswer {
@@ -342,9 +324,5 @@ class FinalizationMonitorImplTest {
         testContext.completeNow()
       }
       .whenException(testContext::failNow)
-  }
-
-  private fun intToBytes32(i: Int): Bytes32 {
-    return Bytes32.leftPad(Bytes.wrap(listOf(i.toByte()).toByteArray()))
   }
 }

--- a/coordinator/persistence/aggregation/src/integrationTest/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandlerTest.kt
+++ b/coordinator/persistence/aggregation/src/integrationTest/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandlerTest.kt
@@ -133,10 +133,9 @@ class RecordsCleanupFinalizationHandlerTest : CleanDbTestSuiteParallel() {
   fun `verify that cleanup on block finalization does not delete last blob and aggregation`() {
     setup()
     val update = FinalizationMonitor.FinalizationUpdate(
-      blockNumber = 21u,
-      blockHash = Bytes32.random(),
-      zkStateRootHash = Bytes32.random(),
-    )
+    blockNumber = 21u,
+    blockHash = Bytes32.random(),
+  )
 
     val batchesBeforeCleanup = batchesContentQuery().execute().get()
     val blobsBeforeCleanup = blobsContentQuery().execute().get()


### PR DESCRIPTION
## Description
This PR removes the unnecessary `zkStateRootHash` field from `FinalizationMonitor.FinalizationUpdate`, simplifying the implementation and reducing L1 queries.

## Changes Made
- Removed `zkStateRootHash` field from `FinalizationUpdate` data class
- Removed the `contract.blockStateRootHash()` call in `FinalizationMonitorImpl.getFinalizationState()`
- Updated test files to remove `zkStateRootHash` parameter from mock objects and assertions
- Changed `thenCombine` to `thenApply` since we're no longer combining multiple futures

## Motivation
As described in #2304, this field was not being used and caused unnecessary L1 contract queries on every finalization check. Removing it:
- Reduces load on L1 
- Simplifies the codebase
- Improves maintainability

## Testing
- All existing tests have been updated and pass
- No new tests needed as this is a removal of unused functionality

Closes #2304

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this deletes an unused field and eliminates an extra L1 contract read; main impact is ensuring no downstream code still expects `zkStateRootHash`.
> 
> **Overview**
> Removes `zkStateRootHash` from `FinalizationMonitor.FinalizationUpdate` and updates consumers to only track finalized L2 `blockNumber` and `blockHash`.
> 
> `FinalizationMonitorImpl.getFinalizationState()` no longer queries `contract.blockStateRootHash()` (switching from `thenCombine` to a single `thenApply`), and unit/integration tests are adjusted to stop mocking/asserting the removed field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70ba0654aad9267e4dfc653498afafe754c69329. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->