### PR TITLE
fix(sdk-release): fix workflow syntax issues

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -181,22 +181,22 @@ jobs:
           fi
 
           BODY_FILE=$(mktemp)
-          cat > "$BODY_FILE" <<PREOF
-## Release @consensys/linea-${PACKAGE} v${NEXT_VERSION}
-
-**Bump type:** ${BUMP}
-**Previous version:** ${CURRENT_VERSION}
-
-### Changes
-
-${COMMITS}
-
-### After merging
-
-1. Note the **commit SHA** from this merged PR (visible on the merged PR page or via git log main -1)
-2. Go to **Actions → sdk-publish → Run workflow**
-3. Select ${PACKAGE}, paste the commit SHA, and run
-PREOF
+          {
+            echo "## Release @consensys/linea-${PACKAGE} v${NEXT_VERSION}"
+            echo ""
+            echo "**Bump type:** ${BUMP}"
+            echo "**Previous version:** ${CURRENT_VERSION}"
+            echo ""
+            echo "### Changes"
+            echo ""
+            echo "${COMMITS}"
+            echo ""
+            echo "### After merging"
+            echo ""
+            echo "1. Note the **commit SHA** from this merged PR (visible on the merged PR page or via git log main -1)"
+            echo "2. Go to **Actions → sdk-publish → Run workflow**"
+            echo "3. Select ${PACKAGE}, paste the commit SHA, and run"
+          } > "$BODY_FILE"
 
           gh pr create \
             --base main \


### PR DESCRIPTION
## Summary

- Replace heredoc (`<<PREOF`) with brace-redirect for the PR body file to fix heredoc parsing issues in GitHub Actions


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts how the PR body file is generated; behavior should remain the same aside from improved shell/GitHub Actions parsing reliability.
> 
> **Overview**
> Updates `sdk-release` GitHub Actions workflow to generate the release PR body via a brace-redirected series of `echo` statements instead of a heredoc.
> 
> This keeps the PR content the same while avoiding heredoc parsing/syntax issues during the `Create pull request` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d559d3ac5560d39c0c67e65f7baa333bf03d3e49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->