### PR TITLE
chore: trigger CodeQL java-kotlin analysis verification

### DIFF
--- a/jvm-libs/linea/core/traces/src/main/kotlin/net/consensys/linea/traces/TracingModule.kt
+++ b/jvm-libs/linea/core/traces/src/main/kotlin/net/consensys/linea/traces/TracingModule.kt
@@ -1,5 +1,6 @@
 package net.consensys.linea.traces
 
+// Tracing module definitions for Linea ZK-EVM trace collection.
 sealed interface TracingModule {
   val name: String
 }


### PR DESCRIPTION
Follow-up to #2515. This PR touches a Kotlin file to confirm that the re-enabled java-kotlin CodeQL analysis correctly triggers and completes end-to-end on Java/Kotlin file changes, as requested by @fluentcrafter.

Closes issue #2148

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a file-level comment with no functional or behavioral changes.
> 
> **Overview**
> Adds a brief header comment to `TracingModule.kt` to clarify that it contains tracing module definitions for Linea ZK-EVM trace collection (intended to trigger Java/Kotlin CodeQL analysis on Kotlin changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2346496cb7a8b090c12048d1607dcefec7263f55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->