### PR TITLE
fix: reduce ValidatorContainerProofVerifier prepopulation in flaky setup

### DIFF
--- a/contracts/test/hardhat/yield/unit/ValidatorContainerProofVerifier.ts
+++ b/contracts/test/hardhat/yield/unit/ValidatorContainerProofVerifier.ts
@@ -39,7 +39,7 @@ describe("ValidatorContainerProofVerifier", () => {
     sszMerkleTree = localTree.sszMerkleTree;
     firstValidatorLeafIndex = localTree.firstValidatorLeafIndex;
     // populate merkle tree with validators
-    for (let i = 1; i < 50; i++) {
+    for (let i = 1; i < 10; i++) {
       await sszMerkleTree.addValidatorLeaf(generateValidatorContainer());
     }
     // after adding validators, all newly added validator indexes will +n from this


### PR DESCRIPTION
This PR implements issue(s) #2453

### Summary
- Reduces suite-level setup work in `ValidatorContainerProofVerifier` by lowering validator pre-population in `before` from 49 extra validators to 9.
- Targets CI flakiness where the `before all` hook intermittently exceeds the 20s timeout under coverage.

### Problem
`contracts/test/hardhat/yield/unit/ValidatorContainerProofVerifier.ts` performs expensive pre-population in a shared `before` hook. Under CI load, this can push setup past timeout and fail the suite as a hook timeout.

### Solution
In the shared `before` hook, changed:
- `for (let i = 1; i < 50; i++)` -> `for (let i = 1; i < 10; i++)`

This keeps the test behavior while reducing setup cost and timeout risk.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [ ] I have informed the team of any breaking changes if there are any.