### PR TITLE
[Coordinator] Conflation backtesting creates aggregation proof requests

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -6,6 +6,7 @@ import io.vertx.core.Vertx
 import linea.LongRunningService
 import linea.blob.BlobCompressorFactory
 import linea.blob.BlobCompressorVersion
+import linea.contract.l2.Web3JL2MessageServiceSmartContractClient
 import linea.coordinator.config.toJsonRpcRetry
 import linea.coordinator.config.v2.CoordinatorConfig
 import linea.coordinator.config.v2.TracesConfig.ClientApiConfig
@@ -14,18 +15,25 @@ import linea.domain.BlockParameter
 import linea.encoding.BlockRLPEncoder
 import linea.ethapi.EthApiClient
 import linea.kotlin.decodeHex
+import linea.persistence.ftx.DisabledForcedTransactionsDao
+import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper
 import net.consensys.zkevm.coordinator.app.conflation.TracesClientFactory
 import net.consensys.zkevm.coordinator.blockcreation.BlockCreationMonitor
+import net.consensys.zkevm.coordinator.blockcreation.FixedLaggingHeadSafeBlockProvider
 import net.consensys.zkevm.coordinator.blockcreation.LastProvenBlockNumberProviderSync
 import net.consensys.zkevm.coordinator.clients.ExecutionProverClientV2
 import net.consensys.zkevm.coordinator.clients.prover.ProverClientFactory
 import net.consensys.zkevm.coordinator.clients.prover.ProverConfig
-import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.domain.Aggregation
 import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
