### PR TITLE
[Chore] - add poseidon 2 audit

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -23,6 +23,12 @@
 
 ---
 
+## Linea Poseidon2 Audit
+**Diligence**
+- Linea Poseidon2 - [https://diligence.security/audits/2026/01/linea-poseidon2/](https://diligence.security/audits/2026/01/linea-poseidon2/)
+
+---
+
 ## Linea Burn Mechanism Smart Contract Audits
 **Diligence**
 - Linea Burn Mechanism - [https://diligence.consensys.io/audits/2025/10/linea-burn-mechanism/](https://diligence.consensys.io/audits/2025/10/linea-burn-mechanism/)


### PR DESCRIPTION
Adding links to the Poseidon2 and SparseMerkleProof audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new external audit link; no runtime code or configs are affected.
> 
> **Overview**
> Adds a new **Linea Poseidon2** section to `docs/audits.md`, linking to the Consensys Diligence audit page for Poseidon2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f2d59b1065769547a843d9300120de9c696b180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->