### PR TITLE
fix: add leaf length check in sparse merkle proof contrct

### DIFF
--- a/contracts/src/libraries/SparseMerkleProof.sol
+++ b/contracts/src/libraries/SparseMerkleProof.sol
@@ -36,19 +36,9 @@ library SparseMerkleProof {
   }
 
   /**
-   * Thrown when the first proof element (index 0) has an incorrect bytes length.
+   * Thrown when expected bytes length is incorrect.
    */
-  error WrongProofNodeBytesLength(uint256 expectedLength, uint256 bytesLength);
-
-  /**
-   * Thrown when the leaf bytes length is incorrect.
-   */
-  error WrongLeafBytesLength(uint256 expectedLength, uint256 bytesLength);
-
-  /**
-   * Thrown when the account bytes length is incorrect.
-   */
-  error WrongAccountBytesLength(uint256 expectedLength, uint256 bytesLength);
+  error WrongBytesLength(uint256 expectedLength, uint256 bytesLength);
 
   /**
    * Thrown when the length of bytes is not in exactly 32 byte chunks.
@@ -159,7 +149,7 @@ library SparseMerkleProof {
    */
   function _parseLeaf(bytes calldata _encodedLeaf) private pure returns (Leaf memory) {
     if (_encodedLeaf.length != LEAF_BYTES_LENGTH) {
-      revert WrongLeafBytesLength(LEAF_BYTES_LENGTH, _encodedLeaf.length);
+      revert WrongBytesLength(LEAF_BYTES_LENGTH, _encodedLeaf.length);
     }
     return abi.decode(_encodedLeaf, (Leaf));
   }
