### PR TITLE
feat(vortex): Level 2 streaming — never materialize encoded matrix W'

### DIFF
--- a/prover/crypto/vortex/prover_common.go
+++ b/prover/crypto/vortex/prover_common.go
@@ -1,6 +1,7 @@
 package vortex
 
 import (
+	"github.com/consensys/linea-monorepo/prover/crypto/reedsolomon"
 	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/common/vectorext"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
@@ -67,6 +68,109 @@ func LinearCombination(proof *OpeningProof, v []smartvectors.SmartVector, random
 		}
 		copy(linComb[start:stop], localLinComb)
 	})
+
+	proof.LinearCombination = smartvectors.NewRegularExt(linComb)
+}
+
+// LinearCombinationStreaming computes ∑ᵢxⁱ * v[i] where v is formed by
+// concatenating encodedRows (already RS-encoded) followed by originalRows
+// (re-encoded on the fly using rsParams). This avoids materializing the full
+// encoded matrix for the original rows.
+//
+// The ordering matters: encodedRows come first in the power series, then
+// originalRows. This matches the NoSIS-before-SIS stacking convention.
+func LinearCombinationStreaming(
+	proof *OpeningProof,
+	encodedRows []smartvectors.SmartVector,
+	originalRows []smartvectors.SmartVector,
+	rsParams *reedsolomon.RsParams,
+	randomCoin fext.Element,
+) {
+	totalRows := len(encodedRows) + len(originalRows)
+	if totalRows == 0 {
+		utils.Panic("attempted to open an empty witness")
+	}
+
+	// Determine output length.
+	var n int
+	if len(encodedRows) > 0 {
+		n = encodedRows[0].Len()
+	} else {
+		n = rsParams.NbEncodedColumns()
+	}
+
+	linComb := make([]fext.Element, n)
+
+	// Process already-encoded rows using the efficient column-parallel approach.
+	if len(encodedRows) > 0 {
+		parallel.Execute(n, func(start, stop int) {
+			x := fext.One()
+			scratch := make(vectorext.Vector, stop-start)
+			localLinComb := make(vectorext.Vector, stop-start)
+			for i := range encodedRows {
+				sv := encodedRows[i]
+				switch svt := sv.(type) {
+				case *smartvectors.Constant:
+					cst := svt.GetExt(0)
+					cst.Mul(&cst, &x)
+					for j := range localLinComb {
+						localLinComb[j].Add(&localLinComb[j], &cst)
+					}
+					x.Mul(&x, &randomCoin)
+					continue
+				case *smartvectors.Regular:
+					svSlice := field.Vector((*svt)[start:stop])
+					for j := range scratch {
+						fext.SetFromBase(&scratch[j], &svSlice[j])
+					}
+				default:
+					sub := svt.SubVector(start, stop)
+					sub.WriteInSliceExt(scratch)
+				}
+				scratch.ScalarMul(scratch, &x)
+				localLinComb.Add(localLinComb, scratch)
+				x.Mul(&x, &randomCoin)
+			}
+			copy(linComb[start:stop], localLinComb)
+		})
+	}
+
+	// Process original rows by re-encoding each one on the fly.
+	// We use a row-streaming approach: for each row, re-encode it, then
+	// accumulate x^i * encoded[col] into linComb across all columns.
+	x := fext.One()
+	// Advance x past the encoded rows.
+	for range encodedRows {
+		x.Mul(&x, &randomCoin)
+	}
+
+	for _, row := range originalRows {
+		encoded := rsParams.RsEncodeBase(row)
+
+		// Handle constant vectors efficiently.
+		if cst, ok := encoded.(*smartvectors.Constant); ok {
+			val := cst.GetExt(0)
+			val.Mul(&val, &x)
+			for col := range linComb {
+				linComb[col].Add(&linComb[col], &val)
+			}
+			x.Mul(&x, &randomCoin)
+			continue
+		}
+
+		// For regular/other vectors, parallelize over columns.
+		xCopy := x // capture for closure
+		parallel.Execute(n, func(start, stop int) {
+			for col := start; col < stop; col++ {
+				val := encoded.Get(col)
+				var valExt fext.Element
+				fext.SetFromBase(&valExt, &val)
+				valExt.Mul(&valExt, &xCopy)
+				linComb[col].Add(&linComb[col], &valExt)
+			}
+		})
+		x.Mul(&x, &randomCoin)
+	}
 
 	proof.LinearCombination = smartvectors.NewRegularExt(linComb)
 }

