### PR TITLE
[Coordinator] Add native secp lib to coordinator jar

### DIFF
--- a/coordinator/app/build.gradle
+++ b/coordinator/app/build.gradle
@@ -69,6 +69,7 @@ dependencies {
   testImplementation testFixtures(project(':jvm-libs:generic:json-rpc'))
   testImplementation project(':coordinator:ethereum:test-utils')
   testImplementation "io.vertx:vertx-junit5"
+  runtimeOnly "org.hyperledger.besu:secp256k1:${libs.versions.secp.get()}"
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ tuweni = "2.7.1"
 vertx = "4.5.14"
 web3j = "5.0.2"
 web3jPlugin = "4.14.0"
+secp = "1.4.2"
 
 # Other
 googleJavaFormat = "1.27.0"


### PR DESCRIPTION
This PR implements issue(s) #1555 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new native/runtime dependency to the coordinator distribution, which can impact packaging and runtime behavior across environments if the library is missing or incompatible.
> 
> **Overview**
> The coordinator app now bundles Hyperledger Besu’s `secp256k1` native library as a `runtimeOnly` dependency so it is present on the runtime classpath and included in the built distribution.
> 
> Gradle version catalog is updated to pin the new `secp` version (`1.4.2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2aa94d11e524c65e13811809b7c7b33f646cec2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->