### PR TITLE
feat: make the githook execution gradle version-agnostic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,17 @@ def allowCompilationWarnings = System.getenv('LINEA_DEV_ALLOW_WARNINGS') != null
 // this would break all Gradle invocations (including help/tasks).
 if (file('.git').exists()) {
   try {
-    def hooksPathResult = exec {
-      commandLine 'git', 'config', 'core.hooksPath', '.githooks'
-      ignoreExitValue = true
-    }
-    if (hooksPathResult.exitValue != 0) {
+    def proc = [
+      'git',
+      'config',
+      'core.hooksPath',
+      '.githooks'
+    ].execute()
+    proc.waitFor()
+    if (proc.exitValue() != 0) {
       logger.warn(
           "Could not set git core.hooksPath to .githooks (git exited with {}). Local hooks under .githooks may not run.",
-          hooksPathResult.exitValue,
+          proc.exitValue(),
           )
     }
   } catch (Exception e) {


### PR DESCRIPTION
This PR implements issue(s) #2097

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how `git config core.hooksPath .githooks` is invoked during Gradle configuration, without affecting build outputs. Main risk is slightly different process/exit-code behavior on unusual environments where `git` execution differs.
> 
> **Overview**
> Makes the repository’s local git-hook bootstrap more Gradle-version agnostic by replacing the configuration-phase `exec {}` call with direct `['git','config','core.hooksPath','.githooks'].execute()` and checking the resulting process exit code.
> 
> Failure handling remains the same (warn and continue), but the invocation path no longer depends on Gradle’s `ExecResult` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f4c60e2a24f198d80bcfe5c21d08cbab2129c9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->