### PR TITLE
[Coordinator] Fix NPE for dynamic gas price

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -275,32 +275,30 @@ class L1DependentApp(
       null
     }
 
-  private val gasPriceCapProviderForDataSubmission = if (configs.l1Submission!!.dynamicGasPriceCap.isEnabled()) {
-    GasPriceCapProviderForDataSubmission(
-      config = GasPriceCapProviderForDataSubmission.Config(
-        maxPriorityFeePerGasCap = configs.l1Submission.blob.gas.maxPriorityFeePerGasCap,
-        maxFeePerGasCap = configs.l1Submission.blob.gas.maxFeePerGasCap,
-        maxFeePerBlobGasCap = configs.l1Submission.blob.gas.maxFeePerBlobGasCap,
-      ),
-      gasPriceCapProvider = gasPriceCapProvider!!,
-      metricsFacade = metricsFacade,
-    )
-  } else {
-    null
-  }
+  private val gasPriceCapProviderForDataSubmission =
+    gasPriceCapProvider?.let { provider ->
+      GasPriceCapProviderForDataSubmission(
+        config = GasPriceCapProviderForDataSubmission.Config(
+          maxPriorityFeePerGasCap = configs.l1Submission!!.blob.gas.maxPriorityFeePerGasCap,
+          maxFeePerGasCap = configs.l1Submission.blob.gas.maxFeePerGasCap,
+          maxFeePerBlobGasCap = configs.l1Submission.blob.gas.maxFeePerBlobGasCap,
+        ),
+        gasPriceCapProvider = provider,
+        metricsFacade = metricsFacade,
+      )
+    }
 
-  private val gasPriceCapProviderForFinalization = if (configs.l1Submission!!.dynamicGasPriceCap.isEnabled()) {
-    GasPriceCapProviderForFinalization(
-      config = GasPriceCapProviderForFinalization.Config(
-        maxPriorityFeePerGasCap = configs.l1Submission.aggregation.gas.maxPriorityFeePerGasCap,
-        maxFeePerGasCap = configs.l1Submission.aggregation.gas.maxFeePerGasCap,
-      ),
-      gasPriceCapProvider = gasPriceCapProvider!!,
-      metricsFacade = metricsFacade,
-    )
-  } else {
-    null
-  }
+  private val gasPriceCapProviderForFinalization =
+    gasPriceCapProvider?.let { provider ->
+      GasPriceCapProviderForFinalization(
+        config = GasPriceCapProviderForFinalization.Config(
+          maxPriorityFeePerGasCap = configs.l1Submission!!.aggregation.gas.maxPriorityFeePerGasCap,
+          maxFeePerGasCap = configs.l1Submission.aggregation.gas.maxFeePerGasCap,
+        ),
+        gasPriceCapProvider = provider,
+        metricsFacade = metricsFacade,
+      )
+    }
 
   private val lastFinalizedBlock = lastFinalizedBlock().get()
   private val lastProcessedBlockNumber = resumeConflationFrom(


### PR DESCRIPTION
### Summary
Fixes a startup `NullPointerException` in the coordinator when dynamic L1 gas price caps were enabled but L1 submission (as a whole) was disabled. Wrapper types were created whenever `dynamicGasPriceCap` was on and then forced `gasPriceCapProvider!!`, while the base `gasPriceCapProvider` is only constructed when **both** L1 submission is enabled **and** dynamic gas caps are enabled.

### Root cause

- `gasPriceCapProvider` is created only if `configs.l1Submission.isEnabled() && configs.l1Submission.dynamicGasPriceCap.isEnabled()`.
- `gasPriceCapProviderForDataSubmission` / `gasPriceCapProviderForFinalization` previously only checked `dynamicGasPriceCap.isEnabled()` and called `gasPriceCapProvider!!`.
- If L1 submission was disabled (`blob` and `aggregation` both disabled in config semantics) but dynamic gas cap stayed enabled, `gasPriceCapProvider` stayed `null` and the forced unwrap crashed during `L1DependentApp` construction.

### Fix
Build the data-submission and finalization gas cap wrappers only when `gasPriceCapProvider` is non-null, using `gasPriceCapProvider?.let { ... }` and passing the non-null provider into the wrappers. Downstream callers already accept nullable `GasPriceCapProvider?`, so passing `null` when the base provider is absent is correct.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small initialization/nullable-handling change that prevents a crash; behavior only changes in misconfigured/disabled L1 submission scenarios.
> 
> **Overview**
> Prevents coordinator startup crashes when `dynamicGasPriceCap` is enabled but L1 submission is disabled by **removing forced unwraps** of `gasPriceCapProvider`.
> 
> `gasPriceCapProviderForDataSubmission` and `gasPriceCapProviderForFinalization` are now created via `gasPriceCapProvider?.let { ... }`, so downstream components receive `null` wrappers when the base provider isn’t constructed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac528ff9247fba2d7a68cff8dc112ce4e3b22a76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->