### PR TITLE
feat: allow MAX_VALIDATOR_WITHDRAWAL_REQUESTS_PER_TRANSACTION=0 to disable withdrawals

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,4 @@
 name: main
-# TODO: revert - temporary change to trigger docker build for PR #2481
 
 on:
   pull_request:

--- a/.github/workflows/native-yield-automation-service-build-and-publish.yml
+++ b/.github/workflows/native-yield-automation-service-build-and-publish.yml
@@ -62,7 +62,7 @@ jobs:
       COMMIT_TAG: ${{ inputs.commit_tag }}
       DEVELOP_TAG: ${{ inputs.develop_tag }}
       IMAGE_NAME: ${{ inputs.image_name }}
-      PUSH_IMAGE: true # TODO: revert - temporarily force push for PR #2481
+      PUSH_IMAGE: ${{ inputs.push_image }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:

--- a/native-yield-operations/automation-service/Dockerfile
+++ b/native-yield-operations/automation-service/Dockerfile
@@ -1,5 +1,4 @@
 ARG NODE_VERSION=lts
-# TODO: revert - temporary change to trigger docker build for PR #2481
 
 FROM node:${NODE_VERSION}-slim AS base
 

--- a/native-yield-operations/automation-service/src/application/main/config/config.schema.ts
+++ b/native-yield-operations/automation-service/src/application/main/config/config.schema.ts
@@ -107,8 +107,8 @@ export const configSchema = z
       .union([z.string(), z.number(), z.bigint()])
       .transform((val) => BigInt(val))
       .refine((v) => v >= 0n, { message: "Must be nonnegative" }),
-    // Maximum number of validator withdrawal requests that will be batched in a single transaction.
-    // Set to 0 to disable all withdrawal submissions (partial withdrawals and validator exits).
+    // Maximum number of validator withdrawal requests (partial withdrawals and validator exits)
+    // batched in a single transaction. Set to 0 to disable all withdrawal submissions.
     MAX_VALIDATOR_WITHDRAWAL_REQUESTS_PER_TRANSACTION: z.coerce.number().int().nonnegative(),
     /**
      * The available withdrawal balance must exceed this amount before any withdrawal operation proceeds.


### PR DESCRIPTION
## Summary

Closes #2480

- Change `MAX_VALIDATOR_WITHDRAWAL_REQUESTS_PER_TRANSACTION` schema validation from `positive()` to `nonnegative()` so setting it to `0` disables all withdrawal submissions (partial withdrawals and validator exits)
- Add schema tests for zero acceptance and negative rejection
- Add regression tests confirming `unstake` is never called when `maxValidatorsPerTx=0`

**Context:** QuickNode's Hoodi beacon node returns stale `pending_partial_withdrawals` data, causing duplicate withdrawal requests. Setting the value to `0` is the simplest kill switch while the RPC issue is resolved - the rest of the service (monitoring, metrics, yield reporting) continues normally.

## Test plan

- [x] Schema test: `"0"` parses to `0` successfully
- [x] Schema test: `"-1"` is rejected
- [x] Client test: `submitWithdrawalRequestsToFulfilAmount` with `maxValidatorsPerTx=0` never calls `unstake`
- [x] Client test: `submitMaxAvailableWithdrawalRequests` with `maxValidatorsPerTx=0` never calls `unstake` (covers both partial withdrawals and exits)
- [x] All 49 schema tests pass, all 18 client tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation change guarded by tests; only affects behavior when this env var is explicitly set to `0`.
> 
> **Overview**
> Allows `MAX_VALIDATOR_WITHDRAWAL_REQUESTS_PER_TRANSACTION` to be set to `0` as an operational kill-switch, disabling submission of both partial withdrawal requests and validator exits while still rejecting negative values.
> 
> Adds/updates unit tests to confirm the config schema parses `"0"` to `0` and that `BeaconChainStakingClient` never calls `unstake` when configured with `maxValidatorsPerTx=0` (for both `submitWithdrawalRequestsToFulfilAmount` and `submitMaxAvailableWithdrawalRequests`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 148fb1a595641de60e77e49c7632a8202f106cbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->