### PR TITLE
fix(coordinator) - message anchoring app hardcoded L1HighestBlockTag …

### DIFF
--- a/coordinator/ethereum/message-anchoring/src/main/kotlin/linea/anchoring/clients/L1MessageSentEventsFetcher.kt
+++ b/coordinator/ethereum/message-anchoring/src/main/kotlin/linea/anchoring/clients/L1MessageSentEventsFetcher.kt
@@ -90,7 +90,7 @@ internal class L1MessageSentEventsFetcher(
   ): SafeFuture<EthLogEvent<L1RollingHashUpdatedEvent>?> {
     return l1EventsSearcher.getLogs(
       fromBlock = fromBlock.toBlockParameter(),
-      toBlock = BlockParameter.Tag.FINALIZED,
+      toBlock = l1HighestBlock,
       address = l1SmartContractAddress,
       topics = listOf(
         L1RollingHashUpdatedEvent.topic,

--- a/coordinator/ethereum/message-anchoring/src/test/kotlin/linea/anchoring/MessageAnchoringAppTest.kt
+++ b/coordinator/ethereum/message-anchoring/src/test/kotlin/linea/anchoring/MessageAnchoringAppTest.kt
@@ -63,6 +63,7 @@ class MessageAnchoringAppTest {
     l1SuccessBackoffDelay: Duration = 1.milliseconds,
     messageQueueCapacity: UInt = 100u,
     maxMessagesToAnchorPerL2Transaction: UInt = 10u,
+    l1HighestBlockTag: BlockParameter = BlockParameter.Tag.FINALIZED,
   ): MessageAnchoringApp {
     return MessageAnchoringApp(
       vertx = vertx,
@@ -70,7 +71,7 @@ class MessageAnchoringAppTest {
         l1PollingInterval = l1PollingInterval,
         l1SuccessBackoffDelay = l1SuccessBackoffDelay,
         l1ContractAddress = L1_CONTRACT_ADDRESS,
-        l1HighestBlockTag = BlockParameter.Tag.FINALIZED,
+        l1HighestBlockTag = l1HighestBlockTag,
         l2HighestBlockTag = BlockParameter.Tag.LATEST,
         anchoringTickInterval = anchoringTickInterval,
         l1RequestRetryConfig = RetryConfig.noRetries,
@@ -273,6 +274,41 @@ class MessageAnchoringAppTest {
 
     assertThat(l2MessageService.getAnchoredMessageHashes())
       .isEqualTo(ethLogs.map { it.messageSent.event.messageHash })
+
+    anchoringApp.stop().get()
+  }
+
+  @Test
+  fun `should anchor messages when l1HighestBlockTag is LATEST and events are beyond FINALIZED`() {
+    // Regression test: L1MessageSentEventsFetcher.findL1RollingHashUpdatedEvent had a hardcoded
+    // BlockParameter.Tag.FINALIZED instead of using the configurable l1HighestBlock.
+    // When l1HighestBlockTag=LATEST and events exist beyond the FINALIZED block, the hardcoded
+    // FINALIZED would cause the RollingHashUpdated lookup to miss them.
+    val ethLogs = createL1MessageSentV1Logs(
+      l1BlocksWithMessages = listOf(100UL, 200UL, 300UL),
+      numberOfMessagesPerBlock = 1,
+    )
+    addLogsToFakeEthClient(ethLogs)
+    val anchoringApp = createApp(
+      l1HighestBlockTag = BlockParameter.Tag.LATEST,
+      l1EventSearchBlockChunk = 100u,
+      anchoringTickInterval = 50.milliseconds,
+    )
+    anchoringApp.start().get()
+    // FINALIZED is set below the event blocks so that with the bug (hardcoded FINALIZED in
+    // findL1RollingHashUpdatedEvent) the lookup would not find any RollingHashUpdated events.
+    // LATEST is set above all events so the correctly-configured fetcher finds them.
+    l1Client.setLatestBlockTag(ethLogs.last().messageSent.log.blockNumber + 10UL)
+    l1Client.setFinalizedBlockTag(50UL)
+
+    await()
+      .atMost(5.seconds.toJavaDuration())
+      .untilAsserted {
+        assertThat(l2MessageService.getLastAnchoredL1MessageNumber(block = BlockParameter.Tag.LATEST).get())
+          .isEqualTo(ethLogs.last().l1RollingHashUpdated.event.messageNumber)
+        assertThat(l2MessageService.getLastAnchoredRollingHash())
+          .isEqualTo(ethLogs.last().l1RollingHashUpdated.event.rollingHash)
+      }
 
     anchoringApp.stop().get()
   }


### PR DESCRIPTION
…to FINALIZED

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the L1 event search upper bound used for anchoring, which can alter which messages get anchored when switching between `FINALIZED` and `LATEST`. Risk is moderate because it impacts core message-anchoring behavior, but the change is small and covered by a new regression test.
> 
> **Overview**
> Fixes a bug where the RollingHashUpdated lookup in `L1MessageSentEventsFetcher` ignored the configured `l1HighestBlock` and always queried up to `FINALIZED`, causing missed events when `l1HighestBlockTag` is set to `LATEST`.
> 
> Updates tests to allow configuring `l1HighestBlockTag` in `MessageAnchoringAppTest.createApp` and adds a regression test that anchors messages whose events exist beyond the `FINALIZED` block when `LATEST` is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cade2ce7fb363c39f96e99d9100634a1aa6443b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->