### PR TITLE
feat: split chain_id and sum it to check zeroness

### DIFF
--- a/tracer-constraints/rlpauth/rlpauth.zkasm
+++ b/tracer-constraints/rlpauth/rlpauth.zkasm
@@ -44,11 +44,11 @@ authority_ecrecover_success u1, authority_nonce u64, authority_has_empty_code_or
         ;; verify that chain_id is 0 or the ID of the current chain
         ;; the following is a hack to reduce the number of constraints generated and has no effect on the logic
         var chain_id_lo_1, chain_id_lo_2, chain_id_hi_1, chain_id_hi_2 u64
-        var sum_chain_id_lo_hi_1 u66
+        var sum_chain_id_lo_hi u66
         chain_id_hi_2, chain_id_hi_1, chain_id_lo_2, chain_id_lo_1 = chain_id
-        sum_chain_id_lo_hi_1 = chain_id_lo_1 + chain_id_lo_2 + chain_id_hi_1 + chain_id_hi_2
+        sum_chain_id_lo_hi = chain_id_lo_1 + chain_id_lo_2 + chain_id_hi_1 + chain_id_hi_2
         ;; this line is equivalent to : if chain_id == 0 goto step2
-        if sum_chain_id_lo_hi_1 == 0 goto step_2
+        if sum_chain_id_lo_hi == 0 goto step_2
         if chain_id == network_chain_id goto step_2
         invalid_step = 1
         goto exit_invalid


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization-validation constraints in `rlpauth`; although intended to be logic-equivalent, any mismatch in the limb-sum zeroness check could incorrectly accept/reject authorization tuples.
> 
> **Overview**
> Updates `rlpauth`’s chain-id validation to avoid a direct `chain_id == 0` comparison by splitting the `u256` into four `u64` limbs and checking `sum == 0` before falling back to `chain_id == network_chain_id`.
> 
> All other changes are non-functional cleanups (whitespace/comment tweaks and adding a trailing newline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05845ffcca94fb706825101c4d2a2682f9cff000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->