### PR TITLE
coordinator: fixes 1896 MinMineableFeesPricerServiceTest flaky test

### DIFF
--- a/coordinator/ethereum/gas-pricing/static-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/staticcap/MinMineableFeesPricerServiceTest.kt
+++ b/coordinator/ethereum/gas-pricing/static-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/staticcap/MinMineableFeesPricerServiceTest.kt
@@ -85,9 +85,6 @@ class MinMineableFeesPricerServiceTest {
       )
     monitor.start().get()
     runCatching {
-
-    }
-    runCatching {
       await()
         .atMost(5.seconds.toJavaDuration())
         .untilAsserted {


### PR DESCRIPTION
This PR implements issue(s) #1896

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test synchronization, replacing Vert.x timer/test context usage with Awaitility-based assertions to reduce timing flakiness.
> 
> **Overview**
> Improves reliability of `MinMineableFeesPricerServiceTest.start_startsPollingProcess` by removing `VertxTestContext`/`setTimer`-based synchronization and instead waiting (via Awaitility) until the polling loop has executed and expected interactions occur.
> 
> The test now starts the service synchronously (`start().get()`), asserts within a bounded wait (`atMost(5s)`), and ensures `monitor.stop()` is always called after the assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7a1cca4908c5b5fffa63e4b14c07e2bbb8160f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->