--- a/prover/crypto/vortex/prover_common_test.go
+++ b/prover/crypto/vortex/prover_common_test.go
@@ -19,8 +19,8 @@ func TestLinearCombinationStreamingMatchesBaseline(t *testing.T) {
 	rsParams := reedsolomon.NewRsParams(numCols, rate)
 
 	testCases := []struct {
-		name           string
-		numEncodedRows int // rows already encoded (NoSIS)
+		name            string
+		numEncodedRows  int // rows already encoded (NoSIS)
 		numOriginalRows int // rows to re-encode on the fly (SIS L2)
 	}{
 		{"all_encoded", 20, 0},

--- a/prover/crypto/vortex/prover_common_test.go
+++ b/prover/crypto/vortex/prover_common_test.go
@@ -1,0 +1,79 @@
+package vortex
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover/crypto/reedsolomon"
+	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+	"github.com/consensys/linea-monorepo/prover/maths/field"
+	"github.com/consensys/linea-monorepo/prover/maths/field/fext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinearCombinationStreamingMatchesBaseline(t *testing.T) {
+	const (
+		numCols    = 512
+		rate       = 2
+		numEncoded = numCols * rate
+	)
+	rsParams := reedsolomon.NewRsParams(numCols, rate)
+
+	testCases := []struct {
+		name           string
+		numEncodedRows int // rows already encoded (NoSIS)
+		numOriginalRows int // rows to re-encode on the fly (SIS L2)
+	}{
+		{"all_encoded", 20, 0},
+		{"all_original", 0, 20},
+		{"mixed_5_15", 5, 15},
+		{"mixed_10_10", 10, 10},
+		{"single_original", 0, 1},
+		{"single_encoded", 1, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			totalRows := tc.numEncodedRows + tc.numOriginalRows
+
+			// Create original rows
+			originalRows := make([]smartvectors.SmartVector, totalRows)
+			for i := 0; i < totalRows; i++ {
+				vec := make([]field.Element, numCols)
+				for j := range vec {
+					vec[j] = field.NewElement(uint64((i+1)*(j+1) + 7))
+				}
+				originalRows[i] = smartvectors.NewRegular(vec)
+			}
+
+			// RS-encode all rows for the reference
+			allEncoded := make([]smartvectors.SmartVector, totalRows)
+			for i := range originalRows {
+				allEncoded[i] = rsParams.RsEncodeBase(originalRows[i])
+			}
+
+			randomCoin := fext.NewFromUint(42, 17, 3, 99)
+
+			// Reference: LinearCombination with all encoded rows
+			refProof := &OpeningProof{}
+			LinearCombination(refProof, allEncoded, randomCoin)
+
+			// Split: first numEncodedRows are pre-encoded, rest are original
+			encodedPart := allEncoded[:tc.numEncodedRows]
+			originalPart := originalRows[tc.numEncodedRows:]
+
+			// Streaming: encoded + original
+			streamProof := &OpeningProof{}
+			LinearCombinationStreaming(streamProof, encodedPart, originalPart, rsParams, randomCoin)
+
+			// Compare
+			require.Equal(t, refProof.LinearCombination.Len(), streamProof.LinearCombination.Len(),
+				"output length mismatch")
+			for i := 0; i < refProof.LinearCombination.Len(); i++ {
+				refVal := refProof.LinearCombination.GetExt(i)
+				streamVal := streamProof.LinearCombination.GetExt(i)
+				require.Equal(t, refVal, streamVal,
+					"mismatch at column %d", i)
+			}
+		})
+	}
+}

--- a/prover/crypto/vortex/vortex_koalabear/commitment_test.go
+++ b/prover/crypto/vortex/vortex_koalabear/commitment_test.go
@@ -203,6 +203,95 @@ func TestStreamingCommitMatchesNonStreaming(t *testing.T) {
 	}
 }
 
