### PR TITLE
[Fix] - Add sanity check for final forced tx number

### DIFF
--- a/contracts/src/rollup/LineaRollupBase.sol
+++ b/contracts/src/rollup/LineaRollupBase.sol
@@ -392,6 +392,10 @@ abstract contract LineaRollupBase is
       _finalizationData.finalForcedTransactionNumber
     ];
 
+    if (_finalizationData.finalForcedTransactionNumber > 0 && finalForcedTransactionRollingHash == EMPTY_HASH) {
+      revert MissingRollingHashForForcedTransactionNumber(_finalizationData.finalForcedTransactionNumber);
+    }
+
     _verifyProof(
       _computePublicInput(
         _finalizationData,

--- a/contracts/src/rollup/forcedTransactions/interfaces/IAcceptForcedTransactions.sol
+++ b/contracts/src/rollup/forcedTransactions/interfaces/IAcceptForcedTransactions.sol
@@ -42,6 +42,11 @@ interface IAcceptForcedTransactions {
   error ForcedTransactionExistsForBlockOrIsTooLow(uint256 blockNumber);
 
   /**
+   * @dev Thrown when a rolling hash is missing for a forced transaction number.
+   */
+  error MissingRollingHashForForcedTransactionNumber(uint256 forcedTransactionNumber);
+
+  /**
    * @notice Provides state fields for forced transactions.
    * @return finalizedState The last finalized state hash.
    * @return previousForcedTransactionRollingHash The previous forced transaction rolling hash.

--- a/contracts/test/hardhat/rollup/LineaRollup/BlobSubmission.ts
+++ b/contracts/test/hardhat/rollup/LineaRollup/BlobSubmission.ts
@@ -719,6 +719,46 @@ describe("Linea Rollup contract: EIP-4844 Blob submission tests", () => {
     });
   });
 
+  it("Should fail to finalize if finalForcedTransactionNumber is non-zero but rolling hash is empty", async () => {
+    // Submit 2 blobs
+    await sendBlobTransaction(lineaRollup, 0, 2, true);
+    // Submit another 2 blobs
+    await sendBlobTransaction(lineaRollup, 2, 4, true);
+
+    const finalizationData = await generateFinalizationData({
+      l1RollingHash: blobAggregatedProof1To155.l1RollingHash,
+      l1RollingHashMessageNumber: BigInt(blobAggregatedProof1To155.l1RollingHashMessageNumber),
+      lastFinalizedTimestamp: BigInt(blobAggregatedProof1To155.parentAggregationLastBlockTimestamp),
+      endBlockNumber: BigInt(blobAggregatedProof1To155.finalBlockNumber),
+      parentStateRootHash: HASH_ZERO,
+      finalTimestamp: BigInt(blobAggregatedProof1To155.finalTimestamp),
+      l2MerkleRoots: blobAggregatedProof1To155.l2MerkleRoots,
+      l2MerkleTreesDepth: BigInt(blobAggregatedProof1To155.l2MerkleTreesDepth),
+      l2MessagingBlocksOffsets: blobAggregatedProof1To155.l2MessagingBlocksOffsets,
+      aggregatedProof: blobAggregatedProof1To155.aggregatedProof,
+      shnarfData: generateBlobParentShnarfData(4, false),
+      lastFinalizedL1RollingHash: HASH_ZERO,
+      lastFinalizedL1RollingHashMessageNumber: 0n,
+      finalForcedTransactionNumber: 1n,
+    });
+
+    await lineaRollup.setRollingHash(
+      blobAggregatedProof1To155.l1RollingHashMessageNumber,
+      blobAggregatedProof1To155.l1RollingHash,
+    );
+
+    await lineaRollup.setLastFinalizedBlock(10_000_000);
+
+    await expectRevertWithCustomError(
+      lineaRollup,
+      lineaRollup
+        .connect(operator)
+        .finalizeBlocks(blobAggregatedProof1To155.aggregatedProof, TEST_PUBLIC_VERIFIER_INDEX, finalizationData),
+      "MissingRollingHashForForcedTransactionNumber",
+      [1],
+    );
+  });
+
   it("Should fail to finalize if there are missing forced transactions", async () => {
     // Submit 2 blobs
     await sendBlobTransaction(lineaRollup, 0, 2, true);


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive validation that only introduces an earlier revert in finalization when forced-transaction state is inconsistent; covered by a new test.
> 
> **Overview**
> Adds a **sanity check** during `finalizeBlocks` to ensure that when `finalForcedTransactionNumber` is non-zero, the corresponding `forcedTransactionRollingHashes` entry is present; otherwise it reverts with new custom error `MissingRollingHashForForcedTransactionNumber`.
> 
> Updates the forced-transactions interface to expose this new error and adds a Hardhat test covering the new revert path when finalization references a forced transaction number without a stored rolling hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69b4997a6b8bb2d76ef7980b05923eb754275ba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->