### PR TITLE
feat: add BugBot versioning guidelines and restructure rules

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -2,41 +2,22 @@
 
 Automated security and code quality enforcement across the Linea monorepo.
 
-## Reference
+## Rule Sets
 
-Refer to [security-logging-guidelines](rules/security-logging-guidelines/EXAMPLES.md) for detailed examples of what to do, and what not to do. That rule applies to every code file (`.ts`, `.js`, `.kt`, `.java`, `.go`, `.sol`, `.py`).
+### Security Logging
 
-## MUST NOT
+Prevents leaking secrets, credentials, and sensitive data in logs, error messages, tests, and config files. Applies to all code files (`.ts`, `.js`, `.kt`, `.java`, `.go`, `.sol`, `.py`).
 
-- Log passwords, API keys, auth tokens, session IDs, private keys (cryptographic/SSH/PGP), JWT tokens, AWS keys, or GitHub tokens.
-- Log URLs containing sensitive query parameters (`token`, `apiKey`, `secret`, `password`, `auth`) without sanitization.
-- Log environment variables wholesale or config objects without redacting sensitive fields.
-- Log RPC URLs with embedded tokens or database connection strings containing credentials.
-- Log private keys or raw signatures during transaction signing or message signing.
-- Expose secrets in error messages, stack traces, exception propagation, metrics labels, trace data, or health-check endpoints.
-- Hardcode secrets in source code, operation scripts, configuration files, documentation, or code comments.
-- Include real credentials in tests, fixtures, mock servers, Postman collections, or example code.
-- Log request/response bodies or headers that contain auth tokens.
+- [Rules](rules/security-logging-guidelines/RULES.md)
+- [Examples](rules/security-logging-guidelines/EXAMPLES.md)
 
-## MUST
+### API and Asset Versioning
 
-- Sanitize URLs by redacting sensitive query parameters before any logging.
-- Redact sensitive fields when logging objects or configuration; override `toString()` on config classes (Kotlin/Java) to redact secrets.
-- Configure structured logging frameworks (Log4j/SLF4J/etc.) to filter sensitive data.
-- Load secrets from environment variables or secure vaults exclusively.
-- Use obviously fake/placeholder credentials in all tests, fixtures, `.env.template` files, and documentation.
-- Ensure `.env` files are in `.gitignore` and template files reference placeholders only.
-- Sanitize error details before propagation -- log `error.message` and `error.code`, not full config or request objects.
+Enforces backwards compatibility for public APIs and versioned assets (ABIs, configs). Components released beyond devnet must create new versioned methods/assets instead of breaking existing ones. Applies to all code files plus `.abi` and `.json`.
 
-## MAY log
-
-- Log levels, categories, timestamps, and request IDs.
-- Endpoint paths without query parameters.
-- Error types and status codes.
-- Configuration keys (not values); indicate presence with `[CONFIGURED]` / `[NOT SET]`.
-- Wallet addresses and transaction hashes (never private keys).
-- Partial identifiers (last 4 characters).
+- [Rules](rules/versioning-guidelines/RULES.md)
+- [Examples](rules/versioning-guidelines/EXAMPLES.md)
 
 ## Enforcement
 
-When a violation is detected, **block the change** with a clear explanation and suggest a safe alternative. Always reference [security-logging-guidelines](rules/security-logging-guidelines/EXAMPLES.md) for correct patterns.
+When a violation is detected, **block the change** with a clear explanation and suggest a safe alternative. Always reference the relevant rule's examples for correct patterns.

--- a/.cursor/rules/security-logging-guidelines/RULES.md
+++ b/.cursor/rules/security-logging-guidelines/RULES.md
@@ -1,0 +1,44 @@
+---
+description: Security-Sensitive Information Logging Prevention - Rules
+globs: "**/*.ts, **/*.js, **/*.kt, **/*.java, **/*.go, **/*.sol, **/*.py"
+alwaysApply: true
+---
+
+# Security Logging Rules
+
+Refer to [EXAMPLES.md](EXAMPLES.md) for detailed examples of what to do and what not to do.
+
+## MUST NOT
+
+- Log passwords, API keys, auth tokens, session IDs, private keys (cryptographic/SSH/PGP), JWT tokens, AWS keys, or GitHub tokens.
+- Log URLs containing sensitive query parameters (`token`, `apiKey`, `secret`, `password`, `auth`) without sanitization.
+- Log environment variables wholesale or config objects without redacting sensitive fields.
+- Log RPC URLs with embedded tokens or database connection strings containing credentials.
+- Log private keys or raw signatures during transaction signing or message signing.
+- Expose secrets in error messages, stack traces, exception propagation, metrics labels, trace data, or health-check endpoints.
+- Hardcode secrets in source code, operation scripts, configuration files, documentation, or code comments.
+- Include real credentials in tests, fixtures, mock servers, Postman collections, or example code.
+- Log request/response bodies or headers that contain auth tokens.
+
+## MUST
+
+- Sanitize URLs by redacting sensitive query parameters before any logging.
+- Redact sensitive fields when logging objects or configuration; override `toString()` on config classes (Kotlin/Java) to redact secrets.
+- Configure structured logging frameworks (Log4j/SLF4J/etc.) to filter sensitive data.
+- Load secrets from environment variables or secure vaults exclusively.
+- Use obviously fake/placeholder credentials in all tests, fixtures, `.env.template` files, and documentation.
+- Ensure `.env` files are in `.gitignore` and template files reference placeholders only.
+- Sanitize error details before propagation - log `error.message` and `error.code`, not full config or request objects.
+
+## MAY log
+
+- Log levels, categories, timestamps, and request IDs.
+- Endpoint paths without query parameters.
+- Error types and status codes.
+- Configuration keys (not values); indicate presence with `[CONFIGURED]` / `[NOT SET]`.
+- Wallet addresses and transaction hashes (never private keys).
+- Partial identifiers (last 4 characters).
+
+## Enforcement
+
+When a violation is detected, **block the change** with a clear explanation and suggest a safe alternative. Always reference [EXAMPLES.md](EXAMPLES.md) for correct patterns.

