### PR TITLE
[ZkTracer] chore: update corset to 1.2.0

### DIFF
--- a/tracer/gradle/corset.gradle
+++ b/tracer/gradle/corset.gradle
@@ -28,7 +28,7 @@ tasks.register('corsetExists') {
 ext {
   corsetVersion = project.hasProperty('corsetVersion')
     ? project.property('corsetVersion')
-    : System.getenv().getOrDefault('CORSET_VERSION', "v1.2.0-rc8")
+    : System.getenv().getOrDefault('CORSET_VERSION', "v1.2.0")
 }
 
 tasks.register('installGoCorset') {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-script default version bump with no runtime logic changes; risk is limited to potential tool/version compatibility issues in CI/local builds.
> 
> **Overview**
> Updates the default `go-corset` tool version used by the tracer Gradle build from the `v1.2.0-rc8` release candidate to the stable `v1.2.0` (still overridable via the `corsetVersion` property or `CORSET_VERSION` env var).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c87a55e580aa3d0b00bc10fe55cafaec76036100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->