### PR TITLE
[Chore] - remove sub-module dependancy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "contracts/lib/forge-std"]
-	path = contracts/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/contracts/.solhintignore
+++ b/contracts/.solhintignore
@@ -1,5 +1,4 @@
 node_modules
-lib/forge-std
 test/foundry
 src/_testing
 src/proxies

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -2,6 +2,7 @@
 src = 'src'
 out = 'out'
 libs = ['node_modules', 'lib']
+remappings = ["forge-std/=node_modules/forge-std/src/"]
 cache_path  = 'cache_forge'
 foundry_version = "stable"
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -47,6 +47,7 @@
     "csv-parser": "3.2.0",
     "dotenv": "catalog:",
     "ethers": "6.16.0",
+    "forge-std": "github:foundry-rs/forge-std#v1.9.4",
     "hardhat": "2.28.3",
     "hardhat-deploy": "0.12.4",
     "hardhat-gas-reporter": "2.3.0",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -47,7 +47,7 @@
     "csv-parser": "3.2.0",
     "dotenv": "catalog:",
     "ethers": "6.16.0",
-    "forge-std": "github:foundry-rs/forge-std#v1.9.4",
+    "forge-std": "github:foundry-rs/forge-std#1eea5bae12ae557d589f9f0f0edae2faa47cb262",
     "hardhat": "2.28.3",
     "hardhat-deploy": "0.12.4",
     "hardhat-gas-reporter": "2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,7 +330,7 @@ importers:
         specifier: 6.16.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       forge-std:
-        specifier: github:foundry-rs/forge-std#v1.9.4
+        specifier: github:foundry-rs/forge-std#1eea5bae12ae557d589f9f0f0edae2faa47cb262
         version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
       hardhat:
         specifier: 2.28.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
       ethers:
         specifier: 6.16.0
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      forge-std:
+        specifier: github:foundry-rs/forge-std#v1.9.4
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262
       hardhat:
         specifier: 2.28.3
         version: 2.28.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@24.12.2)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -8519,6 +8522,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262}
+    version: 1.9.4
 
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
@@ -19258,7 +19265,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.80.12
       node-fetch: 2.7.0(encoding@0.1.13)
       querystring: 0.2.1
@@ -19281,7 +19288,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.80.12
       node-fetch: 2.7.0(encoding@0.1.13)
       querystring: 0.2.1
@@ -21247,7 +21254,7 @@ snapshots:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.47.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
-      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     optionalDependencies:
       '@tanstack/query-core': 5.91.2
       ox: 0.14.7(typescript@5.9.3)(zod@4.3.6)
@@ -24974,6 +24981,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/1eea5bae12ae557d589f9f0f0edae2faa47cb262: {}
+
   form-data-encoder@2.1.4: {}
 
   form-data@4.0.5:
@@ -26971,13 +26980,13 @@ snapshots:
       flow-enums-runtime: 0.0.6
       metro-core: 0.80.12
 
-  metro-config@0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  metro-config@0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro: 0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-cache: 0.80.12
       metro-core: 0.80.12
       metro-runtime: 0.80.12
@@ -27080,7 +27089,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   metro-transform-worker@0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -27129,7 +27137,7 @@ snapshots:
       metro-babel-transformer: 0.80.12
       metro-cache: 0.80.12
       metro-cache-key: 0.80.12
-      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.80.12
       metro-file-map: 0.80.12
       metro-resolver: 0.80.12
@@ -27150,7 +27158,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-    optional: true
 
   metro@0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -27179,7 +27186,7 @@ snapshots:
       metro-babel-transformer: 0.80.12
       metro-cache: 0.80.12
       metro-cache-key: 0.80.12
-      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.80.12(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       metro-core: 0.80.12
       metro-file-map: 0.80.12
       metro-resolver: 0.80.12


### PR DESCRIPTION
Removed the forge-std and pins particular package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/test tooling is changed by switching `forge-std` from a git submodule to a pinned npm/GitHub dependency and updating Foundry remappings, which could affect CI or local Foundry compilation if paths differ. No Solidity runtime logic is modified, but dependency/lockfile churn can introduce integration issues.
> 
> **Overview**
> Removes the `forge-std` git submodule and instead installs `forge-std` as a pinned `devDependency` (GitHub SHA), updating `pnpm-lock.yaml` accordingly.
> 
> Updates Foundry configuration to resolve `forge-std` from `node_modules` via `remappings`, and cleans up lint ignores by dropping the old `lib/forge-std` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7128ee2ebbbc8e705d47be46c47cfc01bb2cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->