### PR TITLE
Chore: update Besu to 25.12.0-linea4.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ undercouchDownload = "5.6.0"
 
 # Runtime
 arithmetization="beta-v4.4-rc7.4"
-besu = "25.12.0-linea4"
+besu = "25.12.0-linea4.1"
 blobCompressor = "2.1.0-rc1"
 blobShnarfCalculator = "1.2.0"
 bouncycastle = "1.79"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with no code changes; risk is limited to any upstream Besu behavior/regression affecting runtime.
> 
> **Overview**
> Updates the pinned Hyperledger Besu runtime dependency version in `gradle/libs.versions.toml` from `25.12.0-linea4` to `25.12.0-linea4.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c18d4121cba0b98604760e8ae2762b9d48441d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->