### PR TITLE
feat: update greclipse to 4.35 and spotless to 8.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ allprojects {
         // spotless check applied to build.gradle (groovy) files
         groovyGradle {
           target '*.gradle'
-          greclipse("4.32")
+          greclipse("4.35")
           leadingTabsToSpaces(2)
           endWithNewline()
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 docker = { id = "com.avast.gradle.docker-compose", version = "0.17.12" }
 web3j = { id = "org.web3j", version.ref = "web3jPlugin" }
 web3jSolidity = { id = "org.web3j.solidity", version = "0.5.0" }
-spotless = { id = "com.diffplug.spotless", version = "8.1.0" }
+spotless = { id = "com.diffplug.spotless", version = "8.2.1" }
 jreleaser = {id = "org.jreleaser", version = "1.15.0"}
 dependencyLicenseReport = { id = "com.github.jk1.dependency-license-report", version = "2.9" }
 lombok = { id = "io.freefair.lombok", version = "8.6" }


### PR DESCRIPTION
This PR implements issue(s) #2596

From Cursor with Opus 4.6 max:

**Root Cause**
The error is a known, well-documented race condition in the Spotless Gradle plugin's Eclipse/Groovy formatter when it downloads P2 metadata from the Eclipse update site. The exact stack trace is:
```
java.io.IOException: Failed to load eclipse groovy formatter: java.lang.RuntimeException: java.io.EOFException
This happens because:
```
Spotless uses the Equo Solstice library to download Eclipse P2 bundles (the Groovy-Eclipse formatter).
When multiple spotlessGroovyGradle tasks run in parallel across subprojects, they race to download and cache the same P2 metadata files.
One task writes a truncated/corrupt cache file, and another task reads it mid-write, producing an EOFException on deserialization (SerializableMisc.fromFile -> ObjectInputStream).
CI environments are particularly affected because there is no warm cache -- every build starts fresh on ephemeral runners.
This is tracked as:

[diffplug/spotless#2331](https://github.com/diffplug/spotless/issues/2331) (race condition)
[equodev/equo-ide#188](https://github.com/equodev/equo-ide/issues/188) (corrupted P2 index metadata)
[diffplug/spotless#1787](https://github.com/diffplug/spotless/issues/1787) (original report)

**The Fix**
The fix was shipped in Spotless 8.2.1 (released 2026-01-27), which implemented P2 dependency caching to avoid the parallel download race condition (see [#2788](https://github.com/diffplug/spotless/issues/2788)). The current version in this repo is 8.1.0, which is vulnerable.

The recommended fix is to upgrade Spotless from 8.1.0 to 8.2.1 (or later) and bump the greclipse version to 4.35 which was validated as working in Spotless 7.0.4+.

**Summary**
The problem: A race condition in Spotless's P2 metadata downloading causes intermittent EOFException failures on CI. Multiple parallel spotlessGroovyGradle tasks across subprojects compete to download and cache Eclipse Groovy formatter bundles. On ephemeral CI runners with no warm cache, one task can write a truncated cache file that another task then reads, producing the EOFException.

**The fix (two changes):**

gradle/libs.versions.toml — Bumped Spotless plugin from 8.1.0 to 8.2.1. Version 8.2.1 specifically fixed this by implementing P2 dependency caching, which prevents the OutOfMemoryError and race conditions in the configuration phase for Eclipse-based formatters.

build.gradle — Bumped greclipse from 4.32 to 4.35. The 4.32 version had known issues with P2 metadata published in compressed format (content.xml.xz), which contributed to resolution failures. Version 4.35 was validated as the stable default starting from Spotless 7.0.4.

These are the only two changes needed. The fix is minimal and targeted -- no logic changes, just version bumps to pick up upstream bug fixes.


To reproduce the race condition specifically and simulate CI conditions more closely by running parallel P2 downloads from multiple subprojects, I run the following:
```rm -rf ~/.m2/repository/dev/equo/p2-data/ && ./gradlew spotlessCheck --parallel```
This runs all spotless tasks (including multiple spotlessGroovyGradle tasks across subprojects) in parallel with a cold cache, which is the scenario that triggers the corrupt metadata / EOFException.

I could reproduce the issue locally on the main branch, but no longer be able to do so on this feature branch

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5cfbd3135ec0adf0694ba7d7019fa59ed6127dab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->