### PR TITLE
[Lido] Force Docker image push for lido-governance-monitor

### DIFF
--- a/native-yield-operations/lido-governance-monitor/Dockerfile
+++ b/native-yield-operations/lido-governance-monitor/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=lts
-
+# trigger CI build
 FROM node:${NODE_VERSION}-slim AS base
 
 ENV PNPM_HOME="/pnpm"

--- a/native-yield-operations/lido-governance-monitor/README.md
+++ b/native-yield-operations/lido-governance-monitor/README.md
@@ -1,5 +1,4 @@
 # Lido Governance Monitor
-<!-- trigger CI -->
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Hardcodes `push_image` to `true` in the lido-governance-monitor build workflow so the Docker image gets pushed to DockerHub on PR branches (not just on main).
- Adds a trivial README change to trigger the CI path filter for `native-yield-operations/lido-governance-monitor/**`.

## Test plan
- [ ] Verify the `lido-governance-monitor` build job runs and pushes the image to DockerHub
- [ ] Revert the `PUSH_IMAGE` hardcoding before merging to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forcing image pushes can publish unintended builds from non-main branches and impact registry state; code changes themselves are minimal.
> 
> **Overview**
> Forces the `lido-governance-monitor` GitHub Actions build workflow to *always* push the Docker image by hardcoding `PUSH_IMAGE` to `'true'`, ignoring the `push_image` input.
> 
> Adds a trivial comment to the `native-yield-operations/lido-governance-monitor/Dockerfile` (no functional image build changes) to trigger the workflow/path filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 314070876d80e59bec0f877095daa6a97823dae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->