### PR TITLE
fix(sdk-release): rename sdk release branch and move linting and testing steps

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -73,14 +73,8 @@ jobs:
         with:
           pnpm-install-options: "--frozen-lockfile --prefer-offline"
   
-      - name: Lint sdk-core
-        run: pnpm -F @consensys/linea-sdk-core run lint
-
       - name: Build sdk-core
         run: pnpm -F @consensys/linea-sdk-core run build
-
-      - name: Test sdk-core
-        run: pnpm -F @consensys/linea-sdk-core run test
 
       - name: Check if version already published
         id: check
@@ -151,14 +145,8 @@ jobs:
             exit 1
           fi
       
-      - name: Lint sdk-viem
-        run: pnpm -F @consensys/linea-sdk-viem run lint
-
       - name: Build sdk-viem
         run: pnpm -F "@consensys/linea-sdk-viem..." run build
-
-      - name: Test sdk-viem
-        run: pnpm -F @consensys/linea-sdk-viem run test
 
       - name: Check if version already published
         id: check

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -147,6 +147,26 @@ jobs:
             echo "$DELIMITER"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Setup nodejs environment
+        uses: ./.github/actions/setup-nodejs
+        with:
+          pnpm-install-options: "--frozen-lockfile --prefer-offline"
+
+      - name: Lint
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: pnpm -F "@consensys/linea-${PACKAGE}" run lint
+
+      - name: Build
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: pnpm -F "@consensys/linea-${PACKAGE}..." run build
+
+      - name: Test
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: pnpm -F "@consensys/linea-${PACKAGE}" run test
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -157,7 +177,7 @@ jobs:
           PACKAGE: ${{ inputs.package }}
           NEXT_VERSION: ${{ steps.version.outputs.next }}
         run: |
-          BRANCH="release/${PACKAGE}-v${NEXT_VERSION}"
+          BRANCH="release-${PACKAGE}-v${NEXT_VERSION}"
           git checkout -B "$BRANCH"
           git add -A
           git commit -m "release(${PACKAGE}): v${NEXT_VERSION}"
@@ -172,7 +192,7 @@ jobs:
           BUMP: ${{ inputs.bump }}
           COMMITS: ${{ steps.changelog.outputs.commits }}
         run: |
-          BRANCH="release/${PACKAGE}-v${NEXT_VERSION}"
+          BRANCH="release-${PACKAGE}-v${NEXT_VERSION}"
 
           EXISTING=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number' 2>/dev/null || true)
           if [[ -n "$EXISTING" ]]; then


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to CI workflows, but could disrupt the release pipeline if branch naming expectations or pnpm filters are incorrect.
> 
> **Overview**
> Streamlines the SDK CI release pipeline by running **lint/build/test** during `sdk-release` (before creating the release PR), using a parameterized `pnpm -F "@consensys/linea-${PACKAGE}"`/`...` filter.
> 
> Updates the release branch naming convention from `release/${PACKAGE}-v${NEXT_VERSION}` to `release-${PACKAGE}-v${NEXT_VERSION}` and removes redundant `lint`/`test` steps from `sdk-publish`, leaving publish-time builds and version checks intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3f541b1ea97f732cf00ca4bf70c493240952120. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->