### PR TITLE
feat(coordinator): target checkpoint pause for conflation with L1Finalization/API gates

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
@@ -57,5 +57,9 @@ data class ConflationConfig(
     val aggregationSizeMultipleOf: UInt = 1u,
     val timestampBasedHardForks: List<Instant> = emptyList(),
     val waitForNoL2ActivityToTriggerAggregation: Boolean = false,
+    /** When true with [waitApiResumeAfterTargetBlock], block import pauses until L1 finalizes through the required height. */
+    val waitTargetBlockL1Finalization: Boolean = false,
+    /** When true with [waitTargetBlockL1Finalization], block import pauses until resume JSON-RPC is invoked. */
+    val waitApiResumeAfterTargetBlock: Boolean = false,
   )
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
@@ -61,6 +61,8 @@ data class ConflationToml(
     val aggregationSizeMultipleOf: UInt = 1u,
     val timestampBasedHardForks: List<Instant> = emptyList(),
     val waitForNoL2ActivityToTriggerAggregation: Boolean = false,
+    val waitTargetBlockL1Finalization: Boolean = false,
+    val waitApiResumeAfterTargetBlock: Boolean = false,
   ) {
     init {
       require(timestampBasedHardForks.toSet().size == timestampBasedHardForks.size) {
@@ -79,6 +81,8 @@ data class ConflationToml(
         aggregationSizeMultipleOf = this.aggregationSizeMultipleOf,
         timestampBasedHardForks = timestampBasedHardForks,
         waitForNoL2ActivityToTriggerAggregation = this.waitForNoL2ActivityToTriggerAggregation,
+        waitTargetBlockL1Finalization = this.waitTargetBlockL1Finalization,
+        waitApiResumeAfterTargetBlock = this.waitApiResumeAfterTargetBlock,
       )
     }
   }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/Api.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/Api.kt
@@ -15,6 +15,7 @@ import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.vertx.ObservabilityServer
 import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationCreateProverRequestHandler
 import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationGetJobStatusRequestHandler
+import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationTargetCheckpointResumeRequestHandler
 import net.consensys.zkevm.coordinator.app.conflationbacktesting.ConflationBacktestingService
 import org.apache.logging.log4j.LogManager
 import java.util.concurrent.CompletableFuture
@@ -25,6 +26,7 @@ class Api(
   private val vertx: Vertx,
   private val conflationBacktestingService: ConflationBacktestingService,
   private val metricsFacade: MetricsFacade,
+  private val signalTargetCheckpointResume: () -> Boolean,
 ) : LongRunningService {
   data class Config(
     val observabilityPort: UInt,
@@ -52,6 +54,8 @@ class Api(
         ConflationCreateProverRequestHandler(conflationBacktestingService = conflationBacktestingService),
       ConflationGetJobStatusRequestHandler.METHOD_NAME to
         ConflationGetJobStatusRequestHandler(conflationBacktestingService = conflationBacktestingService),
+      ConflationTargetCheckpointResumeRequestHandler.METHOD_NAME to
+        ConflationTargetCheckpointResumeRequestHandler(signalResume = signalTargetCheckpointResume),
     )
     val messageHandler: JsonRpcMessageHandler =
       JsonRpcMessageProcessor(JsonRpcRequestRouter(requestHandlers), metricsFacade)

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/requesthandlers/ConflationTargetCheckpointResumeRequestHandler.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/requesthandlers/ConflationTargetCheckpointResumeRequestHandler.kt
@@ -1,0 +1,38 @@
+package net.consensys.zkevm.coordinator.api.requesthandlers
+
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import io.vertx.core.Future
+import io.vertx.core.json.JsonObject
+import io.vertx.ext.auth.User
+import net.consensys.linea.jsonrpc.JsonRpcErrorResponse
+import net.consensys.linea.jsonrpc.JsonRpcRequest
+import net.consensys.linea.jsonrpc.JsonRpcRequestHandler
+import net.consensys.linea.jsonrpc.JsonRpcSuccessResponse
+
+/**
+ * JSON-RPC: signals that target checkpoint pause may resume when [linea.coordinator.config.v2.ConflationConfig.ProofAggregation.waitApiResumeAfterTargetBlock] is enabled.
+ */
+class ConflationTargetCheckpointResumeRequestHandler(
+  private val signalResume: () -> Boolean,
+) : JsonRpcRequestHandler {
+  companion object {
+    const val METHOD_NAME = "conflation_signalTargetCheckpointResume"
+  }
+
+  override fun invoke(
+    user: User?,
+    request: JsonRpcRequest,
+    requestJson: JsonObject,
+  ): Future<Result<JsonRpcSuccessResponse, JsonRpcErrorResponse>> {
+    val accepted = signalResume()
+    return Future.succeededFuture(
+      Ok(
+        JsonRpcSuccessResponse(
+          id = request.id,
+          result = accepted,
+        ),
+      ),
+    )
+  }
+}

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/CoordinatorApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/CoordinatorApp.kt
@@ -64,18 +64,6 @@ class CoordinatorApp(
     configs = configs,
     metricsFacade = MicrometerMetricsFacade(NoopBackendRegistry.INSTANCE.meterRegistry, "conflationbacktesting"),
   )
-  private val api =
-    Api(
-      configs = Api.Config(
-        observabilityPort = configs.api.observabilityPort,
-        jsonRpcPort = configs.api.jsonRpcPort,
-        jsonRpcPath = configs.api.jsonRpcPath,
-        jsonRpcServerVerticles = configs.api.jsonRpcServerVerticles,
-      ),
-      vertx = vertx,
-      conflationBacktestingService = conflationBacktestingService,
-      metricsFacade = micrometerMetricsFacade,
-    )
 
   private val persistenceRetryer =
     PersistenceRetryer(
@@ -158,6 +146,20 @@ class CoordinatorApp(
       smartContractErrors = configs.smartContractErrors,
       metricsFacade = micrometerMetricsFacade,
       clock = this.clock,
+    )
+
+  private val api =
+    Api(
+      configs = Api.Config(
+        observabilityPort = configs.api.observabilityPort,
+        jsonRpcPort = configs.api.jsonRpcPort,
+        jsonRpcPath = configs.api.jsonRpcPath,
+        jsonRpcServerVerticles = configs.api.jsonRpcServerVerticles,
+      ),
+      vertx = vertx,
+      conflationBacktestingService = conflationBacktestingService,
+      metricsFacade = micrometerMetricsFacade,
+      signalTargetCheckpointResume = { l1App.signalTargetCheckpointResumeFromApi() },
     )
 
   private val requestFileCleanup =

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/L1DependentApp.kt
@@ -695,6 +695,10 @@ class L1DependentApp(
       }
   }
 
+  fun signalTargetCheckpointResumeFromApi(): Boolean {
+    return conflationApp.signalTargetCheckpointResumeFromApi()
+  }
+
   override fun stop(): CompletableFuture<Unit> {
     return SafeFuture.allOf(
       conflationApp.stop(),

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -28,6 +28,7 @@ import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resume
 import net.consensys.zkevm.coordinator.app.conflation.TracesClientFactory.createTracesClients
 import net.consensys.zkevm.coordinator.blockcreation.BatchesRepoBasedLastProvenBlockNumberProvider
 import net.consensys.zkevm.coordinator.blockcreation.BlockCreationMonitor
+import net.consensys.zkevm.coordinator.blockcreation.ConflationTargetCheckpointPauseController
 import net.consensys.zkevm.coordinator.blockcreation.FixedLaggingHeadSafeBlockProvider
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.coordinator.clients.prover.ProverClientFactory
@@ -193,6 +194,33 @@ class ConflationApp(
     lastProcessedBlockNumber.toBlockParameter(),
   ).get()
   private val lastProcessedTimestamp = Instant.fromEpochSeconds(lastProcessedBlock!!.timestamp.toLong())
+
+  private val lastProvenBlockNumberProvider = run {
+    val lastProvenConsecutiveBatchBlockNumberProvider = BatchesRepoBasedLastProvenBlockNumberProvider(
+      lastProcessedBlockNumber.toLong(),
+      lastFinalizedBlock.toLong(),
+      batchesRepository,
+    )
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BATCH,
+      name = "proven.highest.consecutive.block.number",
+      description = "Highest proven consecutive execution batch block number",
+      measurementSupplier = { lastProvenConsecutiveBatchBlockNumberProvider.getLastKnownProvenBlockNumber() },
+    )
+    lastProvenConsecutiveBatchBlockNumberProvider
+  }
+
+  private val targetCheckpointPauseController =
+    ConflationTargetCheckpointPauseController(
+      ConflationTargetCheckpointPauseController.Config(
+        initialLastImportedBlockTimestamp = lastProcessedTimestamp,
+        targetEndBlocks = (configs.conflation.proofAggregation.targetEndBlocks ?: emptyList()).toSet(),
+        targetTimestamps = configs.conflation.proofAggregation.timestampBasedHardForks,
+        waitTargetBlockL1Finalization = configs.conflation.proofAggregation.waitTargetBlockL1Finalization,
+        waitApiResumeAfterTargetBlock = configs.conflation.proofAggregation.waitApiResumeAfterTargetBlock,
+      ),
+      latestL1FinalizedBlockProvider = lastProvenBlockNumberProvider,
+    )
 
   private val dynamicTargetEndBlockNumberSet =
     DynamicBlockNumberSet(
@@ -486,21 +514,6 @@ class ConflationApp(
     )
   }
 
-  private val lastProvenBlockNumberProvider = run {
-    val lastProvenConsecutiveBatchBlockNumberProvider = BatchesRepoBasedLastProvenBlockNumberProvider(
-      lastProcessedBlockNumber.toLong(),
-      lastFinalizedBlock.toLong(),
-      batchesRepository,
-    )
-    metricsFacade.createGauge(
-      category = LineaMetricsCategory.BATCH,
-      name = "proven.highest.consecutive.block.number",
-      description = "Highest proven consecutive execution batch block number",
-      measurementSupplier = { lastProvenConsecutiveBatchBlockNumberProvider.getLastKnownProvenBlockNumber() },
-    )
-    lastProvenConsecutiveBatchBlockNumberProvider
-  }
-
   // This object acts as an independent periodic polling service which is responsible
   // for monitoring the highest consecutive proven block number in the batch db
   private val provenBlockNumberMonitor = object : VertxPeriodicPollingService(
@@ -533,6 +546,7 @@ class ConflationApp(
         lastL2BlockNumberToProcessInclusive = configs.conflation.forceStopConflationAtBlockInclusive?.inc(),
         lastL2BlockTimestampToProcessInclusive = configs.conflation.forceStopConflationAtBlockTimestampInclusive,
       ),
+      targetCheckpointPauseController = targetCheckpointPauseController,
     )
     blockCreationMonitor
   }
@@ -573,5 +587,9 @@ class ConflationApp(
 
   fun updateLatestL1FinalizedBlock(blockNumber: Long): SafeFuture<Unit> {
     return lastProvenBlockNumberProvider.updateLatestL1FinalizedBlock(blockNumber)
+  }
+
+  fun signalTargetCheckpointResumeFromApi(): Boolean {
+    return targetCheckpointPauseController.signalResumeFromApi()
   }
 }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -7,6 +7,7 @@ import linea.LongRunningService
 import linea.coordinator.config.toJsonRpcRetry
 import linea.coordinator.config.v2.CoordinatorConfig
 import linea.coordinator.config.v2.TracesConfig.ClientApiConfig
+import linea.domain.Block
 import linea.domain.BlockInterval
 import linea.domain.BlockParameter
 import linea.encoding.BlockRLPEncoder
@@ -19,6 +20,7 @@ import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper
 import net.consensys.zkevm.coordinator.app.conflation.TracesClientFactory
 import net.consensys.zkevm.coordinator.blockcreation.BlockCreationMonitor
 import net.consensys.zkevm.coordinator.blockcreation.LastProvenBlockNumberProviderSync
+import net.consensys.zkevm.coordinator.blockcreation.TargetCheckpointPauseController
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.coordinator.clients.prover.ProverClientFactory
 import net.consensys.zkevm.coordinator.clients.prover.ProverConfig
@@ -347,6 +349,11 @@ class ConflationBacktestingApp(
       lastL2BlockNumberToProcessInclusive = conflationBacktestingAppConfig.endBlockNumber + 1uL,
     ),
     log = log,
+    targetCheckpointPauseController = object : TargetCheckpointPauseController {
+      override fun shouldPauseConflation(): Boolean = false
+      override fun importBlock(block: Block) = Unit
+      override fun signalResumeFromApi(): Boolean = false
+    },
   )
 
   override fun start(): SafeFuture<Unit> {

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitor.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitor.kt
@@ -27,6 +27,7 @@ class BlockCreationMonitor(
   private val blockCreationListener: BlockCreationListener,
   private val lastProvenBlockNumberProviderSync: LastProvenBlockNumberProviderSync,
   private val config: Config,
+  private val targetCheckpointPauseController: TargetCheckpointPauseController,
   private val log: Logger = LogManager.getLogger(BlockCreationMonitor::class.java),
 ) : VertxPeriodicPollingService(
   vertx = vertx,
@@ -100,6 +101,10 @@ class BlockCreationMonitor(
   }
 
   override fun action(): SafeFuture<*> {
+    if (targetCheckpointPauseController.shouldPauseConflation()) {
+      log.trace("target checkpoint pause: skipping tick nexBlockNumberToFetch={}", nexBlockNumberToFetch)
+      return SafeFuture.completedFuture(Unit)
+    }
     log.trace("tick start: nexBlockNumberToFetch={}", nexBlockNumberToFetch)
     return lastProvenBlockNumberProviderSync.getLastKnownProvenBlockNumber()
       .let { lastProvenBlockNumber ->
@@ -149,6 +154,7 @@ class BlockCreationMonitor(
                         _nexBlockNumberToFetch.incrementAndGet(),
                       )
                       expectedParentBlockHash.set(block.hash)
+                      targetCheckpointPauseController.importBlock(block)
                     }
                 } else {
                   reorgDetected.set(true)

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseController.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseController.kt
@@ -1,0 +1,224 @@
+package net.consensys.zkevm.coordinator.blockcreation
+
+import linea.domain.Block
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Instant
+
+/**
+ * Optional gate used by [BlockCreationMonitor] to pause L2 block import / conflation at configured **target
+ * checkpoints** (block numbers or timestamp thresholds) until L1 finalization and/or an operator API signal allows
+ * resuming.
+ *
+ * The monitor is expected to call [shouldPauseConflation] at the start of each poll tick. Implementations may clear
+ * internal pause state there when release conditions are met. [importBlock] is called after a block has been
+ * successfully handed to conflation for that tick.
+ *
+ * @see ConflationTargetCheckpointPauseController
+ */
+interface TargetCheckpointPauseController {
+  /**
+   * Evaluates whether this poll tick must stay idle because a target checkpoint pause is still active, and may clear
+   * that pause when configured gates (e.g. L1-finalized L2 height, API acknowledgement) are satisfied.
+   *
+   * Intended to be invoked once per [BlockCreationMonitor] poll tick before fetching the next block.
+   *
+   * @return `true` if the monitor must skip work for this tick (conflation stays paused at a checkpoint);
+   *   `false` if the monitor may proceed (no pause, or pause was released this call).
+   */
+  fun shouldPauseConflation(): Boolean
+
+  /**
+   * Notifies the controller that [block] was successfully delivered to conflation for the current progression.
+   * Implementations typically update last-seen timestamps and, when a checkpoint is crossed, record what must be true
+   * on L1 (and optionally via [signalResumeFromApi]) before [shouldPauseConflation] stops returning `true`.
+   *
+   * @param block the L2 block that was just imported into conflation
+   */
+  fun importBlock(block: Block)
+
+  /**
+   * Operator-facing resume signal (e.g. JSON-RPC). Implementations should acknowledge only when an API-gated checkpoint
+   * pause is actually active.
+   *
+   * @return `true` if the signal was applied (e.g. API gate enabled and a checkpoint pause is waiting on API ack);
+   *   `false` if the signal was ignored.
+   */
+  fun signalResumeFromApi(): Boolean
+}
+
+/**
+ * Coordinates pausing [BlockCreationMonitor] at configured target end blocks and timestamp thresholds when
+ * [Config.waitTargetBlockL1Finalization] and/or [Config.waitApiResumeAfterTargetBlock] are enabled.
+ *
+ * L1 finalization height is read from [latestL1FinalizedBlockProvider] (same source as
+ * [BatchesRepoBasedLastProvenBlockNumberProvider]). Pause release is driven from [BlockCreationMonitor] via
+ * [shouldPauseConflation].
+ */
+class ConflationTargetCheckpointPauseController(
+  private val config: Config,
+  private val latestL1FinalizedBlockProvider: LatestL1FinalizedBlockProviderSync,
+  private val log: Logger = LogManager.getLogger(ConflationTargetCheckpointPauseController::class.java),
+) : TargetCheckpointPauseController {
+  data class Config(
+    val initialLastImportedBlockTimestamp: Instant,
+    val targetEndBlocks: Set<ULong>,
+    val targetTimestamps: List<Instant>,
+    val waitTargetBlockL1Finalization: Boolean,
+    val waitApiResumeAfterTargetBlock: Boolean,
+  )
+
+  init {
+    val ts = config.targetTimestamps
+    if (ts.isNotEmpty()) {
+      require(ts.toSet().size == ts.size) {
+        "Target timestamps list contains duplicates (misconfiguration)"
+      }
+      require(ts.sorted() == ts) {
+        "Target timestamps must be sorted in ascending order"
+      }
+    }
+  }
+
+  private val apiAcknowledged = AtomicBoolean(false)
+
+  /**
+   * Minimum L2 block number finalized on L1 required before conflation may resume; when non-null, a target checkpoint
+   * was hit and [BlockCreationMonitor] must idle until [shouldPauseConflation] returns false once L1 finalization
+   * and/or API gates (see [Config]) allow release.
+   */
+  private val requiredL1FinalizedL2BlockToResumeConflation = AtomicReference<ULong?>(null)
+
+  /**
+   * O(1) lookup: a block-number checkpoint is the configured `targetBlockNumber` whose completion is observed when
+   * conflation imports block `targetBlockNumber + 1`.
+   */
+  private val targetEndBlockNumbers: Set<ULong> = config.targetEndBlocks
+
+  /**
+   * Last processed block timestamp; crossing detection matches
+   * [net.consensys.zkevm.ethereum.coordination.conflation.TimestampHardForkConflationCalculator.checkOverflow].
+   */
+  private val lastImportedBlockTimestamp = AtomicReference(config.initialLastImportedBlockTimestamp)
+
+  val pauseFeatureEnabled: Boolean
+    get() =
+      config.waitTargetBlockL1Finalization ||
+        config.waitApiResumeAfterTargetBlock
+
+  /**
+   * @return true if the API resume signal was applied: API gate is enabled, and a checkpoint pause
+   *   is active (required L1-finalized L2 block to resume is set). Gates are re-evaluated on the next poll tick via
+   *   [shouldPauseConflation].
+   */
+  override fun signalResumeFromApi(): Boolean {
+    if (!config.waitApiResumeAfterTargetBlock) {
+      return false
+    }
+    if (requiredL1FinalizedL2BlockToResumeConflation.get() == null) {
+      return false
+    }
+    apiAcknowledged.set(true)
+    return true
+  }
+
+  /**
+   * Called after a block has been successfully delivered to conflation (listener completed).
+   * May record a checkpoint pause; [BlockCreationMonitor] drives release through [shouldPauseConflation].
+   */
+  override fun importBlock(block: Block) {
+    if (!pauseFeatureEnabled) {
+      return
+    }
+    if (requiredL1FinalizedL2BlockToResumeConflation.get() != null) {
+      return
+    }
+
+    val currentBlockNumber = block.number
+    val currentBlockTimestamp = Instant.fromEpochSeconds(block.timestamp.toLong())
+    val prevBlockTimestamp = lastImportedBlockTimestamp.get()
+
+    var blockHit = false
+    var tsHit = false
+    var requiredL1 = 0UL
+
+    if (currentBlockNumber >= 1U) {
+      val targetBlockNumber = currentBlockNumber - 1U
+      if (targetBlockNumber in targetEndBlockNumbers) {
+        blockHit = true
+        requiredL1 = maxOf(requiredL1, targetBlockNumber)
+      }
+    }
+
+    // Same predicate as TimestampHardForkConflationCalculator.checkOverflow (first matching threshold in list order).
+    val crossedTimestamp =
+      config.targetTimestamps.find { t ->
+        prevBlockTimestamp < t && currentBlockTimestamp >= t
+      }
+    if (crossedTimestamp != null) {
+      tsHit = true
+      val targetBlockNumber =
+        if (currentBlockNumber >= 1U) {
+          currentBlockNumber - 1U
+        } else {
+          0U
+        }
+      requiredL1 = maxOf(requiredL1, targetBlockNumber)
+    }
+
+    lastImportedBlockTimestamp.set(currentBlockTimestamp)
+
+    if (!blockHit && !tsHit) {
+      return
+    }
+
+    requiredL1FinalizedL2BlockToResumeConflation.set(requiredL1)
+    if (config.waitApiResumeAfterTargetBlock) {
+      apiAcknowledged.set(false)
+    } else {
+      apiAcknowledged.set(true)
+    }
+
+    log.info(
+      "target checkpoint pause: blockNumber={} requiredL1FinalizedL2BlockToResumeConflation={} waitL1={} waitApi={}",
+      currentBlockNumber,
+      requiredL1,
+      config.waitTargetBlockL1Finalization,
+      config.waitApiResumeAfterTargetBlock,
+    )
+  }
+
+  /**
+   * Whether conflation must stay idle for a target-checkpoint pause, and clears that pause when L1 finalization and/or
+   * API gates are satisfied. Invoked only from [BlockCreationMonitor] each poll tick.
+   *
+   * @return `true` if the monitor must skip this tick (checkpoint pause still active);
+   *   `false` if the monitor may run (no checkpoint pause, or pause was released).
+   */
+  override fun shouldPauseConflation(): Boolean {
+    if (!pauseFeatureEnabled) {
+      return false
+    }
+
+    val required = requiredL1FinalizedL2BlockToResumeConflation.get() ?: return false
+
+    val l1Ok =
+      !config.waitTargetBlockL1Finalization ||
+        latestL1FinalizedBlockProvider.getLatestL1FinalizedBlock().toULong() >= required
+    val apiOk =
+      !config.waitApiResumeAfterTargetBlock ||
+        apiAcknowledged.get()
+
+    if (l1Ok && apiOk) {
+      requiredL1FinalizedL2BlockToResumeConflation.set(null)
+      apiAcknowledged.set(false)
+      log.info("target checkpoint pause released")
+      return false
+    }
+    return true
+  }
+
+  internal fun isPausedForTests(): Boolean = requiredL1FinalizedL2BlockToResumeConflation.get() != null
+}

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseController.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseController.kt
@@ -219,6 +219,4 @@ class ConflationTargetCheckpointPauseController(
     }
     return true
   }
-
-  internal fun isPausedForTests(): Boolean = requiredL1FinalizedL2BlockToResumeConflation.get() != null
 }

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
@@ -87,6 +87,8 @@ class ConflationParsingTest {
             Instant.fromEpochSeconds(1758083127L),
           ),
           waitForNoL2ActivityToTriggerAggregation = true,
+          waitTargetBlockL1Finalization = false,
+          waitApiResumeAfterTargetBlock = false,
         ),
       )
 
@@ -118,6 +120,8 @@ class ConflationParsingTest {
           coordinatorPollingInterval = 3.seconds,
           targetEndBlocks = null,
           timestampBasedHardForks = emptyList(),
+          waitTargetBlockL1Finalization = false,
+          waitApiResumeAfterTargetBlock = false,
         ),
       )
 

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitorTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitorTest.kt
@@ -86,6 +86,11 @@ class BlockCreationMonitorTest {
       blockCreationListener = blockCreationListener,
       lastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,
       config = config,
+      targetCheckpointPauseController = object : TargetCheckpointPauseController {
+        override fun shouldPauseConflation(): Boolean = false
+        override fun importBlock(block: Block) = Unit
+        override fun signalResumeFromApi(): Boolean = false
+      },
     )
   }
 

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseControllerTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseControllerTest.kt
@@ -38,13 +38,15 @@ class ConflationTargetCheckpointPauseControllerTest {
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetEndBlocks = setOf(9uL),
+          targetEndBlocks = setOf(9uL, 19uL),
         ),
         l1,
       )
     assertThat(c.pauseFeatureEnabled).isFalse()
     c.importBlock(createBlock(number = 10uL))
