### PR TITLE
Forced transactions - enable in local stack

### DIFF
--- a/config/coordinator/coordinator-config-v2.toml
+++ b/config/coordinator/coordinator-config-v2.toml
@@ -251,7 +251,7 @@ trust-store-path = "/tls-files/web3signer-truststore.p12"
 trust-store-password = "changeit"
 
 [forced-transactions]
-disabled = true
+disabled = false
 l1-highest-block-tag = "LATEST"
 processing-tick-interval = "PT5S"
 processing-delay = "PT0S"
@@ -299,6 +299,7 @@ port=5432
 username = "postgres"
 password = "postgres"
 schema = "linea_coordinator"
+schemaVersion = 5
 read-pool-size = 10
 read-pipelining-limit = 10
 transactional-pool-size = 10

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -233,7 +233,7 @@ services:
   prover-v3: # prover compatible with the traces from zkbesu
     container_name: prover-v3
     hostname: prover-v3
-    image: consensys/linea-prover:${PROVER_TAG:-2fc4392}
+    image: consensys/linea-prover:${PROVER_TAG:-dd96f52}
     platform: linux/amd64
     # to avoid spinning up on CI for now
     profiles: [ "l2" ]


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables `forced-transactions` by default in the coordinator local config and introduces a `schemaVersion` setting, which may require matching DB migrations and can change local stack runtime behavior. Also updates the prover Docker image tag, which could introduce compatibility/regression issues in the local L2 setup.
> 
> **Overview**
> **Local stack behavior changes**: flips `forced-transactions.disabled` to `false` in `coordinator-config-v2.toml`, enabling forced transaction processing by default.
> 
> Adds `database.schemaVersion = 5` to the coordinator config and updates the `prover-v3` Docker image default tag in `compose-spec-l2-services.yml` to a newer build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f1638786e528c13969886a67d07bf1d419b9e19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->