### PR TITLE
chore(e2e) - update coordinator image tag and rename to LINEA_COORDIN…

### DIFF
--- a/coordinator/AGENTS.md
+++ b/coordinator/AGENTS.md
@@ -22,7 +22,7 @@ docker buildx build --file coordinator/Dockerfile \
   --tag consensys/linea-coordinator:local .
 
 # Run as part of full stack
-make start-env-with-tracing-v2 COORDINATOR_TAG=local
+make start-env-with-tracing-v2 LINEA_COORDINATOR_TAG=local
 ```
 
 ### Test

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -307,7 +307,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${COORDINATOR_TAG:-0fa30b6}
+    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-7c850f2}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:

--- a/docs/local-development-guide.md
+++ b/docs/local-development-guide.md
@@ -68,7 +68,7 @@ The recommended way to run the coordinator is as part of the complete Linea stac
 
 ```bash
 # Start the entire stack with tracing v2 using your local coordinator image
-COORDINATOR_TAG=local make start-env-with-tracing-v2
+LINEA_COORDINATOR_TAG=local make start-env-with-tracing-v2
 ```
 
 This command:

--- a/docs/tech/components/coordinator.md
+++ b/docs/tech/components/coordinator.md
@@ -285,7 +285,7 @@ docker buildx build \
 
 ```bash
 # With full stack
-COORDINATOR_TAG=local make start-env-with-tracing-v2
+LINEA_COORDINATOR_TAG=local make start-env-with-tracing-v2
 
 # Standalone (requires dependencies)
 java -jar coordinator/app/build/libs/coordinator.jar \

--- a/docs/tech/development/README.md
+++ b/docs/tech/development/README.md
@@ -202,7 +202,7 @@ docker buildx build \
   --tag consensys/linea-coordinator:local .
 
 # Use local image
-COORDINATOR_TAG=local make start-env-with-tracing-v2
+LINEA_COORDINATOR_TAG=local make start-env-with-tracing-v2
 ```
 
 ### Pulling Pre-built Images
@@ -303,7 +303,7 @@ Key environment variables for stack customization:
 # Container image versions
 export BESU_PACKAGE_TAG=latest
 export MARU_TAG=latest
-export COORDINATOR_TAG=latest
+export LINEA_COORDINATOR_TAG=latest
 export PROVER_TAG=latest
 export POSTMAN_TAG=latest
 


### PR DESCRIPTION
…ATOR_TAG

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/compose wiring change; main risk is breaking local scripts or CI that still set `COORDINATOR_TAG` instead of `LINEA_COORDINATOR_TAG`.
> 
> **Overview**
> Updates local stack configuration to use `LINEA_COORDINATOR_TAG` (instead of `COORDINATOR_TAG`) when selecting the coordinator Docker image.
> 
> Bumps the compose default coordinator image tag and aligns developer docs (`AGENTS.md`, local dev guide, and tech docs) to the new environment variable name/usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646bc2c04bbda7cd958a4ed8f4294ec0c9bb054b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->