### PR TITLE
fix(sdk-release): remove release label from PR creation

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -222,5 +222,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "release(${PACKAGE}): v${NEXT_VERSION}" \
-            --label release \
             --body-file "$BODY_FILE"


### PR DESCRIPTION
## Summary
- Removes `--label release` from `gh pr create` in the sdk-release workflow
- The flag fails if the "release" label doesn't exist in the repo, breaking the workflow

## Test plan
- [ ] Trigger sdk-release workflow manually and verify the PR is created without error

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that removes a failing `gh pr create` label argument; impact is limited to how release PRs are created in GitHub Actions.
> 
> **Overview**
> Release PR creation in the `sdk-release` GitHub Actions workflow no longer passes `--label release` to `gh pr create`.
> 
> This prevents the workflow from failing in repositories that don’t have a `release` label configured, while leaving the rest of the release PR generation unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c2b807a57a2d98c71ec234a82ac88f3223be2a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->