### PR TITLE
fix: moved registerKotlinModule to companion init

### DIFF
--- a/jvm-libs/generic/json-rpc/src/main/kotlin/net/consensys/linea/jsonrpc/JsonRpcMessageProcessor.kt
+++ b/jvm-libs/generic/json-rpc/src/main/kotlin/net/consensys/linea/jsonrpc/JsonRpcMessageProcessor.kt
@@ -61,10 +61,6 @@ class JsonRpcMessageProcessor(
     override val name: String = "jsonrpc"
   },
 ) : JsonRpcMessageHandler {
-  init {
-    DatabindCodec.mapper().registerKotlinModule()
-  }
-
   override fun invoke(user: User?, messageJsonStr: String): Future<String> =
     handleAndMeasureRequestProcessing(user, messageJsonStr)
 
@@ -278,9 +274,10 @@ class JsonRpcMessageProcessor(
   }
 
   companion object {
-    // init {
-    //   DatabindCodec.mapper().enable(SerializationFeature.INDENT_OUTPUT)
-    // }
+    init {
+      DatabindCodec.mapper().registerKotlinModule()
+    }
+
     fun parseRequest(json: Any): Result<Pair<JsonRpcRequest, JsonObject>, JsonRpcErrorResponse> {
       try {
         json as JsonObject

--- a/transaction-exclusion-api/app/src/integrationTest/kotlin/net/consensys/linea/transactionexclusion/TransactionExclusionAppTest.kt
+++ b/transaction-exclusion-api/app/src/integrationTest/kotlin/net/consensys/linea/transactionexclusion/TransactionExclusionAppTest.kt
@@ -64,7 +64,7 @@ class TransactionExclusionAppTest : CleanDbTestSuiteParallel() {
   private lateinit var requestSpecification: RequestSpecification
   private lateinit var app: TransactionExclusionApp
 
-  @BeforeEach()
+  @BeforeEach
   fun beforeEach() {
     app = TransactionExclusionApp(
       config = AppConfig(


### PR DESCRIPTION
This PR implements issue(s) #

This PR is to fix the flaky integration test in `transaction-exclusion-api/app/src/integrationTest/kotlin/net/consensys/linea/transactionexclusion/TransactionExclusionAppTest.kt`

Summary from Cursor:

```
Summary
The Bug
The intermittent hang is caused by a race condition with duplicate KotlinModule registration on Vertx's global DatabindCodec.mapper().

How it happens
Your test creates a new TransactionExclusionApp (and thus a new JsonRpcMessageProcessor) in @BeforeEach for every test method.

Each JsonRpcMessageProcessor instance called DatabindCodec.mapper().registerKotlinModule() in its instance init block — line 64-66 of the original code.

DatabindCodec.mapper() returns a JVM-wide singleton ObjectMapper. The first registration works fine. On subsequent registrations, although IGNORE_DUPLICATE_MODULE_REGISTRATIONS is enabled by default, there's a window where the mapper's internal DeserializerCache can observe an inconsistent state: the KotlinInstantiators.findValueInstantiator() method expects the existing ValueInstantiator to be StdValueInstantiator, but it's already been replaced by KotlinValueInstantiator from the first registration.

This throws IllegalStateException on the Vert.x event loop thread. Since parseRequest doesn't catch IllegalStateException (only ClassCastException and DecodeException), the exception propagates as an unhandled error, and no HTTP response is ever sent.

The test's REST-assured HTTP call blocks forever waiting for a response that will never come.

This is the exact same bug described in [jackson-module-kotlin#528](https://github.com/FasterXML/jackson-module-kotlin/issues/528), where another Vert.x user (@bitkid) reported the same stack trace and the same fix.

The Fix
Moved DatabindCodec.mapper().registerKotlinModule() from the instance init block to the companion object init block. The companion object init runs exactly once when the class is first loaded, guaranteeing single registration regardless of how many JsonRpcMessageProcessor instances are created:
```

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: moves a Jackson/Vert.x mapper initialization to a companion `init` so it runs once, plus a test annotation tweak; no business logic changes.
> 
> **Overview**
> Moves `DatabindCodec.mapper().registerKotlinModule()` from `JsonRpcMessageProcessor` instance initialization to a `companion object` `init`, ensuring the Vert.x Jackson mapper is configured once at class load time.
> 
> Cleans up an integration test by changing `@BeforeEach()` to `@BeforeEach` (no behavioral change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1c20f4f829d9103e4c294019ae8033a4dd4eab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->