### PR TITLE
[ZkTracer] feat: delegation phase in ZkCounter

### DIFF
--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/ZkCounter.java
@@ -421,7 +421,7 @@ public class ZkCounter implements LineCountingTracer {
         blockTransactions.traceStartTx(null, null);
         final boolean triggersEvm = computeRequiresEvmExecution(worldView, tx);
         if (tx.getType().supportsDelegateCode()) {
-          // TODO count the delegation phase size of the HUB
+          hub.updateTally(2 * tx.codeDelegationListSize() + 1);
         }
         if (triggersEvm) {
           hub.updateTally(NB_ROWS_HUB_INIT + NB_ROWS_HUB_FINL);


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only adjusts line-count/tally calculations during transaction preparation; no consensus, state-transition, or security-critical logic is modified.
> 
> **Overview**
> Updates `ZkCounter.tracePrepareTransaction` to account for **delegate-code transaction delegation overhead** by incrementing the `HUB` tally with `2 * tx.codeDelegationListSize() + 1` when the transaction type `supportsDelegateCode()`, replacing a previous TODO placeholder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8940c01d08ae83014254edc9a5b1769cc2abe472. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->