### PR TITLE
fix: update gh token in sdk release workflow

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
           PACKAGE: ${{ inputs.package }}
           NEXT_VERSION: ${{ steps.version.outputs.next }}
           CURRENT_VERSION: ${{ steps.version.outputs.current }}


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the credential used by the `sdk-release` workflow when creating release PRs; incorrect scoping or secret configuration could break automated releases or unintentionally broaden GitHub API access.
> 
> **Overview**
> Switches the `sdk-release` GitHub Actions workflow to use `secrets._GITHUB_TOKEN_RELEASE_ACCESS` instead of the default `GITHUB_TOKEN` for the `gh pr create` step, changing which token/permissions are used to open release pull requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d9979b49e2148f3e55fcb644d46d6d7e00754ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->