### PR TITLE
[Chore] - Tracer coverage

### DIFF
--- a/.github/workflows/tracer-gradle-tests.yml
+++ b/.github/workflows/tracer-gradle-tests.yml
@@ -25,7 +25,8 @@ jobs:
   build:
     # if: github.event.pull_request.draft == false && github.base_ref != 'main'
     # if: ${{ github.ref != 'refs/heads/main' }}
-    if: ${{ github.event.pull_request.draft == false }}
+    # Run on push/workflow_call/workflow_dispatch; on PRs, skip draft PRs.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-med
     steps:
       - name: Show metadata
@@ -75,7 +76,8 @@ jobs:
   replay-tests:
     # if: github.event.pull_request.draft == false && github.base_ref != 'main'
     # if: ${{ github.ref != 'refs/heads/main' }}
-    if: ${{ github.event.pull_request.draft == false }}
+    # Run on push/workflow_call/workflow_dispatch; on PRs, skip draft PRs.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     needs: [ build ]
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-xxl
     steps:

--- a/.github/workflows/tracer-testing.yml
+++ b/.github/workflows/tracer-testing.yml
@@ -26,12 +26,14 @@ on:
 
 jobs:
   run-tracer-tests:
-    if: github.event.pull_request.head.repo.fork == false
+    # Allow push-to-main runs; for PRs, keep same-repo-only guard.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     uses: ./.github/workflows/tracer-gradle-tests.yml
     secrets: inherit
 
   validation-reference-test-flow:
-    if: github.event.pull_request.head.repo.fork == false
+    # Allow push-to-main runs; for PRs, keep same-repo-only guard.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     uses: ./.github/workflows/reusable-tracer-blockchain-tests.yml
     secrets: inherit
     with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters when tracer workflows run; main risk is unintentionally skipping or running jobs in certain GitHub event contexts (push vs PR, draft vs ready, fork vs same-repo).
> 
> **Overview**
> Updates tracer GitHub Actions workflows to broaden execution beyond PRs while keeping existing safety checks.
> 
> `tracer-gradle-tests.yml` now runs `build` and `replay-tests` for non-PR triggers (`push`/`workflow_call`/`workflow_dispatch`) and continues to *skip draft PRs*. `tracer-testing.yml` similarly allows push-to-`main` runs while preserving the *same-repo-only* guard for PRs from forks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f3553d3f97bf704dc1ccfee79c4d309a0e664e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->