### PR TITLE
fix: Add error handling for transaction history in the bridge UI

### DIFF
--- a/bridge-ui/src/adapters/cctp/history/fetchCctpBridgeEvents.ts
+++ b/bridge-ui/src/adapters/cctp/history/fetchCctpBridgeEvents.ts
@@ -44,50 +44,55 @@ export async function fetchCctpBridgeEvents(
 
   await Promise.all(
     filteredUSDCLogs.map(async (log) => {
-      const transactionHash = log.transactionHash;
+      try {
+        const transactionHash = log.transactionHash;
 
-      if (
-        restoreFromTransactionCache(
-          historyStoreActions,
-          fromChain.id,
-          transactionHash,
-          transactionsMap,
-          transactionHash,
-        )
-      ) {
-        return;
+        if (
+          restoreFromTransactionCache(
+            historyStoreActions,
+            fromChain.id,
+            transactionHash,
+            transactionsMap,
+            transactionHash,
+          )
+        ) {
+          return;
+        }
+
+        const fromBlock = await fromChainClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
+        if (isBlockTooOld(fromBlock)) return;
+
+        const token = tokens.find((token) => isCctp(token));
+        if (isUndefined(token)) return;
+
+        const cctpMessage = await getCctpMessageByTxHash(transactionHash, fromChain.cctpDomain, fromChain.testnet);
+        if (isUndefined(cctpMessage)) return;
+        const nonce = cctpMessage.eventNonce;
+
+        const status = await getCctpTransactionStatus(toChain, cctpMessage, nonce, wagmiConfig);
+
+        const tx: BridgeTransaction = {
+          adapterId: "cctp",
+          status,
+          token,
+          fromChain,
+          toChain,
+          timestamp: fromBlock.timestamp,
+          bridgingTx: log.transactionHash,
+          message: {
+            amountSent: BigInt(log.args.amount),
+            nonce: nonce,
+            attestation: cctpMessage.attestation,
+            message: cctpMessage.message,
+          },
+          mode: getCctpModeFromFinalityThreshold(log.args.minFinalityThreshold),
+        };
+
+        saveToTransactionCache(historyStoreActions, tx);
+        transactionsMap.set(transactionHash, tx);
+      } catch (error) {
+        console.error(`Failed to process CCTP transaction ${log.transactionHash}:`, error);
       }
-
-      const fromBlock = await fromChainClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
-      if (isBlockTooOld(fromBlock)) return;
-
-      const token = tokens.find((token) => isCctp(token));
-      if (isUndefined(token)) return;
-
-      const cctpMessage = await getCctpMessageByTxHash(transactionHash, fromChain.cctpDomain, fromChain.testnet);
-      if (isUndefined(cctpMessage)) return;
-      const nonce = cctpMessage.eventNonce;
-      const status = await getCctpTransactionStatus(toChain, cctpMessage, nonce, wagmiConfig);
-
-      const tx: BridgeTransaction = {
-        adapterId: "cctp",
-        status,
-        token,
-        fromChain,
-        toChain,
-        timestamp: fromBlock.timestamp,
-        bridgingTx: log.transactionHash,
-        message: {
-          amountSent: BigInt(log.args.amount),
-          nonce: nonce,
-          attestation: cctpMessage.attestation,
-          message: cctpMessage.message,
-        },
-        mode: getCctpModeFromFinalityThreshold(log.args.minFinalityThreshold),
-      };
-
-      saveToTransactionCache(historyStoreActions, tx);
-      transactionsMap.set(transactionHash, tx);
     }),
   );
 

--- a/bridge-ui/src/adapters/cctp/utils.ts
+++ b/bridge-ui/src/adapters/cctp/utils.ts
@@ -2,7 +2,7 @@ import { getPublicClient, GetPublicClientReturnType } from "@wagmi/core";
 import { Config } from "wagmi";
 
 import { Chain, TransactionStatus } from "@/types";
-import { isUndefined } from "@/utils/misc";
+import { isUndefined, isUndefinedOrNull } from "@/utils/misc";
 
 import { MESSAGE_TRANSMITTER_V2_ABI } from "./abis";
 import {
@@ -55,6 +55,7 @@ export const getCctpTransactionStatus = async (
     chainId: toChain.id,
   });
   if (isUndefined(toChainClient)) return TransactionStatus.PENDING;
+  if (isUndefinedOrNull(cctpAttestationMessage.message)) return TransactionStatus.PENDING;
   // Attestation/message not yet available
   if (cctpAttestationMessage.message.length < CCTP_V2_MESSAGE_HEADER_LENGTH) return TransactionStatus.PENDING;
   const isNonceUsed = await isCctpNonceUsed(toChainClient, nonce, toChain.cctpMessageTransmitterV2Address);
@@ -75,7 +76,11 @@ export const getCctpTransactionStatus = async (
       : TransactionStatus.READY_TO_CLAIM;
 
   // Message has expired, must reattest
-  await reattestCctpV2PreFinalityMessage(nonce, toChain.testnet);
+  try {
+    await reattestCctpV2PreFinalityMessage(nonce, toChain.testnet);
+  } catch (error) {
+    console.error(`Failed to reattest CCTP message with nonce ${nonce}:`, error);
+  }
 
   /**
    * We will not re-query to get a new message/attestation set here:

--- a/bridge-ui/src/adapters/hyperlane/history/fetchHyperlaneBridgeEvents.ts
+++ b/bridge-ui/src/adapters/hyperlane/history/fetchHyperlaneBridgeEvents.ts
@@ -80,45 +80,49 @@ export async function fetchHyperlaneBridgeEvents(
 
   await Promise.all(
     allLogs.map(async (log) => {
-      const transactionHash = log.transactionHash;
+      try {
+        const transactionHash = log.transactionHash;
 
-      if (
-        restoreFromTransactionCache(
-          historyStoreActions,
-          fromChain.id,
-          transactionHash,
-          transactionsMap,
-          transactionHash,
-        )
-      ) {
-        return;
+        if (
+          restoreFromTransactionCache(
+            historyStoreActions,
+            fromChain.id,
+            transactionHash,
+            transactionsMap,
+            transactionHash,
+          )
+        ) {
+          return;
+        }
+
+        const fromBlock = await fromChainClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
+        if (isBlockTooOld(fromBlock)) return;
+
+        const messageId = log.args.messageId;
+        const status = await getHyperlaneTransactionStatus(messageId, toChain, wagmiConfig);
+
+        const tx: BridgeTransaction = {
+          adapterId: "hyperlane",
+          status,
+          token,
+          fromChain,
+          toChain,
+          timestamp: fromBlock.timestamp,
+          bridgingTx: transactionHash,
+          message: {
+            messageId,
+            amountSent: log.args.amount,
+            transferIndex: log.args.index,
+            sender: log.args.sender,
+            recipient: log.args.recipient,
+          },
+        };
+
+        saveToTransactionCache(historyStoreActions, tx);
+        transactionsMap.set(transactionHash, tx);
+      } catch (error) {
+        console.error(`Failed to process Hyperlane transaction ${log.transactionHash}:`, error);
       }
-
-      const fromBlock = await fromChainClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
-      if (isBlockTooOld(fromBlock)) return;
-
-      const messageId = log.args.messageId;
-      const status = await getHyperlaneTransactionStatus(messageId, toChain, wagmiConfig);
-
-      const tx: BridgeTransaction = {
-        adapterId: "hyperlane",
-        status,
-        token,
-        fromChain,
-        toChain,
-        timestamp: fromBlock.timestamp,
-        bridgingTx: transactionHash,
-        message: {
-          messageId,
-          amountSent: log.args.amount,
-          transferIndex: log.args.index,
-          sender: log.args.sender,
-          recipient: log.args.recipient,
-        },
-      };
-
-      saveToTransactionCache(historyStoreActions, tx);
-      transactionsMap.set(transactionHash, tx);
     }),
   );
 

--- a/bridge-ui/src/adapters/native/history/fetchERC20BridgeEvents.ts
+++ b/bridge-ui/src/adapters/native/history/fetchERC20BridgeEvents.ts
@@ -74,86 +74,90 @@ export async function fetchERC20BridgeEvents(
 
   await Promise.all(
     Array.from(uniqueLogsMap.values()).map(async (log) => {
-      const transactionHash = log.transactionHash;
+      try {
+        const transactionHash = log.transactionHash;
 
-      if (
-        restoreFromTransactionCache(
-          historyStoreActions,
-          fromChain.id,
+        if (
+          restoreFromTransactionCache(
+            historyStoreActions,
+            fromChain.id,
+            transactionHash,
+            transactionsMap,
+            transactionHash,
+          )
+        ) {
+          return;
+        }
+
+        const block = await originLayerClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
+        if (isBlockTooOld(block)) return;
+
+        const message = await getMessagesByTransactionHash(originLayerClient as Client, {
           transactionHash,
-          transactionsMap,
-          transactionHash,
-        )
-      ) {
-        return;
+          ...(config.e2eTestMode
+            ? { messageServiceAddress: config.chains[fromChain.id].messageServiceAddress as Address }
+            : {}),
+        });
+
+        if (isUndefinedOrNull(message) || message.length === 0) {
+          return;
+        }
+
+        const messageStatus =
+          fromChain.layer === ChainLayer.L1
+            ? await getL1ToL2MessageStatus(destinationLayerClient as Client, {
+                messageHash: message[0].messageHash,
+                ...(config.e2eTestMode
+                  ? { l2MessageServiceAddress: config.chains[toChain.id].messageServiceAddress as Address }
+                  : {}),
+              })
+            : await getL2ToL1MessageStatus(destinationLayerClient as Client, {
+                messageHash: message[0].messageHash,
+                l2Client: originLayerClient as Client,
+                ...(config.e2eTestMode
+                  ? {
+                      lineaRollupAddress: config.chains[toChain.id].messageServiceAddress as Address,
+                      l2MessageServiceAddress: config.chains[fromChain.id].messageServiceAddress as Address,
+                    }
+                  : {}),
+              });
+
+        const token = tokens.find(
+          (token) =>
+            token.L1?.toLowerCase() === log.args.token.toLowerCase() ||
+            token.L2?.toLowerCase() === log.args.token.toLowerCase(),
+        );
+
+        if (isUndefined(token)) {
+          return;
+        }
+
+        const [amount] = decodeAbiParameters([{ type: "uint256", name: "amount" }], log.data);
+        const tx = {
+          adapterId: "native",
+          status: formatOnChainMessageStatus(messageStatus),
+          token,
+          fromChain,
+          toChain,
+          timestamp: block.timestamp,
+          bridgingTx: log.transactionHash,
+          message: {
+            from: message[0].from as Address,
+            to: message[0].to as Address,
+            fee: message[0].fee,
+            value: message[0].value,
+            nonce: message[0].nonce,
+            calldata: message[0].calldata,
+            messageHash: message[0].messageHash,
+            amountSent: amount,
+          },
+        };
+
+        saveToTransactionCache(historyStoreActions, tx);
+        transactionsMap.set(transactionHash, tx);
+      } catch (error) {
+        console.error(`Failed to process native ERC20 transaction ${log.transactionHash}:`, error);
       }
-
-      const block = await originLayerClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
-      if (isBlockTooOld(block)) return;
-
-      const message = await getMessagesByTransactionHash(originLayerClient as Client, {
-        transactionHash,
-        ...(config.e2eTestMode
-          ? { messageServiceAddress: config.chains[fromChain.id].messageServiceAddress as Address }
-          : {}),
-      });
-
-      if (isUndefinedOrNull(message) || message.length === 0) {
-        return;
-      }
-
-      const messageStatus =
-        fromChain.layer === ChainLayer.L1
-          ? await getL1ToL2MessageStatus(destinationLayerClient as Client, {
-              messageHash: message[0].messageHash,
-              ...(config.e2eTestMode
-                ? { l2MessageServiceAddress: config.chains[toChain.id].messageServiceAddress as Address }
-                : {}),
-            })
-          : await getL2ToL1MessageStatus(destinationLayerClient as Client, {
-              messageHash: message[0].messageHash,
-              l2Client: originLayerClient as Client,
-              ...(config.e2eTestMode
-                ? {
-                    lineaRollupAddress: config.chains[toChain.id].messageServiceAddress as Address,
-                    l2MessageServiceAddress: config.chains[fromChain.id].messageServiceAddress as Address,
-                  }
-                : {}),
-            });
-
-      const token = tokens.find(
-        (token) =>
-          token.L1?.toLowerCase() === log.args.token.toLowerCase() ||
-          token.L2?.toLowerCase() === log.args.token.toLowerCase(),
-      );
-
-      if (isUndefined(token)) {
-        return;
-      }
-
-      const [amount] = decodeAbiParameters([{ type: "uint256", name: "amount" }], log.data);
-      const tx = {
-        adapterId: "native",
-        status: formatOnChainMessageStatus(messageStatus),
-        token,
-        fromChain,
-        toChain,
-        timestamp: block.timestamp,
-        bridgingTx: log.transactionHash,
-        message: {
-          from: message[0].from as Address,
-          to: message[0].to as Address,
-          fee: message[0].fee,
-          value: message[0].value,
-          nonce: message[0].nonce,
-          calldata: message[0].calldata,
-          messageHash: message[0].messageHash,
-          amountSent: amount,
-        },
-      };
-
-      saveToTransactionCache(historyStoreActions, tx);
-      transactionsMap.set(transactionHash, tx);
     }),
   );
 

--- a/bridge-ui/src/adapters/native/history/fetchETHBridgeEvents.ts
+++ b/bridge-ui/src/adapters/native/history/fetchETHBridgeEvents.ts
@@ -70,62 +70,72 @@ export async function fetchETHBridgeEvents(
 
   await Promise.all(
     Array.from(uniqueLogsMap.values()).map(async (log) => {
-      const uniqueKey = `${log.args._from}-${log.args._to}-${log.transactionHash}`;
+      try {
+        const uniqueKey = `${log.args._from}-${log.args._to}-${log.transactionHash}`;
 
-      if (
-        restoreFromTransactionCache(historyStoreActions, fromChain.id, log.transactionHash, transactionsMap, uniqueKey)
-      ) {
-        return;
+        if (
+          restoreFromTransactionCache(
+            historyStoreActions,
+            fromChain.id,
+            log.transactionHash,
+            transactionsMap,
+            uniqueKey,
+          )
+        ) {
+          return;
+        }
+
+        const messageHash = log.args._messageHash as Hex;
+
+        const block = await originLayerClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
+        if (isBlockTooOld(block)) return;
+
+        const messageStatus =
+          fromChain.layer === ChainLayer.L1
+            ? await getL1ToL2MessageStatus(destinationLayerClient as Client, {
+                messageHash,
+                ...(config.e2eTestMode
+                  ? { l2MessageServiceAddress: config.chains[toChain.id].messageServiceAddress as Address }
+                  : {}),
+              })
+            : await getL2ToL1MessageStatus(destinationLayerClient as Client, {
+                messageHash,
+                l2Client: originLayerClient as Client,
+                ...(config.e2eTestMode
+                  ? {
+                      lineaRollupAddress: config.chains[toChain.id].messageServiceAddress as Address,
+                      l2MessageServiceAddress: config.chains[fromChain.id].messageServiceAddress as Address,
+                    }
+                  : {}),
+              });
+
+        const token = tokens.find((token) => token.type.includes("eth"));
+
+        const tx = {
+          adapterId: "native",
+          status: formatOnChainMessageStatus(messageStatus),
+          token: token || defaultTokensConfig.MAINNET[0],
+          fromChain,
+          toChain,
+          timestamp: block.timestamp,
+          bridgingTx: log.transactionHash,
+          message: {
+            from: log.args._from,
+            to: log.args._to,
+            fee: log.args._fee,
+            value: log.args._value,
+            nonce: log.args._nonce,
+            calldata: log.args._calldata,
+            messageHash: log.args._messageHash,
+            amountSent: log.args._value,
+          },
+        };
+
+        saveToTransactionCache(historyStoreActions, tx);
+        transactionsMap.set(uniqueKey, tx);
+      } catch (error) {
+        console.error(`Failed to process native ETH transaction ${log.transactionHash}:`, error);
       }
-
-      const messageHash = log.args._messageHash as Hex;
-
-      const block = await originLayerClient.getBlock({ blockNumber: log.blockNumber, includeTransactions: false });
-      if (isBlockTooOld(block)) return;
-
-      const messageStatus =
-        fromChain.layer === ChainLayer.L1
-          ? await getL1ToL2MessageStatus(destinationLayerClient as Client, {
-              messageHash,
-              ...(config.e2eTestMode
-                ? { l2MessageServiceAddress: config.chains[toChain.id].messageServiceAddress as Address }
-                : {}),
-            })
-          : await getL2ToL1MessageStatus(destinationLayerClient as Client, {
-              messageHash,
-              l2Client: originLayerClient as Client,
-              ...(config.e2eTestMode
-                ? {
-                    lineaRollupAddress: config.chains[toChain.id].messageServiceAddress as Address,
-                    l2MessageServiceAddress: config.chains[fromChain.id].messageServiceAddress as Address,
-                  }
-                : {}),
-            });
-
-      const token = tokens.find((token) => token.type.includes("eth"));
-
-      const tx = {
-        adapterId: "native",
-        status: formatOnChainMessageStatus(messageStatus),
-        token: token || defaultTokensConfig.MAINNET[0],
-        fromChain,
-        toChain,
-        timestamp: block.timestamp,
-        bridgingTx: log.transactionHash,
-        message: {
-          from: log.args._from,
-          to: log.args._to,
-          fee: log.args._fee,
-          value: log.args._value,
-          nonce: log.args._nonce,
-          calldata: log.args._calldata,
-          messageHash: log.args._messageHash,
-          amountSent: log.args._value,
-        },
-      };
-
-      saveToTransactionCache(historyStoreActions, tx);
-      transactionsMap.set(uniqueKey, tx);
     }),
   );
 

--- a/bridge-ui/src/utils/history/fetchTransactionsHistory.ts
+++ b/bridge-ui/src/utils/history/fetchTransactionsHistory.ts
@@ -38,10 +38,13 @@ async function fetchBridgeEvents(
   wagmiConfig: Config,
 ): Promise<BridgeTransaction[]> {
   const adapters = getAllAdapters();
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     adapters.map((adapter) =>
       adapter.fetchHistory({ historyStoreActions, address, fromChain, toChain, tokens, wagmiConfig }),
     ),
   );
-  return results.flat();
+
+  return results
+    .filter((result): result is PromiseFulfilledResult<BridgeTransaction[]> => result.status === "fulfilled")
+    .flatMap((result) => result.value);
 }

--- a/bridge-ui/src/utils/history/restoreFromTransactionCache.ts
+++ b/bridge-ui/src/utils/history/restoreFromTransactionCache.ts
@@ -22,6 +22,7 @@ export function restoreFromTransactionCache(
   if (cachedCompletedTx) {
     if (isTimestampTooOld(cachedCompletedTx.timestamp)) {
       historyStoreActions.deleteCompleteTx(cacheKey);
+      return false; // Cached transaction expired, re-process from chain
     }
     transactionsMap.set(mapKey, cachedCompletedTx);
     return true; // Found valid cached transaction, skip processing


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction-history aggregation and status determination; while changes are mostly defensive, they can affect which bridge transactions appear and how they’re marked (e.g., pending vs claimable). Failures are now logged instead of surfacing as hard errors, which could mask upstream issues if not monitored.
> 
> **Overview**
> Improves resiliency of bridge transaction history fetching by **isolating failures per adapter/log**: CCTP, Hyperlane, and native (ETH/ERC20) history processors now wrap per-log processing in `try/catch` and log errors instead of aborting the whole fetch.
> 
> History aggregation in `fetchTransactionsHistory` now uses `Promise.allSettled` so a single adapter failure doesn’t prevent returning results from other adapters.
> 
> Hardens CCTP status checks by treating missing/`null` messages as `PENDING` and by catching/logging failures when attempting CCTP message re-attestation. Also clarifies cache behavior by returning `false` when an expired cached transaction is deleted so it will be re-processed from chain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f908a00c6cb60fb78ce1e27cb6c6f963b018241. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->