--- a/.cursor/rules/versioning-guidelines/EXAMPLES.md
+++ b/.cursor/rules/versioning-guidelines/EXAMPLES.md
@@ -1,0 +1,107 @@
+---
+description: API and Asset Versioning - Examples
+globs: "**/*.ts, **/*.js, **/*.kt, **/*.java, **/*.go, **/*.sol, **/*.py, **/*.abi, **/*.json"
+alwaysApply: true
+---
+
+# API and Asset Versioning - WRONG / CORRECT Examples
+
+## Method Versioning
+
+```kotlin
+// WRONG - breaking change to existing method signature
+fun doSomething(items: List<Item>): Result {
+    // changed from List to Map, breaking all callers
+}
+
+// CORRECT - new versioned method, old one deprecated
+@Deprecated("please use doSomethingV2")
+fun doSomethingV1(items: List<Item>): Result {
+    // original implementation preserved
+}
+
+fun doSomethingV2(items: Map<String, Item>): Result {
+    // new implementation with breaking signature
+}
+```
+
+## Smart Contract / Solidity Versioning
+
+```solidity
+// WRONG - modifying existing interface that external consumers depend on
+interface ILineaRollup {
+    // changed parameter type, breaks all integrators
+    function submitData(bytes32[] calldata data) external;
+}
+
+// CORRECT - new versioned interface
+interface ILineaRollupV1 {
+    function submitData(bytes calldata data) external;
+}
+
+interface ILineaRollupV2 {
+    // new signature with breaking changes
+    function submitData(bytes32[] calldata data) external;
+}
+```
+
+## ABI / Asset Versioning
+
+```
+# WRONG - overwriting existing ABI consumed by deployed coordinator
+contracts/
+  ValidiumV1.abi    <-- modified in-place, breaks coordinator on next update
+
+# CORRECT - new versioned asset alongside existing one
+contracts/
+  ValidiumV1.abi    <-- unchanged, coordinator continues to work
+  ValidiumV2.abi    <-- new version with breaking changes
+```
+
+## TypeScript / JavaScript API Versioning
+
+```typescript
+// WRONG - renaming exported function that other packages import
+export function getProof(blockNumber: number): Proof { ... }
+// renamed to getProofWithValidation, breaking all importers
+
+// CORRECT - deprecate and add new version
+/** @deprecated Use getProofV2 instead */
+export function getProofV1(blockNumber: number): Proof { ... }
+
+export function getProofV2(blockNumber: number, options: ProofOptions): Proof { ... }
+```
+
+## REST / JSON-RPC API Versioning
+
+```typescript
+// WRONG - changing response shape of existing endpoint
+app.get('/api/v1/status', (req, res) => {
+    // changed from { status: string } to { state: string, details: object }
+    // breaks all clients parsing the old shape
+});
+
+// CORRECT - new versioned endpoint
+app.get('/api/v1/status', (req, res) => {
+    // preserved for existing clients
+    res.json({ status: 'ok' });
+});
+
+app.get('/api/v2/status', (req, res) => {
+    // new shape for new clients
+    res.json({ state: 'ok', details: { ... } });
+});
+```
+
+## Configuration / JSON Asset Versioning
+
+```
+# WRONG - overwriting deployed config schema
+config/
+  coordinator-config.json    <-- changed schema, breaks deployed instances
+
+# CORRECT - versioned config
+config/
+  coordinator-config-v1.json  <-- unchanged
+  coordinator-config-v2.json  <-- new schema
+```