-    assertThat(c.isPausedForTests()).isFalse()
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 20uL))
+    assertThat(c.shouldPauseConflation()).isFalse()
   }
 
   @Test
@@ -53,82 +55,103 @@ class ConflationTargetCheckpointPauseControllerTest {
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetEndBlocks = setOf(9uL),
+          targetEndBlocks = setOf(9uL, 19uL, 29uL),
           waitL1 = true,
         ),
         l1,
       )
     c.importBlock(createBlock(number = 10uL))
-    assertThat(c.isPausedForTests()).isTrue()
     assertThat(c.shouldPauseConflation()).isTrue()
     l1.setLatest(8L)
     assertThat(c.shouldPauseConflation()).isTrue()
     l1.setLatest(9L)
     assertThat(c.shouldPauseConflation()).isFalse()
-    assertThat(c.isPausedForTests()).isFalse()
+    c.importBlock(createBlock(number = 20uL))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(18L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(19L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 30uL))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(28L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(29L)
+    assertThat(c.shouldPauseConflation()).isFalse()
   }
 
   @Test
   fun `timestamp pauses only on first block that crosses from strictly below threshold`() {
-    val tbt = Instant.fromEpochSeconds(1000L)
+    val tbt1 = Instant.fromEpochSeconds(1000L)
+    val tbt2 = Instant.fromEpochSeconds(2000L)
     val l1 = TestL1Provider()
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetTimestamps = listOf(tbt),
+          targetTimestamps = listOf(tbt1, tbt2),
           waitL1 = true,
         ),
         l1,
       )
     c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(999L)))
