### PR TITLE
fix(coordinator) - fix cleanup should keep last finalized FTX

### DIFF
--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
@@ -13,8 +13,14 @@ internal class ForcedTransactionsSafeBlockNumberManager(
   private val ftxInSequencerForProcessing: MutableList<ULong> = mutableListOf()
 
   private fun updateSafeBlockNumber(value: ULong?) {
+    val effectiveUpdate = value != safeBlockNumber
+    if (effectiveUpdate) {
+      log.info("updating safeBlockNumber from {} to {}", safeBlockNumber, value)
+    }
     safeBlockNumber = value
-    listener.onSafeBlockNumberUpdate(safeBlockNumber)
+    if (effectiveUpdate) {
+      listener.onSafeBlockNumberUpdate(safeBlockNumber)
+    }
   }
 
   @Synchronized
@@ -81,7 +87,6 @@ internal class ForcedTransactionsSafeBlockNumberManager(
     if (!startUpScanFinished) {
       return
     }
-    log.info("releasing Safe Block Number lock")
     updateSafeBlockNumber(null)
   }
 

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
@@ -13,14 +13,8 @@ internal class ForcedTransactionsSafeBlockNumberManager(
   private val ftxInSequencerForProcessing: MutableList<ULong> = mutableListOf()
 
   private fun updateSafeBlockNumber(value: ULong?) {
-    val effectiveUpdate = value != safeBlockNumber
-    if (effectiveUpdate) {
-      log.info("updating safeBlockNumber from {} to {}", safeBlockNumber, value)
-    }
     safeBlockNumber = value
-    if (effectiveUpdate) {
-      listener.onSafeBlockNumberUpdate(safeBlockNumber)
-    }
+    listener.onSafeBlockNumberUpdate(safeBlockNumber)
   }
 
   @Synchronized
@@ -87,6 +81,7 @@ internal class ForcedTransactionsSafeBlockNumberManager(
     if (!startUpScanFinished) {
       return
     }
+    log.info("releasing Safe Block Number lock")
     updateSafeBlockNumber(null)
   }
 

--- a/coordinator/persistence/aggregation/src/integrationTest/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandlerTest.kt
+++ b/coordinator/persistence/aggregation/src/integrationTest/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandlerTest.kt
@@ -189,10 +189,7 @@ class RecordsCleanupFinalizationHandlerTest : CleanDbTestSuiteParallel() {
       .isNotNull()
 
     val forcedTransactionsAfterCleanup = forcedTransactionsDao.list().get()
-    Assertions.assertThat(forcedTransactionsAfterCleanup.size).isEqualTo(1)
-    Assertions.assertThat(
-      forcedTransactionsDao.findByNumber(ftx4.ftxNumber).get(),
-    )
-      .isNotNull()
+    Assertions.assertThat(forcedTransactionsAfterCleanup.map { it.ftxNumber })
+      .isEqualTo(listOf(3UL, 4UL))
   }
 }

--- a/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandler.kt
+++ b/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RecordsCleanupFinalizationHandler.kt
@@ -49,7 +49,7 @@ class RecordsCleanupFinalizationHandler(
       .deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive = update.blockNumber.toLong() - 1L)
     val ftxRecordsCleanup =
       if (update.forcedTransactionNumber > 0UL) {
-        forcedTransactionsDao.deleteFtxUpToInclusive(update.forcedTransactionNumber)
+        forcedTransactionsDao.deleteFtxUpToInclusive(update.forcedTransactionNumber - 1UL)
       } else {
         SafeFuture.completedFuture(Unit)
       }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts forced-transaction cleanup boundaries on finalization; an off-by-one here could retain extra rows or accidentally delete needed FTX records if assumptions about `forcedTransactionNumber` semantics are wrong.
> 
> **Overview**
> Fixes finalization cleanup to **preserve the most recently finalized forced transaction (FTX)** by deleting FTX records only up to `forcedTransactionNumber - 1` instead of inclusive of `forcedTransactionNumber`.
> 
> Updates the integration test to assert that cleanup retains FTX `3` (the finalized number in the update) along with later records (e.g., `4`), while older FTX entries are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb6f08bf9a59400d9edd44ed4c6265ac5bffc0da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->