+func TestStreamingL2CommitMatchesNonStreaming(t *testing.T) {
+	testCases := []struct {
+		name      string
+		numRows   int
+		numCols   int
+		batchSize int
+	}{
+		{"rows_32_batch_8", 32, 1 << 10, 8},
+		{"rows_128_batch_64", 128, 1 << 10, 64},
+		{"rows_387_batch_50", 387, 1 << 10, 50},
+		{"rows_512_batch_256", 512, 1 << 10, 256},
+		{"rows_128_batch_1", 128, 1 << 10, 1},
+		{"rows_128_batch_larger_than_total", 128, 1 << 10, 999},
+		{"rows_160_default_batch", 160, 1 << 10, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := makeNoSisRows(tc.numRows, tc.numCols)
+			params := NewParams(2, tc.numCols, tc.numRows, 9, 16)
+
+			// Reference: non-streaming
+			_, commitRef, _, hashesRef := params.CommitMerkleWithSIS(rows)
+
+			// Level 2 streaming (no W' materialization)
+			origMatrix, commitL2, _, hashesL2 := params.CommitMerkleWithSISStreamingL2(rows, tc.batchSize)
+
+			// Check identical commitment (Merkle root)
+			require.Equal(t, commitRef, commitL2, "Merkle root mismatch")
+
+			// Check identical SIS hashes
+			require.Equal(t, hashesRef, hashesL2, "SIS hashes mismatch")
+
+			// Check OriginalMatrix wraps the correct data
+			require.Equal(t, len(rows), len(origMatrix.Rows), "original matrix row count mismatch")
+			require.NotNil(t, origMatrix.Params, "params should not be nil")
+		})
+	}
+}
+
+func TestOriginalMatrixExtractColumns(t *testing.T) {
+	testCases := []struct {
+		name    string
+		numRows int
+		numCols int
+	}{
+		{"rows_32", 32, 1 << 10},
+		{"rows_128", 128, 1 << 10},
+		{"rows_387", 387, 1 << 10},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := makeNoSisRows(tc.numRows, tc.numCols)
+			params := NewParams(2, tc.numCols, tc.numRows, 9, 16)
+
+			// Get reference encoded matrix
+			encoded := params.EncodeRows(rows)
+
+			// Create OriginalMatrix
+			origMatrix := &OriginalMatrix{Rows: rows, Params: &params}
+
+			// Select some column positions
+			entryList := []int{0, 5, 42, 100, params.RsParams.NbEncodedColumns() - 1}
+
+			// Extract columns via OriginalMatrix
+			gotCols := origMatrix.ExtractColumns(entryList)
+
+			// Reference: extract from encoded matrix
+			for j, entry := range entryList {
+				for k := 0; k < tc.numRows; k++ {
+					require.Equal(t, encoded[k].Get(entry), gotCols[j][k],
+						"mismatch at entry %d, row %d", entry, k)
+				}
+			}
+
+			// Also test ToEncodedMatrix roundtrip
+			reEncoded := origMatrix.ToEncodedMatrix()
+			require.Equal(t, len(encoded), len(reEncoded))
+			for i := range encoded {
+				for j := 0; j < encoded[i].Len(); j++ {
+					require.Equal(t, encoded[i].Get(j), reEncoded[i].Get(j),
+						"ToEncodedMatrix mismatch at row %d, col %d", i, j)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkCommitMerkleWithSIS(b *testing.B) {
 	const numCols = 1 << 13
 
@@ -263,6 +352,34 @@ func BenchmarkCommitMerkleWithSISStreaming(b *testing.B) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					_, _, _, _ = params.CommitMerkleWithSISStreaming(rows, batchSize)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkCommitMerkleWithSISStreamingL2(b *testing.B) {
+	const numCols = 1 << 13
+
+	rowCounts := []int{256, 512, 768, 1024, 1504, 2208}
+
+	for _, numRows := range rowCounts {
+		rows := makeNoSisRows(numRows, numCols)
+		params := NewParams(2, numCols, numRows, 9, 16)
+
+		batchDivisors := []int{1, 2, 4, 8}
+		for _, div := range batchDivisors {
+			batchSize := numRows / div
+			if batchSize < 1 {
+				batchSize = 1
+			}
+			b.Run(fmt.Sprintf("rows_%d/batch_%d", numRows, batchSize), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ReportMetric(float64(numRows), "rows")
+				b.ReportMetric(float64(batchSize), "batch_size")
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, _, _, _ = params.CommitMerkleWithSISStreamingL2(rows, batchSize)
 				}
 			})
 		}

--- a/prover/crypto/vortex/vortex_koalabear/commtiment.go
+++ b/prover/crypto/vortex/vortex_koalabear/commtiment.go
@@ -262,6 +262,103 @@ func (p *Params) noSisTransversalHash(v []smartvectors.SmartVector) []field.Octu
 	return res
 }
 
+// OriginalMatrix holds the original (non-RS-encoded) witness rows along with
+// the Vortex params needed to re-encode them on demand. Used by Level 2
+// streaming to eliminate the full encoded matrix from prover state.
+type OriginalMatrix struct {
+	Rows   []smartvectors.SmartVector
+	Params *Params
+}
+
+// ToEncodedMatrix re-encodes all rows, producing the full encoded matrix.
+// Used when the full matrix is needed temporarily (e.g., during opening).
+func (om *OriginalMatrix) ToEncodedMatrix() EncodedMatrix {
+	return om.Params.EncodeRows(om.Rows)
+}
+
+// ExtractColumns re-encodes rows one at a time and extracts only the
+// selected column positions, avoiding full W' materialization.
+// Returns columns[j][k] = encode(Rows[k]).Get(entryList[j]).
+func (om *OriginalMatrix) ExtractColumns(entryList []int) [][]field.Element {
+	nbRows := len(om.Rows)
+	columns := make([][]field.Element, len(entryList))
+	for j := range entryList {
+		columns[j] = make([]field.Element, nbRows)
+	}
+	for k := 0; k < nbRows; k++ {
+		encoded := om.Params.RsParams.RsEncodeBase(om.Rows[k])
+		for j := range entryList {
+			columns[j][k] = encoded.Get(entryList[j])
+		}
+	}
+	return columns
+}
+
+// CommitMerkleWithSISStreamingL2 computes the same commitment as CommitMerkleWithSIS
+// but never materializes the full encoded matrix W'. Rows are processed in batches:
+// each batch is RS-encoded, fed to the incremental SIS hasher, then discarded.
+// Returns an OriginalMatrix (wrapping the original polys) instead of EncodedMatrix,
+// so that linear combination and column opening can re-encode on demand.
+func (p *Params) CommitMerkleWithSISStreamingL2(
+	polysMatrix []smartvectors.SmartVector,
+	batchSize int,
+) (*OriginalMatrix, Commitment, *smt_koalabear.Tree, []field.Element) {
+
+	if len(polysMatrix) > p.MaxNbRows {
+		utils.Panic("too many rows: %v, capacity is %v\n", len(polysMatrix), p.MaxNbRows)
+	}
+
+	nbRows := len(polysMatrix)
+	if batchSize <= 0 {
+		batchSize = nbRows / 8
+		if batchSize < 1 {
+			batchSize = 1
+		}
+	}
+
+	// Sanity-check row lengths.
+	for i := range polysMatrix {
+		if polysMatrix[i].Len() != p.NbColumns {
+			utils.Panic("Bad length : expected %v columns but col %v has size %v", p.NbColumns, i, polysMatrix[i].Len())
+		}
+	}
+
+	nbEncodedCols := p.RsParams.NbEncodedColumns()
+	hasher := p.Key.NewIncrementalHasher(nbEncodedCols)
+
+	for start := 0; start < nbRows; start += batchSize {
+		end := start + batchSize
+		if end > nbRows {
+			end = nbRows
+		}
+
+		// RS-encode this batch of rows into a temporary buffer.
+		batch := polysMatrix[start:end]
+		encodedBatch := make(EncodedMatrix, len(batch))
+		parallel.Execute(len(batch), func(s, e int) {
+			for i := s; i < e; i++ {
+				encodedBatch[i] = p.RsParams.RsEncodeBase(batch[i])
+			}
+		})
+
+		// Feed encoded rows to the incremental hasher.
+		hasher.AbsorbBatch(encodedBatch)
+		// encodedBatch is now eligible for GC — not retained.
+	}
+
+	sisHashes := hasher.Finalize()
+	leaves := p.sisHashesToMerkleLeaves(sisHashes)
+
+	tree := smt_koalabear.NewTree(leaves)
+
+	origMatrix := &OriginalMatrix{
+		Rows:   polysMatrix,
+		Params: p,
+	}
+
+	return origMatrix, tree.Root, tree, sisHashes
+}
+
 // EncodeRows returns the encodes `ps` using Reed-Solomon. ps is interpreted as
 // a list of rows of the Vortex witness and encodedMatrix is obtained by
 // encoding each of the [smartvectors.SmartVector] it contains separately.

--- a/prover/protocol/compiler/vortex/compiler.go
+++ b/prover/protocol/compiler/vortex/compiler.go
@@ -225,6 +225,10 @@ type Ctx struct {
 	// StreamingBatchSize controls batch size for streaming commitment.
 	// If <= 0, defaults to max(1, NbRows/8).
 	StreamingBatchSize int
+	// StreamingNoMaterialize enables Level 2 streaming: the encoded matrix W'
+	// is never stored. The original matrix W is kept in prover state and rows
+	// are re-encoded on demand during linear combination and column opening.
+	StreamingNoMaterialize bool
 
 	// By rounds commitments
 	CommitmentsByRounds collection.VecVec[ifaces.ColID]

--- a/prover/protocol/compiler/vortex/option.go
+++ b/prover/protocol/compiler/vortex/option.go
@@ -57,14 +57,29 @@ func AddMerkleRootToPublicInputs(name string, round []int) VortexOp {
 	}
 }
 
-// WithStreamingCommitment enables the streaming SIS commitment path which
-// processes rows in batches for better cache efficiency during Ring-SIS hashing.
+// WithStreamingCommitment enables the streaming SIS commitment path (Level 1)
+// which processes rows in batches for better cache efficiency during Ring-SIS
+// hashing. The full encoded matrix W' is still materialized and stored for the
+// linear combination and opening phases.
 // batchSize controls how many rows are processed at a time. If batchSize <= 0,
 // a default of max(1, NbRows/8) is used.
 func WithStreamingCommitment(batchSize int) VortexOp {
 	return func(ctx *Ctx) {
 		ctx.StreamingCommitment = true
 		ctx.StreamingBatchSize = batchSize
+	}
+}
+
+// WithStreamingCommitmentL2 enables Level 2 streaming: the full encoded matrix
+// W' is never materialized. During commitment, rows are RS-encoded in batches
+// and discarded after SIS hashing. During linear combination and column opening,
+// rows are re-encoded on demand from the original matrix W. This eliminates
+// ~50% of peak memory (at rate=2) at the cost of one additional RS encoding pass.
+func WithStreamingCommitmentL2(batchSize int) VortexOp {
+	return func(ctx *Ctx) {
+		ctx.StreamingCommitment = true
+		ctx.StreamingBatchSize = batchSize
+		ctx.StreamingNoMaterialize = true
 	}
 }
 

--- a/prover/protocol/compiler/vortex/prover.go
+++ b/prover/protocol/compiler/vortex/prover.go
@@ -123,15 +123,22 @@ func (ctx *ColumnAssignmentProverAction) Run(run *wizard.ProverRuntime) {
 
 		if ctx.RoundStatus[round] == IsNoSis {
 			committedMatrix, _, tree, noSisColHashes = ctx.VortexKoalaParams.CommitMerkleWithoutSIS(pols)
+			run.State.InsertNew(ctx.VortexProverStateName(round), committedMatrix)
 		} else if ctx.RoundStatus[round] == IsSISApplied {
-			if ctx.StreamingCommitment {
+			if ctx.StreamingNoMaterialize {
+				// Level 2: never materialize W'. Store OriginalMatrix instead.
+				var origMatrix *vortex_koalabear.OriginalMatrix
+				origMatrix, _, tree, sisColHashes = ctx.VortexKoalaParams.CommitMerkleWithSISStreamingL2(pols, ctx.StreamingBatchSize)
+				run.State.InsertNew(ctx.VortexProverStateName(round), origMatrix)
+			} else if ctx.StreamingCommitment {
 				committedMatrix, _, tree, sisColHashes = ctx.VortexKoalaParams.CommitMerkleWithSISStreaming(pols, ctx.StreamingBatchSize)
+				run.State.InsertNew(ctx.VortexProverStateName(round), committedMatrix)
 			} else {
 				committedMatrix, _, tree, sisColHashes = ctx.VortexKoalaParams.CommitMerkleWithSIS(pols)
+				run.State.InsertNew(ctx.VortexProverStateName(round), committedMatrix)
 			}
 		}
 
-		run.State.InsertNew(ctx.VortexProverStateName(round), committedMatrix)
 		run.State.InsertNew(ctx.MerkleTreeName(round), tree)
 
 		// Only to be read by the self-recursion compiler.
@@ -163,6 +170,10 @@ func (ctx *LinearCombinationComputationProverAction) Run(pr *wizard.ProverRuntim
 	var (
 		committedSVSIS   = []smartvectors.SmartVector{}
 		committedSVNoSIS = []smartvectors.SmartVector{}
+		// Level 2: original (non-encoded) rows from SIS rounds, to be re-encoded on the fly.
+		originalRowsSIS     = []smartvectors.SmartVector{}
+		hasOriginalRows     bool
+		originalRowsRsParam *vortex_koalabear.Params
 	)
 	// Add the precomputed columns
 	if ctx.IsNonEmptyPrecomputed() {
@@ -185,28 +196,43 @@ func (ctx *LinearCombinationComputationProverAction) Run(pr *wizard.ProverRuntim
 			continue
 		}
 
-		committedMatrix := pr.State.MustGet(ctx.VortexProverStateName(round)).(vortex_bls12377.EncodedMatrix)
+		state := pr.State.MustGet(ctx.VortexProverStateName(round))
 
-		// Push pols to the right stack
-		if ctx.RoundStatus[round] == IsNoSis {
-			committedSVNoSIS = append(committedSVNoSIS, committedMatrix...)
-
-		} else if ctx.RoundStatus[round] == IsSISApplied {
-			committedSVSIS = append(committedSVSIS, committedMatrix...)
+		switch m := state.(type) {
+		case *vortex_koalabear.OriginalMatrix:
+			// Level 2: collect original rows for streaming LC
+			originalRowsSIS = append(originalRowsSIS, m.Rows...)
+			hasOriginalRows = true
+			originalRowsRsParam = m.Params
+		default:
+			// EncodedMatrix (works for both vortex_bls12377.EncodedMatrix
+			// and vortex_koalabear.EncodedMatrix — same underlying type)
+			committedMatrix := m.(vortex_bls12377.EncodedMatrix)
+			if ctx.RoundStatus[round] == IsNoSis {
+				committedSVNoSIS = append(committedSVNoSIS, committedMatrix...)
+			} else if ctx.RoundStatus[round] == IsSISApplied {
+				committedSVSIS = append(committedSVSIS, committedMatrix...)
+			}
 		}
 	}
-	// Construct committedSV by stacking the No SIS round
-	// matrices before the SIS round matrices
-	committedSV := append(committedSVNoSIS, committedSVSIS...)
 
 	// And get the randomness
 	randomCoinLC := pr.GetRandomCoinFieldExt(ctx.Items.Alpha.Name)
 
 	// and compute and assign the random linear combination of the rows
 	proof := &vortex.OpeningProof{}
-	vortex.LinearCombination(proof, committedSV, randomCoinLC)
-	pr.AssignColumn(ctx.Items.Ualpha.GetColID(), proof.LinearCombination)
 
+	if hasOriginalRows {
+		// Level 2 streaming: encoded rows (NoSIS + precomputed SIS) first,
+		// then original SIS rows re-encoded on the fly.
+		encodedRows := append(committedSVNoSIS, committedSVSIS...)
+		vortex.LinearCombinationStreaming(proof, encodedRows, originalRowsSIS, originalRowsRsParam.RsParams, randomCoinLC)
+	} else {
+		committedSV := append(committedSVNoSIS, committedSVSIS...)
+		vortex.LinearCombination(proof, committedSV, randomCoinLC)
+	}
+
+	pr.AssignColumn(ctx.Items.Ualpha.GetColID(), proof.LinearCombination)
 }
 
 // ComputeLinearCombFromRsMatrix is the same as ComputeLinearComb but uses
@@ -215,8 +241,11 @@ func (ctx *LinearCombinationComputationProverAction) Run(pr *wizard.ProverRuntim
 func (ctx *Ctx) ComputeLinearCombFromRsMatrix(run *wizard.ProverRuntime) {
 
 	var (
-		committedSVSIS   = []smartvectors.SmartVector{}
-		committedSVNoSIS = []smartvectors.SmartVector{}
+		committedSVSIS      = []smartvectors.SmartVector{}
+		committedSVNoSIS    = []smartvectors.SmartVector{}
+		originalRowsSIS     = []smartvectors.SmartVector{}
+		hasOriginalRows     bool
+		originalRowsRsParam *vortex_koalabear.Params
 	)
 
 	// Add the precomputed columns to commitedSVSIS or commitedSVNoSIS
@@ -234,26 +263,36 @@ func (ctx *Ctx) ComputeLinearCombFromRsMatrix(run *wizard.ProverRuntime) {
 			continue
 		}
 
-		committedMatrix := run.State.MustGet(ctx.VortexProverStateName(round)).(vortex_koalabear.EncodedMatrix)
+		state := run.State.MustGet(ctx.VortexProverStateName(round))
 
-		// Push pols to the right stack
-		if ctx.RoundStatus[round] == IsNoSis {
-			committedSVNoSIS = append(committedSVNoSIS, committedMatrix...)
-		} else if ctx.RoundStatus[round] == IsSISApplied {
-			committedSVSIS = append(committedSVSIS, committedMatrix...)
+		switch m := state.(type) {
+		case *vortex_koalabear.OriginalMatrix:
+			originalRowsSIS = append(originalRowsSIS, m.Rows...)
+			hasOriginalRows = true
+			originalRowsRsParam = m.Params
+		default:
+			committedMatrix := m.(vortex_koalabear.EncodedMatrix)
+			if ctx.RoundStatus[round] == IsNoSis {
+				committedSVNoSIS = append(committedSVNoSIS, committedMatrix...)
+			} else if ctx.RoundStatus[round] == IsSISApplied {
+				committedSVSIS = append(committedSVSIS, committedMatrix...)
+			}
 		}
 	}
-
-	// Construct committedSV by stacking the No SIS round
-	// matrices before the SIS round matrices
-	committedSV := append(committedSVNoSIS, committedSVSIS...)
 
 	// And get the randomness
 	randomCoinLC := run.GetRandomCoinFieldExt(ctx.Items.Alpha.Name)
 
 	// and compute and assign the random linear combination of the rows
 	proof := &vortex.OpeningProof{}
-	vortex.LinearCombination(proof, committedSV, randomCoinLC)
+
+	if hasOriginalRows {
+		encodedRows := append(committedSVNoSIS, committedSVSIS...)
+		vortex.LinearCombinationStreaming(proof, encodedRows, originalRowsSIS, originalRowsRsParam.RsParams, randomCoinLC)
+	} else {
+		committedSV := append(committedSVNoSIS, committedSVSIS...)
+		vortex.LinearCombination(proof, committedSV, randomCoinLC)
+	}
 
 	run.AssignColumn(ctx.Items.Ualpha.GetColID(), proof.LinearCombination)
 }
@@ -303,10 +342,21 @@ func (ctx *OpenSelectedColumnsProverAction) Run(run *wizard.ProverRuntime) {
 		if ctx.RoundStatus[round] == IsEmpty {
 			continue
 		}
-		// Fetch it from the state
-		committedMatrix := run.State.MustGet(ctx.VortexProverStateName(round)).(vortex_koalabear.EncodedMatrix)
+		// Fetch it from the state. For Level 2, SIS rounds store
+		// *OriginalMatrix; convert to EncodedMatrix on the fly.
+		state := run.State.MustGet(ctx.VortexProverStateName(round))
 		// and delete it because it won't be needed anymore and its very heavy
 		run.State.Del(ctx.VortexProverStateName(round))
+
+		var committedMatrix vortex_koalabear.EncodedMatrix
+		switch m := state.(type) {
+		case *vortex_koalabear.OriginalMatrix:
+			// Level 2: re-encode from original rows. The temporary encoded
+			// matrix is freed after this function returns.
+			committedMatrix = m.ToEncodedMatrix()
+		default:
+			committedMatrix = m.(vortex_koalabear.EncodedMatrix)
+		}
 
 		// Also fetches the trees from the prover state
 		if ctx.IsBLS {

--- a/prover/protocol/compiler/vortex/vortex_test.go
+++ b/prover/protocol/compiler/vortex/vortex_test.go
@@ -518,3 +518,107 @@ func TestCompiler(t *testing.T) {
 		})
 	}
 }
+
+// TestCompilerWithStreamingL2 exercises the Level 2 streaming path
+// (never materialize W') through the full compile → prove → verify pipeline.
+func TestCompilerWithStreamingL2(t *testing.T) {
+	var (
+		polSize         = 1 << 4
+		nPols           = 16
+		numRounds       = 4
+		nPolsMultiRound = []int{14, 8, 9, 16}
+		rowsMultiRound  = make([][]ifaces.Column, numRounds)
+		rng             = rand.New(rand.NewPCG(0, 0))
+	)
+	testCases := []struct {
+		Explainer string
+		Define    func(b *wizard.Builder)
+		Prove     func(pr *wizard.ProverRuntime)
+	}{
+		{
+			Explainer: "L2: single round using SIS",
+			Define: func(b *wizard.Builder) {
+				rows := make([]ifaces.Column, nPols)
+				for i := range rows {
+					rows[i] = b.RegisterCommit(ifaces.ColIDf("P_%v", i), polSize)
+				}
+				b.UnivariateEval("EVAL", rows...)
+			},
+			Prove: func(pr *wizard.ProverRuntime) {
+				ys := make([]fext.Element, nPols)
+				x := fext.NewFromInt(57, 1, 2, 4)
+				for i := 0; i < nPols; i++ {
+					p := smartvectors.PseudoRand(rng, polSize)
+					ys[i] = smartvectors.EvaluateBasePolyLagrange(p, x)
+					pr.AssignColumn(ifaces.ColIDf("P_%v", i), p)
+				}
+				pr.AssignUnivariateExt("EVAL", x, ys...)
+			},
+		},
+		{
+			Explainer: "L2: multiple rounds with both SIS and non-SIS",
+			Define: func(b *wizard.Builder) {
+				for round := 0; round < numRounds; round++ {
+					var offsetIndex int
+					if round != 0 {
+						_ = b.RegisterRandomCoin(coin.Namef("COIN_%v", round), coin.FieldExt)
+						for i := 0; i < round; i++ {
+							offsetIndex += nPolsMultiRound[i]
+						}
+					}
+					rowsMultiRound[round] = make([]ifaces.Column, nPolsMultiRound[round])
+					for i := range nPolsMultiRound[round] {
+						rowsMultiRound[round][i] = b.RegisterCommit(ifaces.ColIDf("P_%v", offsetIndex+i), polSize)
+					}
+				}
+				b.UnivariateEval("EVAL", utils.Join(rowsMultiRound...)...)
+			},
+			Prove: func(pr *wizard.ProverRuntime) {
+				numPolys := 0
+				for i := range nPolsMultiRound {
+					numPolys += nPolsMultiRound[i]
+				}
+				ys := make([]fext.Element, numPolys)
+				x := fext.NewFromInt(57, 1, 4, 2)
+				for round := range rowsMultiRound {
+					var offsetIndex int
+					if round != 0 {
+						_ = pr.GetRandomCoinFieldExt(coin.Namef("COIN_%v", round))
+						for i := 0; i < round; i++ {
+							offsetIndex += nPolsMultiRound[i]
+						}
+					}
+					for i, row := range rowsMultiRound[round] {
+						p := smartvectors.PseudoRand(rng, polSize)
+						ys[offsetIndex+i] = smartvectors.EvaluateBasePolyLagrange(p, x)
+						pr.AssignColumn(row.GetColID(), p)
+					}
+				}
+				pr.AssignUnivariateExt("EVAL", x, ys...)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Explainer, func(t *testing.T) {
+			logrus.Infof("Testing %s", tc.Explainer)
+			compiled := wizard.Compile(
+				tc.Define,
+				vortex.Compile(
+					4,
+					false,
+					vortex.WithOptionalSISHashingThreshold(9),
+					vortex.ForceNumOpenedColumns(10),
+					vortex.WithSISParams(&ringsis.Params{
+						LogTwoBound:  16,
+						LogTwoDegree: 4,
+					}),
+					vortex.WithStreamingCommitmentL2(0), // Level 2: never materialize W'
+				),
+			)
+			proof := wizard.Prove(compiled, tc.Prove)
+			valid := wizard.Verify(compiled, proof)
+			require.NoErrorf(t, valid, "the proof did not pass with L2 streaming")
+		})
+	}
+}

--- a/prover/protocol/compiler/vortex/vortex_test.go
+++ b/prover/protocol/compiler/vortex/vortex_test.go
@@ -528,7 +528,7 @@ func TestCompilerWithStreamingL2(t *testing.T) {
 		numRounds       = 4
 		nPolsMultiRound = []int{14, 8, 9, 16}
 		rowsMultiRound  = make([][]ifaces.Column, numRounds)
-		rng             = rand.New(rand.NewPCG(0, 0))
+		rng             = rand.New(rand.NewPCG(0, 0)) // #nosec G404 -- test only
 	)
 	testCases := []struct {
 		Explainer string


### PR DESCRIPTION
## Summary


**Note: This PR is currently a technical spike that emerged unexpectedly while I was working on a different task. It is currently experimental in nature with Claude. I am still in the process of verifying the results and assessing the full implications of these changes. As such, this is a Draft PR and is not yet ready for formal review. Have not tested it yet with a real trace file. As of now, it is created purely for my reference - to be revisited later.**

Extends the Level 1 streaming commitment (see [PR#2727](https://github.com/Consensys/linea-monorepo/pull/2727)) with **Level 2**: the full RS-encoded matrix W' is never stored in prover state. Instead, only the original matrix W is retained and rows are re-encoded on demand.

- **Commitment**: RS-encode rows in batches, hash via IncrementalHasher, discard encoded batches. Store `OriginalMatrix` (W) instead of `EncodedMatrix` (W') in prover state.
- **Linear combination**: New `LinearCombinationStreaming` re-encodes each row on the fly — only one encoded row (~64 KB) in memory at a time.
- **Column opening**: Temporarily re-encodes W' for the last prover action (pragmatic choice; memory freed immediately after).
- **Config**: `WithStreamingCommitmentL2(batchSize)` option, behind `StreamingNoMaterialize` flag.

### Memory model

| Phase | Baseline | Level 2 |
|-------|----------|---------|
| After commit | W' in state (~136 MB at 2208 rows) | W in state (~67 MB) |
| During LC | W' in state | Re-encode row by row (~64 KB peak) |
| During opening | W' in state (freed after) | Temporarily re-encode W' (freed after) |

**Net**: ~50% reduction in persistent prover state for SIS rounds at rate=2, at the cost of one additional RS encoding pass (~38 ms at 2208 rows).

### Files changed

| File | Description |
|------|-------------|
| `crypto/vortex/vortex_koalabear/commtiment.go` | `OriginalMatrix` type, `CommitMerkleWithSISStreamingL2`, `ExtractColumns`, `ToEncodedMatrix` |
| `crypto/vortex/prover_common.go` | `LinearCombinationStreaming` — handles encoded + original rows |
| `protocol/compiler/vortex/prover.go` | Type-switches for `*OriginalMatrix` in commit, LC, opening actions |
| `protocol/compiler/vortex/option.go` | `WithStreamingCommitmentL2` option |
| `protocol/compiler/vortex/compiler.go` | `StreamingNoMaterialize` field on `Ctx` |

## Test plan

- [x] `TestStreamingL2CommitMatchesNonStreaming` — 7 configs (batch 1 to N, default, larger-than-total)
- [x] `TestOriginalMatrixExtractColumns` — 3 row counts, verifies column extraction matches reference
- [x] `TestLinearCombinationStreamingMatchesBaseline` — 6 configs (all-encoded, all-original, mixed)
- [x] `TestCompilerWithStreamingL2` — full compile→prove→verify for single-round SIS and multi-round SIS+NoSIS
- [x] All 9 existing integration tests pass (regression check)
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes prover commitment/linear-combination/opening data paths in a cryptographic protocol and introduces new state types (`*OriginalMatrix`) with on-demand RS re-encoding that could affect correctness/performance and memory behavior.
> 
> **Overview**
> Adds **Level 2 streaming** for Vortex SIS commitments so the prover no longer stores the full RS-encoded witness matrix `W'` in state; SIS rows are kept as an `OriginalMatrix` and RS-encoded on demand.
> 
> This introduces `CommitMerkleWithSISStreamingL2` (batch RS-encode → incremental SIS hash → discard), `LinearCombinationStreaming` (mixes already-encoded rows with per-row re-encoding for the linear combination), and updates prover actions to type-switch between `EncodedMatrix` vs `*OriginalMatrix` (including temporarily re-encoding during column opening). Adds a compiler option/flag (`WithStreamingCommitmentL2`, `StreamingNoMaterialize`) plus targeted tests and a benchmark to assert L2 results match the existing non-streaming path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94d15b9769584e0e01e0b55c7533416b2caeaa9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->