### PR TITLE
chore(e2e) - prefix docker image env vars with LINEA_

### DIFF
--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -151,7 +151,7 @@ jobs:
         shell: bash
         run: |
           rm -fr linea-besu-package/linea-besu/besu/plugins/besu-fleet-plugin* || true
-      
+
       - name: build and push the combined manifest (without Besu fleet plugin)
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 #v7.0.0
         env:
@@ -188,12 +188,12 @@ jobs:
           echo "| Module | Version | SHA-256 |" >> output.md
           echo "|--------|---------|--------------|" >> output.md
           echo "| linea-besu | ${{ steps.build-plugins-and-assemble.outputs.besu_version }} | $(sha256sum ../linea-besu-package/tmp/besu-${{ steps.build-plugins-and-assemble.outputs.besu_version }}.tar.gz | awk '{ print $1 }' ) |" >> output.md
-          echo "| linea-sequencer-plugin | ${{ steps.build-plugins-and-assemble.outputs.sequencer_plugin_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-sequencer-${{steps.build-plugins-and-assemble.outputs.sequencer_plugin_version }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-tracer-plugin | ${{ steps.build-plugins-and-assemble.outputs.tracer_plugin_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-tracer-${{ steps.build-plugins-and-assemble.outputs.tracer_plugin_version }}.jar | awk '{ print $1 }' ) |" >> output.md    
-          echo "| linea-staterecovery-plugin | ${{ steps.build-plugins-and-assemble.outputs.staterecovery_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-staterecovery-besu-plugin-v${{ steps.build-plugins-and-assemble.outputs.staterecovery_version }}.jar | awk '{ print $1 }' ) |" >> output.md    
+          echo "| linea-sequencer-plugin | ${{ steps.build-plugins-and-assemble.outputs.sequencer_plugin_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-sequencer-${{steps.build-plugins-and-assemble.outputs.sequencer_plugin_version }}.jar | awk '{ print $1 }' ) |" >> output.md
+          echo "| linea-tracer-plugin | ${{ steps.build-plugins-and-assemble.outputs.tracer_plugin_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-tracer-${{ steps.build-plugins-and-assemble.outputs.tracer_plugin_version }}.jar | awk '{ print $1 }' ) |" >> output.md
+          echo "| linea-staterecovery-plugin | ${{ steps.build-plugins-and-assemble.outputs.staterecovery_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/linea-staterecovery-besu-plugin-v${{ steps.build-plugins-and-assemble.outputs.staterecovery_version }}.jar | awk '{ print $1 }' ) |" >> output.md
           echo "| shomei-plugin | ${{ steps.build-plugins-and-assemble.outputs.shomei_version }} | $(sha256sum ../linea-besu-package/linea-besu/besu/plugins/besu-shomei-plugin-v${{ steps.build-plugins-and-assemble.outputs.shomei_version }}.jar | awk '{ print $1 }' ) |" >> output.md
           if [[ "${{ inputs.with_besu_fleet_plugin }}" == "true" ]]; then
-            echo "| besu-fleet-plugin | ${{ steps.build-plugins-and-assemble.outputs.besu_fleet_version }} | ${{ steps.besu-fleet-plugin-checksum.outputs.sha256sum }} |" >> output.md    
+            echo "| besu-fleet-plugin | ${{ steps.build-plugins-and-assemble.outputs.besu_fleet_version }} | ${{ steps.besu-fleet-plugin-checksum.outputs.sha256sum }} |" >> output.md
           fi
           echo "" >> output.md
 

--- a/.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
+++ b/.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
   # Required job
   run-e2e-tests:
     env:
-      BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
+      LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
     # We can only use conditionals, and not path filters to 'successfully' skip a required job - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     if: ${{ inputs.has-changes-requiring-e2e-testing == 'true' }}
     env:
-      LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_LINEA_BESU_PACKAGE_TAG }}
+      LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
     # We can only use conditionals, and not path filters to 'successfully' skip a required job - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     if: ${{ inputs.has-changes-requiring-e2e-testing == 'true' }}
     env:
