### PR TITLE
[ZkTracer] bump corset version to v1.2.7

### DIFF
--- a/tracer/gradle/corset.gradle
+++ b/tracer/gradle/corset.gradle
@@ -28,7 +28,7 @@ tasks.register('corsetExists') {
 ext {
   corsetVersion = project.hasProperty('corsetVersion')
     ? project.property('corsetVersion')
-    : System.getenv().getOrDefault('CORSET_VERSION', "v1.2.6")
+    : System.getenv().getOrDefault('CORSET_VERSION', "v1.2.7")
 }
 
 tasks.register('installGoCorset') {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the default `CORSET_VERSION` fallback used by the Gradle `go-corset` install/check tasks.
> 
> **Overview**
> Updates the Gradle `corset.gradle` default `corsetVersion` fallback from `v1.2.6` to `v1.2.7`, so builds that don’t explicitly set `corsetVersion`/`CORSET_VERSION` will install and validate `go-corset@v1.2.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2f53e4859f427a2f68f15b2d947e4bf25ae876e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->