### PR TITLE
fix(sis): adds overflow check in the multiset hash

### DIFF
--- a/prover/circuits/execution/builder_limitless.go
+++ b/prover/circuits/execution/builder_limitless.go
@@ -97,11 +97,16 @@ func (c *CircuitExecution) checkLimitlessConglomerationCompletion(api frontend.A
 		vkMerkleRoot[i] = wvc.GetPublicInput(api, fmt.Sprintf("%s_%d", distributed.VerifyingKeyMerkleRootPublicInput, i))
 	}
 
+	segmentCount := frontend.Variable(0)
 	for module := 0; module < numModule; module++ {
-		_ = api.ToBinary(target[module], multisethashing.OverflowBoundBits)
+		segmentCount = api.Add(segmentCount, target[module], target[module])
 		api.AssertIsEqual(target[module], countGL[module])
 		api.AssertIsEqual(target[module], countLPP[module])
 	}
+
+	// This rangechecks that the total number of segments does not overflow the
+	// multiset hash limit.
+	_ = api.ToBinary(segmentCount, multisethashing.OverflowBoundBits)
 
 	for k := range generalMSet {
 		api.AssertIsEqual(generalMSet[k], 0)

--- a/prover/circuits/execution/builder_limitless.go
+++ b/prover/circuits/execution/builder_limitless.go
@@ -98,6 +98,7 @@ func (c *CircuitExecution) checkLimitlessConglomerationCompletion(api frontend.A
 	}
 
 	for module := 0; module < numModule; module++ {
+		_ = api.ToBinary(target[module], multisethashing.OverflowBoundBits)
 		api.AssertIsEqual(target[module], countGL[module])
 		api.AssertIsEqual(target[module], countLPP[module])
 	}

--- a/prover/circuits/execution/builder_limitless.go
+++ b/prover/circuits/execution/builder_limitless.go
@@ -99,14 +99,25 @@ func (c *CircuitExecution) checkLimitlessConglomerationCompletion(api frontend.A
 
 	segmentCount := frontend.Variable(0)
 	for module := 0; module < numModule; module++ {
-		segmentCount = api.Add(segmentCount, target[module], target[module])
+		segmentCount = api.Add(segmentCount, target[module])
 		api.AssertIsEqual(target[module], countGL[module])
 		api.AssertIsEqual(target[module], countLPP[module])
 	}
 
+	// The multiplication by 6 is because we need to account for the fact that
+	// in each segment, we do the following updates:
+	//
+	//				| GL		| LPP		|
+	//  | General	| 3			| 3			|
+	//  | Rand		| 1			| 0			|
+	//
+	// General and Rand are distinct multiset hashes that we accumulate in
+	// each segments. The LPP segment does not use the Rand multiset.
+	msetOpsCount := api.Mul(segmentCount, 6)
+
 	// This rangechecks that the total number of segments does not overflow the
 	// multiset hash limit.
-	_ = api.ToBinary(segmentCount, multisethashing.OverflowBoundBits)
+	_ = api.ToBinary(msetOpsCount, multisethashing.OverflowBoundBits)
 
 	for k := range generalMSet {
 		api.AssertIsEqual(generalMSet[k], 0)

--- a/prover/crypto/multisethashing_koalabear/msethash.go
+++ b/prover/crypto/multisethashing_koalabear/msethash.go
@@ -16,29 +16,30 @@ const (
 	// 		from estimator.sis_parameters import *
 	//
 	//		// The modulus of the field (approximatively)
-	//		q = 2**31 for koalabear
+	//		q = 2**31 - 2**24 + 1 for koalabear
 	//		// max_number is the maximal number of parts we can have in the hash
 	//		// We are looking for a SIS instance that is secure for an L1 norm
 	//		// of at most that. We use the bound L1(x) > L2(x), to reduce that
 	//		// to finding a SIS instance that is secure for the L2 norm.
-	//		max_number = 2**12 (max number of insert/remove)
+	//		max_number = 2**16 (max number of insert/remove)
 	//		// an arbitrary big number to ensure the BKZ solver will find the
 	//		// optimal value to attack.
-	//		m = 2**20
+	//		m = 2**32
 	//
-	// 		params = SISParameters(n=23*8, q=q, length_bound=max_number, m=m, norm=2, tag='MSET')
+	// 		params = SISParameters(n=41*8, q=q, length_bound=max_number, m=m, norm=2, tag='MSET')
 	// 		SIS.estimate(params)
 	//		--------------------
-	//		>>> lattice  :: rop: ≈2^127.7, red: ≈2^127.7, δ: 1.004382, β: 348, d: 950, tag: euclidean
+	//		>>> lattice  :: rop: ≈2^128.6, red: ≈2^128.6, δ: 1.004373, β: 349, d: 1271, tag: euclidean
+	// 		n=328: rop ≈ 2^128.6
 	// ````
 	//
-	ChunkSize    = 23
+	ChunkSize    = 41
 	BlockSize    = 8
 	MSetHashSize = ChunkSize * BlockSize
 	// OverflowBoundBits tells the maximum number of inclusion that can be
 	// done in the multiset before we overflow. Equal to `log2(max_number)` in
 	// the above snippet.
-	OverflowBoundBits = 12
+	OverflowBoundBits = 16
 )
 
 // MSetHash represents a multisets hash (LtHash) instantiated using the MiMC

--- a/prover/crypto/multisethashing_koalabear/msethash.go
+++ b/prover/crypto/multisethashing_koalabear/msethash.go
@@ -31,14 +31,6 @@ const (
 	//		--------------------
 	//		>>> lattice  :: rop: ≈2^127.7, red: ≈2^127.7, δ: 1.004382, β: 348, d: 950, tag: euclidean
 	// ````
-	//		// q = 2**(31*8)
-	//		// max_number = 2**12
-	// 		// m = 2**20
-	// 		// n = 23
-	//
-	// 		params = SISParameters(n=23, q=2**(31*8), length_bound=2**12, m=2**20, norm=2, tag='MSET')
-	// 		// SIS.estimate(params)
-	// 		>>>lattice:: rop: ≈2^127.7, red: ≈2^127.7, δ: 1.004382, β: 348, d: 950, tag: euclidean
 	//
 	ChunkSize    = 23
 	BlockSize    = 8

--- a/prover/crypto/multisethashing_koalabear/msethash.go
+++ b/prover/crypto/multisethashing_koalabear/msethash.go
@@ -43,6 +43,10 @@ const (
 	ChunkSize    = 23
 	BlockSize    = 8
 	MSetHashSize = ChunkSize * BlockSize
+	// OverflowBoundBits tells the maximum number of inclusion that can be
+	// done in the multiset before we overflow. Equal to `log2(max_number)` in
+	// the above snippet.
+	OverflowBoundBits = 12
 )
 
 // MSetHash represents a multisets hash (LtHash) instantiated using the MiMC


### PR DESCRIPTION
@Soleimani193 I'll let you rebase on your own branch

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core cryptographic parameters (`ChunkSize`/`MSetHashSize`) and adds new circuit constraints, which can break proof/public-input compatibility and cause previously-valid proofs to fail.
> 
> **Overview**
> Adds an in-circuit overflow check to the execution limitless conglomeration completion by summing total segment counts and range-checking `segmentCount * 6` against a new multiset hash operation bound.
> 
> Updates KoalaBear multiset hash parameters by increasing `ChunkSize` from `23` to `41` (thus increasing `MSetHashSize`) and introduces `OverflowBoundBits=16`, reflecting a higher supported insert/remove limit in the SIS security notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f657f5055c25ea3100c31c968580d33b84419442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->