### PR TITLE
Revert "Test release"

### DIFF
--- a/gradle/releases.versions.toml
+++ b/gradle/releases.versions.toml
@@ -1,2 +1,2 @@
 [versions]
-arithmetization = "test-beta-release-process"
+arithmetization = "beta-v5.0-rc1"


### PR DESCRIPTION
Reverts Consensys/linea-monorepo#2429

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version-string change in a Gradle versions file; low chance of functional impact beyond which release artifact gets referenced.
> 
> **Overview**
> Updates the Gradle release version pin for `arithmetization` from `test-beta-release-process` to `beta-v5.0-rc1` in `gradle/releases.versions.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3c5174269cae6d97a11a096223796abda4369fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->