### PR TITLE
chore: update default BESU_PACKAGE_TAG in docker compose files

### DIFF
--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5-rc6-20260316125820-f438666}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.1-20260320150354-f908e7d}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -51,7 +51,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5-rc6-20260316125820-f438666}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.1-20260320150354-f908e7d}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -126,7 +126,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5-rc6-20260316125820-f438666}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.1-20260320150354-f908e7d}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -170,7 +170,7 @@ services:
   l2-node-besu-leader:
     hostname: l2-node-besu-leader
     container_name: l2-node-besu-leader
-    image: consensys/linea-besu-package-with-fleet:${BESU_PACKAGE_TAG:-beta-v5-rc7-20260317093900-c131e1a}
+    image: consensys/linea-besu-package-with-fleet:${BESU_PACKAGE_TAG:-beta-v5.1-20260320150354-f908e7d}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -214,7 +214,7 @@ services:
   l2-node-besu-follower:
     hostname: l2-node-besu-follower
     container_name: l2-node-besu-follower
-    image: consensys/linea-besu-package-with-fleet:${BESU_PACKAGE_TAG:-beta-v5-rc7-20260317093900-c131e1a}
+    image: consensys/linea-besu-package-with-fleet:${BESU_PACKAGE_TAG:-beta-v5.1-20260320150354-f908e7d}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -586,7 +586,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5-rc6-20260316125820-f438666}
+    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v5.1-20260320150354-f908e7d}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR implements issue(s) #N/A

### Summary

- update default `BESU_PACKAGE_TAG` in Docker compose specs to `beta-v5.1-20260320150354-f908e7d`
- apply the new default to both `linea-besu-package` and `linea-besu-package-with-fleet` image entries
- update both `docker/compose-spec-l1-services.yml` and `docker/compose-spec-l2-services.yml`

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D0AMPU71CD9/p1774020772923719?thread_ts=1774020772.923719&cid=D0AMPU71CD9)

<div><a href="https://cursor.com/agents/bc-82d32f27-0475-55cc-aa50-0fce3cd3887d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82d32f27-0475-55cc-aa50-0fce3cd3887d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

