### PR TITLE
chore(e2e) - build local prover instead of hardcoded version

### DIFF
--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -124,7 +124,7 @@ jobs:
           timeout_minutes: 10
           command: |
             set -eo pipefail
-            for service in coordinator postman transaction-exclusion-api; do
+            for service in coordinator postman transaction-exclusion-api prover; do
               artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
               if [ -f "$artifact_path" ]; then
                 echo "Loading ${service} from build artifact..."
@@ -137,7 +137,7 @@ jobs:
       - name: Set Docker image tags
         shell: bash
         run: |
-          for service in coordinator postman transaction-exclusion-api; do
+          for service in coordinator postman transaction-exclusion-api prover; do
             artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
             env_var="LINEA_$(echo "${service}" | tr '[:lower:]-' '[:upper:]_')_TAG"
             if [ -f "$artifact_path" ]; then
@@ -146,7 +146,6 @@ jobs:
               echo "${env_var}=develop" >> "$GITHUB_ENV"
             fi
           done
-          echo LINEA_PROVER_TAG=2fc4392 >> "$GITHUB_ENV"
       - name: Load linea-besu-package Docker image
         if: ${{ inputs.linea_besu_package_tag != '' }}
         run: |


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI e2e environment image selection logic, which can affect test stability and what code is exercised, but is limited to GitHub Actions workflow behavior.
> 
> **Overview**
> The reusable `run-e2e-tests` GitHub Actions workflow now treats `prover` like other monorepo services when preparing the e2e environment: it loads a `linea-prover` Docker image from build artifacts when available and otherwise falls back to the `develop` image tag.
> 
> This removes the previous hardcoded `LINEA_PROVER_TAG` pin, so e2e runs can validate the prover built from the current commit tag instead of a fixed version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f25210225ff193709457c95172af9396d1a8dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->