### PR TITLE
[Fix] Ignore fork timestamp and fix deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ __pycache__/
 
 /docker/config/l2-genesis-initialization/*.json
 /docker/config/l2-genesis-initialization/*.toml
+/docker/config/l2-genesis-initialization/fork-timestamp.txt
 
 !.gitkeep
 !operations/bin/

--- a/contracts/deploy/06_deploy_TokenBridgeWithReinitialization.ts
+++ b/contracts/deploy/06_deploy_TokenBridgeWithReinitialization.ts
@@ -26,7 +26,7 @@ const func: DeployFunction = async function () {
     "0x9623609d",
     ethers.AbiCoder.defaultAbiCoder().encode(
       ["address", "address", "bytes"],
-      [proxyAddress, newContract, TokenBridge__factory.createInterface().encodeFunctionData("reinitializeV2")],
+      [proxyAddress, newContract, TokenBridge__factory.createInterface().encodeFunctionData("reinitializeV3")],
     ),
   ]);
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to gitignore and a deployment script’s encoded function name; risk is limited to producing incorrect upgrade calldata if the target contract expects a different reinitializer.
> 
> **Overview**
> Updates `.gitignore` to exclude `docker/config/l2-genesis-initialization/fork-timestamp.txt` from version control.
> 
> Adjusts the `TokenBridge` upgrade calldata sample in `06_deploy_TokenBridgeWithReinitialization.ts` to call `reinitializeV3` (instead of `reinitializeV2`) when encoding the Security Council upgrade transaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f794b1ef4b4c9db2f3f71eb7e30f10f77299d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->