-    assertThat(c.isPausedForTests()).isFalse()
-    c.importBlock(createBlock(number = 2uL, timestamp = tbt))
-    assertThat(c.isPausedForTests()).isTrue()
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 2uL, timestamp = tbt1))
+    assertThat(c.shouldPauseConflation()).isTrue()
   }
 
   @Test
-  fun `after timestamp resume later blocks above threshold do not pause again for same list`() {
-    val tbt = Instant.fromEpochSeconds(1000L)
+  fun `multiple timestamp pauses in order of threshold`() {
+    val tbt1 = Instant.fromEpochSeconds(1000L)
+    val tbt2 = Instant.fromEpochSeconds(2000L)
     val l1 = TestL1Provider()
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetTimestamps = listOf(tbt),
+          targetTimestamps = listOf(tbt1, tbt2),
           waitL1 = true,
         ),
         l1,
       )
-    c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(999L)))
-    c.importBlock(createBlock(number = 2uL, timestamp = tbt))
-    assertThat(c.isPausedForTests()).isTrue()
+    c.importBlock(createBlock(number = 3uL, timestamp = Instant.fromEpochSeconds(999L)))
+    c.importBlock(createBlock(number = 4uL, timestamp = tbt1))
+    assertThat(c.shouldPauseConflation()).isTrue()
     l1.setLatest(1L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(2L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(3L)
     assertThat(c.shouldPauseConflation()).isFalse()
-    assertThat(c.isPausedForTests()).isFalse()
-    c.importBlock(createBlock(number = 3uL, timestamp = Instant.fromEpochSeconds(10_000L)))
-    assertThat(c.isPausedForTests()).isFalse()
+    c.importBlock(createBlock(number = 5uL, timestamp = Instant.fromEpochSeconds(1500L)))
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 10uL, timestamp = tbt2))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(8L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(9L)
+    assertThat(c.shouldPauseConflation()).isFalse()
   }
 
   @Test
   fun `pauses on timestamp threshold and resumes when L1 reaches target block timestamp by block number minus one`() {
-    val tbt = Instant.fromEpochSeconds(1000L)
+    val tbt1 = Instant.fromEpochSeconds(1000L)
+    val tbt2 = Instant.fromEpochSeconds(2000L)
     val l1 = TestL1Provider()
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetTimestamps = listOf(tbt),
+          targetTimestamps = listOf(tbt1, tbt2),
           waitL1 = true,
         ),
         l1,
       )
     c.importBlock(
-      createBlock(number = 5uL, timestamp = tbt),
+      createBlock(number = 5uL, timestamp = tbt1),
     )
