### PR TITLE
fix(contracts): resolve 11 CodeQL code scanning alerts

### DIFF
--- a/contracts/docs/scripts/updateSidebar.js
+++ b/contracts/docs/scripts/updateSidebar.js
@@ -11,7 +11,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 
 /**
  * TYPES
@@ -162,12 +162,13 @@ function createNewSidebarFile(sidebarObject) {
  */
 function lintJSFile(filePath) {
   try {
-    const installCmd = `npm install --save-dev --no-save eslint`;
-    execSync(installCmd, { stdio: "inherit" });
+    execFileSync("npm", ["install", "--save-dev", "--no-save", "eslint"], {
+      stdio: "inherit",
+    });
 
-    const lintCmd = `npx eslint --fix --no-ignore ${filePath}`;
-    // Execute command synchronously and route output directly to the current stdout
-    execSync(lintCmd, { stdio: "inherit" });
+    execFileSync("npx", ["eslint", "--fix", "--no-ignore", filePath], {
+      stdio: "inherit",
+    });
   } catch (error) {
     console.error(`Error:`, error.message);
     console.error(`Exiting...`);

--- a/contracts/integrity-verifier/verifier-core/tests/integration.test.ts
+++ b/contracts/integrity-verifier/verifier-core/tests/integration.test.ts
@@ -10,14 +10,16 @@
 
 import { resolve } from "path";
 import { loadConfig, checkArtifactExists } from "../src/config";
-import { loadArtifact, extractSelectorsFromArtifact } from "../src/utils/abi";
+import { extractSelectorsFromArtifact } from "../src/utils/abi";
+import { loadArtifact } from "../src/utils/abi-node";
 import {
   compareBytecode,
   extractSelectorsFromBytecode,
   stripCborMetadata,
   verifyImmutableValues,
 } from "../src/utils/bytecode";
-import { calculateErc7201BaseSlot, parsePath, loadStorageSchema, decodeSlotValue } from "../src/utils/storage";
+import { calculateErc7201BaseSlot, parsePath, decodeSlotValue } from "../src/utils/storage";
+import { loadStorageSchema } from "../src/utils/storage-node";
 import { parseMarkdownConfig } from "../src/utils/markdown-config";
 import { Verifier } from "../src/verifier";
 import type { Web3Adapter } from "../src/adapter";

--- a/contracts/scripts/operational/tasks/grantContractRolesTask.ts
+++ b/contracts/scripts/operational/tasks/grantContractRolesTask.ts
@@ -29,9 +29,7 @@ task("grantContractRoles", "Grants roles to specific accounts")
   .setAction(async (taskArgs, hre) => {
     const ethers = hre.ethers;
 
-    const { deployments, getNamedAccounts } = hre;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { deployer } = await getNamedAccounts();
+    const { deployments } = hre;
     const { get } = deployments;
 
     const adminAddress = getTaskCliOrEnvValue(taskArgs, "adminAddress", "ADMIN_ADDRESS");

--- a/contracts/scripts/operational/tasks/renounceContractRolesTask.ts
+++ b/contracts/scripts/operational/tasks/renounceContractRolesTask.ts
@@ -36,9 +36,7 @@ task("renounceContractRoles", "Sets the rate limit on a Message Service contract
   .setAction(async (taskArgs, hre) => {
     const ethers = hre.ethers;
 
-    const { deployments, getNamedAccounts } = hre;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { deployer } = await getNamedAccounts();
+    const { deployments } = hre;
     const { get } = deployments;
 
     const oldAdminAddress = getTaskCliOrEnvValue(taskArgs, "oldAdminAddress", "OLD_ADMIN_ADDRESS");

--- a/contracts/scripts/operational/tasks/setRateLimitTask.ts
+++ b/contracts/scripts/operational/tasks/setRateLimitTask.ts
@@ -26,9 +26,7 @@ task("setRateLimit", "Sets the rate limit on a Message Service contract")
   .setAction(async (taskArgs, hre) => {
     const ethers = hre.ethers;
 
-    const { deployments, getNamedAccounts } = hre;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { deployer } = await getNamedAccounts();
+    const { deployments } = hre;
     const { get } = deployments;
 
     const messageServiceContractType = getTaskCliOrEnvValue(taskArgs, "messageServiceType", "MESSAGE_SERVICE_TYPE");

--- a/contracts/scripts/operational/tasks/setVerifierAddressTask.ts
+++ b/contracts/scripts/operational/tasks/setVerifierAddressTask.ts
@@ -27,9 +27,7 @@ task("setVerifierAddress", "Sets the verifier address on a Message Service contr
   .setAction(async (taskArgs, hre) => {
     const ethers = hre.ethers;
 
-    const { deployments, getNamedAccounts } = hre;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { deployer } = await getNamedAccounts();
+    const { deployments } = hre;
     const { get } = deployments;
 
     const proofType = getTaskCliOrEnvValue(taskArgs, "verifierProofType", "VERIFIER_PROOF_TYPE");


### PR DESCRIPTION
## Summary
- **Shell injection fix** (`updateSidebar.js`): Replace `execSync` with `execFileSync` to eliminate shell metacharacter interpretation risk (alert #8, Medium)
- **Broken import fix** (`integration.test.ts`): Correct import paths for `loadArtifact` (from `abi-node`) and `loadStorageSchema` (from `storage-node`) - these were importing from modules that don't export those functions, causing runtime `TypeError` (alerts #18901-#18906, Error)
- **Dead code removal** (4 Hardhat task files): Remove unused `deployer` variable from `getNamedAccounts()` calls in `grantContractRolesTask`, `setVerifierAddressTask`, `setRateLimitTask`, `renounceContractRolesTask` (alerts #144-#147, Note)

## Details

### Alert #8 - Shell command built from environment values
`contracts/docs/scripts/updateSidebar.js:170` used `execSync` with string interpolation to build shell commands. While the input is hardcoded (`__dirname` + `"sidebars.js"`), using `execFileSync` with argument arrays is strictly safer and eliminates the CodeQL alert entirely.

### Alerts #18901-#18906 - Invocation of non-function
`contracts/integrity-verifier/verifier-core/tests/integration.test.ts` imported `loadArtifact` from `../src/utils/abi` and `loadStorageSchema` from `../src/utils/storage`, but these functions were refactored into `-node` suffixed files (`abi-node.ts`, `storage-node.ts`) to avoid bundling `fs` in browser builds. The sibling `run-tests.ts` already had the correct imports.

### Alerts #144-#147 - Unused variable
Four Hardhat task files destructured `deployer` from `await getNamedAccounts()` but never used it. The `getNamedAccounts()` call itself has no required side effect for `deployments.get()` to work - confirmed by other task files in the same directory that don't call it at all.

## Test plan
- [ ] Verify CodeQL alerts are resolved after merge
- [ ] Verify `updateSidebar.js` still runs correctly (dev-only script)
- [ ] Verify integrity-verifier integration tests pass with corrected imports
- [ ] Verify Hardhat tasks still function without `getNamedAccounts()` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are narrow and mostly mechanical (command invocation hardening, test import fixes, and dead-code removal) with minimal impact on production contract logic; main risk is accidental behavior change in scripts if CLI execution differs.
> 
> **Overview**
> Resolves CodeQL security/runtime findings by removing shell interpolation in the docs sidebar update script: `updateSidebar.js` switches from `execSync` string commands to `execFileSync` with argv arrays for `npm`/`npx` execution.
> 
> Fixes the verifier-core integration test to import Node-only filesystem helpers from `abi-node` and `storage-node` (instead of browser-safe modules), preventing runtime `TypeError` when running the test suite.
> 
> Cleans up operational Hardhat tasks by dropping unused `getNamedAccounts()`/`deployer` destructuring in several role/rate-limit/verifier tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ac7b35c7be81f7c2d3de7f104cb666b7aa2bcae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->