### PR TITLE
fix(coordinator) - contract client getFinalizedStateData for V8 witho…

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitor.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/finalization/FinalizationMonitor.kt
@@ -7,7 +7,7 @@ interface FinalizationMonitor {
   data class FinalizationUpdate(
     val blockNumber: ULong,
     val blockHash: Bytes32,
-    val forcedTransactionNumber: ULong? = null, // null means ftx number is not available as contract is still before V8
+    val forcedTransactionNumber: ULong,
   )
 
   fun getLastFinalizationUpdate(): FinalizationUpdate

--- a/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandler.kt
+++ b/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandler.kt
@@ -47,8 +47,12 @@ class RecordsCleanupFinalizationHandler(
     )
     val aggregationsCleanup = aggregationsRepository
       .deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive = update.blockNumber.toLong() - 1L)
-    val ftxRecordsCleanup = update.forcedTransactionNumber?.let { forcedTransactionsDao.deleteFtxUpToInclusive(it) }
-      ?: SafeFuture.completedFuture(Unit)
+    val ftxRecordsCleanup =
+      if (update.forcedTransactionNumber > 0UL) {
+        forcedTransactionsDao.deleteFtxUpToInclusive(update.forcedTransactionNumber)
+      } else {
+        SafeFuture.completedFuture(Unit)
+      }
 
     return SafeFuture.allOf(batchesCleanup, blobsCleanup, aggregationsCleanup, ftxRecordsCleanup)
   }

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/FinalizedStateDataProvider.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/FinalizedStateDataProvider.kt
@@ -6,7 +6,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 interface FinalizedStateDataProvider {
   data class FinalizedStateData(
     val blockNumber: ULong,
-    val forcedTransactionNumber: ULong?,
+    val forcedTransactionNumber: ULong,
   )
 
   fun getFinalizedStateData(blockParameter: BlockParameter): SafeFuture<FinalizedStateData>

--- a/jvm-libs/linea/clients/interfaces/src/testFixtures/kotlin/linea/contract/l1/FakeFinalizedStateDataProvider.kt
+++ b/jvm-libs/linea/clients/interfaces/src/testFixtures/kotlin/linea/contract/l1/FakeFinalizedStateDataProvider.kt
@@ -21,7 +21,7 @@ class FakeFinalizedStateDataProvider(
     return SafeFuture.completedFuture(
       FinalizedStateDataProvider.FinalizedStateData(
         blockNumber = blockNumber,
-        forcedTransactionNumber = null,
+        forcedTransactionNumber = 0UL,
       ),
     )
   }

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -185,33 +185,38 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
     blockParameter: BlockParameter,
   ): SafeFuture<FinalizedStateDataProvider.FinalizedStateData> {
     return getVersion()
-      .thenCompose { version ->
+      .thenCombine(
+        finalizedL2BlockNumber(blockParameter),
+      ) { version, finalizedBlockNumber -> version to finalizedBlockNumber }
+      .thenCompose { (version, finalizedBlockNumber) ->
         when (version) {
           LineaRollupContractVersion.V6,
           LineaRollupContractVersion.V7,
-          -> finalizedL2BlockNumber(blockParameter)
-            .thenApply { blockNumber ->
+          ->
+            SafeFuture.completedFuture(
               FinalizedStateDataProvider.FinalizedStateData(
-                blockNumber = blockNumber,
-                forcedTransactionNumber = null,
-              )
-            }
-          LineaRollupContractVersion.V8,
-          -> getLatestFinalizedState(blockParameter)
-            .thenApply { finalizedState ->
-              FinalizedStateDataProvider.FinalizedStateData(
-                blockNumber = finalizedState.blockNumber,
-                forcedTransactionNumber = finalizedState.forcedTransactionNumber,
-              )
-            }
+                blockNumber = finalizedBlockNumber,
+                forcedTransactionNumber = 0UL, // ftx is not available in V6 and V7 contract, return the initial value
+              ),
+            )
+
+          LineaRollupContractVersion.V8 ->
+            findFinalizedStateEvent(blockParameter, finalizedBlockNumber)
+              .thenApply { finalizedState ->
+                val forcedTransactionNumber = finalizedState?.forcedTransactionNumber ?: 0UL
+                FinalizedStateDataProvider.FinalizedStateData(
+                  blockNumber = finalizedBlockNumber,
+                  forcedTransactionNumber = forcedTransactionNumber,
+                )
+              }
         }
       }
   }
 
-  private fun getFinalizedStateEvent(
+  private fun findFinalizedStateEvent(
     upToBlock: BlockParameter,
     finalisedBlockNumber: ULong,
-  ): SafeFuture<FinalizedStateUpdatedEvent> {
+  ): SafeFuture<FinalizedStateUpdatedEvent?> {
     return ethLogsClient.getLogs(
       fromBlock = BlockParameter.Tag.EARLIEST,
       toBlock = upToBlock,
@@ -223,11 +228,21 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
     ).thenApply { logs ->
       // only one log expected because we use indexed finalized block number
       logs.firstOrNull()
-        ?.let(FinalizedStateUpdatedEvent::fromEthLog)?.event
+        ?.let(FinalizedStateUpdatedEvent::fromEthLog)
+        ?.event
+    }
+  }
+
+  private fun getFinalizedStateEvent(
+    upToBlock: BlockParameter,
+    finalisedBlockNumber: ULong,
+  ): SafeFuture<FinalizedStateUpdatedEvent> {
+    return findFinalizedStateEvent(upToBlock = upToBlock, finalisedBlockNumber = finalisedBlockNumber)
+      .thenApply { event ->
         // it means contract was just upgraded but no event published yet,
         // we cannot deterministically get the finalized fields
         // throw unsupported operation exception to let caller decide what to do, either retry later or fail
-        ?: throw UnsupportedOperationException("event FinalizedStateUpdated not found on L1")
-    }
+        event ?: throw UnsupportedOperationException("event FinalizedStateUpdated not found on L1")
+      }
   }
 }


### PR DESCRIPTION
…ut finalization

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking API change by making `forcedTransactionNumber` non-null and changes V8 finalization data retrieval behavior, which can affect downstream cleanup and finalization-dependent logic. Risk is moderate because the new `0UL` sentinel must be handled consistently across callers.
> 
> **Overview**
> Standardizes `forcedTransactionNumber` as a non-null `ULong` across finalization-related APIs (`FinalizationMonitor.FinalizationUpdate` and `FinalizedStateDataProvider.FinalizedStateData`), using `0UL` as the *"not available"* sentinel.
> 
> Updates finalization-driven cleanup to delete forced-transaction records only when the provided number is > `0UL`.
> 
> Fixes `Web3JLineaRollupSmartContractClientReadOnly.getFinalizedStateData` for V8 upgrades without a published `FinalizedStateUpdated` event by fetching the finalized L2 block number independently and returning `forcedTransactionNumber=0UL` when the event is missing, while keeping the throwing behavior for `getLatestFinalizedState` via a new nullable `findFinalizedStateEvent` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea0d1a3d8e98b6381318657b57c1c4ca405b431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->