### PR TITLE
chore: re-enable CodeQL java-kotlin analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           languages=()
           if [ "${{ steps.changes.outputs.go }}" == "true" ]; then languages+=("\"go\""); fi
-          # if [ "${{ steps.changes.outputs.java-kotlin }}" == "true" ]; then languages+=("\"java-kotlin\""); fi
+          if [ "${{ steps.changes.outputs.java-kotlin }}" == "true" ]; then languages+=("\"java-kotlin\""); fi
           if [ "${{ steps.changes.outputs.javascript-typescript }}" == "true" ]; then languages+=("\"javascript-typescript\""); fi
           if [ "${{ steps.changes.outputs.actions }}" == "true" ]; then languages+=("\"actions\""); fi
           if [ "${{ steps.changes.outputs.python }}" == "true" ]; then languages+=("\"python\""); fi
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 #v4.32.0
+        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e #v4.32.4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -108,12 +108,12 @@ jobs:
 
       - name: Autobuild
         if: matrix.language != 'actions'
-        uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 #v4.32.0
+        uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e #v4.32.4
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 #v4.32.0
+        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e #v4.32.4
         with:
           category: "/language:${{matrix.language}}"
           output: sarif-results


### PR DESCRIPTION
CodeQL now supports Kotlin 2.3.0 (since CLI 2.24.1). Uncomment the java-kotlin language in the build matrix and bump codeql-action from v4.32.0 to v4.32.4 which bundles CLI 2.24.1+.

Closes #2148

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions CodeQL workflow, mainly affecting CI scanning coverage and action versions without touching runtime code.
> 
> **Overview**
> Re-enables **CodeQL `java-kotlin` analysis** by adding it back into the language matrix when Java/Kotlin/Gradle-related files change.
> 
> Updates the pinned `github/codeql-action` (`init`, `autobuild`, `analyze`) from `v4.32.0` to `v4.32.4`, ensuring the workflow runs with the newer bundled CodeQL CLI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e10f2f0701ee9fde35f1104fc98085dae37f226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->