### PR TITLE
[Coordinator] Add client for linea_generateVirtualBlockConflatedTracesToFileV1

### DIFF
--- a/coordinator/clients/traces-generator-api-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/TracesClientResponsesParser.kt
+++ b/coordinator/clients/traces-generator-api-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/TracesClientResponsesParser.kt
@@ -112,4 +112,8 @@ object TracesClientResponsesParser {
       result.getString("tracesEngineVersion"),
     )
   }
+
+  internal fun parseVirtualBlockConflatedTracesToFileResponse(
+    jsonRpcResponse: JsonRpcSuccessResponse,
+  ): GenerateTracesResponse = parseConflatedTracesToFileResponse(jsonRpcResponse)
 }

--- a/coordinator/clients/traces-generator-api-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/TracesGeneratorJsonRpcClientV2.kt
+++ b/coordinator/clients/traces-generator-api-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/TracesGeneratorJsonRpcClientV2.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.mapEither
 import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 import io.vertx.kotlin.core.json.get
+import linea.kotlin.encodeHex
 import net.consensys.linea.async.toSafeFuture
 import net.consensys.linea.errors.ErrorResponse
 import net.consensys.linea.jsonrpc.JsonRpcRequest
@@ -28,7 +29,7 @@ class TracesGeneratorJsonRpcClientV2(
   private val rpcClient: JsonRpcClient,
   private val config: Config,
 ) :
-  TracesCountersClientV2, TracesConflationClientV2 {
+  TracesCountersClientV2, TracesConflationClientV2, TracesConflationVirtualBlockClientV1 {
   constructor(
     vertx: Vertx,
     rpcClient: JsonRpcClient,
@@ -88,6 +89,21 @@ class TracesGeneratorJsonRpcClientV2(
     ) { createFallbackConflatedTracesResponse(startBlockNumber, endBlockNumber) }
   }
 
+  override fun generateVirtualBlockConflatedTracesToFile(
+    blockNumber: ULong,
+    transaction: ByteArray,
+  ): SafeFuture<Result<GenerateTracesResponse, ErrorResponse<TracesServiceErrorType>>> {
+    val jsonRequest =
+      requestBuilder.buildGenerateVirtualBlockConflatedTracesToFileV1Request(
+        blockNumber = blockNumber,
+        transaction = transaction,
+      )
+    return executeWithFallback(
+      jsonRequest,
+      TracesClientResponsesParser::parseVirtualBlockConflatedTracesToFileResponse,
+    ) { createFallbackVirtualBlockConflatedTracesResponse(blockNumber) }
+  }
+
   private fun createFallbackTracesCountersResponse(): GetTracesCountersResponse {
     return GetTracesCountersResponse(
       tracesCounters = config.fallBackTracesCounters,
@@ -100,6 +116,16 @@ class TracesGeneratorJsonRpcClientV2(
     endBlockNumber: ULong,
   ): GenerateTracesResponse {
     val defaultFileName = "$startBlockNumber-$endBlockNumber.fake-empty.conflated.${config.expectedTracesApiVersion}.lt"
+    return GenerateTracesResponse(
+      tracesFileName = defaultFileName,
+      tracesEngineVersion = config.expectedTracesApiVersion,
+    )
+  }
+
+  private fun createFallbackVirtualBlockConflatedTracesResponse(
+    blockNumber: ULong,
+  ): GenerateTracesResponse {
+    val defaultFileName = "$blockNumber.fake-empty.conflated.${config.expectedTracesApiVersion}.lt"
     return GenerateTracesResponse(
       tracesFileName = defaultFileName,
       tracesEngineVersion = config.expectedTracesApiVersion,
@@ -178,10 +204,33 @@ class TracesGeneratorJsonRpcClientV2(
         ),
       )
     }
+
+    fun buildGenerateVirtualBlockConflatedTracesToFileV1Request(
+      blockNumber: ULong,
+      transaction: ByteArray,
+    ): JsonRpcRequest {
+      return JsonRpcRequestListParams(
+        "2.0",
+        id.incrementAndGet(),
+        "linea_generateVirtualBlockConflatedTracesToFileV1",
+        listOf(
+          JsonObject.of(
+            "blockNumber",
+            blockNumber,
+            "txsRlpEncoded",
+            listOf(transaction.encodeHex()),
+          ),
+        ),
+      )
+    }
   }
 
   companion object {
-    internal val retryableMethods = setOf("linea_getBlockTracesCountersV2", "linea_generateConflatedTracesToFileV2")
+    internal val retryableMethods = setOf(
+      "linea_getBlockTracesCountersV2",
+      "linea_generateConflatedTracesToFileV2",
+      "linea_generateVirtualBlockConflatedTracesToFileV1",
+    )
 
     @Suppress("UNCHECKED_CAST")
     val requestPriorityComparator =


### PR DESCRIPTION

This PR implements issue(s) #2386 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external JSON-RPC method and request format (tx encoding) and expands retry/fallback paths; failures could impact traces generation behavior but changes are localized and covered by tests.
> 
> **Overview**
> Adds a new `generateVirtualBlockConflatedTracesToFile` API to `TracesGeneratorJsonRpcClientV2` to call `linea_generateVirtualBlockConflatedTracesToFileV1`, encoding the provided transaction as hex and returning the same `GenerateTracesResponse` shape used by existing conflation calls.
> 
> Extends retry/fallback behavior to this new method (including adding it to `retryableMethods`) and adds WireMock tests covering success, JSON-RPC error mapping, and HTTP-retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a609aa06471a6fbc35fc3f7c54d390b7102e677. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->