### PR TITLE
ci: rename `direct_prompt` to `prompt` in Claude review workflow

### DIFF
--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: --model claude-opus-4-6
-          direct_prompt: |
+          prompt: |
             You are reviewing the full Kotlin/JVM codebase in the `coordinator/` and
             `jvm-libs/` modules of the Linea monorepo.
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small CI workflow input rename and only affects how the Claude review GitHub Action receives its prompt.
> 
> **Overview**
> Updates the `claude-coordinator-review.yml` GitHub Actions workflow to pass the review instructions to `anthropics/claude-code-action` via `prompt` instead of `direct_prompt`, aligning with the action’s expected input name.
> 
> No functional code changes outside CI; behavior should remain the same aside from ensuring the prompt is actually applied during the automated coordinator review run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ed9b173038b7bbff25a0292d542efcf7c489d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->