### PR TITLE
[Fix] - use oz account recovery

### DIFF
--- a/contracts/src/rollup/forcedTransactions/ForcedTransactionGateway.sol
+++ b/contracts/src/rollup/forcedTransactions/ForcedTransactionGateway.sol
@@ -147,14 +147,13 @@ contract ForcedTransactionGateway is AccessControl, IForcedTransactionGateway {
 
     address signer;
     unchecked {
-      (signer, ) = ECDSA.tryRecover(
+      signer = ECDSA.recover(
         hashedPayload,
         _forcedTransaction.yParity + 27,
         bytes32(_forcedTransaction.r),
         bytes32(_forcedTransaction.s)
       );
     }
-    require(signer != address(0), SignerAddressZero());
 
     if (useAddressFilter) {
       require(!ADDRESS_FILTER.addressIsFiltered(signer), AddressIsFiltered());

--- a/contracts/src/rollup/forcedTransactions/interfaces/IForcedTransactionGateway.sol
+++ b/contracts/src/rollup/forcedTransactions/interfaces/IForcedTransactionGateway.sol
@@ -118,11 +118,6 @@ interface IForcedTransactionGateway {
   error ForcedTransactionFeeNotMet(uint256 expected, uint256 value);
 
   /**
-   * @dev Thrown when the signer address is zero.
-   */
-  error SignerAddressZero();
-
-  /**
    * @notice Function to submit forced transactions.
    * @param _forcedTransaction The fields required for the transaction excluding chainId.
    * @param _lastFinalizedState The last finalized state validated to use the timestamp in block number calculation.

--- a/contracts/test/hardhat/rollup/LineaRollup/ForcedTransactionGateway.ts
+++ b/contracts/test/hardhat/rollup/LineaRollup/ForcedTransactionGateway.ts
@@ -566,10 +566,9 @@ describe("Linea Rollup contract: Forced Transactions", () => {
       forcedTransaction.r = 0n;
       forcedTransaction.s = 0n;
       forcedTransaction.yParity = 0n;
-      await expectRevertWithCustomError(
-        forcedTransactionGateway,
+      await expectRevertWithReason(
         forcedTransactionGateway.submitForcedTransaction(forcedTransaction, defaultFinalizedState),
-        "SignerAddressZero",
+        "ECDSA: invalid signature",
       );
     });
 


### PR DESCRIPTION
Added for best practice

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signature recovery/validation for forced transactions, which can affect who is considered the sender and how invalid signatures fail, but the change is localized and covered by an updated test.
> 
> **Overview**
> `ForcedTransactionGateway` now uses OpenZeppelin `ECDSA.recover` instead of raw `ecrecover` when deriving the forced transaction signer, relying on OZ’s signature validation behavior.
> 
> The custom `SignerAddressZero` error is removed from `IForcedTransactionGateway`, and the Hardhat test is updated to expect an `"ECDSA: invalid signature"` revert reason for zeroed signature parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f53bd4a35983f4d90586205f03f008f9c5c9eda4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->