### PR TITLE
fix: coordinator caught up transition on fast chain

### DIFF
--- a/jvm-libs/linea/clients/eth-logs-searcher/src/main/kotlin/linea/ethapi/EthLogsFilterSubscriptionPollingBased.kt
+++ b/jvm-libs/linea/clients/eth-logs-searcher/src/main/kotlin/linea/ethapi/EthLogsFilterSubscriptionPollingBased.kt
@@ -204,6 +204,12 @@ class EthLogsFilterPoller(
           lastSearchedBlock = result.endBlockNumber
           log.trace("no new logs found in block range {}..{}", result.startBlockNumber, result.endBlockNumber)
         }
+
+        // We searched all blocks up to the resolved chain head — we are caught up
+        // even though new blocks will appear by the next tick.
+        if (lastSearchedBlock != null && lastSearchedBlock!! >= end) {
+          transitionTo(EthLogsFilterState.CaughtUp(lastSearchedBlockNumber = lastSearchedBlock!!))
+        }
       }
     }
   }

--- a/jvm-libs/linea/clients/eth-logs-searcher/src/test/kotlin/linea/ethapi/EthLogsFilterPollerTest.kt
+++ b/jvm-libs/linea/clients/eth-logs-searcher/src/test/kotlin/linea/ethapi/EthLogsFilterPollerTest.kt
@@ -491,6 +491,62 @@ class EthLogsFilterPollerTest {
     }
   }
 
+  @Test
+  fun `should transition to CaughtUp after searching up to chain head even when chain keeps advancing`() {
+    // This test verifies the fix for the bug where the poller never reached CaughtUp
+    // on fast chains. With toBlock=LATEST and blocks produced faster than the polling
+    // interval, the old code required fromBlock > LATEST (which never happened).
+    // The fix transitions to CaughtUp after a search that covers the full resolved range.
+
+    val log1 = templateLog.copy(blockNumber = 10UL, logIndex = 0UL)
+    fakeEthApiClient.setLogs(listOf(log1))
+    fakeEthApiClient.setLatestBlockTag(30UL)
+
+    val stateTransitions = CopyOnWriteArrayList<Pair<EthLogsFilterState, EthLogsFilterState>>()
+    val consumedLogs = CopyOnWriteArrayList<EthLog>()
+    poller = createPoller(
+      fromBlock = BlockParameter.BlockNumber(0UL),
+      toBlock = BlockParameter.Tag.LATEST,
+      pollingInterval = 50.milliseconds,
+      consumer = { log -> consumedLogs.add(log) },
+    )
+    poller.setStateListener { oldState, newState ->
+      stateTransitions.add(oldState to newState)
+    }
+
+    poller.start().get()
+
+    // After searching 0..30 (the full range up to resolved LATEST), should reach CaughtUp
+    awaitUntilAsserted {
+      assertThat(consumedLogs).containsExactly(log1)
+      assertThat(stateTransitions).anyMatch { (_, newState) ->
+        newState is EthLogsFilterState.CaughtUp && newState.lastSearchedBlockNumber == 30UL
+      }
+    }
+
+    // Simulate a continuously advancing chain: LATEST moves forward and new logs appear
+    val log2 = templateLog.copy(blockNumber = 40UL, logIndex = 0UL)
+    fakeEthApiClient.addLogs(setOf(log2))
+    fakeEthApiClient.setLatestBlockTag(50UL)
+
+    // Should search the new range (31..50) and reach CaughtUp(50) again
+    awaitUntilAsserted {
+      assertThat(consumedLogs).containsExactly(log1, log2)
+      assertThat(stateTransitions).anyMatch { (_, newState) ->
+        newState is EthLogsFilterState.CaughtUp && newState.lastSearchedBlockNumber == 50UL
+      }
+    }
+
+    // Advance chain again with no new logs — should still reach CaughtUp at new head
+    fakeEthApiClient.setLatestBlockTag(80UL)
+
+    awaitUntilAsserted {
+      assertThat(stateTransitions).anyMatch { (_, newState) ->
+        newState is EthLogsFilterState.CaughtUp && newState.lastSearchedBlockNumber == 80UL
+      }
+    }
+  }
+
   private fun createPoller(
     fromBlock: BlockParameter,
     toBlock: BlockParameter,


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core polling state-transition behavior for `toBlock` tags (notably `LATEST`), which can affect coordination/monitoring semantics on live chains. Covered by a new regression test, but mistakes could cause incorrect caught-up signaling or missed wakeups.
> 
> **Overview**
> Ensures the polling-based logs subscription transitions to `EthLogsFilterState.CaughtUp` once a poll iteration has searched through the full resolved `from..to` range, even when `toBlock=LATEST` and the chain head advances before the next tick.
> 
> Adds a regression test that simulates a continuously advancing `LATEST` head (with and without new logs) to verify the poller reaches `CaughtUp` at each new head and continues searching new ranges correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff38ba9c97b63b2ffb5de42ce9cc2b47d194252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->