### PR TITLE
feat: exec env test in .lt

### DIFF
--- a/tracer/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
+++ b/tracer/testing/src/main/java/net/consensys/linea/testing/ExecutionEnvironment.java
@@ -119,7 +119,7 @@ public class ExecutionEnvironment {
       TestInfo testInfo) {
     try {
       String prefix = constructTestPrefix(zkTracer.getChain(), testInfo);
-      Path traceFilePath = Files.createTempFile(prefix, ".lt.gz");
+      Path traceFilePath = Files.createTempFile(prefix, ".lt");
       zkTracer.writeToFile(traceFilePath, startBlock, endBlock);
       final Path finalTraceFilePath = traceFilePath;
       logger.ifPresent(log -> log.debug("trace written to {}", finalTraceFilePath));


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to test trace file naming/format; risk is limited to potentially breaking tooling that assumes gzip-compressed traces.
> 
> **Overview**
> Execution-environment tracer tests now create temporary trace files with a `.lt` suffix (uncompressed) instead of `.lt.gz` before running Corset validation and optional cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88b8de6be9bfbd61713bd2b77331dae883320496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->