### PR TITLE
fix(limitless): use runtime config for compat check

### DIFF
--- a/prover/backend/execution/limitless/prove.go
+++ b/prover/backend/execution/limitless/prove.go
@@ -310,6 +310,10 @@ func RunBootstrapper(cfg *config.Config, zkevmWitness *zkevm.Witness, merkleTree
 		utils.Panic("could not load zkevm: %v", err)
 	}
 
+	// Override the compatibility check setting from the runtime config, since
+	// the serialized asset may have been built with a different value.
+	assets.Zkevm.Arithmetization.Settings.IgnoreCompatibilityCheck = &cfg.Execution.IgnoreCompatibilityCheck
+
 	if err := assets.LoadDisc(cfg); err != nil || assets.DistWizard.Disc == nil {
 		utils.Panic("could not load disc: %v", err)
 	}


### PR DESCRIPTION
The IgnoreCompatibilityCheck setting was baked into the serialized `zkevm-wiop.bin` asset at setup time. At prove time the deserialized value was used instead of the runtime config, causing panics even when `ignore_compatibility_check = true` in the deployment config.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a safety/validation toggle in the proving pipeline; mis-setting it could either reintroduce prove-time panics or unintentionally bypass compatibility checks for mismatched assets/traces.
> 
> **Overview**
> Ensures the Limitless prover uses the **runtime** `cfg.Execution.IgnoreCompatibilityCheck` value when running the bootstrapper.
> 
> After `LoadZkEVM`, the code now explicitly overrides `assets.Zkevm.Arithmetization.Settings.IgnoreCompatibilityCheck` so a serialized `zkevm` asset built with a different setting can’t force prove-time compatibility-check behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f466ca95f264028608b989a8b2e6afbd057d01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->