-    assertThat(c.isPausedForTests()).isTrue()
+    assertThat(c.shouldPauseConflation()).isTrue()
     l1.setLatest(3L)
     assertThat(c.shouldPauseConflation()).isTrue()
     l1.setLatest(4L)
     assertThat(c.shouldPauseConflation()).isFalse()
-    assertThat(c.isPausedForTests()).isFalse()
   }
 
   @Test
@@ -137,18 +160,17 @@ class ConflationTargetCheckpointPauseControllerTest {
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetEndBlocks = setOf(9uL),
+          targetEndBlocks = setOf(9uL, 19uL),
           waitApi = true,
         ),
         l1,
       )
     c.importBlock(createBlock(number = 10uL))
-    assertThat(c.isPausedForTests()).isTrue()
+    assertThat(c.shouldPauseConflation()).isTrue()
     l1.setLatest(100L)
     assertThat(c.shouldPauseConflation()).isTrue()
     assertThat(c.signalResumeFromApi()).isTrue()
     assertThat(c.shouldPauseConflation()).isFalse()
-    assertThat(c.isPausedForTests()).isFalse()
   }
 
   @Test
@@ -170,11 +192,138 @@ class ConflationTargetCheckpointPauseControllerTest {
     val c =
       ConflationTargetCheckpointPauseController(
         pauseConfig(
-          targetEndBlocks = setOf(9uL),
+          targetEndBlocks = setOf(9uL, 19uL),
           waitApi = true,
         ),
         l1,
       )
     assertThat(c.signalResumeFromApi()).isFalse()
+  }
+
+  @Test
+  fun `multiple target timestamps pause sequentially with independent L1 gates`() {
+    val t1 = Instant.fromEpochSeconds(1000L)
+    val t2 = Instant.fromEpochSeconds(2000L)
+    val t3 = Instant.fromEpochSeconds(3000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetTimestamps = listOf(t1, t2, t3),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(500L)))
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 2uL, timestamp = t1))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(1L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 3uL, timestamp = t2))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(2L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 4uL, timestamp = t3))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(2L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(3L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+  }
+
+  @Test
+  fun `single import crossing multiple timestamp thresholds uses first in list order for required L1 height`() {
+    val t1 = Instant.fromEpochSeconds(1000L)
+    val t2 = Instant.fromEpochSeconds(2000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetTimestamps = listOf(t1, t2),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(500L)))
+    c.importBlock(createBlock(number = 2uL, timestamp = Instant.fromEpochSeconds(2500L)))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(0L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(1L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+  }
+
+  @Test
+  fun `multiple target end blocks and timestamps each gate conflation in order`() {
+    val t1 = Instant.fromEpochSeconds(1000L)
+    val t2 = Instant.fromEpochSeconds(2000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          initialTs = Instant.fromEpochSeconds(0L),
+          targetEndBlocks = setOf(9uL, 14uL),
+          targetTimestamps = listOf(t1, t2),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 9uL, timestamp = Instant.fromEpochSeconds(500L)))
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 10uL, timestamp = Instant.fromEpochSeconds(900L)))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(8L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(9L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 11uL, timestamp = Instant.fromEpochSeconds(1500L)))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(9L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(10L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 15uL, timestamp = Instant.fromEpochSeconds(1600L)))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(13L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(14L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 16uL, timestamp = t2))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(14L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(15L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+  }
+
+  @Test
+  fun `same import hitting block checkpoint and timestamp uses max of required L1 block numbers`() {
+    val t1 = Instant.fromEpochSeconds(1000L)
+    val t2 = Instant.fromEpochSeconds(2000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          initialTs = Instant.fromEpochSeconds(500L),
+          targetEndBlocks = setOf(9uL, 19uL),
+          targetTimestamps = listOf(t1, t2),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(600L)))
+    c.importBlock(createBlock(number = 10uL, timestamp = Instant.fromEpochSeconds(1500L)))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(8L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(9L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    c.importBlock(createBlock(number = 20uL, timestamp = Instant.fromEpochSeconds(2500L)))
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(18L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(19L)
+    assertThat(c.shouldPauseConflation()).isFalse()
   }
 }

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseControllerTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/ConflationTargetCheckpointPauseControllerTest.kt
@@ -1,0 +1,180 @@
+package net.consensys.zkevm.coordinator.blockcreation
+
+import linea.domain.createBlock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Instant
+
+class ConflationTargetCheckpointPauseControllerTest {
+  private class TestL1Provider(
+    initial: Long = 0L,
+  ) : LatestL1FinalizedBlockProviderSync {
+    private val inner = AtomicLong(initial)
+    override fun getLatestL1FinalizedBlock(): Long = inner.get()
+    fun setLatest(block: Long) {
+      inner.set(block)
+    }
+  }
+
+  private fun pauseConfig(
+    initialTs: Instant = Instant.fromEpochSeconds(0L),
+    targetEndBlocks: Set<ULong> = emptySet(),
+    targetTimestamps: List<Instant> = emptyList(),
+    waitL1: Boolean = false,
+    waitApi: Boolean = false,
+  ): ConflationTargetCheckpointPauseController.Config =
+    ConflationTargetCheckpointPauseController.Config(
+      initialLastImportedBlockTimestamp = initialTs,
+      targetEndBlocks = targetEndBlocks,
+      targetTimestamps = targetTimestamps,
+      waitTargetBlockL1Finalization = waitL1,
+      waitApiResumeAfterTargetBlock = waitApi,
+    )
+
+  @Test
+  fun `does nothing when both wait switches are false`() {
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetEndBlocks = setOf(9uL),
+        ),
+        l1,
+      )
+    assertThat(c.pauseFeatureEnabled).isFalse()
+    c.importBlock(createBlock(number = 10uL))
+    assertThat(c.isPausedForTests()).isFalse()
+  }
+
+  @Test
+  fun `pauses at target block number plus one and resumes on L1 only`() {
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetEndBlocks = setOf(9uL),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 10uL))
+    assertThat(c.isPausedForTests()).isTrue()
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(8L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(9L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    assertThat(c.isPausedForTests()).isFalse()
+  }
+
+  @Test
+  fun `timestamp pauses only on first block that crosses from strictly below threshold`() {
+    val tbt = Instant.fromEpochSeconds(1000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetTimestamps = listOf(tbt),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(999L)))
+    assertThat(c.isPausedForTests()).isFalse()
+    c.importBlock(createBlock(number = 2uL, timestamp = tbt))
+    assertThat(c.isPausedForTests()).isTrue()
+  }
+
+  @Test
+  fun `after timestamp resume later blocks above threshold do not pause again for same list`() {
+    val tbt = Instant.fromEpochSeconds(1000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetTimestamps = listOf(tbt),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 1uL, timestamp = Instant.fromEpochSeconds(999L)))
+    c.importBlock(createBlock(number = 2uL, timestamp = tbt))
+    assertThat(c.isPausedForTests()).isTrue()
+    l1.setLatest(1L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    assertThat(c.isPausedForTests()).isFalse()
+    c.importBlock(createBlock(number = 3uL, timestamp = Instant.fromEpochSeconds(10_000L)))
+    assertThat(c.isPausedForTests()).isFalse()
+  }
+
+  @Test
+  fun `pauses on timestamp threshold and resumes when L1 reaches target block timestamp by block number minus one`() {
+    val tbt = Instant.fromEpochSeconds(1000L)
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetTimestamps = listOf(tbt),
+          waitL1 = true,
+        ),
+        l1,
+      )
+    c.importBlock(
+      createBlock(number = 5uL, timestamp = tbt),
+    )
+    assertThat(c.isPausedForTests()).isTrue()
+    l1.setLatest(3L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    l1.setLatest(4L)
+    assertThat(c.shouldPauseConflation()).isFalse()
+    assertThat(c.isPausedForTests()).isFalse()
+  }
+
+  @Test
+  fun `API resume when waitApi true`() {
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetEndBlocks = setOf(9uL),
+          waitApi = true,
+        ),
+        l1,
+      )
+    c.importBlock(createBlock(number = 10uL))
+    assertThat(c.isPausedForTests()).isTrue()
+    l1.setLatest(100L)
+    assertThat(c.shouldPauseConflation()).isTrue()
+    assertThat(c.signalResumeFromApi()).isTrue()
+    assertThat(c.shouldPauseConflation()).isFalse()
+    assertThat(c.isPausedForTests()).isFalse()
+  }
+
+  @Test
+  fun `signalResumeFromApi returns false when API gate disabled`() {
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          waitL1 = true,
+        ),
+        l1,
+      )
+    assertThat(c.signalResumeFromApi()).isFalse()
+  }
+
+  @Test
+  fun `signalResumeFromApi returns false when no checkpoint pause active`() {
+    val l1 = TestL1Provider()
+    val c =
+      ConflationTargetCheckpointPauseController(
+        pauseConfig(
+          targetEndBlocks = setOf(9uL),
+          waitApi = true,
+        ),
+        l1,
+      )
+    assertThat(c.signalResumeFromApi()).isFalse()
+  }
+}


