### PR TITLE
feat(vortex): add streaming commitment prototype (behind flag)

### DIFF
--- a/prover/crypto/ringsis/ringsis.go
+++ b/prover/crypto/ringsis/ringsis.go
@@ -244,6 +244,174 @@ func (s *Key) FlattenedKey() []field.Element {
 	return res
 }
 
+// IncrementalHasher supports streaming SIS hashing of matrix columns.
+// Rows are fed in batches via AbsorbBatch; after all batches, Finalize
+// produces the same column hashes as TransversalHash.
+//
+// The core challenge is that a batch's limbs may not align with SIS key
+// polynomial boundaries. For example, 1 row produces 2 limbs (at LogTwoBound=16),
+// but each key polynomial covers Degree=512 limbs. Multiple batches' limbs
+// may map into the same polynomial slot. We handle this by tracking the global
+// limb offset and placing each batch's limbs at the correct position within
+// the polynomial buffer.
+type IncrementalHasher struct {
+	key *Key
+	// nbCols is the number of columns (i.e., the length of each row SmartVector).
+	nbCols int
+	// accumulators holds NTT-domain partial sums, one per column.
+	// Layout: accumulators[col*outputSize : (col+1)*outputSize].
+	accumulators []field.Element
+	// globalLimbOffset tracks how many limbs have been consumed across all
+	// batches so far. This determines where the next batch's limbs are placed
+	// within the SIS key polynomial structure.
+	globalLimbOffset int
+}
+
+// NewIncrementalHasher creates a new IncrementalHasher for streaming column
+// hashing over a matrix with nbCols columns.
+func (s *Key) NewIncrementalHasher(nbCols int) *IncrementalHasher {
+	return &IncrementalHasher{
+		key:              s,
+		nbCols:           nbCols,
+		accumulators:     make([]field.Element, nbCols*s.OutputSize()),
+		globalLimbOffset: 0,
+	}
+}
+
+// AbsorbBatch processes a batch of rows and accumulates their contribution
+// into the per-column NTT-domain accumulators. Each row in batchRows must
+// have length equal to nbCols.
+func (ih *IncrementalHasher) AbsorbBatch(batchRows []smartvectors.SmartVector) {
+	nbRows := len(batchRows)
+	if nbRows == 0 {
+		return
+	}
+
+	degree := ih.key.modulusDegree()
+	outputSize := ih.key.OutputSize()
+	numLimbsPerField := ih.key.NumLimbs()
+	batchLimbCount := nbRows * numLimbsPerField
+
+	globalLimbStart := ih.globalLimbOffset
+	globalLimbEnd := globalLimbStart + batchLimbCount
+
+	// Which key polynomials are touched by this batch's limbs.
+	firstPoly := globalLimbStart / degree
+	lastPoly := (globalLimbEnd - 1) / degree
+
+	parallel.Execute(ih.nbCols, func(start, end int) {
+		// Windowed transposition for cache efficiency — same pattern as TransversalHash.
+		const windowSize = 32
+		const padding = 8
+		paddedNbRows := nbRows + padding
+
+		transposedArena := arena.NewVectorArena[field.Element](paddedNbRows * windowSize)
+		transposed := make([][]field.Element, windowSize)
+		for i := range transposed {
+			fullSlice := arena.Get[field.Element](transposedArena, paddedNbRows)
+			transposed[i] = fullSlice[:nbRows]
+		}
+
+		// Thread-local buffer for the polynomial accumulation.
+		k := make(field.Vector, degree)
+		kz := make(field.Vector, degree)
+		// Buffer for decomposed limbs.
+		limbBuf := make([]uint32, batchLimbCount)
+
+		for col := start; col < end; col += windowSize {
+			currentWindowSize := windowSize
+			if col+currentWindowSize > end {
+				currentWindowSize = end - col
+			}
+
+			// Transpose: extract column values from each row in the batch.
+			for i := 0; i < nbRows; i++ {
+				switch vi := batchRows[i].(type) {
+				case *smartvectors.Constant:
+					cst := vi.Value
+					for j := 0; j < currentWindowSize; j++ {
+						transposed[j][i] = cst
+					}
+				case *smartvectors.Regular:
+					src := (*vi)[col : col+currentWindowSize]
+					for j := 0; j < currentWindowSize; j++ {
+						transposed[j][i] = src[j]
+					}
+				default:
+					for j := 0; j < currentWindowSize; j++ {
+						transposed[j][i] = batchRows[i].Get(col + j)
+					}
+				}
+			}
+
+			// For each column in the window, decompose into limbs and
+			// accumulate into the correct polynomial slots.
+			for j := 0; j < currentWindowSize; j++ {
+				colIdx := col + j
+				accSlice := field.Vector(ih.accumulators[colIdx*outputSize : (colIdx+1)*outputSize])
+
+				// Decompose batch column values into limbs.
+				it := sis.NewLimbIterator(sis.NewVectorIterator(field.Vector(transposed[j])), ih.key.LogTwoBound()/8)
+				for li := 0; li < batchLimbCount; li++ {
+					l, ok := it.NextLimb()
+					if !ok {
+						break
+					}
+					limbBuf[li] = l
+				}
+
+				// Place limbs into the correct polynomial buffer positions.
+				limbIdx := 0
+				for poly := firstPoly; poly <= lastPoly; poly++ {
+					copy(k, kz) // zero k
+
+					polyLimbStart := poly * degree
+					// Where within this polynomial do our limbs start/end?
+					fillStart := globalLimbStart - polyLimbStart
+					if fillStart < 0 {
+						fillStart = 0
+					}
+					fillEnd := globalLimbEnd - polyLimbStart
+					if fillEnd > degree {
+						fillEnd = degree
+					}
+
+					zero := uint32(0)
+					for pos := fillStart; pos < fillEnd; pos++ {
+						k[pos][0] = limbBuf[limbIdx]
+						zero |= limbBuf[limbIdx]
+						limbIdx++
+					}
+
+					if zero == 0 {
+						continue
+					}
+
+					ih.key.SisGnarkCrypto.Domain.FFT(k, fft.DIF, fft.OnCoset(), fft.WithNbTasks(1))
+					k.Mul(k, field.Vector(ih.key.SisGnarkCrypto.Ag[poly]))
+					accSlice.Add(accSlice, k)
+				}
+			}
+		}
+	})
+
+	ih.globalLimbOffset = globalLimbEnd
+}
+
+// Finalize applies the final IFFT to each column's NTT-domain accumulator,
+// converting to coefficient domain. Returns the column hashes in the same
+// flat layout as TransversalHash: length nbCols * OutputSize.
+func (ih *IncrementalHasher) Finalize() []field.Element {
+	outputSize := ih.key.OutputSize()
+	parallel.Execute(ih.nbCols, func(start, end int) {
+		for col := start; col < end; col++ {
+			accSlice := field.Vector(ih.accumulators[col*outputSize : (col+1)*outputSize])
+			ih.key.SisGnarkCrypto.Domain.FFTInverse(accSlice, fft.DIT, fft.OnCoset(), fft.WithNbTasks(1))
+		}
+	})
+	return ih.accumulators
+}
+
 // TransversalHash evaluates SIS hashes transversally over a list of smart-vectors.
 // Each smart-vector is seen as the row of a matrix. All rows must have the same
 // size or panic. The function returns the hash of the columns. The column hashes