-      BESU_PACKAGE_TAG: ${{ inputs.linea_besu_package_tag }}
+      LINEA_BESU_PACKAGE_TAG: ${{ inputs.linea_LINEA_BESU_PACKAGE_TAG }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:
@@ -139,14 +139,14 @@ jobs:
         run: |
           for service in coordinator postman transaction-exclusion-api; do
             artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
-            env_var="$(echo "${service}" | tr '[:lower:]-' '[:upper:]_')_TAG"
+            env_var="LINEA_$(echo "${service}" | tr '[:lower:]-' '[:upper:]_')_TAG"
             if [ -f "$artifact_path" ]; then
               echo "${env_var}=${{ inputs.commit_tag }}" >> "$GITHUB_ENV"
             else
               echo "${env_var}=develop" >> "$GITHUB_ENV"
             fi
           done
-          echo PROVER_TAG=2fc4392 >> "$GITHUB_ENV"
+          echo LINEA_PROVER_TAG=2fc4392 >> "$GITHUB_ENV"
       - name: Load linea-besu-package Docker image
         if: ${{ inputs.linea_besu_package_tag != '' }}
         run: |

--- a/docker/compose-spec-l1-services.yml
+++ b/docker/compose-spec-l1-services.yml
@@ -2,7 +2,7 @@ services:
   l1-el-node:
     container_name: l1-el-node
     hostname: l1-el-node
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
     profiles: [ "l1", "debug", "external-to-monorepo" ]
     depends_on:
       l1-node-genesis-generator:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -51,7 +51,7 @@ services:
   sequencer:
     hostname: sequencer
     container_name: sequencer
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       l2-genesis-initialization:
@@ -126,7 +126,7 @@ services:
   l2-node-besu:
     hostname: l2-node-besu
     container_name: l2-node-besu
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -170,7 +170,7 @@ services:
   l2-node-besu-leader:
     hostname: l2-node-besu-leader
     container_name: l2-node-besu-leader
-    image: consensys/linea-besu-package-with-fleet:${BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
+    image: consensys/linea-besu-package-with-fleet:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -214,7 +214,7 @@ services:
   l2-node-besu-follower:
     hostname: l2-node-besu-follower
     container_name: l2-node-besu-follower
-    image: consensys/linea-besu-package-with-fleet:${BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
+    image: consensys/linea-besu-package-with-fleet:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
     profiles: [ "l2", "l2-bc", "debug", "external-to-monorepo" ]
     depends_on:
       sequencer:
@@ -266,7 +266,7 @@ services:
   prover-v3: # prover compatible with the traces from zkbesu
     container_name: prover-v3
     hostname: prover-v3
-    image: consensys/linea-prover:${PROVER_TAG:-7d56432}
+    image: consensys/linea-prover:${LINEA_PROVER_TAG:-7d56432}
     platform: linux/amd64
     # to avoid spinning up on CI for now
     profiles: [ "l2" ]
@@ -287,7 +287,7 @@ services:
   postman:
     container_name: postman
     hostname: postman
-    image: consensys/linea-postman:${POSTMAN_TAG:-fe6de52}
+    image: consensys/linea-postman:${LINEA_POSTMAN_TAG:-fe6de52}
     profiles: [ "l2", "debug" ]
     restart: on-failure
     ports:
@@ -493,7 +493,7 @@ services:
   transaction-exclusion-api:
     hostname: transaction-exclusion-api
     container_name: transaction-exclusion-api
-    image: consensys/linea-transaction-exclusion-api:${TRANSACTION_EXCLUSION_API_TAG:-7d56432}
+    image: consensys/linea-transaction-exclusion-api:${LINEA_TRANSACTION_EXCLUSION_API_TAG:-7d56432}
     profiles: [ "l2", "debug" ]
     restart: on-failure
     depends_on:
@@ -586,7 +586,7 @@ services:
         ipv4_address: 10.10.10.205
 
   zkbesu-shomei-sr:
-    image: consensys/linea-besu-package:${BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
+    image: consensys/linea-besu-package:${LINEA_BESU_PACKAGE_TAG:-beta-v6-20260410083640-74d51b7}
     hostname: zkbesu-shomei-sr
     container_name: zkbesu-shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]

--- a/docs/tech/architecture/EXTERNAL-DEPENDENCIES.md
+++ b/docs/tech/architecture/EXTERNAL-DEPENDENCIES.md
@@ -237,6 +237,6 @@ docker exec sequencer besu --version
 
 # Use matching tags
 export MARU_TAG=v1.0.0
-export BESU_PACKAGE_TAG=v24.0.0
+export LINEA_BESU_PACKAGE_TAG=v24.0.0
 make start-env-with-tracing-v2
 ```

--- a/docs/tech/development/README.md
+++ b/docs/tech/development/README.md
@@ -301,11 +301,11 @@ Key environment variables for stack customization:
 
 ```bash
 # Container image versions
-export BESU_PACKAGE_TAG=latest
+export LINEA_BESU_PACKAGE_TAG=latest
 export MARU_TAG=latest
 export LINEA_COORDINATOR_TAG=latest
-export PROVER_TAG=latest
-export POSTMAN_TAG=latest
+export LINEA_PROVER_TAG=latest
+export LINEA_POSTMAN_TAG=latest
 
 # Coordinator settings
 export LINEA_COORDINATOR_SIGNER_TYPE=web3j  # or web3signer

--- a/linea-besu-package/Makefile
+++ b/linea-besu-package/Makefile
@@ -50,7 +50,7 @@ build-image:
 	fi
 
 run-e2e-test:
-	cd .. && BESU_PACKAGE_TAG=$(TAG) make start-env-with-tracing-v2-ci && pnpm run -F e2e test:local
+	cd .. && LINEA_BESU_PACKAGE_TAG=$(TAG) make start-env-with-tracing-v2-ci && pnpm run -F e2e test:local
 
 run-e2e-test-cleanup:
 	cd .. && make clean-environment


### PR DESCRIPTION
This PR implements issue(s) #2746 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it renames multiple environment variables used by GitHub Actions, Make targets, and docker-compose; any missed reference could cause CI or local stack to pull/build the wrong images or default tags.
> 
> **Overview**
> Standardizes Docker image tag environment variables by prefixing them with `LINEA_` across E2E workflows and local compose files.
> 
> GitHub Actions E2E runners now export `LINEA_BESU_PACKAGE_TAG` and set service tags like `LINEA_POSTMAN_TAG`, `LINEA_TRANSACTION_EXCLUSION_API_TAG`, and `LINEA_PROVER_TAG`, and the docker-compose specs/docs/`linea-besu-package/Makefile` are updated to consume these new names instead of the previous unprefixed vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04843d5368257e565127b30502c9fed0d3b54f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->