### PR TITLE
besu update - support for java 25 build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ undercouchDownload = "5.6.0"
 # Besu commit hash from https://github.com/besu-eth/besu
 # when updates it, should run "gradlew buildAndUpdateBesuVersionInLibsVersions" to
 # checkout and build Besu from source, and will auto-update the "besu" version below
-besuCommit = "e19f9a90cbf9536b8a33a16601eaeaca91d54b8e"
+besuCommit = "2c9f113125ea7c31a3411fcb645047120daaa3ed"
 
 besu = "26.2.0-RC1-e19f9a9"
 blobCompressor = "3.0.2"


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the pinned Besu source commit used by the build, which can affect runtime behavior and compatibility. The `besu` version string remains unchanged, so reviewers should confirm the commit/version alignment and downstream build expectations.
> 
> **Overview**
> Bumps the pinned Besu source `besuCommit` in `gradle/libs.versions.toml` to a newer upstream commit (intended to support Java 25 builds).
> 
> No other dependency versions or code paths are changed; the `besu` version identifier is left as-is despite the new commit pin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24fc3eb6fd403538f1d525bc181a8f0c0a997e83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->