--- a/prover/crypto/vortex/vortex_koalabear/commitment_test.go
+++ b/prover/crypto/vortex/vortex_koalabear/commitment_test.go
@@ -109,6 +109,166 @@ func BenchmarkVortexHashPathsByRows(b *testing.B) {
 	}
 }
 
+func TestIncrementalHasherMatchesTransversalHash(t *testing.T) {
+	testCases := []struct {
+		name      string
+		numRows   int
+		numCols   int
+		batchSize int
+	}{
+		{"batch_equals_total", 32, 1024, 32},
+		{"batch_1", 32, 1024, 1},
+		{"batch_7_uneven", 32, 1024, 7},
+		{"batch_16", 32, 1024, 16},
+		{"large_rows_batch_50", 387, 1024, 50},
+		{"large_rows_batch_256", 512, 1024, 256},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := makeNoSisRows(tc.numRows, tc.numCols)
+			params := NewParams(2, tc.numCols, tc.numRows, 9, 16)
+			encoded := params.EncodeRows(rows)
+			nbEncodedCols := params.RsParams.NbEncodedColumns()
+
+			// Reference: TransversalHash
+			refHashes := make([]field.Element, nbEncodedCols*params.Key.OutputSize())
+			refHashes = params.Key.TransversalHash(encoded, refHashes)
+
+			// Streaming: IncrementalHasher
+			hasher := params.Key.NewIncrementalHasher(nbEncodedCols)
+			for start := 0; start < len(encoded); start += tc.batchSize {
+				end := start + tc.batchSize
+				if end > len(encoded) {
+					end = len(encoded)
+				}
+				hasher.AbsorbBatch(encoded[start:end])
+			}
+			streamHashes := hasher.Finalize()
+
+			require.Equal(t, len(refHashes), len(streamHashes))
+			for i := range refHashes {
+				require.Equal(t, refHashes[i], streamHashes[i],
+					"mismatch at index %d (col %d, offset %d)",
+					i, i/params.Key.OutputSize(), i%params.Key.OutputSize())
+			}
+		})
+	}
+}
+
+func TestStreamingCommitMatchesNonStreaming(t *testing.T) {
+	testCases := []struct {
+		name      string
+		numRows   int
+		numCols   int
+		batchSize int
+	}{
+		{"rows_32_batch_8", 32, 1 << 10, 8},
+		{"rows_128_batch_64", 128, 1 << 10, 64},
+		{"rows_387_batch_50", 387, 1 << 10, 50},
+		{"rows_512_batch_256", 512, 1 << 10, 256},
+		{"rows_128_batch_1", 128, 1 << 10, 1},
+		{"rows_128_batch_larger_than_total", 128, 1 << 10, 999},
+		{"rows_160_default_batch", 160, 1 << 10, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := makeNoSisRows(tc.numRows, tc.numCols)
+			params := NewParams(2, tc.numCols, tc.numRows, 9, 16)
+
+			// Reference: non-streaming
+			encRef, commitRef, _, hashesRef := params.CommitMerkleWithSIS(rows)
+
+			// Streaming
+			encStr, commitStr, _, hashesStr := params.CommitMerkleWithSISStreaming(rows, tc.batchSize)
+
+			// Check identical commitment (Merkle root)
+			require.Equal(t, commitRef, commitStr, "Merkle root mismatch")
+
+			// Check identical SIS hashes
+			require.Equal(t, hashesRef, hashesStr, "SIS hashes mismatch")
+
+			// Check identical encoded matrix
+			require.Equal(t, len(encRef), len(encStr), "encoded matrix row count mismatch")
+			for i := range encRef {
+				require.Equal(t, encRef[i].Len(), encStr[i].Len(),
+					"encoded row %d length mismatch", i)
+				for j := 0; j < encRef[i].Len(); j++ {
+					require.Equal(t, encRef[i].Get(j), encStr[i].Get(j),
+						"encoded matrix mismatch at row %d, col %d", i, j)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCommitMerkleWithSIS(b *testing.B) {
+	const numCols = 1 << 13
+
+	rowCounts := []int{256, 512, 768, 1024, 1504, 2208}
+
+	for _, numRows := range rowCounts {
+		rows := makeNoSisRows(numRows, numCols)
+		params := NewParams(2, numCols, numRows, 9, 16)
+
+		b.Run(fmt.Sprintf("full_commit/rows_%d", numRows), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ReportMetric(float64(numRows), "rows")
+			b.ReportMetric(float64(numCols*2), "encoded_cols")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, _, _ = params.CommitMerkleWithSIS(rows)
+			}
+		})
+
+		b.Run(fmt.Sprintf("encode_rows_only/rows_%d", numRows), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = params.EncodeRows(rows)
+			}
+		})
+
+		b.Run(fmt.Sprintf("sis_hash_only/rows_%d", numRows), func(b *testing.B) {
+			encoded := params.EncodeRows(rows)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = params.sisTransversalHash(encoded)
+			}
+		})
+	}
+}
+
+func BenchmarkCommitMerkleWithSISStreaming(b *testing.B) {
+	const numCols = 1 << 13
+
+	rowCounts := []int{256, 512, 768, 1024, 1504, 2208}
+
+	for _, numRows := range rowCounts {
+		rows := makeNoSisRows(numRows, numCols)
+		params := NewParams(2, numCols, numRows, 9, 16)
+
+		batchDivisors := []int{1, 2, 4, 8, 16}
+		for _, div := range batchDivisors {
+			batchSize := numRows / div
+			if batchSize < 1 {
+				batchSize = 1
+			}
+			b.Run(fmt.Sprintf("rows_%d/batch_%d", numRows, batchSize), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ReportMetric(float64(numRows), "rows")
+				b.ReportMetric(float64(batchSize), "batch_size")
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, _, _, _ = params.CommitMerkleWithSISStreaming(rows, batchSize)
+				}
+			})
+		}
+	}
+}
+
 func referenceNoSisTransversalHash(v []smartvectors.SmartVector) []field.Octuplet {
 	nbRows := len(v)
 	nbCols := v[0].Len()

--- a/prover/crypto/vortex/vortex_koalabear/commtiment.go
+++ b/prover/crypto/vortex/vortex_koalabear/commtiment.go
@@ -75,6 +75,67 @@ func (p *Params) CommitMerkleWithSIS(polysMatrix []smartvectors.SmartVector) (En
 	return encodedMatrix, commitment, tree, colHashes
 }
 
+// CommitMerkleWithSISStreaming computes the same commitment as CommitMerkleWithSIS
+// but processes rows in batches to improve cache locality during Ring-SIS hashing.
+// The encoded matrix is still fully materialized and returned for use by the
+// linear combination and opening phases.
+//
+// batchSize controls how many rows are RS-encoded and SIS-hashed at a time.
+// If batchSize <= 0, defaults to max(1, NbRows/8).
+func (p *Params) CommitMerkleWithSISStreaming(
+	polysMatrix []smartvectors.SmartVector,
+	batchSize int,
+) (EncodedMatrix, Commitment, *smt_koalabear.Tree, []field.Element) {
+
+	if len(polysMatrix) > p.MaxNbRows {
+		utils.Panic("too many rows: %v, capacity is %v\n", len(polysMatrix), p.MaxNbRows)
+	}
+
+	nbRows := len(polysMatrix)
+	if batchSize <= 0 {
+		batchSize = nbRows / 8
+		if batchSize < 1 {
+			batchSize = 1
+		}
+	}
+
+	// Sanity-check row lengths.
+	for i := range polysMatrix {
+		if polysMatrix[i].Len() != p.NbColumns {
+			utils.Panic("Bad length : expected %v columns but col %v has size %v", p.NbColumns, i, polysMatrix[i].Len())
+		}
+	}
+
+	nbEncodedCols := p.RsParams.NbEncodedColumns()
+	encodedMatrix := make(EncodedMatrix, nbRows)
+	hasher := p.Key.NewIncrementalHasher(nbEncodedCols)
+
+	for start := 0; start < nbRows; start += batchSize {
+		end := start + batchSize
+		if end > nbRows {
+			end = nbRows
+		}
+
+		// RS-encode this batch of rows.
+		batch := polysMatrix[start:end]
+		parallel.Execute(len(batch), func(s, e int) {
+			for i := s; i < e; i++ {
+				encodedMatrix[start+i] = p.RsParams.RsEncodeBase(batch[i])
+			}
+		})
+
+		// Feed encoded rows to the incremental hasher.
+		hasher.AbsorbBatch(encodedMatrix[start:end])
+	}
+
+	sisHashes := hasher.Finalize()
+	leaves := p.sisHashesToMerkleLeaves(sisHashes)
+
+	tree := smt_koalabear.NewTree(leaves)
+
+	return encodedMatrix, tree.Root, tree, sisHashes
+}
+
 func (p *Params) sisTransversalHash(v []smartvectors.SmartVector) ([]field.Octuplet, []field.Element) {
 
 	// sisHashes = [ [a, b ...], ... ] where [a, b, ...] is the sis hash of a column, a, b etc are on koalabear
@@ -82,6 +143,13 @@ func (p *Params) sisTransversalHash(v []smartvectors.SmartVector) ([]field.Octup
 	// compute [ h([a, b ...]), .. ]
 	sisHashes := make([]field.Element, p.RsParams.NbEncodedColumns()*p.Key.OutputSize())
 	sisHashes = p.Key.TransversalHash(v, sisHashes)
+	leaves := p.sisHashesToMerkleLeaves(sisHashes)
+	return leaves, sisHashes
+}
+
+// sisHashesToMerkleLeaves compresses SIS column hashes via Poseidon2 into
+// Merkle tree leaves. sisHashes has length NbEncodedColumns * OutputSize.
+func (p *Params) sisHashesToMerkleLeaves(sisHashes []field.Element) []field.Octuplet {
 	chunkSize := p.Key.OutputSize()
 	numCols := p.RsParams.NbEncodedColumns()
 	leaves := make([]field.Octuplet, numCols)
@@ -100,7 +168,7 @@ func (p *Params) sisTransversalHash(v []smartvectors.SmartVector) ([]field.Octup
 				leaves[chunkID] = hasher.SumElement()
 			}
 		})
-		return leaves, sisHashes
+		return leaves
 	}
 
 	// process the n full chunks of 16 columns using optimized SIMD implementation
