### PR TITLE
feat: update arithmetization release version

### DIFF
--- a/gradle/releases.versions.toml
+++ b/gradle/releases.versions.toml
@@ -1,2 +1,2 @@
 [versions]
-arithmetization = "beta-v5.0-rc1"
+arithmetization = "beta-v5.0-rc2"


### PR DESCRIPTION
This updates the release version of the tracer to beta-v5.0-rc2 which includes fix for a type conversion bug (#2375).

This PR implements issue(s) #2445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-version bump in Gradle version catalog; risk is limited to potential dependency compatibility/regression issues in the updated release.
> 
> **Overview**
> Bumps the `arithmetization` release pin in `gradle/releases.versions.toml` from `beta-v5.0-rc1` to `beta-v5.0-rc2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d28e3b378d22e53109a437eaf8baef25353c564b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->