### PR TITLE
[ZkTracer] fix conversion bytes to int/long

### DIFF
--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/romlex/RomLex.java
@@ -21,7 +21,7 @@ import static net.consensys.linea.zktracer.module.ModuleName.ROM_LEX;
 import static net.consensys.linea.zktracer.types.AddressUtils.getDeploymentAddress;
 import static net.consensys.linea.zktracer.types.AddressUtils.highPart;
 import static net.consensys.linea.zktracer.types.AddressUtils.lowPart;
-import static net.consensys.linea.zktracer.types.Conversions.bytesToInt;
+import static net.consensys.linea.zktracer.types.Conversions.bytesToLong;
 
 import com.google.common.base.Preconditions;
 import java.util.*;
@@ -270,11 +270,11 @@ public class RomLex implements OperationSetModule<RomOperation>, ContextEntryDef
     final boolean couldBeDelegationCode =
         operation.byteCode().size() == EIP_7702_DELEGATED_ACCOUNT_CODE_SIZE
             && !operation.metadata().underDeployment();
-    final int leadingThreeBytes =
-        couldBeDelegationCode ? bytesToInt(operation.byteCode().slice(0, 3)) : 0;
+    final long leadingThreeBytes =
+        couldBeDelegationCode ? bytesToLong(operation.byteCode().slice(0, 3)) : 0;
     final boolean actuallyDelegationCode = leadingThreeBytes == EIP_7702_DELEGATION_INDICATOR;
-    final int potentiallyAddressHi =
-        couldBeDelegationCode ? bytesToInt(operation.byteCode().slice(3, 4)) : 0;
+    final long potentiallyAddressHi =
+        couldBeDelegationCode ? bytesToLong(operation.byteCode().slice(3, 4)) : 0;
     final Bytes potentiallyAddressLo =
         couldBeDelegationCode ? operation.byteCode().slice(7, LLARGE) : Bytes.EMPTY;
     trace

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Conversions.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/types/Conversions.java
@@ -133,12 +133,6 @@ public class Conversions {
     return sb.toString().trim();
   }
 
-  public static int bytesToInt(Bytes bytes) {
-    final Bytes trimmedBytes = bytes.trimLeadingZeros();
-    checkArgument(trimmedBytes.size() <= 4, "Input bytes must be at most 4 bytes long");
-    return Math.toIntExact(bytes.trimLeadingZeros().toLong());
-  }
-
   /**
    * This method expects a "small-ish" long value and returns the corresponding int value.
    *


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small, localized change, but it alters low-level byte-to-number conversion semantics and could change runtime behavior or throw on edge-case values where previous signed `toLong()` decoding differed.
> 
> **Overview**
> Fixes byte-slice numeric decoding by making `Conversions.bytesToLong` interpret input as *unsigned* via `toUnsignedBigInteger().longValueExact()` and enforcing the 8-byte limit.
> 
> Updates `RomLex` delegation-code detection (EIP-7702) to use `bytesToLong` and `long` intermediates, and removes the unused `Conversions.bytesToInt` helper to prevent accidental signed/overflow-prone conversions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f96b3507919d92f8870e40d56fc379790bfbda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->