### PR TITLE
ci: expand Claude review paths and improve PR filtering logic

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,10 +14,6 @@ on:
       - "**/*.py"
       - "**/*.rs"
       - "**/*.sol"
-      - "**/*.cpp"
-      - "**/*.c"
-      - "**/*.h"
-      - "**/*.cs"
       - "**/*.zkasm"
       - "**/*.lisp"
       - "**/Makefile"
@@ -70,8 +66,7 @@ jobs:
             You are a senior software engineer performing a thorough code review on PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
             Review ONLY changed files with the following extensions or names:
-            .js .jsx .ts .tsx .java .kt .go .py .rs .sol .cpp .c .h .cs .rb .php .swift .scala
-            .sh .bash .gradle .gradle.kts .mk .dockerfile .zkasm .lisp
+            .js .jsx .ts .tsx .java .kt .go .py .rs .sol .sh .bash .gradle .gradle.kts .mk .dockerfile .zkasm .lisp
             Makefile gradlew gradle.properties settings.gradle settings.gradle.kts Dockerfile Dockerfile.*
 
             For each issue you find, post an inline pull request review comment on the exact file and line where the problem occurs.


### PR DESCRIPTION
- Added support for additional file extensions in workflow triggers
- Enhanced PR filter to require `@claude-review` mention and specific author associations
- Updated direct prompt with detailed code review scope and guidelines

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; the main risk is accidental under/over-triggering of reviews due to new path filters and PR body gating.
> 
> **Overview**
> Updates the `Claude Code Review` GitHub Actions workflow to **trigger only when relevant source/build files change** (expanded `pull_request.paths` list) and to include PR `edited` events.
> 
> Tightens execution conditions so the job runs only for same-repo PRs that include `@claude-review` in the PR body and are authored by `OWNER`/`MEMBER`/`COLLABORATOR`. It also replaces the prior plugin-based prompt configuration with a more detailed `direct_prompt` instructing Claude to comment inline on changed files only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab5808f66bed241dde54c8608c314bf8c2062564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->