### PR TITLE
fix: add nonce to tx signature in eth-transfer cron job

### DIFF
--- a/operations/src/commands/eth-transfer.ts
+++ b/operations/src/commands/eth-transfer.ts
@@ -171,6 +171,8 @@ export default class EthTransfer extends Command {
       return;
     }
 
+    this.log(`Sender: address=${senderAddress} balance=${formatEther(senderBalance)} ETH nonce=${nonce.toString()}`);
+
     const rewards = calculateRewards(senderBalance);
 
     if (rewards === 0n) {
@@ -208,6 +210,7 @@ export default class EthTransfer extends Command {
       gas: gasLimit,
       maxFeePerGas: baseFeePerGas + priorityFeePerGas,
       maxPriorityFeePerGas: priorityFeePerGas,
+      nonce,
     };
 
     const signature = await this.signTransaction(


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ETH transfer transaction construction/signing; an incorrect nonce could cause failed or replaced transactions, though the change is small and targeted.
> 
> **Overview**
> Fixes the `eth-transfer` cron/CLI command to **explicitly include the sender `nonce` in the EIP-1559 transaction payload that is serialized and sent to Web3Signer for signing**, aligning the signed bytes with the intended on-chain nonce.
> 
> Also adds a log line that prints the sender address, balance, and computed nonce to aid troubleshooting when transfers are skipped or fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 757338a46aedffdbe844da8f1d937e9c8341b206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->