### PR TITLE
refactor: combine notify attempt increment with state transition

### DIFF
--- a/native-yield-operations/lido-governance-monitor/src/core/repositories/IProposalRepository.ts
+++ b/native-yield-operations/lido-governance-monitor/src/core/repositories/IProposalRepository.ts
@@ -20,7 +20,8 @@ export interface IProposalRepository {
     promptVersion: string,
   ): Promise<Proposal>;
   incrementAnalysisAttempt(id: string): Promise<Proposal>;
-  incrementNotifyAttempt(id: string): Promise<Proposal>;
   markNotified(id: string): Promise<Proposal>;
+  markNotifyFailed(id: string): Promise<Proposal>;
+  attemptMarkNotifyFailed(id: string): Promise<Proposal | null>;
   findLatestSourceIdBySource(source: ProposalSource): Promise<string | null>;
 }

--- a/native-yield-operations/lido-governance-monitor/src/services/__tests__/ProposalProcessor.test.ts
+++ b/native-yield-operations/lido-governance-monitor/src/services/__tests__/ProposalProcessor.test.ts
@@ -83,8 +83,9 @@ describe("ProposalProcessor", () => {
       attemptUpdateState: jest.fn(),
       saveAnalysis: jest.fn(),
       incrementAnalysisAttempt: jest.fn(),
-      incrementNotifyAttempt: jest.fn(),
       markNotified: jest.fn(),
+      markNotifyFailed: jest.fn(),
+      attemptMarkNotifyFailed: jest.fn(),
       findLatestSourceIdBySource: jest.fn(),
     } as jest.Mocked<IProposalRepository>;
 


### PR DESCRIPTION
This PR implements issue(s) # N/A

## Summary

- Remove the separate `incrementNotifyAttempt` DB write that occurred before the Slack send in `NotificationService`
- Combine the attempt count increment atomically with the state transition in `markNotified` (success path) and a new `markNotifyFailed` method (failure path)
- Add `attemptMarkNotifyFailed` as a best-effort wrapper for the catch block
- Remove now-unused `incrementNotifyAttempt` from `IProposalRepository` interface and `ProposalRepository` implementation

## Problem

The notification flow performed a separate DB write to increment `notifyAttemptCount` before sending the Slack notification, then performed another DB write for the state transition. This created an unnecessary intermediate round-trip and a window where the counter and state could be inconsistent (e.g., counter incremented but state not yet transitioned if the process crashed between the two writes).

## Solution

The attempt count is now incremented in the same Prisma `update` call as the state transition:
- **Success:** `markNotified` sets state=NOTIFIED, notifiedAt, and increments `notifyAttemptCount`
- **Failure:** New `markNotifyFailed` sets state=NOTIFY_FAILED and increments `notifyAttemptCount`
- **Error (catch):** `attemptMarkNotifyFailed` replaces `attemptUpdateState` for best-effort recovery

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core notification persistence and retry behavior; while the logic is simpler and better aligned, any mistake could impact retry counts or state transitions for alerts.
> 
> **Overview**
> Refactors the notification pipeline to remove the separate `incrementNotifyAttempt` write and instead **atomically** increment `notifyAttemptCount` during state transitions.
> 
> `markNotified` now increments attempts on success, and a new `markNotifyFailed`/`attemptMarkNotifyFailed` path handles validation failures, Slack send failures, and catch-block recovery; the repository interface/implementation and unit/integration tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbe66607680f7f08a7c3f664a07bb51cb3d891af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->