### PR TITLE
[Coordinator] Conflation backtesting fixes and documentation

### DIFF
--- a/config/coordinator/coordinator-config-v2.toml
+++ b/config/coordinator/coordinator-config-v2.toml
@@ -25,6 +25,7 @@ conflation-deadline = "PT6S" # =3*l2_block_time
 conflation-deadline-check-interval = "PT3S"
 conflation-deadline-last-block-confirmation-delay = "PT2S" # recommended: at least 2 * blockInterval
 l2-fetch-blocks-limit = 4000
+backtesting-directory = "/data/conflation-backtesting"
 force-stop-conflation-at-block-inclusive=100_000_000
 #force-stop-conflation-at-block-timestamp-inclusive=2000000000
 
@@ -312,3 +313,4 @@ failures-warning-threshold = 2
 
 [api]
 observability-port = 9545
+json-rpc-port = 9546

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -4,6 +4,8 @@ import build.linea.clients.StateManagerClientV1
 import build.linea.clients.StateManagerV1JsonRpcClient
 import io.vertx.core.Vertx
 import linea.LongRunningService
+import linea.blob.BlobCompressorFactory
+import linea.blob.BlobCompressorVersion
 import linea.coordinator.config.toJsonRpcRetry
 import linea.coordinator.config.v2.CoordinatorConfig
 import linea.coordinator.config.v2.TracesConfig.ClientApiConfig
