### PR TITLE
[Coordinator] Poll multiple execution proof response per tick

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -44,6 +44,7 @@ class ProofGeneratingConflationHandlerImpl(
   data class Config(
     val conflationAndProofGenerationRetryBackoffDelay: Duration,
     val executionProofPollingInterval: Duration,
+    val executionProofPollsPerTick: Int = 200,
   )
 
   private val proofRequestsInProgress = ConcurrentLinkedDeque<ExecutionProofIndex>()
@@ -57,26 +58,34 @@ class ProofGeneratingConflationHandlerImpl(
     )
   }
 
-  override fun action(): SafeFuture<*> {
-    return if (proofRequestsInProgress.isNotEmpty()) {
-      val proofIndex = proofRequestsInProgress.peekFirst()
-      zkProofProductionCoordinator.isZkProofRequestProven(proofIndex).thenCompose { proven ->
-        if (proven) {
-          val batch = Batch(
-            startBlockNumber = proofIndex.startBlockNumber,
-            endBlockNumber = proofIndex.endBlockNumber,
-          )
-          log.info("execution proof generated: batch={}", batch)
-          batchProofHandler.acceptNewBatch(batch).thenApply {
-            proofRequestsInProgress.remove(proofIndex)
-          }
-        } else {
-          SafeFuture.completedFuture(Unit)
+  private fun pollProofIndex(proofIndex: ExecutionProofIndex): SafeFuture<*> {
+    return zkProofProductionCoordinator.isZkProofRequestProven(proofIndex).thenCompose { proven ->
+      if (proven) {
+        val batch = Batch(
+          startBlockNumber = proofIndex.startBlockNumber,
+          endBlockNumber = proofIndex.endBlockNumber,
+        )
+        log.info("execution proof generated: batch={}", batch)
+        batchProofHandler.acceptNewBatch(batch).thenApply {
+          proofRequestsInProgress.remove(proofIndex)
         }
+      } else {
+        SafeFuture.completedFuture(Unit)
       }
-    } else {
-      SafeFuture.completedFuture(Unit)
     }
+  }
+
+  override fun action(): SafeFuture<*> {
+    if (proofRequestsInProgress.isEmpty()) {
+      return SafeFuture.completedFuture(Unit)
+    }
+    val iterator = proofRequestsInProgress.iterator()
+    val proofIndicesToPoll = mutableListOf<ExecutionProofIndex>()
+    while (iterator.hasNext() && proofIndicesToPoll.size < config.executionProofPollsPerTick) {
+      proofIndicesToPoll.add(iterator.next())
+    }
+    val proofsPollFutures = proofIndicesToPoll.map { pollProofIndex(it) }
+    return SafeFuture.allOf(proofsPollFutures.stream())
   }
 
   override fun handleConflatedBatch(conflation: BlocksConflation): SafeFuture<*> {


### PR DESCRIPTION
This PR implements issue(s) #2673

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the proof-status polling loop to issue many concurrent status checks per tick, which could increase load on the proof coordinator and surface concurrency/ordering issues when removing completed requests.
> 
> **Overview**
> Updates `ProofGeneratingConflationHandlerImpl` to poll **multiple** in-flight `ExecutionProofIndex` entries per polling tick (instead of only the head of the queue), running the checks concurrently and removing proven indices after `acceptNewBatch` completes.
> 
> Adds a new config knob, `executionProofPollsPerTick` (default `200`), to cap how many pending proofs are checked each tick.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54fde7f0bea91f3b9137adc6408162c6514546b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->