### PR TITLE
Update block processor method used in Besu

### DIFF
--- a/tracer/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/tracer/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.*;
+import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList;
 import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview.BonsaiWorldState;
@@ -75,7 +76,7 @@ public class CorsetBlockProcessor extends MainnetBlockProcessor {
       final Blockchain blockchain,
       final MutableWorldState worldState,
       final Block block,
-      final PreprocessingFunction preprocessingBlockFunction) {
+      final Optional<BlockAccessList> blockAccessList) {
 
     var blockHeader = block.getHeader();
     var blockBody = block.getBody();


### PR DESCRIPTION
In [Besu PR 9629](https://github.com/besu-eth/besu/pull/9629) we added a new overload for `processBlock` . In CorsetBlockProcessor we override this method and expect it to be called during tracing, but because a new processBlock is now used in Besu we override an overload that is not called anymore in Besu.

This PR overrides the newly method overload to fix the block processor. 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small signature update to keep compatibility with an upstream Besu API change; behavior is unchanged aside from ensuring the override is actually called.
> 
> **Overview**
> Fixes a compatibility break with upstream Besu by updating `CorsetBlockProcessor` to override the new `processBlock(..., Optional<BlockAccessList>)` overload (and importing `BlockAccessList`).
> 
> This ensures the custom block-processing path used during tracing continues to be invoked after Besu switched to the new method signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb84a73aeb09a4a821f06af0db4551ca365c2261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->