### PR TITLE
docs: add AGENTS.md with GitHub issue creation instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agents
+
+## Creating GitHub Issues
+
+When creating a GitHub issue or ticket in this repository, you **must** use one of the issue templates in `.github/ISSUE_TEMPLATE/`:
+
+- **bug-report.md** - For filing bug reports. Requires impact, steps to reproduce, actual result, and expected result.
+- **feature_request.md** - For feature requests. Requires description, motivation, tasks, acceptance criteria, and risks.
+- **epic.md** - For epics or major features. Requires description, motivation, architecture, implementation guidelines, and rollout plan.
+- **operational_task_template.md** - For operational tasks. Requires problem statement, background, desired solution, and acceptance criteria.
+
+Read the chosen template file before creating the issue and fill in all sections. Do not create blank issues - this repository has blank issues disabled.


### PR DESCRIPTION
This PR implements issue(s) # None

### Summary
- Adds a new `AGENTS.md` file at the repo root
- Instructs AI agents to use the existing `.github/ISSUE_TEMPLATE/` templates (bug report, feature request, epic, operational task) when creating GitHub issues
- Notes that blank issues are disabled in this repository

### Checklist

* [x] I wrote new tests for my new core changes.
  - N/A - documentation-only change, no code modified
* [x] I have successfully ran tests, style checker and build against my new changes locally.
  - N/A - markdown file only
* [x] I have informed the team of any breaking changes if there are any.
  - No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or data/security paths.
> 
> **Overview**
> Adds a new root-level `AGENTS.md` that instructs contributors/agents to create GitHub issues using the existing templates in `.github/ISSUE_TEMPLATE/` (bug, feature request, epic, operational task) and notes that blank issues are disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ca110448458f3766471e491ae62ce1473e07765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->