@@ -27,7 +29,6 @@ import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobShnarfMetaData
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
-import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProvider
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
@@ -62,6 +63,9 @@ class ConflationBacktestingApp(
   init {
     require(mainCoordinatorConfig.conflation.backtestingDirectory != null) {
       "Backtesting requests parent directory must be set in conflation config"
+    }
+    require(conflationBacktestingAppConfig.blobCompressorVersion != BlobCompressorVersion.V2) {
+      "Blob compressor version 2 is not supported for backtesting"
     }
     mainCoordinatorConfig.traces.common?.endpoints?.contains(conflationBacktestingAppConfig.tracesApi.endpoint)
       ?.let { require(!it) { "Cannot use same traces endpoint for backtesting and main conflation" } }
@@ -128,14 +132,8 @@ class ConflationBacktestingApp(
         endpoints = listOf(conflationBacktestingAppConfig.tracesApi.endpoint),
         requestLimitPerEndpoint = conflationBacktestingAppConfig.tracesApi.requestLimitPerEndpoint,
       ),
-      counters = mainCoordinatorConfig.traces.counters?.copy(
-        endpoints = listOf(conflationBacktestingAppConfig.tracesApi.endpoint),
-        requestLimitPerEndpoint = conflationBacktestingAppConfig.tracesApi.requestLimitPerEndpoint,
-      ),
-      conflation = mainCoordinatorConfig.traces.conflation?.copy(
-        endpoints = listOf(conflationBacktestingAppConfig.tracesApi.endpoint),
-        requestLimitPerEndpoint = conflationBacktestingAppConfig.tracesApi.requestLimitPerEndpoint,
-      ),
+      counters = null,
+      conflation = null,
     ),
     stateManager = mainCoordinatorConfig.stateManager.copy(
       endpoints = listOf(conflationBacktestingAppConfig.shomeiApi.endpoint),
@@ -165,13 +163,13 @@ class ConflationBacktestingApp(
       backtestingCoordinatorConfig.conflation.proofAggregation.targetEndBlocks ?: emptyList(),
     )
 
+  val blobCompressor = BlobCompressorFactory.getInstance(
+    compressorVersion = backtestingCoordinatorConfig.conflation.blobCompression.blobCompressorVersion,
+    dataLimit = backtestingCoordinatorConfig.conflation.blobCompression.blobSizeLimit.toInt(),
+  )
+
   private val conflationCalculator: TracesConflationCalculator = run {
     // To fail faster for JNA reasons
-    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
-      compressorVersion = backtestingCoordinatorConfig.conflation.blobCompression.blobCompressorVersion,
-      dataLimit = backtestingCoordinatorConfig.conflation.blobCompression.blobSizeLimit,
-      metricsFacade = metricsFacade,
-    )
 
     val compressedBlobCalculator = ConflationCalculatorByDataCompressed(
       blobCompressor = blobCompressor,
@@ -364,6 +362,11 @@ class ConflationBacktestingApp(
       blobCompressionProofCoordinator.stop(),
       blockCreationMonitor.stop(),
     ).thenApply {
+      try {
+        blobCompressor.close()
+      } catch (_: Throwable) {
+        // Ignored, we want to attempt to close the compressor but it should not prevent the rest of the shutdown
+      }
       log.info("Conflation backtesting stopped successfully")
     }
   }

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -120,6 +120,147 @@ Files use `.inprogress` suffix during processing. Naming pattern: `$startBlock-$
 
 If the coordinator goes down, blocks continue to be produced by the sequencer. On restart, the coordinator resumes from the last persisted state, re-submitting unfinalized blobs and aggregations.
 
+## Conflation Backtesting
+
+Conflation backtesting allows re-running the conflation and proof-request pipeline over a historical block range without affecting the live submission pipeline. It is useful for testing new blob compressor versions, batch sizing strategies, or conflation parameter changes against real historical data.
+
+### How It Works
+
+1. Submit one or more backtesting jobs via `conflation_createProverRequests`, each specifying a block range, blob compressor version, and the traces/state-manager endpoints to use.
+2. Each job spins up an isolated `ConflationBacktestingApp` instance that fetches trace counts from the given Traces API, compresses blobs using the specified compressor version, and writes prover request files to disk — identical in format to the live pipeline.
+3. Poll job status via `conflation_getReconflationJobsStatus` until `COMPLETED`.
+
+
+### JSON-RPC API
+
+#### `conflation_createProverRequests`
+
+Submits one or more backtesting jobs. Each element in `params` is an independent job. Returns a list of job IDs (one per submitted job).
+
+**Blob compressor versions:** `V1_2`, `V2`, `V3`
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "conflation_createProverRequests",
+  "params": [
+    {
+      "startBlockNumber": 1,
+      "endBlockNumber": 2,
+      "blobCompressorVersion": "V3",
+      "batchesFixedSize": null,
+      "parentBlobShnarf": null,
+      "tracesApi": {
+        "endpoint": "http://<traces-node-ip>:8545",
+        "version": "v2",
+        "requestLimitPerEndpoint": 1
+      },
+      "shomeiApi": {
+        "endpoint": "http://shomei:8888",
+        "version": "v0.0.4",
+        "requestLimitPerEndpoint": 1
+      }
+    }
+  ]
+}
+```
+
+**curl:**
+
+> Port `9546` is the coordinator's JSON-RPC API port (`json-rpc-port` under `[api]` in the coordinator config, mapped in `docker/compose-spec-l2-services.yml` as `"9546:9546"`).
+
+```bash
+curl -X POST http://localhost:9546 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "conflation_createProverRequests",
+    "params": [
+      {
+        "startBlockNumber": 1,
+        "endBlockNumber": 2,
+        "blobCompressorVersion": "V3",
+        "batchesFixedSize": null,
+        "parentBlobShnarf": null,
+        "tracesApi": {
+          "endpoint": "http://<traces-node-ip>:8545",
+          "version": "beta-v5.0-rc6",
+          "requestLimitPerEndpoint": 1
+        },
+        "shomeiApi": {
+          "endpoint": "http://shomei:8888",
+          "version": "3.0.0",
+          "requestLimitPerEndpoint": 1
+        }
+      }
+    ]
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": ["1-2-hash"]
+}
+```
+
+#### `conflation_getReconflationJobsStatus`
+
+Polls the status of one or more jobs by ID. Returns `IN_PROGRESS` or `COMPLETED` for each.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "conflation_getReconflationJobsStatus",
+  "params": ["1-2-hash"]
+}
+```
+
+**curl:**
+
+```bash
+curl -X POST http://localhost:9546 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "conflation_getReconflationJobsStatus",
+    "params": ["1-2-hash"]
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": ["COMPLETED"]
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `startBlockNumber` | integer | ✓ | First block of the range to backtest (inclusive) |
+| `endBlockNumber` | integer | ✓ | Last block of the range to backtest (inclusive) |
+| `blobCompressorVersion` | string | ✓ | Compressor version to use: `V1_2`, `V2`, or `V3` |
+| `batchesFixedSize` | integer\|null | | Override batch size; `null` uses calculator-driven batching |
+| `parentBlobShnarf` | string\|null | | Hex-encoded parent shnarf to chain from; `null` starts fresh |
+| `tracesApi.endpoint` | string | ✓ | Traces API URL (typically the backtesting traces node) |
+| `tracesApi.version` | string | ✓ | Traces API version string |
+| `tracesApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to the traces endpoint |
+| `shomeiApi.endpoint` | string | ✓ | State manager (Shomei) URL |
+| `shomeiApi.version` | string | ✓ | Shomei API version string |
+| `shomeiApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to Shomei |
+
 ## Test Coverage
 
 | Test File | Runner | Validates |


### PR DESCRIPTION
This PR implements issue(s) #2240 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch coordinator runtime configuration and the conflation backtesting pipeline’s blob compression instantiation/shutdown, which could affect backtesting runs and local setups if misconfigured. No changes to live L1 submission logic, but the new ports/paths and compressor handling warrant validation in local environments.
> 
> **Overview**
> Adds local setup support for **conflation backtesting** by extending the coordinator config with a `conflation.backtesting-directory` output path and a dedicated `api.json-rpc-port`.
> 
> Updates `ConflationBacktestingApp` to use `BlobCompressorFactory` (and explicitly close it on shutdown), disallow backtesting with `BlobCompressorVersion.V2`, and isolate backtesting traces usage by forcing `traces.counters`/`traces.conflation` to `null`.
> 
> Expands coordinator docs with a new *Conflation Backtesting* section describing the JSON-RPC methods (`conflation_createProverRequests`, `conflation_getReconflationJobsStatus`), required fields, and example calls against port `9546`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5800e6ef38565003a4a70dbf4a8645f1f517cdd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->