### PR TITLE
[Compresor] Use updated compressor go binaries

### DIFF
--- a/jvm-libs/linea/blob-compressor/build.gradle
+++ b/jvm-libs/linea/blob-compressor/build.gradle
@@ -35,7 +35,7 @@ downloadNativeLibs {
   fetchLibs {
     urls = [
       "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v2.1.0-rc1/linea-blob-libs-v2.1.0-rc1.zip",
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v4.0.0/linea-blob-libs-v4.0.0.zip",
+      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v4.0.1/linea-blob-libs-v4.0.1.zip",
     ]
     libs = ["blob_compressor"]
   }

--- a/jvm-libs/linea/blob-compressor/src/main/kotlin/linea/blob/GoNativeBlobCompressor.kt
+++ b/jvm-libs/linea/blob-compressor/src/main/kotlin/linea/blob/GoNativeBlobCompressor.kt
@@ -125,8 +125,8 @@ interface GoNativeBlobCompressorV4JnaLib : GoNativeBlobCompressorV4, Library
 
 enum class BlobCompressorVersion(val version: String) {
   V2("v2.1.0"),
-  V3("v4.0.0"),
-  V4("v4.0.0"),
+  V3("v4.0.1"),
+  V4("v4.0.1"),
 }
 
 /**


### PR DESCRIPTION
This PR implements issue(s) #2638 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the referenced native compressor binaries for `V3`/`V4`, which can change compression behavior/output and introduces dependency on the new release artifacts.
> 
> **Overview**
> Bumps the blob compressor native library dependency from `v4.0.0` to `v4.0.1` by updating the download URL and the `BlobCompressorVersion` mappings for `V3`/`V4`.
> 
> No JVM API shape changes, but runtime behavior now depends on the newer native Go binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb53f6e6efc09ef6ba8db13924a4e9a3b52fc22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->