### PR TITLE
[Fix] - Add genesis shnarf init forced tx

### DIFF
--- a/contracts/src/rollup/LineaRollupBase.sol
+++ b/contracts/src/rollup/LineaRollupBase.sol
@@ -197,7 +197,7 @@ abstract contract LineaRollupBase is
 
     addressFilter = IAddressFilter(_initializationData.addressFilter);
 
-    emit LineaRollupBaseInitialized(bytes8(bytes(CONTRACT_VERSION())), _initializationData);
+    emit LineaRollupBaseInitialized(bytes8(bytes(CONTRACT_VERSION())), _initializationData, _genesisShnarf);
   }
 
   /**

--- a/contracts/src/rollup/interfaces/ILineaRollupBase.sol
+++ b/contracts/src/rollup/interfaces/ILineaRollupBase.sol
@@ -158,8 +158,13 @@ interface ILineaRollupBase {
    * @notice Emitted when the LineaRollupBase contract is initialized.
    * @param initialContractVersion The initial contract version.
    * @param initializationData The initialization data.
+   * @param genesisShnarf The genesis shnarf.
    */
-  event LineaRollupBaseInitialized(bytes8 indexed initialContractVersion, BaseInitializationData initializationData);
+  event LineaRollupBaseInitialized(
+    bytes8 indexed initialContractVersion,
+    BaseInitializationData initializationData,
+    bytes32 genesisShnarf
+  );
 
   /**
    * @dev Thrown when finalizationData.l1RollingHash does not exist on L1 (Feedback loop).

--- a/contracts/test/hardhat/rollup/LineaRollup.ts
+++ b/contracts/test/hardhat/rollup/LineaRollup.ts
@@ -317,7 +317,7 @@ describe("Linea Rollup contract", () => {
         lineaRollup,
         receipt!,
         "LineaRollupBaseInitialized",
-        [ethers.zeroPadBytes(ethers.toUtf8Bytes("8.0"), 8), expectedAsTuple],
+        [ethers.zeroPadBytes(ethers.toUtf8Bytes("8.0"), 8), expectedAsTuple, prevShnarf],
         38,
       );
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a public event signature (ABI/log decoding impact) for a core contract initializer; runtime logic is otherwise unchanged.
> 
> **Overview**
> The rollup initialization event `LineaRollupBaseInitialized` now includes the genesis shnarf, and `__LineaRollup_init` emits it as a third argument.
> 
> This updates the `ILineaRollupBase` event signature (ABI change) and adjusts the Hardhat initialization test to assert the extra emitted value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39eed64461afc0e321953b2b62c7580a5a60a866. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->