### PR TITLE
feat: add app access token for sdk release

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -196,7 +196,7 @@ jobs:
           echo "path=${BODY_FILE}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        id: app-token
+        id: app_token
         with:
           app-id: ${{ secrets.CREATE_GITHUB_PR_APP_ID }}
           private-key: ${{ secrets.CREATE_GITHUB_PR_PRIVATE_KEY }}
@@ -205,7 +205,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app_token.outputs.token }}
           commit-message: "release(${{ inputs.package }}): v${{ steps.version.outputs.next }}"
           branch: release-${{ inputs.package }}-v${{ steps.version.outputs.next }}
           base: main


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes authentication for the release PR automation; misconfigured GitHub App secrets/permissions could cause workflow failures or alter which identity creates PRs.
> 
> **Overview**
> Updates the `sdk-release` GitHub Actions workflow to mint a GitHub App installation token (`actions/create-github-app-token`) and use it for `peter-evans/create-pull-request` instead of the default token.
> 
> This shifts release PR creation to rely on `CREATE_GITHUB_PR_APP_ID`/`CREATE_GITHUB_PR_PRIVATE_KEY` secrets and the app’s granted repo permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4893c2d11822fe73dd5a90edc0f0b73ba58bcbe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->