### PR TITLE
[Coordinator] Remove redundant blob compressor interface in coordinator

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/EstimateGasTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/EstimateGasTest.kt
@@ -82,7 +82,7 @@ open class EstimateGasTest : LineaPluginPoSTestBase() {
       profitabilityConf,
       CachingTransactionCompressor(
         BlobCompressorSelectorByTimestamp(
-          mapOf(BlobCompressorVersion.V2 to Instant.DISTANT_PAST),
+          mapOf(BlobCompressorVersion.V3 to Instant.DISTANT_PAST),
           128 * 1024,
         ),
       ),

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionSelectorCliOptions.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionSelectorCliOptions.java
@@ -61,7 +61,7 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
   public static final String BLOB_COMPRESSOR_VERSION_TIMESTAMPS =
       "--plugin-linea-blob-compressor-version-timestamps";
   public static final String BLOB_COMPRESSOR_VERSION_TIMESTAMPS_DEFAULT =
-      String.format("%s=%s", BlobCompressorVersion.V2.name(), Instant.Companion.getDISTANT_PAST());
+      String.format("%s=%s", BlobCompressorVersion.V3.name(), Instant.Companion.getDISTANT_PAST());
 
   @Positive
   @CommandLine.Option(
@@ -156,7 +156,7 @@ public class LineaTransactionSelectorCliOptions implements LineaCliOptions {
       completionCandidates = BlobCompressorVersionCandidates.class,
       description =
           "Comma-separated map of BlobCompressorVersion to Instant, "
-              + "e.g. V1_2=2025-01-01T00:00:00Z,V2=2026-01-01T00:00:00Z ."
+              + "e.g. V2=2025-01-01T00:00:00Z,V3=2026-01-01T00:00:00Z ."
               + "Available versions: ${COMPLETION-CANDIDATES} . "
               + "(default: ${DEFAULT-VALUE})")
   private String blobCompressorVersionTimestampsRaw = BLOB_COMPRESSOR_VERSION_TIMESTAMPS_DEFAULT;

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/LineaTransactionSelectorCliOptionsTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/LineaTransactionSelectorCliOptionsTest.java
@@ -21,19 +21,19 @@ class LineaTransactionSelectorCliOptionsTest {
   @Test
   void parseBlobCompressorVersionTimestamps_validInput() {
     LineaTransactionSelectorCliOptions opts = new LineaTransactionSelectorCliOptions();
-    String input = "V1_2=2025-01-01T00:00:00Z,V2=2026-01-01T00:00:00Z";
+    String input = "V2=2025-01-01T00:00:00Z,V3=2026-01-01T00:00:00Z";
     Map<BlobCompressorVersion, Instant> result = opts.parseBlobCompressorVersionTimestamps(input);
     assertEquals(2, result.size());
     assertEquals(
-        Instant.Companion.parse("2025-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V1_2));
+        Instant.Companion.parse("2025-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V2));
     assertEquals(
-        Instant.Companion.parse("2026-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V2));
+        Instant.Companion.parse("2026-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V3));
   }
 
   @Test
   void parseBlobCompressorVersionTimestamps_invalidInput() {
     LineaTransactionSelectorCliOptions opts = new LineaTransactionSelectorCliOptions();
-    String input = "V1_2=2025-01-01T00:00:00Z,V2";
+    String input = "V2=2025-01-01T00:00:00Z,V3";
     Exception ex =
         assertThrows(
             IllegalArgumentException.class, () -> opts.parseBlobCompressorVersionTimestamps(input));

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/ProfitabilityValidatorTest.java
@@ -81,7 +81,7 @@ public class ProfitabilityValidatorTest {
     final var transactionCompressor =
         new CachingTransactionCompressor(
             new BlobCompressorSelectorByTimestamp(
-                Map.of(BlobCompressorVersion.V2, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
+                Map.of(BlobCompressorVersion.V3, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
 
     final var profitabilityCalculatorAlways =
         new TransactionProfitabilityCalculator(

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/LineaTransactionSelectorFactoryTest.java
@@ -134,7 +134,7 @@ class LineaTransactionSelectorFactoryTest {
     final var transactionCompressor =
         new CachingTransactionCompressor(
             new BlobCompressorSelectorByTimestamp(
-                Map.of(BlobCompressorVersion.V2, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
+                Map.of(BlobCompressorVersion.V3, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
     TransactionProfitabilityCalculator transactionProfitabilityCalculator =
         new TransactionProfitabilityCalculator(
             mockProfitabilityConfiguration, transactionCompressor);

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/CompressionAwareTransactionSelectorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/CompressionAwareTransactionSelectorTest.java
@@ -51,7 +51,7 @@ class CompressionAwareTransactionSelectorTest {
   private static final TransactionCompressor TX_COMPRESSOR =
       new CachingTransactionCompressor(
           new BlobCompressorSelectorByTimestamp(
-              Map.of(BlobCompressorVersion.V2, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
+              Map.of(BlobCompressorVersion.V3, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
 
   private SelectorsStateManager selectorsStateManager;
   private TestTransactionFactory txFactory;
@@ -70,7 +70,7 @@ class CompressionAwareTransactionSelectorTest {
   private static BlobCompressorSelectorByTimestamp compressorSelectorWithLimit(
       final int dataLimit) {
     return new BlobCompressorSelectorByTimestamp(
-        Map.of(BlobCompressorVersion.V2, Instant.Companion.getDISTANT_PAST()), dataLimit);
+        Map.of(BlobCompressorVersion.V3, Instant.Companion.getDISTANT_PAST()), dataLimit);
   }
 
   @Test

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txselection/selectors/ProfitableTransactionSelectorTest.java
@@ -92,7 +92,7 @@ public class ProfitableTransactionSelectorTest {
     final var transactionCompressor =
         new CachingTransactionCompressor(
             new BlobCompressorSelectorByTimestamp(
-                Map.of(BlobCompressorVersion.V2, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
+                Map.of(BlobCompressorVersion.V3, Instant.Companion.getDISTANT_PAST()), 128 * 1024));
     final var transactionProfitabilityCalculator =
         new TransactionProfitabilityCalculator(profitabilityConf, transactionCompressor);
     return new ProfitableTransactionSelector(

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
@@ -37,7 +37,7 @@ data class ConflationConfig(
     val blobSizeLimit: UInt = 102400u,
     val handlerPollingInterval: Duration = 1.seconds,
     val batchesLimit: UInt? = null,
-    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V2,
+    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V3,
   ) {
     val shnarfCalculatorVersion: ShnarfCalculatorVersion
       get() = when (blobCompressorVersion) {

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
@@ -37,13 +37,13 @@ data class ConflationConfig(
     val blobSizeLimit: UInt = 102400u,
     val handlerPollingInterval: Duration = 1.seconds,
     val batchesLimit: UInt? = null,
-    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V1_2,
+    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V2,
   ) {
     val shnarfCalculatorVersion: ShnarfCalculatorVersion
       get() = when (blobCompressorVersion) {
-        BlobCompressorVersion.V1_2 -> ShnarfCalculatorVersion.V1_2
         BlobCompressorVersion.V2 -> ShnarfCalculatorVersion.V1_2
         BlobCompressorVersion.V3 -> ShnarfCalculatorVersion.V3
+        BlobCompressorVersion.V4 -> ShnarfCalculatorVersion.V3
       }
   }
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
@@ -39,7 +39,7 @@ data class ConflationToml(
     val blobSizeLimit: UInt = 102400u,
     val handlerPollingInterval: Duration = 1.seconds,
     val batchesLimit: UInt? = null,
-    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V1_2,
+    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V2,
   ) {
     fun reified(): ConflationConfig.BlobCompression {
       return ConflationConfig.BlobCompression(

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
@@ -39,7 +39,7 @@ data class ConflationToml(
     val blobSizeLimit: UInt = 102400u,
     val handlerPollingInterval: Duration = 1.seconds,
     val batchesLimit: UInt? = null,
-    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V2,
+    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V3,
   ) {
     fun reified(): ConflationConfig.BlobCompression {
       return ConflationConfig.BlobCompression(

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -47,7 +47,7 @@ import net.consensys.zkevm.ethereum.coordination.aggregation.InvalidityProofProv
 import net.consensys.zkevm.ethereum.coordination.aggregation.ProofAggregationCoordinatorService
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
-import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressor
+import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProviderImpl
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
@@ -213,7 +213,7 @@ class ConflationApp(
     val logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java)
 
     // To fail faster for JNA reasons
-    val blobCompressor = GoBackedBlobCompressor.getInstance(
+    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
       compressorVersion = configs.conflation.blobCompression.blobCompressorVersion,
       dataLimit = configs.conflation.blobCompression.blobSizeLimit,
       metricsFacade = metricsFacade,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -27,7 +27,7 @@ import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobShnarfMetaData
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
-import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressor
+import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProvider
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
@@ -167,7 +167,7 @@ class ConflationBacktestingApp(
 
   private val conflationCalculator: TracesConflationCalculator = run {
     // To fail faster for JNA reasons
-    val blobCompressor = GoBackedBlobCompressor.getInstance(
+    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
       compressorVersion = backtestingCoordinatorConfig.conflation.blobCompression.blobCompressorVersion,
       dataLimit = backtestingCoordinatorConfig.conflation.blobCompression.blobSizeLimit,
       metricsFacade = metricsFacade,

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
@@ -108,7 +108,7 @@ class ConflationParsingTest {
           blobSizeLimit = 102_400U,
           handlerPollingInterval = 1.seconds,
           batchesLimit = null,
-          blobCompressorVersion = BlobCompressorVersion.V1_2,
+          blobCompressorVersion = BlobCompressorVersion.V2,
         ),
         proofAggregation =
         ConflationToml.ProofAggregationToml(
@@ -134,9 +134,9 @@ class ConflationParsingTest {
 
     @JvmStatic
     fun blobCompressionVersionTestCases(): Stream<Arguments> = Stream.of(
-      Arguments.of(BlobCompressorVersion.V1_2, ShnarfCalculatorVersion.V1_2),
       Arguments.of(BlobCompressorVersion.V2, ShnarfCalculatorVersion.V1_2),
       Arguments.of(BlobCompressorVersion.V3, ShnarfCalculatorVersion.V3),
+      Arguments.of(BlobCompressorVersion.V4, ShnarfCalculatorVersion.V3),
     )
   }
 

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
@@ -108,7 +108,7 @@ class ConflationParsingTest {
           blobSizeLimit = 102_400U,
           handlerPollingInterval = 1.seconds,
           batchesLimit = null,
-          blobCompressorVersion = BlobCompressorVersion.V2,
+          blobCompressorVersion = BlobCompressorVersion.V3,
         ),
         proofAggregation =
         ConflationToml.ProofAggregationToml(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
@@ -115,7 +115,7 @@ class FakeBlobCompressor(
 ) : BlobCompressor {
   val log = LogManager.getLogger(FakeBlobCompressor::class.java)
 
-  override val version: BlobCompressorVersion = BlobCompressorVersion.V2
+  override val version: BlobCompressorVersion = BlobCompressorVersion.V3
 
   init {
     require(dataLimit > 0) { "dataLimit must be greater than 0" }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
@@ -1,70 +1,36 @@
 package net.consensys.zkevm.ethereum.coordination.blob
 
+import linea.blob.BlobCompressor
 import linea.blob.BlobCompressorVersion
-import linea.blob.GoNativeBlobCompressor
-import linea.blob.GoNativeBlobCompressorFactory
-import linea.kotlin.encodeHex
+import linea.blob.GoBackedBlobCompressor
 import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Timer
 import org.apache.logging.log4j.LogManager
 import kotlin.random.Random
 
-class BlobCompressionException(message: String) : RuntimeException(message)
-
-interface BlobCompressor {
-  /**
-   * @Throws(BlobCompressionException::class) when blockRLPEncoded is invalid
-   */
-  fun canAppendBlock(blockRLPEncoded: ByteArray): Boolean
-
-  /**
-   * @Throws(BlobCompressionException::class) when blockRLPEncoded is invalid
-   */
-  fun appendBlock(blockRLPEncoded: ByteArray): AppendResult
-
-  fun startNewBatch()
-
-  fun getCompressedData(): ByteArray
-
-  fun reset()
-
-  data class AppendResult(
-    // returns false if last chunk would go over dataLimit. Does  not append last block.
-    val blockAppended: Boolean,
-    val compressedSizeBefore: Int,
-    // even when block is not appended, compressedSizeAfter should as if it was appended
-    val compressedSizeAfter: Int,
-  )
-}
-
-class GoBackedBlobCompressor private constructor(
-  internal val goNativeBlobCompressor: GoNativeBlobCompressor,
+class GoBackedBlobCompressorAdapter private constructor(
+  internal val goBackedBlobCompressor: BlobCompressor,
   private val dataLimit: UInt,
   private val metricsFacade: MetricsFacade,
 ) : BlobCompressor {
   companion object {
     @Volatile
-    private var instance: GoBackedBlobCompressor? = null
+    private var instance: GoBackedBlobCompressorAdapter? = null
 
     fun getInstance(
       compressorVersion: BlobCompressorVersion,
       dataLimit: UInt,
       metricsFacade: MetricsFacade,
-    ): GoBackedBlobCompressor {
+    ): GoBackedBlobCompressorAdapter {
       if (instance == null) {
         synchronized(this) {
           if (instance == null) {
-            val goNativeBlobCompressor = GoNativeBlobCompressorFactory.getInstance(compressorVersion)
-            val initialized =
-              goNativeBlobCompressor.Init(
-                dataLimit.toInt(),
-                GoNativeBlobCompressorFactory.dictionaryPath.toString(),
-              )
-            if (!initialized) {
-              throw InstantiationException(goNativeBlobCompressor.Error())
-            }
-            instance = GoBackedBlobCompressor(goNativeBlobCompressor, dataLimit, metricsFacade)
+            val goBackedBlobCompressor = GoBackedBlobCompressor.getInstance(
+              compressorVersion = compressorVersion,
+              dataLimit = dataLimit.toInt(),
+            )
+            instance = GoBackedBlobCompressorAdapter(goBackedBlobCompressor, dataLimit, metricsFacade)
           } else {
             throw IllegalStateException("Compressor singleton instance already created")
           }
@@ -103,21 +69,23 @@ class GoBackedBlobCompressor private constructor(
       isRatio = true,
     )
 
-  private val log = LogManager.getLogger(GoBackedBlobCompressor::class.java)
+  private val log = LogManager.getLogger(GoBackedBlobCompressorAdapter::class.java)
+
+  override val version: BlobCompressorVersion = goBackedBlobCompressor.version
 
   override fun canAppendBlock(blockRLPEncoded: ByteArray): Boolean {
     return canAppendBlockTimer.captureTime {
-      goNativeBlobCompressor.CanWrite(blockRLPEncoded, blockRLPEncoded.size)
+      goBackedBlobCompressor.canAppendBlock(blockRLPEncoded)
     }
   }
 
   override fun appendBlock(blockRLPEncoded: ByteArray): BlobCompressor.AppendResult {
-    val compressionSizeBefore = goNativeBlobCompressor.Len()
-    val appended =
+    val appendResult =
       appendBlockTimer.captureTime {
-        goNativeBlobCompressor.Write(blockRLPEncoded, blockRLPEncoded.size)
+        goBackedBlobCompressor.appendBlock(blockRLPEncoded)
       }
-    val compressedSizeAfter = goNativeBlobCompressor.Len()
+    val compressionSizeBefore = appendResult.compressedSizeBefore
+    val compressedSizeAfter = appendResult.compressedSizeAfter
     val compressionRatio =
       (1.0 - (compressedSizeAfter - compressionSizeBefore).toDouble() / blockRLPEncoded.size)
         .also { compressionRatioHistogram.record(it) }
@@ -129,27 +97,26 @@ class GoBackedBlobCompressor private constructor(
       compressedSizeAfter,
       compressionRatio,
     )
-    val error = goNativeBlobCompressor.Error()
-    if (error != null) {
-      log.error("Failure while writing the following RLP encoded block: {}", blockRLPEncoded.encodeHex())
-      throw BlobCompressionException(error)
-    }
-    return BlobCompressor.AppendResult(appended, compressionSizeBefore, compressedSizeAfter)
+
+    return appendResult
   }
 
   override fun startNewBatch() {
-    goNativeBlobCompressor.StartNewBatch()
+    goBackedBlobCompressor.startNewBatch()
   }
 
   override fun getCompressedData(): ByteArray {
-    val compressedData = ByteArray(goNativeBlobCompressor.Len())
-    goNativeBlobCompressor.Bytes(compressedData)
-    utilizationRatioHistogram.record(goNativeBlobCompressor.Len().toDouble() / dataLimit.toInt())
+    val compressedData = goBackedBlobCompressor.getCompressedData()
+    utilizationRatioHistogram.record(compressedData.size.toDouble() / dataLimit.toInt())
     return compressedData
   }
 
   override fun reset() {
-    goNativeBlobCompressor.Reset()
+    goBackedBlobCompressor.reset()
+  }
+
+  override fun compressedSize(data: ByteArray): Int {
+    return goBackedBlobCompressor.compressedSize(data)
   }
 }
 
@@ -161,6 +128,8 @@ class FakeBlobCompressor(
   private val fakeCompressionRatio: Double = 1.0,
 ) : BlobCompressor {
   val log = LogManager.getLogger(FakeBlobCompressor::class.java)
+
+  override val version: BlobCompressorVersion = BlobCompressorVersion.V2
 
   init {
     require(dataLimit > 0) { "dataLimit must be greater than 0" }
@@ -204,5 +173,9 @@ class FakeBlobCompressor(
   override fun reset() {
     log.trace("resetting to empty state")
     compressedData = byteArrayOf()
+  }
+
+  override fun compressedSize(data: ByteArray): Int {
+    return (data.size * fakeCompressionRatio).toInt()
   }
 }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
@@ -1,8 +1,8 @@
 package net.consensys.zkevm.ethereum.coordination.blob
 
 import linea.blob.BlobCompressor
+import linea.blob.BlobCompressorFactory
 import linea.blob.BlobCompressorVersion
-import linea.blob.GoBackedBlobCompressor
 import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Timer
@@ -13,7 +13,7 @@ class GoBackedBlobCompressorAdapter private constructor(
   internal val goBackedBlobCompressor: BlobCompressor,
   private val dataLimit: UInt,
   private val metricsFacade: MetricsFacade,
-) : BlobCompressor {
+) : BlobCompressor by goBackedBlobCompressor {
   companion object {
     @Volatile
     private var instance: GoBackedBlobCompressorAdapter? = null
@@ -26,7 +26,7 @@ class GoBackedBlobCompressorAdapter private constructor(
       if (instance == null) {
         synchronized(this) {
           if (instance == null) {
-            val goBackedBlobCompressor = GoBackedBlobCompressor.getInstance(
+            val goBackedBlobCompressor = BlobCompressorFactory.getInstance(
               compressorVersion = compressorVersion,
               dataLimit = dataLimit.toInt(),
             )
@@ -71,8 +71,6 @@ class GoBackedBlobCompressorAdapter private constructor(
 
   private val log = LogManager.getLogger(GoBackedBlobCompressorAdapter::class.java)
 
-  override val version: BlobCompressorVersion = goBackedBlobCompressor.version
-
   override fun canAppendBlock(blockRLPEncoded: ByteArray): Boolean {
     return canAppendBlockTimer.captureTime {
       goBackedBlobCompressor.canAppendBlock(blockRLPEncoded)
@@ -101,22 +99,10 @@ class GoBackedBlobCompressorAdapter private constructor(
     return appendResult
   }
 
-  override fun startNewBatch() {
-    goBackedBlobCompressor.startNewBatch()
-  }
-
   override fun getCompressedData(): ByteArray {
     val compressedData = goBackedBlobCompressor.getCompressedData()
     utilizationRatioHistogram.record(compressedData.size.toDouble() / dataLimit.toInt())
     return compressedData
-  }
-
-  override fun reset() {
-    goBackedBlobCompressor.reset()
-  }
-
-  override fun compressedSize(data: ByteArray): Int {
-    return goBackedBlobCompressor.compressedSize(data)
   }
 }
 
@@ -177,5 +163,9 @@ class FakeBlobCompressor(
 
   override fun compressedSize(data: ByteArray): Int {
     return (data.size * fakeCompressionRatio).toInt()
+  }
+
+  override fun close() {
+    // Nothing to do
   }
 }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByDataCompressed.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByDataCompressed.kt
@@ -1,8 +1,8 @@
 package net.consensys.zkevm.ethereum.coordination.conflation
 
+import linea.blob.BlobCompressor
 import net.consensys.zkevm.domain.BlockCounters
 import net.consensys.zkevm.domain.ConflationTrigger
-import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressor
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/FakeBlobCompressorTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/FakeBlobCompressorTest.kt
@@ -1,6 +1,6 @@
 package net.consensys.zkevm.coordination.blob
 
-import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressor
+import linea.blob.BlobCompressor
 import net.consensys.zkevm.ethereum.coordination.blob.FakeBlobCompressor
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
@@ -24,7 +24,7 @@ class GoBackedBlobCompressorAdapterTest {
     private val metricsFacade: MetricsFacade = MicrometerMetricsFacade(registry = meterRegistry, "linea")
     private val compressor =
       GoBackedBlobCompressorAdapter.getInstance(
-        BlobCompressorVersion.V2,
+        BlobCompressorVersion.V3,
         DATA_LIMIT.toUInt(),
         metricsFacade,
       )

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
@@ -24,7 +24,7 @@ class GoBackedBlobCompressorAdapterTest {
     private val metricsFacade: MetricsFacade = MicrometerMetricsFacade(registry = meterRegistry, "linea")
     private val compressor =
       GoBackedBlobCompressorAdapter.getInstance(
-        BlobCompressorVersion.V1_2,
+        BlobCompressorVersion.V2,
         DATA_LIMIT.toUInt(),
         metricsFacade,
       )

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
@@ -1,11 +1,11 @@
 package net.consensys.zkevm.coordination.blob
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import linea.blob.BlobCompressionException
 import linea.blob.BlobCompressorVersion
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
-import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionException
-import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressor
+import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,21 +16,21 @@ import java.nio.ByteOrder
 import kotlin.random.Random
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class GoBackedBlobCompressorTest {
+class GoBackedBlobCompressorAdapterTest {
   companion object {
     private const val DATA_LIMIT = 16 * 1024
     private val TEST_DATA = loadTestData()
     private val meterRegistry = SimpleMeterRegistry()
     private val metricsFacade: MetricsFacade = MicrometerMetricsFacade(registry = meterRegistry, "linea")
     private val compressor =
-      GoBackedBlobCompressor.getInstance(
+      GoBackedBlobCompressorAdapter.getInstance(
         BlobCompressorVersion.V1_2,
         DATA_LIMIT.toUInt(),
         metricsFacade,
       )
 
     private fun loadTestData(): Array<ByteArray> {
-      val data = GoBackedBlobCompressorTest::class.java.getResourceAsStream("rlp_blocks.bin")!!.readAllBytes()
+      val data = GoBackedBlobCompressorAdapterTest::class.java.getResourceAsStream("rlp_blocks.bin")!!.readAllBytes()
 
       // first 4 bytes are the number of blocks
       val numBlocks = ByteBuffer.wrap(data, 0, 4).order(ByteOrder.LITTLE_ENDIAN).int
@@ -96,21 +96,21 @@ class GoBackedBlobCompressorTest {
   @Test
   fun `test reset`() {
     val blocks = TEST_DATA.iterator()
-    assertThat(compressor.goNativeBlobCompressor.Len()).isZero()
+    assertThat(compressor.goBackedBlobCompressor.getCompressedData().size).isZero()
     var res = compressor.appendBlock(blocks.next())
     assertThat(res.blockAppended).isTrue()
     assertThat(res.compressedSizeBefore).isZero()
     assertThat(res.compressedSizeAfter).isGreaterThan(0)
-    assertThat(res.compressedSizeAfter).isEqualTo(compressor.goNativeBlobCompressor.Len())
+    assertThat(res.compressedSizeAfter).isEqualTo(compressor.goBackedBlobCompressor.getCompressedData().size)
 
     compressor.reset()
 
-    assertThat(compressor.goNativeBlobCompressor.Len()).isZero()
+    assertThat(compressor.goBackedBlobCompressor.getCompressedData().size).isZero()
     res = compressor.appendBlock(blocks.next())
     assertThat(res.blockAppended).isTrue()
     assertThat(res.compressedSizeBefore).isZero()
     assertThat(res.compressedSizeAfter).isGreaterThan(0)
-    assertThat(res.compressedSizeAfter).isEqualTo(compressor.goNativeBlobCompressor.Len())
+    assertThat(res.compressedSizeAfter).isEqualTo(compressor.goBackedBlobCompressor.getCompressedData().size)
   }
 
   @Test

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByDataCompressedTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByDataCompressedTest.kt
@@ -1,10 +1,10 @@
 package net.consensys.zkevm.ethereum.coordination.conflation
 
+import linea.blob.BlobCompressionException
+import linea.blob.BlobCompressor
 import net.consensys.linea.traces.fakeTracesCountersV2
 import net.consensys.zkevm.domain.BlockCounters
 import net.consensys.zkevm.domain.ConflationTrigger
-import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionException
-import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressor
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlobAwareConflationCalculatorTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlobAwareConflationCalculatorTest.kt
@@ -1,6 +1,7 @@
 package net.consensys.zkevm.ethereum.coordination.conflation
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import linea.blob.BlobCompressor
 import linea.domain.BlockHeaderSummary
 import linea.kotlin.ByteArrayExt
 import net.consensys.FakeFixedClock
@@ -15,7 +16,6 @@ import net.consensys.zkevm.domain.BlockCounters
 import net.consensys.zkevm.domain.ConflationCalculationResult
 import net.consensys.zkevm.domain.ConflationTrigger
 import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
-import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressor
 import net.consensys.zkevm.ethereum.coordination.blob.FakeBlobCompressor
 import net.consensys.zkevm.ethereum.coordination.blockcreation.SafeBlockProvider
 import org.assertj.core.api.Assertions.assertThat

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ undercouchDownload = "5.6.0"
 besuCommit = "067610071de5f6760050ef434f5549c9ab8fbacf"
 
 besu = "26.3.0-RC0-0676100"
-blobCompressor = "3.0.2"
+blobCompressor = "4.0.1"
 commonsIo = "2.21.0"
 blobShnarfCalculator = "3.0.1"
 bouncycastle = "1.83"


### PR DESCRIPTION
This PR implements issue(s) #2638 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the coordinator and sequencer to use a newer blob compressor API/version (defaulting to `V3`) and bumps the compressor dependency, which may subtly change compression sizing/limits and selection behavior at runtime.
> 
> **Overview**
> Switches the coordinator’s blob compression integration to use the upstream `linea.blob.BlobCompressor` directly, replacing the coordinator-local interface and reworking the Go-backed singleton into `GoBackedBlobCompressorAdapter` that delegates to `BlobCompressorFactory` while keeping metrics instrumentation.
> 
> Updates defaults and tests to prefer newer compressor versions: sequencer CLI default `--plugin-linea-blob-compressor-version-timestamps` and related tests move from `V2` to `V3`, coordinator conflation config defaults move to `V3`, and `V4` is mapped to the `V3` shnarf calculator. Also bumps the `blobCompressor` dependency from `3.0.2` to `4.0.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cbcb8f73a61b086e8f92b1181218904e8c4cb1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->