--- a/.cursor/rules/versioning-guidelines/RULES.md
+++ b/.cursor/rules/versioning-guidelines/RULES.md
@@ -1,0 +1,42 @@
+---
+description: API and Asset Versioning - Rules for backwards compatibility
+globs: "**/*.ts, **/*.js, **/*.kt, **/*.java, **/*.go, **/*.sol, **/*.py, **/*.abi, **/*.json"
+alwaysApply: true
+---
+
+# API and Asset Versioning Rules
+
+Components must maintain backwards compatibility, especially those already released beyond devnet (sepolia, external partners). This is critical for Linea Stack/Enterprise, where components (e.g. coordinator, contracts, tracing modules) must coexist across multiple versions.
+
+Refer to [EXAMPLES.md](EXAMPLES.md) for detailed do/don't examples.
+
+## MUST
+
+- Create a new versioned method when introducing breaking changes to a public API consumed by another component. The existing method must remain functional so consumers can migrate on their own schedule.
+- Mark the old method as deprecated with a pointer to the new version.
+- Create a new versioned asset (e.g. `LineaRollupV7.abi`, `LineaRollupV8.abi`) instead of overwriting an existing one.
+- Use simple incremental version suffixes per method/asset (V1, V2, V3), similar to Ethereum Engine API conventions (`engine_getPayloadV1` ... `engine_getPayloadV5`).
+- Bump the version number when a breaking change is introduced to that specific method or asset - not when unrelated parts of the system change.
+
+## MUST NOT
+
+- Refactor, rename, or change the signature of an existing public API method in a way that breaks current consumers.
+- Override or replace a versioned asset (e.g. ABI file) that is already deployed and consumed by external partners or environments beyond devnet.
+- Tie method/asset version numbers to an unrelated release train (e.g. `linea-besu-package` versions) - components are independently versioned.
+
+## Scope
+
+These rules apply when:
+- The component is released on any environment other than devnet (sepolia, mainnet, external partners).
+- The public API or asset is consumed by another component or external integrator.
+
+For internal-only, devnet-only code with no external consumers, lighter versioning practices are acceptable.
+
+## Enforcement
+
+When a PR modifies a public API signature or overwrites an existing versioned asset, **flag the change** and ask:
+1. Is this method/asset consumed by another component or external partner?
+2. If yes, has a new versioned method/asset been created instead of modifying the existing one?
+3. Is the old version deprecated with a pointer to the new one?
+
+Block the change if the answer to (1) is yes and (2) or (3) is no. Reference [EXAMPLES.md](EXAMPLES.md) for correct patterns.

--- a/.gitignore
+++ b/.gitignore
@@ -49,15 +49,9 @@
 .claude/
 .ipynb_checkpoints
 # Ignore .cursor config but commit shared team rules (BUGBOT.md, rules/).
-# Each intermediate directory must be un-ignored then re-ignored so git
-# descends into it and evaluates the deeper negation patterns.
 .cursor/*
 !.cursor/BUGBOT.md
 !.cursor/rules/
-.cursor/rules/*
-!.cursor/rules/security-logging-guidelines/
-.cursor/rules/security-logging-guidelines/*
-!.cursor/rules/security-logging-guidelines/EXAMPLES.md
 
 atlassian-ide-plugin.xml
 circuit.bin


### PR DESCRIPTION
## Summary

- Restructures .cursor/BUGBOT.md from an inline rule file into a lightweight index that references modular rule sets under .cursor/rules/.
- Moves existing security-logging rules into rules/security-logging-guidelines/RULES.md (alongside the existing EXAMPLES.md).
- Adds new rules/versioning-guidelines/ rule set (RULES.md + EXAMPLES.md) enforcing backwards compatibility for public APIs and versioned assets - components released beyond devnet must create new versioned methods/assets instead of breaking existing ones.
- Simplifies .gitignore to include all of .cursor/rules/ instead of per-file allowlisting.

## Test plan

- [ ] Verify .cursor/rules/versioning-guidelines/RULES.md and EXAMPLES.md are tracked by git and visible in the PR diff
- [ ] Verify .cursor/rules/security-logging-guidelines/RULES.md content matches what was previously in BUGBOT.md
- [ ] Verify BUGBOT.md links resolve correctly to each rule set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/config-only changes to Cursor rule files and `.gitignore`, with no runtime code path impact; main risk is misconfigured ignore patterns affecting which rule files are committed.
> 
> **Overview**
> Refactors `.cursor/BUGBOT.md` from an inline rule document into a lightweight index that links to modular rule sets under `.cursor/rules/`.
> 
> Adds a new **API and asset versioning** rule set (`rules` + `examples`) to enforce backwards-compatible changes via versioned methods/assets, and moves the existing **security logging** rules into a dedicated `RULES.md` alongside its examples.
> 
> Simplifies `.gitignore` to allowlist the entire `.cursor/rules/` directory (instead of per-subdirectory exceptions) while still ignoring other `.cursor` config files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2ea16455ce6eed9d40a498c04d375daec9c5878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->