### PR TITLE
[ZkTracer] tmp disable blake constraints

### DIFF
--- a/tracer-constraints/Makefile
+++ b/tracer-constraints/Makefile
@@ -12,8 +12,6 @@ ALU := alu/add.zkasm alu/ext.zkasm alu/mod.zkasm alu/mul.zkasm
 
 BIN := bin/bin.zkasm
 
-BLAKE2f := blake2f/blake2f.zkasm
-
 BLAKE2f_MODEXP_DATA  := blake2fmodexpdata
 
 # constraints used in prod for LINEA, with linea block gas limit
@@ -49,6 +47,8 @@ MMU := mmu
 MXP := mxp
 
 OOB := oob/oob.zkasm
+
+PRECOMPILES := # blake2f/blake2f.zkasm
 
 RLP_ADDR := rlpaddr
 
@@ -88,7 +88,6 @@ ZKEVM_MODULES_COMMON := ${CONSTANTS} \
 		 ${TABLES} \
 		 ${ALU} \
 		 ${BIN} \
-		 ${BLAKE2f} \
 		 ${BLAKE2f_MODEXP_DATA} \
 		 ${BLOCKDATA} \
 		 ${BLOCKHASH} \
@@ -104,6 +103,7 @@ ZKEVM_MODULES_COMMON := ${CONSTANTS} \
 		 ${MMU} \
 		 ${MXP} \
 		 ${OOB} \
+		 ${PRECOMPILES} \
 		 ${RLP_ADDR} \
 		 ${RLP_TXN} \
 		 ${RLP_TXN_RCPT} \


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time exclusion of `blake2f` constraints can reduce proof coverage for that precompile and may mask related correctness issues until re-enabled.
> 
> **Overview**
> Temporarily disables inclusion of the `blake2f` constraint module in `tracer-constraints/Makefile` by removing it from `ZKEVM_MODULES_COMMON` and leaving it commented under a new `PRECOMPILES` variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d372ddd5eb9a92de2b42dd8db286dfaabdf545a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->