@@ -171,7 +161,7 @@ library SparseMerkleProof {
    */
   function _parseAccount(bytes calldata _value) private pure returns (Account memory) {
     if (_value.length != ACCOUNT_BYTES_LENGTH) {
-      revert WrongAccountBytesLength(ACCOUNT_BYTES_LENGTH, _value.length);
+      revert WrongBytesLength(ACCOUNT_BYTES_LENGTH, _value.length);
     }
     return abi.decode(_value, (Account));
   }
@@ -192,11 +182,11 @@ library SparseMerkleProof {
     bytes32[] memory proof = new bytes32[](formattedProofLength);
 
     if (_rawProof[0].length != 0x60) {
-      revert WrongProofNodeBytesLength(0x60, _rawProof[0].length);
+      revert WrongBytesLength(0x60, _rawProof[0].length);
     }
 
     if (_rawProof[rawProofLength - 1].length != LEAF_BYTES_LENGTH) {
-      revert WrongLeafBytesLength(LEAF_BYTES_LENGTH, _rawProof[rawProofLength - 1].length);
+      revert WrongBytesLength(LEAF_BYTES_LENGTH, _rawProof[rawProofLength - 1].length);
     }
 
     (bytes32[2] memory nextFreeNode, bytes32 subSmtRoot) = abi.decode(_rawProof[0], (bytes32[2], bytes32));

--- a/contracts/test/hardhat/libraries/SparseMerkleProof.ts
+++ b/contracts/test/hardhat/libraries/SparseMerkleProof.ts
@@ -106,7 +106,7 @@ describe("SparseMerkleProof", () => {
         await expectRevertWithCustomError(
           sparseMerkleProof,
           sparseMerkleProof.verifyProof(clonedProof, leafIndex, STATE_ROOT),
-          "WrongProofNodeBytesLength",
+          "WrongBytesLength",
           [96, 2],
         );
       });
@@ -126,7 +126,7 @@ describe("SparseMerkleProof", () => {
         await expectRevertWithCustomError(
           sparseMerkleProof,
           sparseMerkleProof.verifyProof(clonedProof, leafIndex, STATE_ROOT),
-          "WrongLeafBytesLength",
+          "WrongBytesLength",
           [192, 2],
         );
       });
@@ -289,7 +289,7 @@ describe("SparseMerkleProof", () => {
       await expectRevertWithCustomError(
         sparseMerkleProof,
         sparseMerkleProof.hashAccountValue(shortValue),
-        "WrongAccountBytesLength",
+        "WrongBytesLength",
         [192, 2],
       );
     });
@@ -301,7 +301,7 @@ describe("SparseMerkleProof", () => {
       await expectRevertWithCustomError(
         sparseMerkleProof,
         sparseMerkleProof.hashAccountValue(longValue),
-        "WrongAccountBytesLength",
+        "WrongBytesLength",
         [192, 195],
       );
     });
@@ -333,7 +333,7 @@ describe("SparseMerkleProof", () => {
         const wrongLeaftValue = `0x${proofRelatedNodes[proofRelatedNodes.length - 1].slice(4)}`;
 
         await expect(sparseMerkleProof.getLeaf(wrongLeaftValue))
-          .to.revertedWithCustomError(sparseMerkleProof, "WrongLeafBytesLength")
+          .to.revertedWithCustomError(sparseMerkleProof, "WrongBytesLength")
           .withArgs(192, ethers.dataLength(wrongLeaftValue));
       });
 
@@ -347,7 +347,7 @@ describe("SparseMerkleProof", () => {
         const wrongLeaftValue = `${proofRelatedNodes[proofRelatedNodes.length - 1]}1234`;
 
         await expect(sparseMerkleProof.getLeaf(wrongLeaftValue))
-          .to.revertedWithCustomError(sparseMerkleProof, "WrongLeafBytesLength")
+          .to.revertedWithCustomError(sparseMerkleProof, "WrongBytesLength")
           .withArgs(192, ethers.dataLength(wrongLeaftValue));
       });
 
@@ -382,7 +382,7 @@ describe("SparseMerkleProof", () => {
         const wrongLeaftValue = `0x${proofRelatedNodes[proofRelatedNodes.length - 1].slice(4)}`;
 
         await expect(sparseMerkleProof.getLeaf(wrongLeaftValue))
-          .to.revertedWithCustomError(sparseMerkleProof, "WrongLeafBytesLength")
+          .to.revertedWithCustomError(sparseMerkleProof, "WrongBytesLength")
           .withArgs(192, ethers.dataLength(wrongLeaftValue));
       });
 
@@ -418,7 +418,7 @@ describe("SparseMerkleProof", () => {
       const wrongAccountValue = `0x${value.slice(4)}`;
 
       await expect(sparseMerkleProof.getAccount(wrongAccountValue))
-        .to.revertedWithCustomError(sparseMerkleProof, "WrongAccountBytesLength")
+        .to.revertedWithCustomError(sparseMerkleProof, "WrongBytesLength")
         .withArgs(192, ethers.dataLength(wrongAccountValue));
     });
 
@@ -432,7 +432,7 @@ describe("SparseMerkleProof", () => {
       const wrongAccountValue = `${value}123456`;
 
       await expect(sparseMerkleProof.getAccount(wrongAccountValue))
-        .to.revertedWithCustomError(sparseMerkleProof, "WrongAccountBytesLength")
+        .to.revertedWithCustomError(sparseMerkleProof, "WrongBytesLength")
         .withArgs(192, ethers.dataLength(wrongAccountValue));
     });
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive validation and constant refactor in proof parsing/verification; main risk is rejecting previously-accepted malformed inputs.
> 
> **Overview**
> Tightens `SparseMerkleProof.verifyProof` input validation by enforcing that the final proof element (the encoded leaf) is exactly 192 bytes before hashing, preventing malformed proofs from being processed.
> 
> Refactors hardcoded `192` checks into named constants (`LEAF_BYTES_LENGTH`, `ACCOUNT_BYTES_LENGTH`) for leaf/account parsing, and adds a Hardhat test asserting `verifyProof` reverts with `WrongBytesLength` when the leaf blob length is incorrect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 238e60288f501e52684e3bf52a9a9729f166debe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->