### PR TITLE
coordinator: align conflation calculator IDs with ConflationTrigger enum

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByTargetBlockNumbers.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByTargetBlockNumbers.kt
@@ -5,9 +5,8 @@ import net.consensys.zkevm.domain.ConflationTrigger
 
 class ConflationCalculatorByTargetBlockNumbers(
   private val targetEndBlockNumbers: Set<ULong>,
+  override val id: String = ConflationTrigger.TARGET_BLOCK_NUMBER.name,
 ) : ConflationCalculator {
-  override val id: String = ConflationTrigger.TARGET_BLOCK_NUMBER.name
-
   override fun checkOverflow(blockCounters: BlockCounters): ConflationCalculator.OverflowTrigger? {
     return if (targetEndBlockNumbers.contains(blockCounters.blockNumber - 1uL)) {
       ConflationCalculator.OverflowTrigger(ConflationTrigger.TARGET_BLOCK_NUMBER, false)

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -24,6 +24,7 @@ import linea.ftx.conflation.InvalidityProofAssembler
 import linea.persistence.ftx.ForcedTransactionsDao
 import net.consensys.zkevm.coordinator.clients.InvalidityProverClientV1
 import net.consensys.zkevm.coordinator.clients.TracesConflationVirtualBlockClientV1
+import net.consensys.zkevm.domain.ConflationTrigger
 import net.consensys.zkevm.ethereum.coordination.aggregation.AggregationTriggerCalculatorByTargetBlockNumbers
 import net.consensys.zkevm.ethereum.coordination.aggregation.SyncAggregationTriggerCalculator
 import net.consensys.zkevm.ethereum.coordination.blockcreation.AlwaysSafeBlockNumberProvider
@@ -102,7 +103,10 @@ internal class DisabledForcedTransactionsApp() : ForcedTransactionsApp,
   DisabledService("forced transactions") {
   private val safeBlockNumberProvider = AlwaysSafeBlockNumberProvider()
   override val conflationSafeBlockNumberProvider: ConflationSafeBlockNumberProvider = safeBlockNumberProvider
-  override val conflationCalculator: ConflationCalculator = ConflationCalculatorByTargetBlockNumbers(emptySet())
+  override val conflationCalculator: ConflationCalculator = ConflationCalculatorByTargetBlockNumbers(
+    targetEndBlockNumbers = emptySet(),
+    id = ConflationTrigger.FORCED_TRANSACTION.name,
+  )
   override val aggregationCalculator: SyncAggregationTriggerCalculator =
     AggregationTriggerCalculatorByTargetBlockNumbers(
       targetEndBlockNumbers = emptyList(),

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -35,7 +35,7 @@ class ConflationCalculatorByForcedTransaction(
   private val processedFtxQueue: Queue<ForcedTransactionInclusionStatus>,
   private val log: Logger = LogManager.getLogger(ConflationCalculatorByForcedTransaction::class.java),
 ) : ConflationCalculator {
-  override val id: String = "FTX_INVALIDITY_PROOF_CONFLATION"
+  override val id: String = ConflationTrigger.FORCED_TRANSACTION.name
 
   // Track pending trigger blocks (blockNumber - 1) for non-included FTXs
   private val pendingTriggerBlocks = mutableSetOf<ULong>()


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to standardizing `ConflationCalculator.id` values, which may affect logging/metrics/lookup keys but does not alter conflation trigger logic.
> 
> **Overview**
> Standardizes conflation calculator identifiers to match `ConflationTrigger` names.
> 
> `ConflationCalculatorByTargetBlockNumbers` now accepts an overridable `id` (defaulting to `TARGET_BLOCK_NUMBER`), and forced-transactions calculators/apps are updated to use `ConflationTrigger.FORCED_TRANSACTION.name` instead of ad-hoc strings (including the disabled forced-transactions configuration).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ef9f028104c10a825bbfd228859e0e8ea174add. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->