### PR TITLE
fix(e2e) - linea_getProof flackiness

### DIFF
--- a/e2e/src/shomei-get-proof.spec.ts
+++ b/e2e/src/shomei-get-proof.spec.ts
@@ -23,7 +23,7 @@ describe("Shomei Linea get proof test suite", () => {
       let targetL2BlockNumber = await awaitUntil(
         async () => {
           try {
-            return await lineaRollupV6.read.currentL2BlockNumber({ blockTag: "finalized" });
+            return await lineaRollupV6.read.currentL2BlockNumber({ blockTag: "latest" });
           } catch (err) {
             if (err instanceof ContractFunctionExecutionError) {
               if (err.shortMessage.includes(`returned no data ("0x")`)) {
@@ -61,7 +61,7 @@ describe("Shomei Linea get proof test suite", () => {
           }
           if (!getProofResponse) {
             const latestFinalizedL2BlockNumber = await lineaRollupV6.read.currentL2BlockNumber({
-              blockTag: "finalized",
+              blockTag: "latest",
             });
             if (!finalizedL2BlockNumbers.includes(latestFinalizedL2BlockNumber)) {
               finalizedL2BlockNumbers.push(latestFinalizedL2BlockNumber);


### PR DESCRIPTION
…to FINALIZED

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts an E2E test’s `blockTag` from `finalized` to `latest`, affecting test stability/behavior but not production logic.
> 
> **Overview**
> The Shomei `linea_getProof` E2E test now reads `currentL2BlockNumber` from the L1 rollup contract using `blockTag: "latest"` (instead of `"finalized"`) both when initially selecting a target block and when polling for additional candidate blocks.
> 
> This shifts proof retrieval/verification to follow the most recent reported L2 block number, which may change test timing and expectations around finality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2373c0ecd4b1f7ec1a9846578ecb5f50d116a6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->