### PR TITLE
[Coordinator,Besu-plugin] Update blob compressor version to v4.0.1

### DIFF
--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/LineaTransactionSelectorCliOptionsTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/LineaTransactionSelectorCliOptionsTest.java
@@ -21,19 +21,19 @@ class LineaTransactionSelectorCliOptionsTest {
   @Test
   void parseBlobCompressorVersionTimestamps_validInput() {
     LineaTransactionSelectorCliOptions opts = new LineaTransactionSelectorCliOptions();
-    String input = "V1_2=2025-01-01T00:00:00Z,V2=2026-01-01T00:00:00Z";
+    String input = "V2=2025-01-01T00:00:00Z,V3=2026-01-01T00:00:00Z";
     Map<BlobCompressorVersion, Instant> result = opts.parseBlobCompressorVersionTimestamps(input);
     assertEquals(2, result.size());
     assertEquals(
-        Instant.Companion.parse("2025-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V1_2));
+        Instant.Companion.parse("2025-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V2));
     assertEquals(
-        Instant.Companion.parse("2026-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V2));
+        Instant.Companion.parse("2026-01-01T00:00:00Z"), result.get(BlobCompressorVersion.V3));
   }
 
   @Test
   void parseBlobCompressorVersionTimestamps_invalidInput() {
     LineaTransactionSelectorCliOptions opts = new LineaTransactionSelectorCliOptions();
-    String input = "V1_2=2025-01-01T00:00:00Z,V2";
+    String input = "V2=2025-01-01T00:00:00Z,V3";
     Exception ex =
         assertThrows(
             IllegalArgumentException.class, () -> opts.parseBlobCompressorVersionTimestamps(input));

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
@@ -37,13 +37,13 @@ data class ConflationConfig(
     val blobSizeLimit: UInt = 102400u,
     val handlerPollingInterval: Duration = 1.seconds,
     val batchesLimit: UInt? = null,
-    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V1_2,
+    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V2,
   ) {
     val shnarfCalculatorVersion: ShnarfCalculatorVersion
       get() = when (blobCompressorVersion) {
-        BlobCompressorVersion.V1_2 -> ShnarfCalculatorVersion.V1_2
         BlobCompressorVersion.V2 -> ShnarfCalculatorVersion.V1_2
         BlobCompressorVersion.V3 -> ShnarfCalculatorVersion.V3
+        BlobCompressorVersion.V4 -> ShnarfCalculatorVersion.V3
       }
   }
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
@@ -39,7 +39,7 @@ data class ConflationToml(
     val blobSizeLimit: UInt = 102400u,
     val handlerPollingInterval: Duration = 1.seconds,
     val batchesLimit: UInt? = null,
-    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V1_2,
+    val blobCompressorVersion: BlobCompressorVersion = BlobCompressorVersion.V2,
   ) {
     fun reified(): ConflationConfig.BlobCompression {
       return ConflationConfig.BlobCompression(

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
@@ -108,7 +108,7 @@ class ConflationParsingTest {
           blobSizeLimit = 102_400U,
           handlerPollingInterval = 1.seconds,
           batchesLimit = null,
-          blobCompressorVersion = BlobCompressorVersion.V1_2,
+          blobCompressorVersion = BlobCompressorVersion.V2,
         ),
         proofAggregation =
         ConflationToml.ProofAggregationToml(
@@ -134,9 +134,9 @@ class ConflationParsingTest {
 
     @JvmStatic
     fun blobCompressionVersionTestCases(): Stream<Arguments> = Stream.of(
-      Arguments.of(BlobCompressorVersion.V1_2, ShnarfCalculatorVersion.V1_2),
       Arguments.of(BlobCompressorVersion.V2, ShnarfCalculatorVersion.V1_2),
       Arguments.of(BlobCompressorVersion.V3, ShnarfCalculatorVersion.V3),
+      Arguments.of(BlobCompressorVersion.V4, ShnarfCalculatorVersion.V3),
     )
   }
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressor.kt
@@ -1,8 +1,8 @@
 package net.consensys.zkevm.ethereum.coordination.blob
 
 import linea.blob.BlobCompressor
+import linea.blob.BlobCompressorFactory
 import linea.blob.BlobCompressorVersion
-import linea.blob.GoBackedBlobCompressor
 import net.consensys.linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Timer
@@ -13,7 +13,7 @@ class GoBackedBlobCompressorAdapter private constructor(
   internal val goBackedBlobCompressor: BlobCompressor,
   private val dataLimit: UInt,
   private val metricsFacade: MetricsFacade,
-) : BlobCompressor {
+) : BlobCompressor by goBackedBlobCompressor {
   companion object {
     @Volatile
     private var instance: GoBackedBlobCompressorAdapter? = null
@@ -26,7 +26,7 @@ class GoBackedBlobCompressorAdapter private constructor(
       if (instance == null) {
         synchronized(this) {
           if (instance == null) {
-            val goBackedBlobCompressor = GoBackedBlobCompressor.getInstance(
+            val goBackedBlobCompressor = BlobCompressorFactory.getInstance(
               compressorVersion = compressorVersion,
               dataLimit = dataLimit.toInt(),
             )
@@ -71,8 +71,6 @@ class GoBackedBlobCompressorAdapter private constructor(
 
   private val log = LogManager.getLogger(GoBackedBlobCompressorAdapter::class.java)
 
-  override val version: BlobCompressorVersion = goBackedBlobCompressor.version
-
   override fun canAppendBlock(blockRLPEncoded: ByteArray): Boolean {
     return canAppendBlockTimer.captureTime {
       goBackedBlobCompressor.canAppendBlock(blockRLPEncoded)
@@ -101,22 +99,10 @@ class GoBackedBlobCompressorAdapter private constructor(
     return appendResult
   }
 
-  override fun startNewBatch() {
-    goBackedBlobCompressor.startNewBatch()
-  }
-
   override fun getCompressedData(): ByteArray {
     val compressedData = goBackedBlobCompressor.getCompressedData()
     utilizationRatioHistogram.record(compressedData.size.toDouble() / dataLimit.toInt())
     return compressedData
-  }
-
-  override fun reset() {
-    goBackedBlobCompressor.reset()
-  }
-
-  override fun compressedSize(data: ByteArray): Int {
-    return goBackedBlobCompressor.compressedSize(data)
   }
 }
 
@@ -177,5 +163,9 @@ class FakeBlobCompressor(
 
   override fun compressedSize(data: ByteArray): Int {
     return (data.size * fakeCompressionRatio).toInt()
+  }
+
+  override fun close() {
+    // Nothing to do
   }
 }

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/coordination/blob/GoBackedBlobCompressorAdapterTest.kt
@@ -24,7 +24,7 @@ class GoBackedBlobCompressorAdapterTest {
     private val metricsFacade: MetricsFacade = MicrometerMetricsFacade(registry = meterRegistry, "linea")
     private val compressor =
       GoBackedBlobCompressorAdapter.getInstance(
-        BlobCompressorVersion.V1_2,
+        BlobCompressorVersion.V2,
         DATA_LIMIT.toUInt(),
         metricsFacade,
       )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ undercouchDownload = "5.6.0"
 besuCommit = "067610071de5f6760050ef434f5549c9ab8fbacf"
 
 besu = "26.3.0-RC0-0676100"
-blobCompressor = "3.0.2"
+blobCompressor = "4.0.1"
 commonsIo = "2.21.0"
 blobShnarfCalculator = "3.0.1"
 bouncycastle = "1.83"


### PR DESCRIPTION
depends on https://github.com/Consensys/linea-monorepo/pull/2789 
This PR implements issue(s) #2638 


### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the blob compressor dependency and changes defaults/factory wiring for compression versions, which can affect blob encoding compatibility and production data paths. Scope is limited to version selection/config and adapter wiring with tests updated accordingly.
> 
> **Overview**
> Bumps the `blobCompressor` dependency to `4.0.1` and updates version defaults across Coordinator and Besu plugin configs/tests (default `blobCompressorVersion` now `V2`, CLI parsing test cases updated).
> 
> Refactors the Coordinator `GoBackedBlobCompressorAdapter` to obtain compressors via `BlobCompressorFactory` and delegate the `BlobCompressor` interface directly, and extends version-to-`ShnarfCalculatorVersion` mapping to handle `V4` (mapped to `V3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ee21981ad25af7ef3b18022e510a1e1a46c1df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->