### PR TITLE
Prover/fix sha2

### DIFF
--- a/prover/.gitignore
+++ b/prover/.gitignore
@@ -1,2 +1,6 @@
 .claude/
 *.log
+*.json
+*.jsonl
+*.success
+*.gz

--- a/prover/Makefile
+++ b/prover/Makefile
@@ -61,7 +61,7 @@ zkevm/arithmetization/zkevm.bin: go-corset extract-constraints-git-archive
 ## Generate the setup (shared across all environments; layer2 config differentiate environments)
 ##
 setup: bin/prover
-	bin/prover setup --config ./config/config-mainnet-limitless.toml --assets-dir ./prover-assets
+	bin/prover setup --config ./config/config-mainnet-limitless.toml --circuits "execution-limitless" --assets-dir ./prover-assets
 
 ##
 ## Copy the prover assets to the S3 bucket (zkuat)

--- a/prover/config/config-mainnet-limitless.toml
+++ b/prover/config/config-mainnet-limitless.toml
@@ -1,5 +1,5 @@
 environment = "mainnet"
-version = "6.2.1"                            # TODO @gbotrel hunt all version definitions.
+version = "7.0.7"                            # TODO @gbotrel hunt all version definitions.
 assets_dir = "./prover-assets"
 log_level = 4                                  # TODO @gbotrel will be refactored with new logger.
 
@@ -9,7 +9,7 @@ spot_instance_reclaim_time_seconds = 120
 termination_grace_period_seconds = 1800
 
 [execution]
-prover_mode = "full"
+prover_mode = "partial"
 conflated_traces_dir = "./"
 requests_root_dir = "./"
 limitless_with_debug = true
@@ -50,10 +50,10 @@ l2_msg_merkle_depth = 5
 l2_msg_max_nb_merkle = 200
 
 [layer2]
-chain_id = 59144
+chain_id = 59141
 base_fee = 7
-coin_base = "0x8F81e2E3F8b46467523463835F965fFE476E1c9E"
-message_service_contract = "0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec"
+coin_base = "0xA27342f1b74c0cfB2cda74bac1628d0C1A9752f2"
+message_service_contract = "0x971e727e956690b9957be6d51Ec16E73AcAC83A7"
 
 [traces_limits]
 modules = [

--- a/prover/config/config-sepolia-limitless.toml
+++ b/prover/config/config-sepolia-limitless.toml
@@ -1,5 +1,5 @@
 environment = "sepolia"
-version = "6.2.1"                            # TODO @gbotrel hunt all version definitions.
+version = "7.0.7"                            # TODO @gbotrel hunt all version definitions.
 assets_dir = "./prover-assets"
 log_level = 4                                  # TODO @gbotrel will be refactored with new logger.
 
@@ -7,6 +7,15 @@ log_level = 4                                  # TODO @gbotrel will be refactore
 retry_delays = [0, 1]
 
 [execution]
+prover_mode = "limitless"
+conflated_traces_dir = "/home/ubuntu/test_sepolia/traces/conflated"
+requests_root_dir = "/home/ubuntu/test_sepolia/prover-execution"
+limitless_with_debug = false
+ignore_compatibility_check = false
+keep_traces_until_block = 9999999999
+serialization = false
+
+[blob_decompression]
 prover_mode = "full"
 conflated_traces_dir = "./"
 requests_root_dir = "./"

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -351,20 +351,30 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 	)
 
 	// As per the padding technique we use, the HashHi and HashLo should not
-	// be zero when isActive.
+	// be zero when isActive. We check that neither the upper 128-bit half nor
+	// the lower 128-bit half is entirely zero by taking the product of the
+	// per-limb IsZero results for each half.
 	var ctxHash [numLimbsPerState]wizard.ProverAction
 
-	sumHash := sym.NewConstant(0)
 	for i := range numLimbsPerState {
 		res.HashIsZero[i], ctxHash[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
-		sumHash = sym.Add(sumHash, res.HashIsZero[i])
 	}
 
 	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
 
+	prodIsZeroHi := sym.NewConstant(1)
+	for i := range numLimbsPerState / 2 {
+		prodIsZeroHi = sym.Mul(prodIsZeroHi, res.HashIsZero[i])
+	}
+
+	prodIsZeroLo := sym.NewConstant(1)
+	for i := numLimbsPerState / 2; i < numLimbsPerState; i++ {
+		prodIsZeroLo = sym.Mul(prodIsZeroLo, res.HashIsZero[i])
+	}
+
 	comp.InsertGlobal(0,
 		ifaces.QueryIDf("%v_HASH_CANT_BE_BOTH_ZERO", inp.Name),
-		sym.Mul(res.IsActive, sumHash),
+		sym.Mul(res.IsActive, sym.Add(prodIsZeroHi, prodIsZeroLo)),
 	)
 
 	return res


### PR DESCRIPTION
This PR implements 

fix(prover): use product instead of sum in SHA2 hash-zero constraint


**Root cause:** In sha2_block.go:353-370, the SHA2_OVER_BLOCK_HASH_CANT_BE_BOTH_ZERO constraint was using a sum of all 16 per-limb IsZero results:

This requires every 16-bit limb to be non-zero. A valid SHA256 hash can legitimately have a zero 16-bit word (probability ~1/65536 per limb), which is exactly what happened in your conflation — the last limb (IS_ZERO_92917) was 1 (= zero limb).

**Fix: Replaced the sum with a product per 128-bit half:**

```
prodIsZeroHi = IsZero(Hash[0]) * ... * IsZero(Hash[7]) — equals 1 only if the entire upper 128 bits are zero
prodIsZeroLo = IsZero(Hash[8]) * ... * IsZero(Hash[15]) — equals 1 only if the entire lower 128 bits are zero
```

**Constraint:** IsActive * (prodIsZeroHi + prodIsZeroLo) = 0 — neither half can be entirely zero
This correctly enforces the intended security property (neither HashHi nor HashLo can be all-zero) while allowing individual 16-bit limbs to be zero.


### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it modifies multiple GitHub Actions workflows (build/publish gating, coverage uploads, CodeQL scheduling/config) and changes default blob-compressor versioning plus removes large verifier contracts, which could affect CI behavior and downstream contract builds.
> 
> **Overview**
> Adds early-fail validation for empty Docker `image_tag`/`COMMIT_TAG` and gates several workflows (`main.yml`, `all-tools.yml`) to avoid building/publishing with invalid tags.
> 
> Expands Codecov support: TS and tracer coverage is now uploaded directly when `CODECOV_TOKEN` is present, and external-fork PR coverage upload (`codecov-external-pr.yml`) now downloads and reports multiple new TS artifacts/flags (Postman, SDK, native-yield, lido), with corresponding `codecov.yml` flag definitions.
> 
> Updates CodeQL to support manual/scheduled runs, bumps the CodeQL action version, and adds a shared `codeql-config.yml` to ignore build outputs; also tweaks build tooling (JaCoCo applies to `acceptanceTests`, pins BouncyCastle in `buildSrc`, updates state-recovery test to use `BlobCompressorFactory`/V2, and switches sequencer tests/default CLI timestamps to `BlobCompressorVersion.V3`).
> 
> Adjusts contracts tooling by removing the `forge-std` git submodule in favor of a `package.json` dependency/remapping, refactors the contracts Makefile include path handling, and deletes two generated `PlonkVerifier*Full.sol` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb98041595d26b8cf55ed4733365cebad3f2d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->