### PR TITLE
fix: skip e2e for tracer support paths

### DIFF
--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -60,6 +60,8 @@ jobs:
           E2E_PATHS_MATCHED: ${{ steps.filter.outputs.e2e-paths }}
           E2E_PATHS_FILES: ${{ steps.filter.outputs.e2e-paths_files }}
         run: |
+          set -euo pipefail
+
           if [[ "$E2E_PATHS_MATCHED" != "true" ]]; then
             echo "No e2e-relevant paths matched"
             echo "result=false" >> $GITHUB_OUTPUT
@@ -84,6 +86,15 @@ jobs:
             if [[ "$file" =~ _test\.go$ ]]; then
               continue
             fi
+
+            # Skip tracer and sequencer acceptance test support paths that should not trigger protocol e2e by themselves.
+            if [[ "$file" =~ ^tracer/reference-tests/ ]] || [[ "$file" =~ ^tracer/testing/ ]]; then
+              continue
+            fi
+
+            if [[ "$file" =~ ^besu-plugins/linea-sequencer/acceptance-tests/ ]]; then
+              continue
+            fi
             
             # Skip doc files
             if [[ "$file" =~ \.(md|mdx)$ ]]; then
@@ -95,5 +106,5 @@ jobs:
             exit 0
           done
           
-          echo "Only test/doc files changed"
+          echo "Only excluded e2e paths, test files, or doc files changed"
           echo "result=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary

- keep `tracer/**` and `besu-plugins/linea-sequencer/**` as E2E-relevant paths by default
- exclude `tracer/reference-tests/**`, `tracer/testing/**`, and `besu-plugins/linea-sequencer/acceptance-tests/**` from triggering protocol E2E on their own
- harden the evaluation step with `set -euo pipefail`
- clarify the non-trigger log message for excluded-only changes

### Problem

The E2E path gate was broad enough that support-only changes under tracer test infrastructure and sequencer acceptance tests triggered the protocol E2E workflow, even when those diffs should not require it.

### Solution

Keep the broad `dorny/paths-filter` match and handle the exception in the evaluator script. That preserves existing `tracer/**` behavior for real protocol-impacting changes while skipping the three excluded subtrees when they are the only matched files.

### Related

None

### Scope

- GitHub Actions CI
- `.github/workflows/get-has-changes-requiring-e2e-testing.yml`

This PR implements issue(s) None

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions gating logic and should only affect when E2E runs are triggered; main risk is inadvertently skipping E2E for a change that should have triggered it due to overly broad exclusions.
> 
> **Overview**
> Tightens the `get-has-changes-requiring-e2e-testing` workflow so changes under `tracer/reference-tests/`, `tracer/testing/`, and `besu-plugins/linea-sequencer/acceptance-tests/` are treated as *excluded-only* and no longer trigger protocol E2E runs by themselves.
> 
> Also hardens the evaluator shell step with `set -euo pipefail` and updates the non-trigger message to reflect excluded paths in addition to test/doc-only changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a0d5fc6c2360f6431e98526085a66a641832f7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->