### PR TITLE
docker: bump linea-besu-package and coordinator images to beta-v5.0-r…

### DIFF
--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:beta-v5.0-rc2-20260219034704-7602d8c
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -39,7 +39,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc2-20260219034704-7602d8c}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -114,7 +114,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc2-20260219034704-7602d8c}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -155,7 +155,7 @@ services:
   l2-node-besu-follower:
     hostname: l2-node-besu-follower
     container_name: l2-node-besu-follower
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc2-20260219034704-7602d8c}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -196,7 +196,7 @@ services:
   traces-node:
     hostname: traces-node
     container_name: traces-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc2-20260219034704-7602d8c}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -274,7 +274,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${COORDINATOR_TAG:-0862246}
+    image: consensys/linea-coordinator:${COORDINATOR_TAG:-93d7863}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:
@@ -381,7 +381,7 @@ services:
       - l1network
 
   zkbesu-shomei:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc2-20260219034704-7602d8c}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     hostname: zkbesu-shomei
     container_name: zkbesu-shomei
     profiles: [ "l2", "l2-bc", "external-to-monorepo" ]
@@ -599,7 +599,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc2-20260219034704-7602d8c}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.0-rc3-20260225114147-93d7863}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]


### PR DESCRIPTION
…c3-20260225114147-93d7863

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates Docker image tags for local/dev compose services; behavior changes are limited to whatever is included in the newer images.
> 
> **Overview**
> Updates the docker compose specs to pull newer default images: all `linea-besu-package`-based services move from `beta-v5.0-rc2-...-7602d8c` to `beta-v5.0-rc3-...-93d7863`, and the `coordinator` service default tag bumps from `0862246` to `93d7863`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2495420d60948ce569c3aaf89721a37bac2930ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->