### PR TITLE
Linea monorepo test PR

### DIFF
--- a/sdk/sdk-core/src/utils/chain.test.ts
+++ b/sdk/sdk-core/src/utils/chain.test.ts
@@ -1,0 +1,39 @@
+import { isLineaMainnet, isLineaSepolia, isMainnet, isSepolia } from "./chain";
+
+describe("chain utils", () => {
+  describe("isLineaSepolia", () => {
+    it("returns true only for Linea Sepolia chain id", () => {
+      expect(isLineaSepolia(59141)).toBe(true);
+      expect(isLineaSepolia(59144)).toBe(false);
+      expect(isLineaSepolia(1)).toBe(false);
+      expect(isLineaSepolia(11155111)).toBe(false);
+    });
+  });
+
+  describe("isLineaMainnet", () => {
+    it("returns true only for Linea Mainnet chain id", () => {
+      expect(isLineaMainnet(59144)).toBe(true);
+      expect(isLineaMainnet(59141)).toBe(false);
+      expect(isLineaMainnet(1)).toBe(false);
+      expect(isLineaMainnet(11155111)).toBe(false);
+    });
+  });
+
+  describe("isMainnet", () => {
+    it("returns true only for Ethereum Mainnet chain id", () => {
+      expect(isMainnet(1)).toBe(true);
+      expect(isMainnet(59141)).toBe(false);
+      expect(isMainnet(59144)).toBe(false);
+      expect(isMainnet(11155111)).toBe(false);
+    });
+  });
+
+  describe("isSepolia", () => {
+    it("returns true only for Ethereum Sepolia chain id", () => {
+      expect(isSepolia(11155111)).toBe(true);
+      expect(isSepolia(1)).toBe(false);
+      expect(isSepolia(59141)).toBe(false);
+      expect(isSepolia(59144)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR serves as a small, safe test PR for the `linea-monorepo`.

It adds unit tests for the `isLineaMainnet`, `isLineaSepolia`, `isMainnet`, and `isSepolia` chain utility functions within `sdk-core`.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

---
<p><a href="https://cursor.com/agents/bc-34584dc0-2fa0-4d42-ae6a-f272aaad7379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34584dc0-2fa0-4d42-ae6a-f272aaad7379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->