+import net.consensys.zkevm.ethereum.coordination.aggregation.AggregationL2StateProviderImpl
+import net.consensys.zkevm.ethereum.coordination.aggregation.AggregationTriggerCalculatorByTargetBlockNumbers
+import net.consensys.zkevm.ethereum.coordination.aggregation.InvalidityProofProviderImpl
+import net.consensys.zkevm.ethereum.coordination.aggregation.ProofAggregationCoordinatorService
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobShnarfMetaData
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
@@ -82,16 +90,16 @@ class ConflationBacktestingApp(
   fun isConflationBacktestingComplete(): Boolean = conflationBacktestingComplete.load()
 
   fun onConflationProgress(
-    proofIndex: CompressionProofIndex,
+    blockNumber: ULong,
   ): SafeFuture<*> {
-    return if (proofIndex.endBlockNumber == conflationBacktestingAppConfig.endBlockNumber) {
+    return if (blockNumber == conflationBacktestingAppConfig.endBlockNumber) {
       conflationBacktestingComplete.store(true)
       log.info("Conflation backtesting complete")
       this.stop()
     } else {
       log.info(
         "Conflation backtesting progress: processed till blockNumber={}, targetEndBlock={}",
-        proofIndex.endBlockNumber,
+        blockNumber,
         conflationBacktestingAppConfig.endBlockNumber,
       )
       SafeFuture.completedFuture(Unit)
@@ -266,6 +274,10 @@ class ConflationBacktestingApp(
     )
   }
 
+  // In-memory blob store: captures per-batch execution proof boundaries at blob-creation
+  // time and promotes blobs to proven once the compression proof request is submitted.
+  private val inMemoryProvenBlobsTracker = InMemoryConsecutiveProvenBlobsProvider()
+
   private val blobCompressionProofCoordinator = run {
     val parentBlobDataProvider = object : ParentBlobDataProvider {
       override fun getParentBlobShnarfMetaData(
@@ -303,8 +315,14 @@ class ConflationBacktestingApp(
       blobCompressionProofHandler = {
         SafeFuture.completedFuture(Unit)
       },
-      blobCompressionProofRequestHandler = { proofIndex, _ ->
-        onConflationProgress(proofIndex)
+      blobCompressionProofRequestHandler = { proofIndex, blobRecord ->
+        log.info(
+          "Backtesting compression proof request produced: blob={}",
+          blobRecord.intervalString(),
+        )
+
+        inMemoryProvenBlobsTracker.acceptProvenBlobRecord(proofIndex, blobRecord)
+        SafeFuture.completedFuture(Unit)
       },
       log = log,
       metricsFacade = metricsFacade,
@@ -314,8 +332,65 @@ class ConflationBacktestingApp(
 
   init {
     conflationService.onConflatedBatch(proofGeneratingConflationHandlerImpl)
-    conflationCalculator.onBlobCreation(blobCompressionProofCoordinator::handleBlob)
+    conflationCalculator.onBlobCreation { blob ->
+      inMemoryProvenBlobsTracker.captureBlobExecutionProofs(blob)
+      blobCompressionProofCoordinator.handleBlob(blob)
+    }
   }
+
+  private val l2MessageService = Web3JL2MessageServiceSmartContractClient.createReadOnly(
+    web3jClient = createWeb3jHttpClient(
+      rpcUrl = backtestingCoordinatorConfig.conflation.l2Endpoint.toString(),
+      log = log,
+    ),
+    ethApiClient = l2EthClient,
+    contractAddress = backtestingCoordinatorConfig.protocol.l2.contractAddress,
+    smartContractErrors = backtestingCoordinatorConfig.smartContractErrors,
+    smartContractDeploymentBlockNumber = backtestingCoordinatorConfig.protocol.l2.contractDeploymentBlockNumber
+      ?.getNumber(),
+  )
+
+  private val proofAggregationCoordinatorService: LongRunningService = ProofAggregationCoordinatorService.create(
+    vertx = vertx,
+    aggregationCoordinatorPollingInterval =
+    backtestingCoordinatorConfig.conflation.proofAggregation.coordinatorPollingInterval,
+    deadlineCheckInterval = backtestingCoordinatorConfig.conflation.proofAggregation.deadlineCheckInterval,
+    aggregationDeadline = backtestingCoordinatorConfig.conflation.proofAggregation.deadline,
+    latestBlockProvider = FixedLaggingHeadSafeBlockProvider(
+      ethApiBlockClient = l2EthClient,
+      blocksToFinalization = 0UL,
+    ),
+    maxProofsPerAggregation = backtestingCoordinatorConfig.conflation.proofAggregation.proofsLimit,
+    maxBlobsPerAggregation = backtestingCoordinatorConfig.conflation.proofAggregation.blobsLimit,
+    startBlockNumberInclusive = conflationBacktestingAppConfig.startBlockNumber,
+    aggregationProofHandler = { aggregation: Aggregation ->
+      SafeFuture.completedFuture(Unit)
+    },
+    aggregationProofRequestHandler = { proofIndex, unProvenAggregation ->
+      log.info(
+        "Backtesting aggregation proof request produced: aggregation={}",
+        unProvenAggregation.intervalString(),
+      )
+      onConflationProgress(proofIndex.endBlockNumber)
+    },
+    invalidityProofProvider = InvalidityProofProviderImpl(DisabledForcedTransactionsDao()),
+    aggregationL2StateProvider = AggregationL2StateProviderImpl(
+      ethApiClient = l2EthClient,
+      messageService = l2MessageService,
+      forcedTransactionsDao = DisabledForcedTransactionsDao(),
+    ),
+    consecutiveProvenBlobsProvider = inMemoryProvenBlobsTracker,
+    proofAggregationClient = proverClientFactory.proofAggregationProverClient(),
+    noL2ActivityTimeout = backtestingCoordinatorConfig.conflation.conflationDeadlineLastBlockConfirmationDelay,
+    waitForNoL2ActivityToTriggerAggregation =
+    backtestingCoordinatorConfig.conflation.proofAggregation.waitForNoL2ActivityToTriggerAggregation,
+    targetEndBlockNumbers = dynamicTargetEndBlockNumberSet,
+    metricsFacade = metricsFacade,
+    aggregationSizeMultipleOf = backtestingCoordinatorConfig.conflation.proofAggregation.aggregationSizeMultipleOf,
+    hardForkTimestamps = backtestingCoordinatorConfig.conflation.proofAggregation.timestampBasedHardForks,
+    initialTimestamp = lastProcessedTimestamp,
+    forcedTransactionTriggerAggCalculator = AggregationTriggerCalculatorByTargetBlockNumbers(emptySet()),
+  )
 
   private val blockToBatchSubmissionCoordinator = BlockToBatchSubmissionCoordinator(
     conflationService = conflationService,
@@ -350,6 +425,7 @@ class ConflationBacktestingApp(
   override fun start(): SafeFuture<Unit> {
     return proofGeneratingConflationHandlerImpl.start()
       .thenCompose { blobCompressionProofCoordinator.start() }
+      .thenCompose { proofAggregationCoordinatorService.start() }
       .thenCompose { blockCreationMonitor.start() }
       .thenPeek {
         log.info("Conflation backtesting started successfully")
@@ -360,6 +436,7 @@ class ConflationBacktestingApp(
     return SafeFuture.allOf(
       proofGeneratingConflationHandlerImpl.stop(),
       blobCompressionProofCoordinator.stop(),
+      SafeFuture.of(proofAggregationCoordinatorService.stop()),
       blockCreationMonitor.stop(),
     ).thenApply {
       try {

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProvider.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProvider.kt
@@ -1,0 +1,87 @@
+package net.consensys.zkevm.coordinator.app.conflationbacktesting
+
+import linea.domain.BlockIntervals
+import net.consensys.zkevm.domain.BlobAndBatchCounters
+import net.consensys.zkevm.domain.BlobCounters
+import net.consensys.zkevm.domain.BlobRecord
+import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.ethereum.coordination.aggregation.ConsecutiveProvenBlobsProvider
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListMap
+
+/**
+ * In-memory implementation of [ConsecutiveProvenBlobsProvider] for conflation backtesting.
+ *
+ * Correlates two events that happen in sequence:
+ *  1. [captureBlobExecutionProofs] — called at blob-creation time (before compression proof),
+ *     while the original Blob.conflations are still available. Stores per-batch block
+ *     boundaries keyed by blob block range.
+ *  2. [acceptProvenBlobRecord] — called when the compression proof request is submitted.
+ *     Looks up the stored execution proofs, builds [BlobAndBatchCounters], and marks the
+ *     blob as ready for aggregation.
+ *
+ * [findConsecutiveProvenBlobs] returns the longest consecutive run of proven blobs starting
+ * from the given fromBlockNumber, mirroring the behaviour of the Postgres-backed implementation.
+ */
+class InMemoryConsecutiveProvenBlobsProvider : ConsecutiveProvenBlobsProvider {
+
+  // Temporary store: "startBlock-endBlock" → per-batch execution proof block intervals.
+  // Populated by captureBlobExecutionProofs before the shnarf is known.
+  private val pendingExecutionProofs = ConcurrentHashMap<String, BlockIntervals>()
+
+  // Ordered by startBlockNumber so that consecutive-run scan is O(n).
+  private val provenBlobs = ConcurrentSkipListMap<ULong, BlobAndBatchCounters>()
+
+  /**
+   * Must be called at blob-creation time (i.e. inside the onBlobCreation callback) so that
+   * the per-batch conflation boundaries are captured before the blob is handed off to the
+   * compression prover.
+   */
+  fun captureBlobExecutionProofs(
+    blob: net.consensys.zkevm.domain.Blob,
+  ) {
+    val key = blobKey(blob.startBlockNumber, blob.endBlockNumber)
+    pendingExecutionProofs[key] = BlockIntervals(
+      startingBlockNumber = blob.conflations.first().startBlockNumber,
+      upperBoundaries = blob.conflations.map { it.endBlockNumber },
+    )
+  }
+
+  /**
+   * Called by BlobCompressionProofRequestHandler when the compression proof request has been
+   * submitted and the shnarf is known. Promotes the blob to the proven set.
+   */
+  fun acceptProvenBlobRecord(
+    proofIndex: CompressionProofIndex,
+    blobRecord: BlobRecord,
+  ) {
+    val key = blobKey(blobRecord.startBlockNumber, blobRecord.endBlockNumber)
+    val executionProofs = pendingExecutionProofs.remove(key) ?: return
+    provenBlobs[blobRecord.startBlockNumber] = BlobAndBatchCounters(
+      blobCounters = BlobCounters(
+        numberOfBatches = blobRecord.batchesCount,
+        startBlockNumber = blobRecord.startBlockNumber,
+        endBlockNumber = blobRecord.endBlockNumber,
+        startBlockTimestamp = blobRecord.startBlockTime,
+        endBlockTimestamp = blobRecord.endBlockTime,
+        expectedShnarf = proofIndex.hash,
+      ),
+      executionProofs = executionProofs,
+    )
+  }
+
+  override fun findConsecutiveProvenBlobs(fromBlockNumber: Long): SafeFuture<List<BlobAndBatchCounters>> {
+    val result = mutableListOf<BlobAndBatchCounters>()
+    var expectedNext = fromBlockNumber.toULong()
+    for ((startBlock, blobAndBatchCounters) in provenBlobs.tailMap(expectedNext)) {
+      if (startBlock != expectedNext) break
+      result.add(blobAndBatchCounters)
+      expectedNext = blobAndBatchCounters.blobCounters.endBlockNumber + 1uL
+    }
+    return SafeFuture.completedFuture(result)
+  }
+
+  private fun blobKey(startBlockNumber: ULong, endBlockNumber: ULong) =
+    "$startBlockNumber-$endBlockNumber"
+}

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProvider.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProvider.kt
@@ -1,6 +1,7 @@
 package net.consensys.zkevm.coordinator.app.conflationbacktesting
 
 import linea.domain.BlockIntervals
+import net.consensys.zkevm.domain.Blob
 import net.consensys.zkevm.domain.BlobAndBatchCounters
 import net.consensys.zkevm.domain.BlobCounters
 import net.consensys.zkevm.domain.BlobRecord
@@ -39,7 +40,7 @@ class InMemoryConsecutiveProvenBlobsProvider : ConsecutiveProvenBlobsProvider {
    * compression prover.
    */
   fun captureBlobExecutionProofs(
-    blob: net.consensys.zkevm.domain.Blob,
+    blob: Blob,
   ) {
     val key = blobKey(blob.startBlockNumber, blob.endBlockNumber)
     pendingExecutionProofs[key] = BlockIntervals(

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProviderTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProviderTest.kt
@@ -105,8 +105,8 @@ class InMemoryConsecutiveProvenBlobsProviderTest {
   @Test
   fun `findConsecutiveProvenBlobs returns longest consecutive chain from fromBlockNumber`() {
     val provider = InMemoryConsecutiveProvenBlobsProvider()
-    proveBlob(provider, 1uL, 2uL, 1u)
-    proveBlob(provider, 3uL, 4uL, 1u)
+    proveBlob(provider, start = 1uL, end = 2uL, batches = 1u)
+    proveBlob(provider, start = 3uL, end = 4uL, batches = 1u)
 
     assertThat(provider.findConsecutiveProvenBlobs(1L).get().map { it.blobCounters.startBlockNumber })
       .containsExactly(1uL, 3uL)
@@ -115,8 +115,8 @@ class InMemoryConsecutiveProvenBlobsProviderTest {
   @Test
   fun `findConsecutiveProvenBlobs stops at first gap in block ranges`() {
     val provider = InMemoryConsecutiveProvenBlobsProvider()
-    proveBlob(provider, 1uL, 2uL, 1u)
-    proveBlob(provider, 5uL, 6uL, 1u)
+    proveBlob(provider, start = 1uL, end = 2uL, batches = 1u)
+    proveBlob(provider, start = 5uL, end = 6uL, batches = 1u)
 
     assertThat(provider.findConsecutiveProvenBlobs(1L).get()).hasSize(1)
     assertThat(provider.findConsecutiveProvenBlobs(1L).get().single().blobCounters.endBlockNumber).isEqualTo(2uL)
@@ -125,8 +125,8 @@ class InMemoryConsecutiveProvenBlobsProviderTest {
   @Test
   fun `findConsecutiveProvenBlobs can start mid chain`() {
     val provider = InMemoryConsecutiveProvenBlobsProvider()
-    proveBlob(provider, 1uL, 2uL, 1u)
-    proveBlob(provider, 3uL, 4uL, 1u)
+    proveBlob(provider, start = 1uL, end = 2uL, batches = 1u)
+    proveBlob(provider, start = 3uL, end = 4uL, batches = 1u)
 
     assertThat(provider.findConsecutiveProvenBlobs(3L).get().map { it.blobCounters.startBlockNumber })
       .containsExactly(3uL)
@@ -135,7 +135,7 @@ class InMemoryConsecutiveProvenBlobsProviderTest {
   @Test
   fun `findConsecutiveProvenBlobs returns empty when fromBlockNumber is after all blobs`() {
     val provider = InMemoryConsecutiveProvenBlobsProvider()
-    proveBlob(provider, 1uL, 2uL, 1u)
+    proveBlob(provider, start = 1uL, end = 2uL, batches = 1u)
 
     assertThat(provider.findConsecutiveProvenBlobs(100L).get()).isEmpty()
   }

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProviderTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/InMemoryConsecutiveProvenBlobsProviderTest.kt
@@ -1,0 +1,193 @@
+package net.consensys.zkevm.coordinator.app.conflationbacktesting
+
+import linea.domain.BlockIntervals
+import net.consensys.linea.traces.TracesCountersV2
+import net.consensys.zkevm.domain.Blob
+import net.consensys.zkevm.domain.BlobRecord
+import net.consensys.zkevm.domain.CompressionProofIndex
+import net.consensys.zkevm.domain.ConflationCalculationResult
+import net.consensys.zkevm.domain.ConflationTrigger
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.time.Instant
+
+class InMemoryConsecutiveProvenBlobsProviderTest {
+
+  private val instant = Instant.DISTANT_PAST
+  private val traces = TracesCountersV2.EMPTY_TRACES_COUNT
+
+  @Test
+  fun `findConsecutiveProvenBlobs returns empty when nothing was accepted`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    assertThat(provider.findConsecutiveProvenBlobs(0L).get()).isEmpty()
+  }
+
+  @Test
+  fun `acceptProvenBlobRecord without prior capture does not register a proven blob`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    val record = blobRecord(start = 1uL, end = 2uL)
+    provider.acceptProvenBlobRecord(
+      CompressionProofIndex(
+        startBlockNumber = 1uL,
+        endBlockNumber = 2uL,
+        hash = Random.nextBytes(32),
+        startBlockTimestamp = Instant.fromEpochSeconds(1),
+      ),
+      record,
+    )
+    assertThat(provider.findConsecutiveProvenBlobs(1L).get()).isEmpty()
+  }
+
+  @Test
+  fun `capture without accept does not expose blobs in findConsecutiveProvenBlobs`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    provider.captureBlobExecutionProofs(singleConflationBlob(10uL, 20uL))
+    assertThat(provider.findConsecutiveProvenBlobs(10L).get()).isEmpty()
+  }
+
+  @Test
+  fun `single proven blob returns BlobAndBatchCounters with execution proofs and shnarf`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    val blob = singleConflationBlob(1uL, 5uL)
+    provider.captureBlobExecutionProofs(blob)
+    val shnarf = Random.nextBytes(32)
+    val record = blobRecord(start = 1uL, end = 5uL, batches = 1u)
+    provider.acceptProvenBlobRecord(
+      CompressionProofIndex(
+        startBlockNumber = 1uL,
+        endBlockNumber = 5uL,
+        hash = shnarf,
+        startBlockTimestamp = Instant.fromEpochSeconds(1),
+      ),
+      record,
+    )
+
+    val result = provider.findConsecutiveProvenBlobs(1L).get()
+    assertThat(result).hasSize(1)
+    assertThat(result[0].executionProofs)
+      .isEqualTo(BlockIntervals(startingBlockNumber = 1uL, upperBoundaries = listOf(5uL)))
+    assertThat(result[0].blobCounters.startBlockNumber).isEqualTo(1uL)
+    assertThat(result[0].blobCounters.endBlockNumber).isEqualTo(5uL)
+    assertThat(result[0].blobCounters.numberOfBatches).isEqualTo(1u)
+    assertThat(result[0].blobCounters.expectedShnarf).isEqualTo(shnarf)
+  }
+
+  @Test
+  fun `multi conflation blob stores per batch upper boundaries`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    val blob =
+      Blob(
+        conflations =
+        listOf(
+          conflation(1uL, 3uL),
+          conflation(4uL, 7uL),
+        ),
+        compressedData = byteArrayOf(),
+        startBlockTime = instant,
+        endBlockTime = instant,
+      )
+    provider.captureBlobExecutionProofs(blob)
+    provider.acceptProvenBlobRecord(
+      CompressionProofIndex(
+        startBlockNumber = 1uL,
+        endBlockNumber = 7uL,
+        hash = Random.nextBytes(32),
+        startBlockTimestamp = Instant.fromEpochSeconds(1),
+      ),
+      blobRecord(start = 1uL, end = 7uL, batches = 2u),
+    )
+
+    assertThat(provider.findConsecutiveProvenBlobs(1L).get().single().executionProofs)
+      .isEqualTo(BlockIntervals(startingBlockNumber = 1uL, upperBoundaries = listOf(3uL, 7uL)))
+  }
+
+  @Test
+  fun `findConsecutiveProvenBlobs returns longest consecutive chain from fromBlockNumber`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    proveBlob(provider, 1uL, 2uL, 1u)
+    proveBlob(provider, 3uL, 4uL, 1u)
+
+    assertThat(provider.findConsecutiveProvenBlobs(1L).get().map { it.blobCounters.startBlockNumber })
+      .containsExactly(1uL, 3uL)
+  }
+
+  @Test
+  fun `findConsecutiveProvenBlobs stops at first gap in block ranges`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    proveBlob(provider, 1uL, 2uL, 1u)
+    proveBlob(provider, 5uL, 6uL, 1u)
+
+    assertThat(provider.findConsecutiveProvenBlobs(1L).get()).hasSize(1)
+    assertThat(provider.findConsecutiveProvenBlobs(1L).get().single().blobCounters.endBlockNumber).isEqualTo(2uL)
+  }
+
+  @Test
+  fun `findConsecutiveProvenBlobs can start mid chain`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    proveBlob(provider, 1uL, 2uL, 1u)
+    proveBlob(provider, 3uL, 4uL, 1u)
+
+    assertThat(provider.findConsecutiveProvenBlobs(3L).get().map { it.blobCounters.startBlockNumber })
+      .containsExactly(3uL)
+  }
+
+  @Test
+  fun `findConsecutiveProvenBlobs returns empty when fromBlockNumber is after all blobs`() {
+    val provider = InMemoryConsecutiveProvenBlobsProvider()
+    proveBlob(provider, 1uL, 2uL, 1u)
+
+    assertThat(provider.findConsecutiveProvenBlobs(100L).get()).isEmpty()
+  }
+
+  private fun proveBlob(
+    provider: InMemoryConsecutiveProvenBlobsProvider,
+    start: ULong,
+    end: ULong,
+    batches: UInt,
+  ) {
+    provider.captureBlobExecutionProofs(singleConflationBlob(start, end))
+    provider.acceptProvenBlobRecord(
+      CompressionProofIndex(
+        startBlockNumber = start,
+        endBlockNumber = end,
+        hash = Random.nextBytes(32),
+        startBlockTimestamp = Instant.fromEpochSeconds(1),
+      ),
+      blobRecord(start = start, end = end, batches = batches),
+    )
+  }
+
+  private fun singleConflationBlob(start: ULong, end: ULong): Blob =
+    Blob(
+      conflations = listOf(conflation(start, end)),
+      compressedData = byteArrayOf(),
+      startBlockTime = instant,
+      endBlockTime = instant,
+    )
+
+  private fun conflation(start: ULong, end: ULong) =
+    ConflationCalculationResult(
+      startBlockNumber = start,
+      endBlockNumber = end,
+      conflationTrigger = ConflationTrigger.TARGET_BLOCK_NUMBER,
+      tracesCounters = traces,
+    )
+
+  private fun blobRecord(
+    start: ULong,
+    end: ULong,
+    batches: UInt = 1u,
+  ): BlobRecord {
+    val hash = Random.nextBytes(32)
+    return BlobRecord(
+      startBlockNumber = start,
+      endBlockNumber = end,
+      blobHash = hash,
+      startBlockTime = instant,
+      endBlockTime = instant,
+      batchesCount = batches,
+      expectedShnarf = hash,
+    )
+  }
+}

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationProofHandler.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationProofHandler.kt
@@ -1,6 +1,7 @@
 package net.consensys.zkevm.ethereum.coordination.aggregation
 
 import net.consensys.zkevm.domain.Aggregation
+import net.consensys.zkevm.domain.AggregationProofIndex
 import net.consensys.zkevm.persistence.AggregationsRepository
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -10,6 +11,13 @@ import java.util.function.Supplier
 
 fun interface AggregationProofHandler {
   fun acceptNewAggregation(provenAggregation: Aggregation): SafeFuture<*>
+}
+
+fun interface AggregationProofRequestHandler {
+  fun acceptNewAggregationProofRequest(
+    proofIndex: AggregationProofIndex,
+    unProvenAggregation: Aggregation,
+  ): SafeFuture<*>
 }
 
 class AggregationProofHandlerImpl(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
@@ -33,6 +33,7 @@ class ProofAggregationCoordinatorService(
   private var nextBlockNumberToPoll: Long,
   private val aggregationCalculator: AggregationCalculator,
   private val aggregationProofHandler: AggregationProofHandler,
+  private val aggregationProofRequestHandler: AggregationProofRequestHandler? = null,
   private val invalidityProofProvider: InvalidityProofProvider,
   private val consecutiveProvenBlobsProvider: ConsecutiveProvenBlobsProvider,
   private val proofAggregationClient: ProofAggregationProverClientV2,
@@ -208,7 +209,17 @@ class ProofAggregationCoordinatorService(
             batchCount = batchCount.toULong(),
             aggregationProof = null,
           )
-        aggregationProofPoller.addProofRequestsInProgressForPolling(aggregationProofIndex, unProvenAggregation)
+        try {
+          aggregationProofRequestHandler?.acceptNewAggregationProofRequest(
+            proofIndex = aggregationProofIndex,
+            unProvenAggregation = unProvenAggregation,
+          )
+        } finally {
+          aggregationProofPoller.addProofRequestsInProgressForPolling(
+            aggregationProofIndex,
+            unProvenAggregation,
+          )
+        }
       }
   }
 
@@ -269,6 +280,7 @@ class ProofAggregationCoordinatorService(
       maxBlobsPerAggregation: UInt?,
       startBlockNumberInclusive: ULong,
       aggregationProofHandler: AggregationProofHandler,
+      aggregationProofRequestHandler: AggregationProofRequestHandler? = null,
       invalidityProofProvider: InvalidityProofProvider,
       aggregationL2StateProvider: AggregationL2StateProvider,
       consecutiveProvenBlobsProvider: ConsecutiveProvenBlobsProvider,
@@ -346,6 +358,7 @@ class ProofAggregationCoordinatorService(
           nextBlockNumberToPoll = startBlockNumberInclusive.toLong(),
           aggregationCalculator = globalAggregationCalculator,
           aggregationProofHandler = aggregationProofHandler,
+          aggregationProofRequestHandler = aggregationProofRequestHandler,
           invalidityProofProvider = invalidityProofProvider,
           consecutiveProvenBlobsProvider = consecutiveProvenBlobsProvider,
           proofAggregationClient = proofAggregationClient,

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorServiceTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorServiceTest.kt
@@ -82,6 +82,7 @@ class ProofAggregationCoordinatorServiceTest {
       )
 
     var provenAggregation = 0UL
+    val aggregationProofRequestCaptures = mutableListOf<Pair<AggregationProofIndex, Aggregation>>()
 
     val proofAggregationCoordinatorService =
       ProofAggregationCoordinatorService(
@@ -92,6 +93,10 @@ class ProofAggregationCoordinatorServiceTest {
         aggregationProofHandler = { aggregation ->
           provenAggregation = aggregation.endBlockNumber
           mockAggregationsRepository.saveNewAggregation(aggregation)
+        },
+        aggregationProofRequestHandler = { proofIndex, unProvenAggregation ->
+          aggregationProofRequestCaptures.add(proofIndex to unProvenAggregation)
+          SafeFuture.completedFuture(Unit)
         },
         consecutiveProvenBlobsProvider = mockAggregationsRepository::findConsecutiveProvenBlobs,
         proofAggregationClient = mockProofAggregationClient,
@@ -335,6 +340,16 @@ class ProofAggregationCoordinatorServiceTest {
         verify(mockProofAggregationClient).findProofResponse(aggregation1ProofIndex)
         verify(mockAggregationsRepository).saveNewAggregation(aggregation1)
         assertThat(provenAggregation).isEqualTo(aggregation1.endBlockNumber)
+        assertThat(aggregationProofRequestCaptures).hasSize(1)
+        assertThat(aggregationProofRequestCaptures.single().first).isEqualTo(aggregation1ProofIndex)
+        assertThat(aggregationProofRequestCaptures.single().second).isEqualTo(
+          Aggregation(
+            startBlockNumber = blobsToAggregate1.startBlockNumber,
+            endBlockNumber = blobsToAggregate1.endBlockNumber,
+            batchCount = compressionBlobs1.sumOf { it.blobCounters.numberOfBatches }.toULong(),
+            aggregationProof = null,
+          ),
+        )
       }
 
     // Second aggregation should Trigger
@@ -354,6 +369,16 @@ class ProofAggregationCoordinatorServiceTest {
         verify(mockProofAggregationClient).findProofResponse(aggregation2ProofIndex)
         verify(mockAggregationsRepository).saveNewAggregation(aggregation2)
         assertThat(provenAggregation).isEqualTo(aggregation2.endBlockNumber)
+        assertThat(aggregationProofRequestCaptures).hasSize(2)
+        assertThat(aggregationProofRequestCaptures[1].first).isEqualTo(aggregation2ProofIndex)
+        assertThat(aggregationProofRequestCaptures[1].second).isEqualTo(
+          Aggregation(
+            startBlockNumber = blobsToAggregate2.startBlockNumber,
+            endBlockNumber = blobsToAggregate2.endBlockNumber,
+            batchCount = compressionBlobs2.sumOf { it.blobCounters.numberOfBatches }.toULong(),
+            aggregationProof = null,
+          ),
+        )
       }
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #2241 

Depends on https://github.com/Consensys/linea-monorepo/pull/2626

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces aggregation-proof request generation in the backtesting app and adds a new callback hook in the core aggregation coordinator; incorrect wiring could affect aggregation triggering and progress/termination behavior.
> 
> **Overview**
> Conflation backtesting now **runs proof aggregation end-to-end**: it tracks proven blobs in-memory, starts `ProofAggregationCoordinatorService`, and marks the job complete based on the *aggregation* proof request end block (instead of blob compression progress).
> 
> Adds `InMemoryConsecutiveProvenBlobsProvider` (with tests) to capture per-batch execution-proof boundaries at blob creation time and promote blobs to “proven” when a compression proof request is submitted.
> 
> Extends the core `ProofAggregationCoordinatorService` with an optional `AggregationProofRequestHandler` hook so callers (like backtesting) can observe/log aggregation proof requests without altering the poller flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3b7ea6ac7d50c26bcb0ffb8a58d20d561bdf68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->