### PR TITLE
gradle: exclude generated files from Javadoc tasks in build configura…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ allprojects {
     dependsOn test
   }
 
+  tasks.withType(Javadoc).configureEach {
+    exclude '**/generated/**'
+  }
+
   tasks.withType(Test).configureEach {
     testLogging {
       events = [


### PR DESCRIPTION
…tion

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only change that only affects documentation generation by omitting `**/generated/**` from Javadoc inputs.
> 
> **Overview**
> Updates `build.gradle` to configure all `Javadoc` tasks to exclude `**/generated/**`, preventing generated sources from being included in generated Javadoc output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e516643c94a914b717deb9a0f99173e51885884c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->