### PR TITLE
fix: enable client-side rendering for centralized exchange page

### DIFF
--- a/bridge-ui/src/app/(layerswap)/centralized-exchange/page.tsx
+++ b/bridge-ui/src/app/(layerswap)/centralized-exchange/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import PageFooter from "@/components/bridge/page-footer";
 import { Widget } from "@/components/layerswap/widget";
 


### PR DESCRIPTION
This PR implements issue(s) #

Adds "use client" directive to the centralized exchange page (bridge-ui/src/app/(layerswap)/centralized-exchange/page.tsx) to force client-side rendering. This fixes issues caused by the page being server-rendered by default in Next.js App Router.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to a single page and only changes its rendering mode, though it could surface client-only hydration/runtime issues if assumptions were previously server-safe.
> 
> **Overview**
> Ensures the `centralized-exchange` page is **client-rendered** by adding the `"use client"` directive at the top of `page.tsx`, preventing it from being treated as a server component in the App Router.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7d50d49c349abfd017ce9d4768406f6cd5e9042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->