### PR TITLE
docs: add CI workflow guide

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,7 +114,7 @@ Fans out to a set of per-component test workflows in parallel. Each receives a b
 | lido-governance-monitor | `lido-governance-monitor-testing.yml` |
 | staterecovery | disabled (pending fixes) |
 
-After all component jobs finish, a `jacoco-report` job aggregates JVM coverage data (coordinator + linea-sequencer + staterecovery + transaction-exclusion-api) and uploads to Codecov under the `kotlin` flag.
+After all component jobs finish, a `jacoco-report` job aggregates JVM coverage data (`coordinator` + `linea-sequencer` + `staterecovery` + `transaction-exclusion-api`) and uploads to Codecov under the `kotlin` flag.
 
 ---
 


### PR DESCRIPTION
This PR implements issue(s) None.

### Summary

- add `docs/ci.md` documenting the main CI workflow from trigger to publish/notify
- explain docs-only skip behavior, Docker image reuse, and the E2E path gate
- call out the manual `docker-build-and-e2e` approval requirement on pull requests

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [x] I have informed the team of any breaking changes if there are any.

### Notes

- Local `pnpm run lint:fix` could not complete in this workspace because project dependencies are not installed (`node_modules` missing, `eslint` not found).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (adds `docs/ci.md`) with no impact on runtime code or CI execution.
> 
> **Overview**
> Adds new documentation at `docs/ci.md` that explains the end-to-end CI pipeline in `.github/workflows/main.yml`, including path-filter driven job skipping, per-component testing fan-out, and Docker image reuse.
> 
> Highlights the *PR-only manual approval gate* for Docker build + E2E (`docker-build-and-e2e` environment), and documents when artifacts/images are published (PR same-repo vs `main`) plus cleanup/Slack notification behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f00a8561eb5aad95c12d6b5ea212fb26227ed823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->