### PR TITLE
docs: align Node.js prerequisite wording with .nvmrc (22.22.2)

### DIFF
--- a/docs/tech/README.md
+++ b/docs/tech/README.md
@@ -111,7 +111,7 @@ linea-monorepo/
 ## Quick Start
 
 ```bash
-# Prerequisites: Node.js v22+, Docker v24+, pnpm v10+, Make, JDK 21
+# Prerequisites: Node.js >= 22.22.2 (see `.nvmrc`), Docker v24+, pnpm v10+, Make, JDK 21
 
 # 1. Install dependencies
 make pnpm-install

--- a/docs/tech/development/README.md
+++ b/docs/tech/development/README.md
@@ -6,7 +6,7 @@
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Node.js | v22+ | TypeScript projects |
+| Node.js | >= 22.22.2 (see `.nvmrc`) | TypeScript projects |
 | pnpm | v10.28+ | Package management |
 | Docker | v24+ | Container runtime |
 | Docker Compose | v2.19+ | Multi-container orchestration |

--- a/native-yield-operations/lido-governance-monitor/README.md
+++ b/native-yield-operations/lido-governance-monitor/README.md
@@ -62,7 +62,7 @@ The Discourse fetcher waits 250ms between proposal detail requests by default. O
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js >= 22.22.2 (see repo root `.nvmrc`)
 - PostgreSQL database
 - Anthropic API key
 - Slack incoming webhook


### PR DESCRIPTION
This PR implements issue(s) # (documentation-only; no linked issue)

### Summary

- Update `docs/tech/development/README.md` prerequisites table from `v22+` to `>= 22.22.2` with pointer to `.nvmrc`.
- Update `docs/tech/README.md` Quick Start comment to match the same minimum Node version.
- Update `native-yield-operations/lido-governance-monitor/README.md` from `Node.js 18+` to `>= 22.22.2` and reference the repo root `.nvmrc`.

### Problem

Some markdown still described Node as `v22+` or `18+`, which is weaker than the monorepo engines requirement and `.nvmrc` (22.22.2).

### Solution

Align prerequisite text with `AGENTS.md`, `CONTRIBUTING.md`, and `.nvmrc` so contributors see a single consistent minimum.

### Related

None

### Scope

- Developer documentation (`docs/tech/`)
- Package README (`native-yield-operations/lido-governance-monitor/`)

### Test plan

- [x] Markdown renders as expected (tables and fenced bash block unchanged aside from the one line).
- [x] No code or config changes; CI documentation checks only as applicable.

### Checklist

* [ ] I wrote new tests for my new core changes. (N/A - documentation only)
* [ ] I have successfully ran tests, style checker and build against my new changes locally. (Not re-run: local agent Node was v22.22.0 while `engines` requires >=22.22.2; change is markdown-only.)
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR. (N/A)
* [ ] I have informed the team of any breaking changes if there are any. (N/A - docs only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only wording updates with no runtime or configuration changes.
> 
> **Overview**
> Aligns Node.js prerequisite wording across developer docs and the `lido-governance-monitor` README to **explicitly require `Node.js >= 22.22.2`** and point contributors to `.nvmrc`, replacing prior `v22+` / `18+` references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9141f1077a6b03b81952c8933ba3220c26dedc94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->