### PR DESCRIPTION
- Add TargetCheckpointPauseController / ConflationTargetCheckpointPauseController
  (target blocks, timestamp thresholds, wait L1 finalization, wait API resume)
- Wire BlockCreationMonitor via shouldPauseConflation + importBlock; JSON-RPC resume

This PR implements issue(s) #2609

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new control flow that can intentionally pause `BlockCreationMonitor`/conflation progression based on config, L1-finalization height, and an operator-triggered JSON-RPC resume, which could halt block import if misconfigured or if the resume path is not exercised.
> 
> **Overview**
> Adds a **target-checkpoint pause mechanism** that can stop L2 block import/conflation when configured block-number or timestamp checkpoints are crossed, and only resume once L1 has finalized the required L2 height and/or an operator acknowledges via API.
> 
> Wires this gate into `BlockCreationMonitor` (skip ticks while paused; notify controller after successful block import), adds config/toml flags (`waitTargetBlockL1Finalization`, `waitApiResumeAfterTargetBlock`), and exposes a new JSON-RPC method `conflation_signalTargetCheckpointResume` to release API-gated pauses.
> 
> Updates `ConflationApp`/`CoordinatorApp`/`L1DependentApp` wiring accordingly, and adds focused unit tests covering pause/resume behavior and config parsing defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47c4ccf537fc206c43e67cb6d8e3f59970ad3677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->