@@ -121,7 +189,7 @@ func (p *Params) sisTransversalHash(v []smartvectors.SmartVector) ([]field.Octup
 		leaves[i] = hasher.SumElement()
 	}
 
-	return leaves, sisHashes
+	return leaves
 }
 
 // CommitMerkleWithoutSIS

--- a/prover/protocol/compiler/vortex/compiler.go
+++ b/prover/protocol/compiler/vortex/compiler.go
@@ -219,6 +219,13 @@ type Ctx struct {
 	// Optional parameter
 	NumOpenedCol int
 
+	// StreamingCommitment enables the streaming SIS commitment path which
+	// processes rows in batches for better cache efficiency during hashing.
+	StreamingCommitment bool
+	// StreamingBatchSize controls batch size for streaming commitment.
+	// If <= 0, defaults to max(1, NbRows/8).
+	StreamingBatchSize int
+
 	// By rounds commitments
 	CommitmentsByRounds collection.VecVec[ifaces.ColID]
 	// SIS round commitments

--- a/prover/protocol/compiler/vortex/option.go
+++ b/prover/protocol/compiler/vortex/option.go
@@ -57,6 +57,17 @@ func AddMerkleRootToPublicInputs(name string, round []int) VortexOp {
 	}
 }
 
+// WithStreamingCommitment enables the streaming SIS commitment path which
+// processes rows in batches for better cache efficiency during Ring-SIS hashing.
+// batchSize controls how many rows are processed at a time. If batchSize <= 0,
+// a default of max(1, NbRows/8) is used.
+func WithStreamingCommitment(batchSize int) VortexOp {
+	return func(ctx *Ctx) {
+		ctx.StreamingCommitment = true
+		ctx.StreamingBatchSize = batchSize
+	}
+}
+
 // AddPrecomputedMerkleRootToPublicInputs tells the compiler to adds
 // a precomputed merkle root to the public inputs of the comp. This is
 // useful for the distributed prover. The name argument is used to set

