### PR TITLE
[Coordinator] Remove etv and stv from execution proof request filename

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -329,11 +329,7 @@ class ConflationApp(
         BatchProofHandlerImpl(batchesRepository)::acceptNewBatch,
       ),
     )
-    val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient(
-      // we cannot use configs.traces.expectedTracesApiVersion because it breaks prover expected version pattern
-      tracesVersion = "2.1.0",
-      stateManagerVersion = configs.stateManager.version,
-    )
+    val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient()
     ProofGeneratingConflationHandlerImpl(
       tracesProductionCoordinator = TracesConflationCoordinatorImpl(
         tracesClients.tracesConflationClient,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -227,12 +227,7 @@ class ConflationBacktestingApp(
   )
 
   val proofGeneratingConflationHandlerImpl = run {
-    val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient(
-      // we cannot use configs.traces.expectedTracesApiVersion because it breaks prover expected version pattern
-      tracesVersion = "2.1.0",
-      stateManagerVersion = backtestingCoordinatorConfig.stateManager.version,
-      log = log,
-    )
+    val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient(log = log)
 
     ProofGeneratingConflationHandlerImpl(
       tracesProductionCoordinator = TracesConflationCoordinatorImpl(

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedExecutionProverClientV2.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedExecutionProverClientV2.kt
@@ -90,26 +90,21 @@ internal class ExecutionProofRequestDtoMapper(
  * Implementation of interface with the Execution Prover through Files.
  *
  * Prover will ingest file like
- * path/to/prover/requests/<startBlockNumber>-<endBlockNumber>--etv<tracesVersion>-stv<stateManagerVersion>-getZkProof.json
+ * path/to/prover/requests/<startBlockNumber>-<endBlockNumber>--getZkProof.json
  *
  * When done prover will output file
- * path/to/prover/responses/<startBlockNumber>-<endBlockNumber>--etv<tracesVersion>-stv<stateManagerVersion>-getZkProof.json
+ * path/to/prover/responses/<startBlockNumber>-<endBlockNumber>-getZkProof.json
  *
  * So, this class will need to watch the file system and wait for the output proof to be generated
  */
 class FileBasedExecutionProverClientV2(
   config: FileBasedProverConfig,
-  private val tracesVersion: String,
-  private val stateManagerVersion: String,
   vertx: Vertx,
   jsonObjectMapper: ObjectMapper = JsonSerialization.proofResponseMapperV1,
   executionProofRequestFileNameProvider: ProverFileNameProvider<ExecutionProofIndex> =
-    ExecutionProofRequestFileNameProvider(
-      tracesVersion = tracesVersion,
-      stateManagerVersion = stateManagerVersion,
-    ),
+    ExecutionProofFileNameProvider,
   executionProofResponseFileNameProvider: ProverFileNameProvider<ExecutionProofIndex> =
-    ExecutionProofResponseFileNameProvider,
+    ExecutionProofFileNameProvider,
   log: Logger,
 ) :
   GenericFileBasedProverClient<

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedProofAggregationClientV2.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedProofAggregationClientV2.kt
@@ -97,7 +97,7 @@ class FileBasedProofAggregationClientV2(
   config: FileBasedProverConfig,
   hashFunction: HashFunction = Sha256HashFunction(),
   executionProofResponseFileNameProvider: ProverFileNameProvider<ExecutionProofIndex> =
-    ExecutionProofResponseFileNameProvider,
+    ExecutionProofFileNameProvider,
   compressionProofResponseFileNameProvider: ProverFileNameProvider<CompressionProofIndex> =
     CompressionProofResponseFileNameProvider,
   jsonObjectMapper: ObjectMapper = JsonSerialization.proofResponseMapperV1,
@@ -137,7 +137,7 @@ class FileBasedProofAggregationClientV2(
     fun createProofIndexProviderFn(
       hashFunction: HashFunction,
       executionProofResponseFileNameProvider: ProverFileNameProvider<ExecutionProofIndex> =
-        ExecutionProofResponseFileNameProvider,
+        ExecutionProofFileNameProvider,
       compressionProofResponseFileNameProvider: ProverFileNameProvider<CompressionProofIndex> =
         CompressionProofResponseFileNameProvider,
     ): (ProofsToAggregate) -> AggregationProofIndex {

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactory.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverClientFactory.kt
@@ -42,11 +42,7 @@ class ProverClientFactory(
     )
   }
 
-  fun executionProverClient(
-    tracesVersion: String,
-    stateManagerVersion: String,
-    log: Logger = FileBasedExecutionProverClientV2.LOG,
-  ): ExecutionProverClientV2 {
+  fun executionProverClient(log: Logger = FileBasedExecutionProverClientV2.LOG): ExecutionProverClientV2 {
     return createClient(
       proverAConfig = config.proverA.execution,
       proverBConfig = config.proverB?.execution,
@@ -55,8 +51,6 @@ class ProverClientFactory(
       FileBasedExecutionProverClientV2(
         config = proverConfig,
         vertx = vertx,
-        tracesVersion = tracesVersion,
-        stateManagerVersion = stateManagerVersion,
         log = log,
       ).also { executionWaitingResponsesMetric.addReporter(it) }
     }

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvider.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvider.kt
@@ -18,17 +18,7 @@ object FileNameSuffixes {
   const val INVALIDITY_PROOF_SUFFIX = "getZkInvalidityProof.json"
 }
 
-class ExecutionProofRequestFileNameProvider(
-  private val tracesVersion: String,
-  private val stateManagerVersion: String,
-) : ProverFileNameProvider<ExecutionProofIndex> {
-  override fun getFileName(proofIndex: ExecutionProofIndex): String {
-    return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}" +
-      "-etv$tracesVersion-stv$stateManagerVersion" +
-      "-${FileNameSuffixes.EXECUTION_PROOF_SUFFIX}"
-  }
-}
-object ExecutionProofResponseFileNameProvider : ProverFileNameProvider<ExecutionProofIndex> {
+object ExecutionProofFileNameProvider : ProverFileNameProvider<ExecutionProofIndex> {
   override fun getFileName(proofIndex: ExecutionProofIndex): String {
     return "${proofIndex.startBlockNumber}-${proofIndex.endBlockNumber}-${FileNameSuffixes.EXECUTION_PROOF_SUFFIX}"
   }
@@ -47,6 +37,7 @@ object CompressionProofRequestFileNameProvider : ProverFileNameProvider<Compress
       FileNameSuffixes.COMPRESSION_PROOF_SUFFIX
   }
 }
+
 object CompressionProofResponseFileNameProvider : ProverFileNameProvider<CompressionProofIndex> {
   private fun encodeHash(hash: ByteArray): String = hash.encodeHex(prefix = false)
 

--- a/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvidersTest.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ProverFileNameProvidersTest.kt
@@ -10,27 +10,10 @@ import org.junit.jupiter.api.Test
 class ProverFileNameProvidersTest {
 
   @Test
-  fun test_getExecutionProof_requestFileName() {
-    val executionProofRequestFileNameProvider = ExecutionProofRequestFileNameProvider(
-      tracesVersion = "0.1",
-      stateManagerVersion = "0.2",
-    )
-    Assertions.assertEquals(
-      "11-17-etv0.1-stv0.2-getZkProof.json",
-      executionProofRequestFileNameProvider.getFileName(
-        ExecutionProofIndex(
-          startBlockNumber = 11u,
-          endBlockNumber = 17u,
-        ),
-      ),
-    )
-  }
-
-  @Test
-  fun test_getExecutionProof_responseFileName() {
+  fun test_getExecutionProof_fileName() {
     Assertions.assertEquals(
       "11-17-getZkProof.json",
-      ExecutionProofResponseFileNameProvider.getFileName(
+      ExecutionProofFileNameProvider.getFileName(
         ExecutionProofIndex(
           startBlockNumber = 11u,
           endBlockNumber = 17u,


### PR DESCRIPTION
This PR implements issue(s) #2242 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk contract used to exchange execution proofs with the file-based prover; deployments must ensure the prover and any tooling expect the new filenames to avoid stalled proof polling.
> 
> **Overview**
> Execution proof file naming is simplified to no longer include `etv`/`stv` version fragments; both request and response filenames now use a single `ExecutionProofFileNameProvider` producing `<start>-<end>-getZkProof.json`.
> 
> This removes version parameters from `ProverClientFactory.executionProverClient` and updates conflation and backtesting apps to construct the execution prover client without passing versions. Aggregation is updated to reference the new execution proof filename provider, and tests are adjusted to validate the new naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15b63e249b011fa976931689349fb30233aa5624. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->