### PR TITLE
Maru update in the local stack test

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -13,7 +13,7 @@ services:
       - ../config/coordinator/coordinator-config-v2.toml:/coordinator/coordinator-config-v2.toml:ro
 
   maru:
-    image: consensys/maru:${MARU_TAG:-9737a45}
+    image: consensys/maru:${MARU_TAG:-v1.2.0-20260406113501-018f692}
     hostname: maru
     container_name: maru
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the default Docker image tag for the `maru` service in local-compose configuration; primary risk is local stack behavior differences from the upgraded Maru version.
> 
> **Overview**
> Updates `docker/compose-spec-l2-services.yml` to bump the default `consensys/maru` image tag used by the `maru` service (from `9737a45` to `v1.2.0-20260406113501-018f692`) for the local L2 stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffab5af08e7f478021f39a915ce44f9fb30b9cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->