--- a/prover/protocol/compiler/vortex/prover.go
+++ b/prover/protocol/compiler/vortex/prover.go
@@ -124,7 +124,11 @@ func (ctx *ColumnAssignmentProverAction) Run(run *wizard.ProverRuntime) {
 		if ctx.RoundStatus[round] == IsNoSis {
 			committedMatrix, _, tree, noSisColHashes = ctx.VortexKoalaParams.CommitMerkleWithoutSIS(pols)
 		} else if ctx.RoundStatus[round] == IsSISApplied {
-			committedMatrix, _, tree, sisColHashes = ctx.VortexKoalaParams.CommitMerkleWithSIS(pols)
+			if ctx.StreamingCommitment {
+				committedMatrix, _, tree, sisColHashes = ctx.VortexKoalaParams.CommitMerkleWithSISStreaming(pols, ctx.StreamingBatchSize)
+			} else {
+				committedMatrix, _, tree, sisColHashes = ctx.VortexKoalaParams.CommitMerkleWithSIS(pols)
+			}
 		}
 
 		run.State.InsertNew(ctx.VortexProverStateName(round), committedMatrix)


### PR DESCRIPTION

**Note: This PR is currently a technical spike that emerged unexpectedly while I was working on a different task. It is currently experimental in nature with Claude. I am still in the process of verifying the results and assessing the full implications of these changes. As such, this is a `Draft` PR and is not yet ready for formal review. Have not yet tested with a real trace file. As of now, it is created purely for my reference - to be revisited later.**

Implements batched RS-extension + incremental Ring-SIS accumulation to reduce peak memory during the commitment phase. The IncrementalHasher accumulates SIS column hashes in NTT domain across row batches, correctly handling limb placement when batches don't align with SIS key polynomial boundaries. Enabled via WithStreamingCommitment(batchSize) option.

Benchmark results (Apple M4 Pro, 8192 cols, rate=2):
- batch=N (single batch): 15-37% memory reduction, ~0% wall-clock overhead
- batch=N/2: ~3-10% wall-clock overhead
- Smaller batches show increasing overhead due to generic (non-AVX512) path

Correctness verified: streaming produces identical Merkle roots, SIS hashes, and encoded matrices as the current path across 13 test configurations.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new incremental Ring-SIS hashing/commitment implementation and switches prover behavior behind a flag; correctness depends on subtle limb-to-polynomial placement and NTT-domain accumulation across batches.
> 
> **Overview**
> Adds a streaming Ring-SIS column hashing implementation (`IncrementalHasher`) that accumulates per-column SIS hashes in the NTT domain across row batches and finalizes with a single inverse FFT to match `TransversalHash` output.
> 
> Introduces `CommitMerkleWithSISStreaming`, which RS-encodes rows in batches and feeds them into the incremental hasher before building the same Merkle commitment, and factors SIS-hash-to-leaf compression into `sisHashesToMerkleLeaves`.
> 
> Wires the new path into the Vortex compiler/prover behind `WithStreamingCommitment(batchSize)` / `Ctx.StreamingCommitment`, and adds tests + benchmarks to verify streaming matches the existing commitment/hashes/encoding across multiple batch sizes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ca0f6065bf1ae7b5852bec7ecbb114b3042256d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->