### PR TITLE
chore(bridge-ui): activate Yield Boost

### DIFF
--- a/bridge-ui/src/adapters/native/adapter.ts
+++ b/bridge-ui/src/adapters/native/adapter.ts
@@ -128,8 +128,7 @@ export const nativeAdapter: BridgeAdapter = {
         return [
           {
             text: "The bridge is currently congested.",
-            // TODO: uncomment this once Yield boost doc is ready.
-            // link: { url: "https://docs.linea.build/network/overview/yield-boost", label: "Learn more." },
+            link: { url: "https://docs.linea.build/network/overview/yield-boost", label: "Learn more." },
           },
         ];
       }

--- a/bridge-ui/src/components/bridge/form/index.tsx
+++ b/bridge-ui/src/components/bridge/form/index.tsx
@@ -110,7 +110,7 @@ export default function BridgeForm() {
           </div>
         </div>
       </div>
-      <PageFooter />
+      <PageFooter showYieldBoost />
     </>
   );
 }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/content change: enables Yield Boost messaging/linking in the bridge footer and deposit congestion warning without altering transaction or fee logic.
> 
> **Overview**
> Activates Yield Boost user-facing messaging in the native bridge UI.
> 
> The L2→L1 ETH congestion warning now includes a live `Learn more.` link to the Yield Boost docs, and the bridge form renders `PageFooter` with `showYieldBoost` enabled (showing the Yield Boost footer on mainnet).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f32569cca925661b174f7b0bdf509529c9bd6145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->