### PR TITLE
[ZkTracer] update `go-corset` to `v1.2.2`

### DIFF
--- a/tracer/gradle/corset.gradle
+++ b/tracer/gradle/corset.gradle
@@ -28,7 +28,7 @@ tasks.register('corsetExists') {
 ext {
   corsetVersion = project.hasProperty('corsetVersion')
     ? project.property('corsetVersion')
-    : System.getenv().getOrDefault('CORSET_VERSION', "v1.2.1")
+    : System.getenv().getOrDefault('CORSET_VERSION', "v1.2.2")
 }
 
 tasks.register('installGoCorset') {


### PR DESCRIPTION
This version contains an important performance-related fix which should improve the overall runtime of tests in the CI pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line build tooling version bump with no production code or data-path changes; risk is limited to potential build/test compatibility issues with the new `go-corset` release.
> 
> **Overview**
> Updates the default `go-corset` version used by the tracer Gradle build from `v1.2.1` to `v1.2.2` when `corsetVersion`/`CORSET_VERSION` are not explicitly set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 990e0044e1040e2a9c64757be2c9dab743c56483. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->