### PR TITLE
feat: add proposal date to lido governance Slack notifications

### DIFF
--- a/native-yield-operations/lido-governance-monitor/src/clients/SlackClient.ts
+++ b/native-yield-operations/lido-governance-monitor/src/clients/SlackClient.ts
@@ -188,6 +188,7 @@ export class SlackClient implements ISlackClient {
       month: "short",
       day: "numeric",
       year: "numeric",
+      timeZone: "UTC",
     });
   }
 

--- a/native-yield-operations/lido-governance-monitor/src/clients/__tests__/SlackClient.test.ts
+++ b/native-yield-operations/lido-governance-monitor/src/clients/__tests__/SlackClient.test.ts
@@ -231,26 +231,11 @@ describe("SlackClient", () => {
     it("includes the proposal date from sourceCreatedAt in the shared fields", async () => {
       // Arrange
       const mockProposal = createMockProposal({
-        sourceCreatedAt: new Date("2024-01-15T08:30:00Z"),
-        createdAt: new Date("2025-02-20T10:00:00Z"),
-        analyzedAt: new Date("2026-03-26T05:40:38Z"),
+        sourceCreatedAt: new Date("2024-01-15T00:30:00Z"),
+        createdAt: new Date("2025-02-20T12:00:00Z"),
+        analyzedAt: new Date("2026-03-26T12:00:00Z"),
       });
       const mockAssessment = createMockAssessment();
-      const expectedProposalDate = mockProposal.sourceCreatedAt.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
-      const createdAtDate = mockProposal.createdAt.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
-      const analyzedAtDate = mockProposal.analyzedAt?.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
       fetchMock.mockResolvedValue({ ok: true, text: () => Promise.resolve("ok") });
 
       // Act
@@ -259,9 +244,9 @@ describe("SlackClient", () => {
       // Assert
       const callBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       const sharedFields = callBody.blocks[1].fields.map((field: { text: string }) => field.text);
-      expect(sharedFields).toContain(`*Proposal Date:* ${expectedProposalDate}`);
-      expect(sharedFields).not.toContain(`*Proposal Date:* ${createdAtDate}`);
-      expect(sharedFields).not.toContain(`*Proposal Date:* ${analyzedAtDate}`);
+      expect(sharedFields).toContain("*Proposal Date:* Jan 15, 2024");
+      expect(sharedFields).not.toContain("*Proposal Date:* Feb 20, 2025");
+      expect(sharedFields).not.toContain("*Proposal Date:* Mar 26, 2026");
     });
   });
 
@@ -446,26 +431,11 @@ describe("SlackClient", () => {
     it("includes the proposal date from sourceCreatedAt in the shared fields", async () => {
       // Arrange
       const mockProposal = createMockProposal({
-        sourceCreatedAt: new Date("2024-01-15T08:30:00Z"),
-        createdAt: new Date("2025-02-20T10:00:00Z"),
-        analyzedAt: new Date("2026-03-26T05:40:38Z"),
+        sourceCreatedAt: new Date("2024-01-15T00:30:00Z"),
+        createdAt: new Date("2025-02-20T12:00:00Z"),
+        analyzedAt: new Date("2026-03-26T12:00:00Z"),
       });
       const mockAssessment = createMockAssessment();
-      const expectedProposalDate = mockProposal.sourceCreatedAt.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
-      const createdAtDate = mockProposal.createdAt.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
-      const analyzedAtDate = mockProposal.analyzedAt?.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
       fetchMock.mockResolvedValue({ ok: true, text: () => Promise.resolve("ok") });
 
       // Act
@@ -474,9 +444,9 @@ describe("SlackClient", () => {
       // Assert
       const callBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       const sharedFields = callBody.blocks[2].fields.map((field: { text: string }) => field.text);
-      expect(sharedFields).toContain(`*Proposal Date:* ${expectedProposalDate}`);
-      expect(sharedFields).not.toContain(`*Proposal Date:* ${createdAtDate}`);
-      expect(sharedFields).not.toContain(`*Proposal Date:* ${analyzedAtDate}`);
+      expect(sharedFields).toContain("*Proposal Date:* Jan 15, 2024");
+      expect(sharedFields).not.toContain("*Proposal Date:* Feb 20, 2025");
+      expect(sharedFields).not.toContain("*Proposal Date:* Mar 26, 2026");
     });
   });
 


### PR DESCRIPTION
This PR implements issue(s) #2657

### Summary

- Add a `Proposal Date` field to the shared Slack Block Kit fields used by both alert and audit messages
- Format the displayed date from `proposal.sourceCreatedAt` with `toLocaleDateString("en-US", { month, day, year, timeZone: "UTC" })`
- Add focused unit tests for both alert and audit payloads using deterministic near-midnight UTC fixtures

### Problem

Lido Governance Monitor Slack notifications did not show when a proposal was originally created. That made old proposals with recent activity harder to triage because reviewers could not immediately distinguish them from newly created proposals.

### Solution

Update `SlackClient.buildSharedBlocks` so both alert and audit payloads include `*Proposal Date:* Mon DD, YYYY` in the first `fields` block, next to `Urgency`. The date is sourced from `proposal.sourceCreatedAt` and formatted with an explicit `en-US` locale and `UTC` timezone to avoid server-local date drift.

### Related

- #2657

### Scope

- Feature: `native-yield-operations/lido-governance-monitor` Slack notification formatting

### Test Plan

- [x] `pnpm --filter @consensys/lido-governance-monitor test -- SlackClient.test.ts`
- [x] `pnpm --filter @consensys/lido-governance-monitor exec eslint src/clients/SlackClient.ts src/clients/__tests__/SlackClient.test.ts`

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [x] I have informed the team of any breaking changes if there are any.