### PR TITLE
[Chore] - E2E flakiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,11 +280,13 @@ These require human approval and follow the release process:
 
 1. Read existing code in the affected area
 2. Check for existing tests, conventions, and patterns in that package
-3. Plan the minimal change needed
-4. **Plan review**: Before starting implementation, review the plan using a separate agent with isolated context — give it only the original user request and the plan document, not the planning conversation or exploration history. This ensures the reviewer cannot inherit reasoning errors made during planning.
-5. Implement with tests
-6. Run the package-specific lint and test commands
-7. Verify no secrets or credentials are exposed
+3. Prefer built-in language, framework, library, and repository helpers over hand-rolled replacements when equivalent functionality already exists
+4. Extend or compose existing helpers before introducing a new utility when that keeps the implementation smaller and clearer
+5. Plan the minimal change needed
+6. **Plan review**: Before starting implementation, review the plan using a separate agent with isolated context — give it only the original user request and the plan document, not the planning conversation or exploration history. This ensures the reviewer cannot inherit reasoning errors made during planning.
+7. Implement with tests
+8. Run the package-specific lint and test commands
+9. Verify no secrets or credentials are exposed
 
 ### Limiting Change Surface
 

--- a/e2e/src/common/test-helpers/deny-list.spec.ts
+++ b/e2e/src/common/test-helpers/deny-list.spec.ts
@@ -9,6 +9,21 @@ type MockSequencerClient = {
   pluginsReloadPluginConfig: ReturnType<typeof jest.fn<() => Promise<unknown>>>;
 };
 
+function createMockSequencerClient(): MockSequencerClient {
+  return {
+    pluginsReloadPluginConfig: jest.fn(async (): Promise<unknown> => undefined),
+  };
+}
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
 function createTempDenyListFile(initialContent = ""): string {
   const directory = mkdtempSync(join(tmpdir(), "deny-list-test-"));
   const denyListPath = join(directory, "deny-list.txt");
@@ -17,45 +32,50 @@ function createTempDenyListFile(initialContent = ""): string {
 }
 
 describe("deny-list helper", () => {
-  it("should append lowercase addresses", () => {
+  it("should append lowercase addresses from the in-memory state", async () => {
     // Arrange
     const denyListPath = createTempDenyListFile("0xexisting\n");
+    const client = createMockSequencerClient();
 
     // Act
-    addToDenyList(["0xAbC123", "0xDEF456"], denyListPath);
+    await addToDenyList(client, ["0xAbC123", "0xDEF456"], denyListPath);
 
     // Assert
     expect(readFileSync(denyListPath, "utf-8")).toEqual("0xexisting\n0xabc123\n0xdef456\n");
+    expect(client.pluginsReloadPluginConfig).toHaveBeenCalledTimes(1);
   });
 
-  it("should insert a separator newline when existing file has no trailing newline", () => {
+  it("should preserve existing file entries without requiring a trailing newline", async () => {
     // Arrange
     const denyListPath = createTempDenyListFile("0xexisting");
+    const client = createMockSequencerClient();
 
     // Act
-    addToDenyList(["0xAbC123"], denyListPath);
+    await addToDenyList(client, ["0xAbC123"], denyListPath);
 
     // Assert
     expect(readFileSync(denyListPath, "utf-8")).toEqual("0xexisting\n0xabc123\n");
+    expect(client.pluginsReloadPluginConfig).toHaveBeenCalledTimes(1);
   });
 
-  it("should remove only target addresses case-insensitively", () => {
+  it("should remove only dynamically added target addresses case-insensitively", async () => {
     // Arrange
-    const denyListPath = createTempDenyListFile("0xabc123\n0xkeepme\n0xDEF456\n");
+    const denyListPath = createTempDenyListFile("0xkeepme\n");
+    const client = createMockSequencerClient();
+    await addToDenyList(client, ["0xAbC123", "0xDEF456"], denyListPath);
 
     // Act
-    removeFromDenyList(["0xAbC123"], denyListPath);
+    await removeFromDenyList(client, ["0xAbC123"], denyListPath);
 
     // Assert
-    expect(readFileSync(denyListPath, "utf-8")).toEqual("0xkeepme\n0xDEF456\n");
+    expect(readFileSync(denyListPath, "utf-8")).toEqual("0xkeepme\n0xdef456\n");
+    expect(client.pluginsReloadPluginConfig).toHaveBeenCalledTimes(2);
   });
 
   it("should reload before and after callback and restore deny-list content", async () => {
     // Arrange
     const denyListPath = createTempDenyListFile();
-    const client: MockSequencerClient = {
-      pluginsReloadPluginConfig: jest.fn().mockResolvedValue(undefined),
-    };
+    const client = createMockSequencerClient();
     const run = jest.fn(async () => {
       expect(readFileSync(denyListPath, "utf-8")).toEqual("0xabc123\n");
     });
@@ -72,9 +92,7 @@ describe("deny-list helper", () => {
   it("should clean up and reload even when callback throws", async () => {
     // Arrange
     const denyListPath = createTempDenyListFile();
-    const client: MockSequencerClient = {
-      pluginsReloadPluginConfig: jest.fn().mockResolvedValue(undefined),
-    };
+    const client = createMockSequencerClient();
     const runError = new Error("callback failed");
 
     // Act
@@ -92,5 +110,111 @@ describe("deny-list helper", () => {
     // Assert
     expect(client.pluginsReloadPluginConfig).toHaveBeenCalledTimes(2);
     expect(readFileSync(denyListPath, "utf-8")).toEqual("");
+  });
+
+  it("should serialize deny-list sessions until the first callback completes", async () => {
+    // Arrange
+    const denyListPath = createTempDenyListFile();
+    const client = createMockSequencerClient();
+    const firstRunEntered = createDeferred();
+    const releaseFirstRun = createDeferred();
+    const secondRunEntered = createDeferred();
+    const releaseSecondRun = createDeferred();
+    const events: string[] = [];
+
+    const first = withDenyListAddresses(
+      client,
+      ["0xabc123"],
+      async () => {
+        events.push("first:start");
+        expect(readFileSync(denyListPath, "utf-8")).toEqual("0xabc123\n");
+        firstRunEntered.resolve();
+        await releaseFirstRun.promise;
+        events.push("first:end");
+      },
+      denyListPath,
+    );
+
+    await firstRunEntered.promise;
+
+    const second = withDenyListAddresses(
+      client,
+      ["0xdef456"],
+      async () => {
+        events.push("second:start");
+        expect(readFileSync(denyListPath, "utf-8")).toEqual("0xdef456\n");
+        secondRunEntered.resolve();
+        await releaseSecondRun.promise;
+        events.push("second:end");
+      },
+      denyListPath,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Assert the second session cannot start until the first callback exits.
+    expect(events).toEqual(["first:start"]);
+    expect(readFileSync(denyListPath, "utf-8")).toEqual("0xabc123\n");
+
+    // Act
+    releaseFirstRun.resolve();
+    await first;
+    await secondRunEntered.promise;
+
+    // Assert the second session begins only after the first session fully cleans up.
+    expect(events).toEqual(["first:start", "first:end", "second:start"]);
+    expect(readFileSync(denyListPath, "utf-8")).toEqual("0xdef456\n");
+
+    // Act
+    releaseSecondRun.resolve();
+    await second;
+
+    // Assert
+    expect(events).toEqual(["first:start", "first:end", "second:start", "second:end"]);
+    expect(client.pluginsReloadPluginConfig).toHaveBeenCalledTimes(4);
+    expect(readFileSync(denyListPath, "utf-8")).toEqual("");
+  });
+
+  it("should block standalone add mutations while a deny-list session callback is active", async () => {
+    // Arrange
+    const denyListPath = createTempDenyListFile();
+    const client = createMockSequencerClient();
+    const runEntered = createDeferred();
+    const releaseRun = createDeferred();
+    let addCompleted = false;
+
+    const session = withDenyListAddresses(
+      client,
+      ["0xabc123"],
+      async () => {
+        runEntered.resolve();
+        await releaseRun.promise;
+      },
+      denyListPath,
+    );
+
+    await runEntered.promise;
+
+    const pendingAdd = addToDenyList(client, ["0xdef456"], denyListPath).then(() => {
+      addCompleted = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Assert the standalone mutation is queued behind the active deny-list session.
+    expect(addCompleted).toBe(false);
+    expect(readFileSync(denyListPath, "utf-8")).toEqual("0xabc123\n");
+
+    // Act
+    releaseRun.resolve();
+    await session;
+    await pendingAdd;
+
+    // Assert
+    expect(addCompleted).toBe(true);
+    expect(client.pluginsReloadPluginConfig).toHaveBeenCalledTimes(3);
+    expect(readFileSync(denyListPath, "utf-8")).toEqual("0xdef456\n");
   });
 });

--- a/e2e/src/common/test-helpers/deny-list.ts
+++ b/e2e/src/common/test-helpers/deny-list.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
 import { SequencerPluginName } from "../../config/clients/linea-rpc/sequencer-plugins";
@@ -8,10 +8,67 @@ import type { PluginsReloadPluginConfigParameters } from "../../config/clients/l
 
 const DEFAULT_DENY_LIST_PATH = resolve(__dirname, "../../../..", "docker/config/linea-besu-sequencer/deny-list.txt");
 const NEWLINE = "\n";
+let denyListOperationQueue: Promise<void> = Promise.resolve();
+
+type DenyListState = {
+  baseAddresses: string[];
+  dynamicAddressCounts: Map<string, number>;
+};
+
+const denyListStates = new Map<string, DenyListState>();
 
 type DenyListControlClient = {
   pluginsReloadPluginConfig: (args: PluginsReloadPluginConfigParameters) => Promise<unknown>;
 };
+
+function withDenyListLock<T>(operation: () => Promise<T>): Promise<T> {
+  const result = denyListOperationQueue.then(operation, operation);
+  denyListOperationQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+function normalizeAddresses(addresses: readonly string[]): string[] {
+  return [...new Set(toLowercaseLines(addresses).filter(Boolean))];
+}
+
+function parseDenyListContent(content: string): string[] {
+  return normalizeAddresses(content.split(NEWLINE));
+}
+
+function getOrCreateDenyListState(denyListPath: string): DenyListState {
+  const existingState = denyListStates.get(denyListPath);
+  if (existingState) {
+    return existingState;
+  }
+
+  const state: DenyListState = {
+    baseAddresses: parseDenyListContent(readFileSync(denyListPath, "utf-8")),
+    dynamicAddressCounts: new Map<string, number>(),
+  };
+  denyListStates.set(denyListPath, state);
+  return state;
+}
+
+function getEffectiveDenyListAddresses(state: DenyListState): string[] {
+  const addresses = [...state.baseAddresses];
+  const existingAddresses = new Set(state.baseAddresses);
+
+  for (const [address, count] of state.dynamicAddressCounts) {
+    if (count > 0 && !existingAddresses.has(address)) {
+      addresses.push(address);
+    }
+  }
+
+  return addresses;
+}
+
+function writeDenyListState(denyListPath: string, state: DenyListState): void {
+  const addresses = getEffectiveDenyListAddresses(state);
+  writeFileSync(denyListPath, addresses.length > 0 ? `${addresses.join(NEWLINE)}${NEWLINE}` : "");
+}
 
 export async function reloadDenyList(client: DenyListControlClient): Promise<void> {
   await client.pluginsReloadPluginConfig({
@@ -19,21 +76,66 @@ export async function reloadDenyList(client: DenyListControlClient): Promise<voi
   });
 }
 
-export function addToDenyList(addresses: readonly string[], denyListPath: string = DEFAULT_DENY_LIST_PATH): void {
-  const existingContent = readFileSync(denyListPath, "utf-8");
-  const prefix = existingContent.length > 0 && !existingContent.endsWith(NEWLINE) ? NEWLINE : "";
-  const data = `${prefix}${toLowercaseLines(addresses).join(NEWLINE)}${NEWLINE}`;
-  appendFileSync(denyListPath, data);
+async function addToDenyListUnlocked(
+  client: DenyListControlClient,
+  normalizedAddresses: readonly string[],
+  denyListPath: string,
+): Promise<void> {
+  const state = getOrCreateDenyListState(denyListPath);
+
+  for (const address of normalizedAddresses) {
+    state.dynamicAddressCounts.set(address, (state.dynamicAddressCounts.get(address) ?? 0) + 1);
+  }
+
+  writeDenyListState(denyListPath, state);
+  await reloadDenyList(client);
 }
 
-export function removeFromDenyList(addresses: readonly string[], denyListPath: string = DEFAULT_DENY_LIST_PATH): void {
-  const current = readFileSync(denyListPath, "utf-8");
-  const toRemove = new Set(toLowercaseLines(addresses));
-  const remaining = current
-    .split(NEWLINE)
-    .filter(Boolean)
-    .filter((address) => !toRemove.has(address.toLowerCase()));
-  writeFileSync(denyListPath, remaining.length ? `${remaining.join(NEWLINE)}${NEWLINE}` : "");
+async function removeFromDenyListUnlocked(
+  client: DenyListControlClient,
+  normalizedAddresses: readonly string[],
+  denyListPath: string,
+): Promise<void> {
+  const state = getOrCreateDenyListState(denyListPath);
+
+  for (const address of normalizedAddresses) {
+    const currentCount = state.dynamicAddressCounts.get(address) ?? 0;
+    if (currentCount <= 1) {
+      state.dynamicAddressCounts.delete(address);
+      continue;
+    }
+
+    state.dynamicAddressCounts.set(address, currentCount - 1);
+  }
+
+  writeDenyListState(denyListPath, state);
+  await reloadDenyList(client);
+}
+
+export async function addToDenyList(
+  client: DenyListControlClient,
+  addresses: readonly string[],
+  denyListPath: string = DEFAULT_DENY_LIST_PATH,
+): Promise<void> {
+  const normalizedAddresses = normalizeAddresses(addresses);
+  if (normalizedAddresses.length === 0) {
+    return;
+  }
+
+  await withDenyListLock(async () => addToDenyListUnlocked(client, normalizedAddresses, denyListPath));
+}
+
+export async function removeFromDenyList(
+  client: DenyListControlClient,
+  addresses: readonly string[],
+  denyListPath: string = DEFAULT_DENY_LIST_PATH,
+): Promise<void> {
+  const normalizedAddresses = normalizeAddresses(addresses);
+  if (normalizedAddresses.length === 0) {
+    return;
+  }
+
+  await withDenyListLock(async () => removeFromDenyListUnlocked(client, normalizedAddresses, denyListPath));
 }
 
 export async function withDenyListAddresses(
@@ -42,13 +144,18 @@ export async function withDenyListAddresses(
   run: () => Promise<void>,
   denyListPath: string = DEFAULT_DENY_LIST_PATH,
 ): Promise<void> {
-  addToDenyList(addresses, denyListPath);
-  await reloadDenyList(client);
-
-  try {
+  const normalizedAddresses = normalizeAddresses(addresses);
+  if (normalizedAddresses.length === 0) {
     await run();
-  } finally {
-    removeFromDenyList(addresses, denyListPath);
-    await reloadDenyList(client);
+    return;
   }
+
+  await withDenyListLock(async () => {
+    try {
+      await addToDenyListUnlocked(client, normalizedAddresses, denyListPath);
+      await run();
+    } finally {
+      await removeFromDenyListUnlocked(client, normalizedAddresses, denyListPath);
+    }
+  });
 }

--- a/e2e/src/common/test-helpers/eip7702-delegation.ts
+++ b/e2e/src/common/test-helpers/eip7702-delegation.ts
@@ -1,0 +1,51 @@
+import {
+  encodeFunctionData,
+  getAddress,
+  isAddress,
+  type PrivateKeyAccount,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
+
+import { TestEIP7702DelegationAbi, TestEIP7702DelegationAbiBytecode } from "../../generated";
+import { estimateLineaGas, sendTransactionWithRetry } from "../utils";
+
+export function encodeEip7702InitializeData(): `0x${string}` {
+  return encodeFunctionData({
+    abi: TestEIP7702DelegationAbi,
+    functionName: "initialize",
+  });
+}
+
+export async function deployTestEip7702Delegation(
+  l2PublicClient: PublicClient,
+  deployerWalletClient: WalletClient,
+  deployer: PrivateKeyAccount,
+): Promise<`0x${string}`> {
+  const deployNonce = await l2PublicClient.getTransactionCount({ address: deployer.address });
+
+  const deployEstimate = await estimateLineaGas(l2PublicClient, {
+    account: deployer,
+    data: TestEIP7702DelegationAbiBytecode,
+  });
+
+  const { receipt: deployReceipt } = await sendTransactionWithRetry(l2PublicClient, (fees) =>
+    deployerWalletClient.sendTransaction({
+      account: deployer,
+      chain: deployerWalletClient.chain,
+      data: TestEIP7702DelegationAbiBytecode,
+      nonce: deployNonce,
+      ...deployEstimate,
+      ...fees,
+    }),
+  );
+
+  if (deployReceipt.status !== "success") {
+    throw new Error(`deployTestEip7702Delegation: deploy failed status=${deployReceipt.status}`);
+  }
+  if (!deployReceipt.contractAddress || !isAddress(deployReceipt.contractAddress)) {
+    throw new Error("deployTestEip7702Delegation: missing contract address");
+  }
+
+  return getAddress(deployReceipt.contractAddress);
+}

--- a/e2e/src/common/utils/index.ts
+++ b/e2e/src/common/utils/index.ts
@@ -28,5 +28,11 @@ export { execDockerCommand, getDockerImageTag } from "./docker";
 export { expectSuccessfulTransaction, getRawTransactionHex, getTransactionHash } from "./transaction";
 
 // Retry
-export { sendTransactionWithRetry } from "./retry";
-export type { FeeOverrides, SendTransactionWithRetryOptions, TransactionResult } from "./retry";
+export { sendTransactionWithGasPriceRetry, sendTransactionWithRetry } from "./retry";
+export type {
+  FeeOverrides,
+  GasPriceFeeOverrides,
+  SendTransactionWithGasPriceRetryOptions,
+  SendTransactionWithRetryOptions,
+  TransactionResult,
+} from "./retry";

--- a/e2e/src/common/utils/retry.spec.ts
+++ b/e2e/src/common/utils/retry.spec.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
+import { BaseError } from "viem";
 
 import { isContractRevert } from "./retry";
 
@@ -31,6 +32,22 @@ describe("retry helper", () => {
         },
       }),
     ).toBe(true);
+  });
+
+  it("uses viem walk for BaseError chains", () => {
+    const revertedError = Object.assign(new BaseError("execution reverted"), {
+      name: "ContractFunctionRevertedError",
+    });
+    const simulationError = Object.assign(new BaseError("simulation failed"), {
+      name: "ContractFunctionExecutionError",
+    });
+    const walkImpl = ((predicate?: (error: unknown) => boolean) =>
+      predicate?.(revertedError) ? revertedError : simulationError) as unknown as BaseError["walk"];
+    const walk = jest.fn(walkImpl);
+    (simulationError as BaseError & { walk: BaseError["walk"] }).walk = walk as unknown as BaseError["walk"];
+
+    expect(isContractRevert(simulationError)).toBe(true);
+    expect(walk).toHaveBeenCalled();
   });
 
   it("ignores non-revert send errors", () => {

--- a/e2e/src/common/utils/retry.spec.ts
+++ b/e2e/src/common/utils/retry.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { isContractRevert } from "./retry";
+
+describe("retry helper", () => {
+  it("detects transaction execution contract reverts", () => {
+    expect(
+      isContractRevert({
+        name: "TransactionExecutionError",
+        cause: { name: "ContractFunctionRevertedError" },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects contract function execution reverts from viem simulation", () => {
+    expect(
+      isContractRevert({
+        name: "ContractFunctionExecutionError",
+        cause: { name: "ContractFunctionRevertedError" },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects nested call execution reverts", () => {
+    expect(
+      isContractRevert({
+        name: "ContractFunctionExecutionError",
+        cause: {
+          name: "EstimateGasExecutionError",
+          cause: { name: "CallExecutionError" },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores non-revert send errors", () => {
+    expect(
+      isContractRevert({
+        name: "TransactionExecutionError",
+        cause: { name: "NonceTooLowError" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/e2e/src/common/utils/retry.ts
+++ b/e2e/src/common/utils/retry.ts
@@ -88,6 +88,15 @@ function isNonceTooLow(error: unknown): boolean {
 }
 
 function hasErrorNameInChain(error: unknown, errorNames: Set<string>): boolean {
+  if (error instanceof BaseError) {
+    return (
+      error.walk((cause) => {
+        const name = (cause as { name?: string }).name;
+        return typeof name === "string" && errorNames.has(name);
+      }) !== null
+    );
+  }
+
   let current = error as { name?: string; cause?: unknown } | undefined;
   let depth = 0;
 

--- a/e2e/src/common/utils/retry.ts
+++ b/e2e/src/common/utils/retry.ts
@@ -1,8 +1,9 @@
-import { Client, Hash, TransactionReceipt } from "viem";
+import { Abi, BaseError, Client, decodeErrorResult, Hash, RawContractError, TransactionReceipt } from "viem";
 import {
   waitForTransactionReceipt,
   getTransactionReceipt,
   getTransaction,
+  call,
   SendTransactionErrorType,
   WaitForTransactionReceiptErrorType,
 } from "viem/actions";
@@ -15,6 +16,7 @@ const DEFAULT_FEE_BUMP_STEP = 20n;
 const MAX_FEE_MULTIPLIER = 10n;
 const DEFAULT_MAX_RETRIES = 20;
 const DEFAULT_OVERALL_TIMEOUT_MS = 3 * 60_000;
+const DEFAULT_RETRY_ON_REVERT_DELAY_MS = 1_000;
 
 export type FeeOverrides = {
   maxPriorityFeePerGas: bigint | undefined;
@@ -27,12 +29,22 @@ export type SendTransactionWithRetryOptions = {
   maxRetries?: number;
   overallTimeoutMs?: number;
   rejectOnRevert?: boolean;
+  abi?: Abi;
+  retryOnRevert?: boolean;
+  retryOnRevertDelayMs?: number;
+  beforeRetry?: () => Promise<void>;
 };
 
 export type TransactionResult = {
   hash: Hash;
   receipt: TransactionReceipt;
 };
+
+export type GasPriceFeeOverrides = {
+  gasPrice: bigint;
+};
+
+export type SendTransactionWithGasPriceRetryOptions = SendTransactionWithRetryOptions;
 
 const logger = createTestLogger();
 
@@ -45,6 +57,34 @@ function isReceiptTimeout(error: unknown): boolean {
 function isNonceTooLow(error: unknown): boolean {
   const e = error as SendTransactionErrorType;
   return e?.name === "TransactionExecutionError" && e?.cause?.name === "NonceTooLowError";
+}
+
+function hasErrorNameInChain(error: unknown, errorNames: Set<string>): boolean {
+  let current = error as { name?: string; cause?: unknown } | undefined;
+  let depth = 0;
+
+  while (current && depth < 10) {
+    if (current.name && errorNames.has(current.name)) {
+      return true;
+    }
+
+    if (!current.cause || typeof current.cause !== "object") {
+      return false;
+    }
+
+    current = current.cause as { name?: string; cause?: unknown };
+    depth++;
+  }
+
+  return false;
+}
+
+export function isContractRevert(error: unknown): boolean {
+  return hasErrorNameInChain(error, new Set(["ContractFunctionRevertedError", "CallExecutionError"]));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function safeGetReceipt(client: Client, hash: Hash): Promise<TransactionReceipt | undefined> {
@@ -89,9 +129,67 @@ function capBumpedFees(fees: FeeOverrides, baseFees: FeeOverrides): FeeOverrides
   };
 }
 
-function assertReceiptSuccess(hash: Hash, receipt: TransactionReceipt, rejectOnRevert: boolean): void {
+function bumpGasPriceFromTx(tx: { gasPrice: bigint | undefined }, bumpFactor: bigint): GasPriceFeeOverrides {
+  if (tx.gasPrice === undefined) {
+    throw new Error("sendTransactionWithGasPriceRetry: transaction has no gasPrice");
+  }
+
+  return { gasPrice: (tx.gasPrice * bumpFactor) / 100n };
+}
+
+function capBumpedGasPrice(fees: GasPriceFeeOverrides, baseGasPrice: bigint): GasPriceFeeOverrides {
+  const maxAllowedGasPrice = baseGasPrice * MAX_FEE_MULTIPLIER;
+  return { gasPrice: fees.gasPrice > maxAllowedGasPrice ? maxAllowedGasPrice : fees.gasPrice };
+}
+
+async function getRevertReason(
+  client: Client,
+  hash: Hash,
+  receipt: TransactionReceipt,
+  abi?: Abi,
+): Promise<string | undefined> {
+  try {
+    const tx = await getTransaction(client, { hash });
+    await call(client, {
+      account: tx.from,
+      to: tx.to,
+      data: tx.input,
+      value: tx.value,
+      gas: tx.gas,
+      blockNumber: receipt.blockNumber,
+    });
+    return "unknown (eth_call did not revert on replay)";
+  } catch (err) {
+    if (!(err instanceof BaseError)) return undefined;
+
+    const rawError = err.walk() as RawContractError;
+    if (rawError.data && abi) {
+      const data = typeof rawError.data === "object" ? rawError.data?.data : rawError.data;
+      if (!data) return undefined;
+
+      try {
+        const decoded = decodeErrorResult({ abi, data });
+        const args = decoded.args?.map((a) => (typeof a === "bigint" ? a.toString() : JSON.stringify(a)));
+        return `${decoded.errorName}(${args?.join(", ") ?? ""})`;
+      } catch {
+        return `raw revert data: ${data}`;
+      }
+    }
+
+    return (err as Error).message ?? String(err);
+  }
+}
+
+async function assertReceiptSuccess(
+  client: Client,
+  hash: Hash,
+  receipt: TransactionReceipt,
+  rejectOnRevert: boolean,
+  abi?: Abi,
+): Promise<void> {
   if (rejectOnRevert && receipt.status === "reverted") {
-    throw new Error(`Transaction reverted: hash=${hash} blockNumber=${receipt.blockNumber}`);
+    const reason = await getRevertReason(client, hash, receipt, abi);
+    throw new Error(`Transaction reverted: hash=${hash} blockNumber=${receipt.blockNumber}\nRevert reason: ${reason}`);
   }
 }
 
@@ -107,21 +205,64 @@ export async function sendTransactionWithRetry(
   const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
   const overallTimeoutMs = options.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS;
   const rejectOnRevert = options.rejectOnRevert ?? true;
+  const abi = options.abi;
+  const retryOnRevert = options.retryOnRevert ?? false;
+  const retryOnRevertDelayMs = options.retryOnRevertDelayMs ?? DEFAULT_RETRY_ON_REVERT_DELAY_MS;
+  const beforeRetry = options.beforeRetry;
 
   const startedAt = Date.now();
-
-  let lastHash = await sendFn();
-
-  const { maxPriorityFeePerGas, maxFeePerGas } = await getTransaction(client, { hash: lastHash });
-  let fees = { maxPriorityFeePerGas, maxFeePerGas };
-  const baseFees = fees;
+  let lastHash!: Hash;
+  let fees!: FeeOverrides;
+  let baseFees!: FeeOverrides;
   let attempt = 0;
+  let needsSend = true;
 
-  logger.debug(
-    `tx sent hash=${lastHash} maxFeePerGas=${fees.maxFeePerGas} maxPriorityFeePerGas=${fees.maxPriorityFeePerGas}`,
-  );
+  function withinLimits(): boolean {
+    return attempt < maxRetries && Date.now() - startedAt <= overallTimeoutMs;
+  }
+
+  async function freshSend(): Promise<void> {
+    lastHash = await sendFn();
+    const tx = await getTransaction(client, { hash: lastHash });
+    fees = { maxPriorityFeePerGas: tx.maxPriorityFeePerGas, maxFeePerGas: tx.maxFeePerGas };
+    baseFees = fees;
+    logger.debug(
+      `tx sent hash=${lastHash} maxFeePerGas=${fees.maxFeePerGas} maxPriorityFeePerGas=${fees.maxPriorityFeePerGas}`,
+    );
+  }
+
+  async function handleRevertRetry(hash: Hash, receipt: TransactionReceipt): Promise<boolean> {
+    if (receipt.status !== "reverted" || !retryOnRevert || !withinLimits()) return false;
+
+    const reason = await getRevertReason(client, hash, receipt, abi);
+    logger.debug(`tx reverted, will retry: hash=${hash} attempt=${attempt} reason=${reason}`);
+
+    await beforeRetry?.();
+    await sleep(retryOnRevertDelayMs);
+    needsSend = true;
+    attempt++;
+    return true;
+  }
 
   while (attempt <= maxRetries) {
+    /* ---------- (re)send ---------- */
+    if (needsSend) {
+      needsSend = false;
+      try {
+        await freshSend();
+      } catch (err) {
+        if (retryOnRevert && isContractRevert(err) && withinLimits()) {
+          logger.debug(`sendFn reverted at simulation, retrying: attempt=${attempt} error=${(err as Error).message}`);
+          await beforeRetry?.();
+          await sleep(retryOnRevertDelayMs);
+          needsSend = true;
+          attempt++;
+          continue;
+        }
+        throw err;
+      }
+    }
+
     /* ---------- hard deadline ---------- */
     if (Date.now() - startedAt > overallTimeoutMs) {
       logger.debug(`overall timeout exceeded hash=${lastHash} attempt=${attempt}; probing receipt`);
@@ -129,7 +270,7 @@ export async function sendTransactionWithRetry(
       const txReceipt = await safeGetReceipt(client, lastHash);
       if (txReceipt) {
         logger.debug(`tx confirmed during final probe hash=${lastHash} blockNumber=${txReceipt.blockNumber}`);
-        assertReceiptSuccess(lastHash, txReceipt, rejectOnRevert);
+        await assertReceiptSuccess(client, lastHash, txReceipt, rejectOnRevert, abi);
         return { hash: lastHash, receipt: txReceipt };
       }
 
@@ -147,7 +288,8 @@ export async function sendTransactionWithRetry(
 
       logger.debug(`tx confirmed hash=${lastHash} blockNumber=${receipt.blockNumber} status=${receipt.status}`);
 
-      assertReceiptSuccess(lastHash, receipt, rejectOnRevert);
+      if (await handleRevertRetry(lastHash, receipt)) continue;
+      await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
       return { hash: lastHash, receipt };
     } catch (err) {
       if (!isReceiptTimeout(err)) throw err;
@@ -159,7 +301,9 @@ export async function sendTransactionWithRetry(
     const raceConditionReceipt = await safeGetReceipt(client, lastHash);
     if (raceConditionReceipt) {
       logger.debug(`tx mined during timeout race hash=${lastHash} blockNumber=${raceConditionReceipt.blockNumber}`);
-      assertReceiptSuccess(lastHash, raceConditionReceipt, rejectOnRevert);
+
+      if (await handleRevertRetry(lastHash, raceConditionReceipt)) continue;
+      await assertReceiptSuccess(client, lastHash, raceConditionReceipt, rejectOnRevert, abi);
       return { hash: lastHash, receipt: raceConditionReceipt };
     }
 
@@ -168,7 +312,7 @@ export async function sendTransactionWithRetry(
 
       const receipt = await safeGetReceipt(client, lastHash);
       if (receipt) {
-        assertReceiptSuccess(lastHash, receipt, rejectOnRevert);
+        await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
         return { hash: lastHash, receipt: receipt };
       }
 
@@ -209,9 +353,21 @@ export async function sendTransactionWithRetry(
 
         const receipt = await safeGetReceipt(client, lastHash);
         if (receipt) {
-          assertReceiptSuccess(lastHash, receipt, rejectOnRevert);
+          if (await handleRevertRetry(lastHash, receipt)) continue;
+          await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
           return { hash: lastHash, receipt: receipt };
         }
+        continue;
+      }
+
+      if (retryOnRevert && isContractRevert(sendError) && withinLimits()) {
+        logger.debug(
+          `sendFn reverted at simulation, retrying: attempt=${attempt} error=${(sendError as Error).message}`,
+        );
+        await beforeRetry?.();
+        await sleep(retryOnRevertDelayMs);
+        needsSend = true;
+        attempt++;
         continue;
       }
 
@@ -220,4 +376,177 @@ export async function sendTransactionWithRetry(
   }
 
   throw new Error("sendTransactionWithRetry: unreachable");
+}
+
+export async function sendTransactionWithGasPriceRetry(
+  client: Client,
+  sendFn: (fees?: GasPriceFeeOverrides) => Promise<Hash>,
+  options: SendTransactionWithGasPriceRetryOptions = {},
+): Promise<TransactionResult> {
+  const receiptTimeoutMs = options.receiptTimeoutMs ?? DEFAULT_RECEIPT_TIMEOUT_MS;
+  const feeBumpFactor = options.feeBumpFactor ?? DEFAULT_FEE_BUMP_FACTOR;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const overallTimeoutMs = options.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS;
+  const rejectOnRevert = options.rejectOnRevert ?? true;
+  const abi = options.abi;
+  const retryOnRevert = options.retryOnRevert ?? false;
+  const retryOnRevertDelayMs = options.retryOnRevertDelayMs ?? DEFAULT_RETRY_ON_REVERT_DELAY_MS;
+  const beforeRetry = options.beforeRetry;
+
+  const startedAt = Date.now();
+  let lastHash!: Hash;
+  let gasPriceFees!: GasPriceFeeOverrides;
+  let baseGasPrice!: bigint;
+  let attempt = 0;
+  let needsSend = true;
+
+  function withinLimits(): boolean {
+    return attempt < maxRetries && Date.now() - startedAt <= overallTimeoutMs;
+  }
+
+  async function freshSendGasPrice(): Promise<void> {
+    lastHash = await sendFn();
+    const tx = await getTransaction(client, { hash: lastHash });
+    if (tx.gasPrice === undefined) {
+      throw new Error("sendTransactionWithGasPriceRetry: transaction has no gasPrice");
+    }
+    gasPriceFees = { gasPrice: tx.gasPrice };
+    baseGasPrice = tx.gasPrice;
+    logger.debug(`tx sent hash=${lastHash} gasPrice=${gasPriceFees.gasPrice}`);
+  }
+
+  async function handleRevertRetryGasPrice(hash: Hash, receipt: TransactionReceipt): Promise<boolean> {
+    if (receipt.status !== "reverted" || !retryOnRevert || !withinLimits()) return false;
+
+    const reason = await getRevertReason(client, hash, receipt, abi);
+    logger.debug(`tx reverted, will retry: hash=${hash} attempt=${attempt} reason=${reason}`);
+
+    await beforeRetry?.();
+    await sleep(retryOnRevertDelayMs);
+    needsSend = true;
+    attempt++;
+    return true;
+  }
+
+  while (attempt <= maxRetries) {
+    if (needsSend) {
+      needsSend = false;
+      try {
+        await freshSendGasPrice();
+      } catch (err) {
+        if (retryOnRevert && isContractRevert(err) && withinLimits()) {
+          logger.debug(`sendFn reverted at simulation, retrying: attempt=${attempt} error=${(err as Error).message}`);
+          await beforeRetry?.();
+          await sleep(retryOnRevertDelayMs);
+          needsSend = true;
+          attempt++;
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    if (Date.now() - startedAt > overallTimeoutMs) {
+      logger.debug(`overall timeout exceeded hash=${lastHash} attempt=${attempt}; probing receipt`);
+
+      const txReceipt = await safeGetReceipt(client, lastHash);
+      if (txReceipt) {
+        logger.debug(`tx confirmed during final probe hash=${lastHash} blockNumber=${txReceipt.blockNumber}`);
+        await assertReceiptSuccess(client, lastHash, txReceipt, rejectOnRevert, abi);
+        return { hash: lastHash, receipt: txReceipt };
+      }
+
+      throw new Error("sendTransactionWithGasPriceRetry: overall timeout exceeded");
+    }
+
+    try {
+      logger.debug(`waiting for receipt hash=${lastHash} attempt=${attempt} timeoutMs=${receiptTimeoutMs}`);
+
+      const receipt = await waitForTransactionReceipt(client, {
+        hash: lastHash,
+        timeout: receiptTimeoutMs,
+      });
+
+      logger.debug(`tx confirmed hash=${lastHash} blockNumber=${receipt.blockNumber} status=${receipt.status}`);
+
+      if (await handleRevertRetryGasPrice(lastHash, receipt)) continue;
+      await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
+      return { hash: lastHash, receipt };
+    } catch (err) {
+      if (!isReceiptTimeout(err)) throw err;
+
+      logger.debug(`receipt timeout for hash=${lastHash} attempt=${attempt}`);
+    }
+
+    const raceConditionReceipt = await safeGetReceipt(client, lastHash);
+    if (raceConditionReceipt) {
+      logger.debug(`tx mined during timeout race hash=${lastHash} blockNumber=${raceConditionReceipt.blockNumber}`);
+
+      if (await handleRevertRetryGasPrice(lastHash, raceConditionReceipt)) continue;
+      await assertReceiptSuccess(client, lastHash, raceConditionReceipt, rejectOnRevert, abi);
+      return { hash: lastHash, receipt: raceConditionReceipt };
+    }
+
+    if (attempt === maxRetries) {
+      logger.debug(`max retries reached hash=${lastHash} attempt=${attempt}; probing receipt`);
+
+      const receipt = await safeGetReceipt(client, lastHash);
+      if (receipt) {
+        await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
+        return { hash: lastHash, receipt };
+      }
+
+      throw new Error("sendTransactionWithGasPriceRetry: max retries exceeded");
+    }
+
+    const bumpFactor = feeBumpFactor + BigInt(attempt) * DEFAULT_FEE_BUMP_STEP;
+    const nextFees = bumpGasPriceFromTx(gasPriceFees, bumpFactor);
+    const cappedFees = capBumpedGasPrice(nextFees, baseGasPrice);
+    const wasCapped = cappedFees.gasPrice !== nextFees.gasPrice;
+
+    logger.debug(
+      `bumping gasPrice hash=${lastHash} attempt=${attempt + 1} bumpFactor=${bumpFactor} ` +
+        `prevGasPrice=${gasPriceFees.gasPrice} nextGasPrice=${cappedFees.gasPrice}`,
+    );
+
+    if (wasCapped) {
+      logger.debug(`gasPrice cap reached hash=${lastHash} cap=${baseGasPrice * MAX_FEE_MULTIPLIER}`);
+    }
+
+    gasPriceFees = cappedFees;
+    attempt++;
+
+    try {
+      lastHash = await sendFn(gasPriceFees);
+
+      logger.debug(`replacement tx sent hash=${lastHash} attempt=${attempt}`);
+    } catch (sendError) {
+      if (isNonceTooLow(sendError)) {
+        logger.debug(`nonce too low while retrying hash=${lastHash}; original tx likely mined`);
+
+        const receipt = await safeGetReceipt(client, lastHash);
+        if (receipt) {
+          if (await handleRevertRetryGasPrice(lastHash, receipt)) continue;
+          await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
+          return { hash: lastHash, receipt };
+        }
+        continue;
+      }
+
+      if (retryOnRevert && isContractRevert(sendError) && withinLimits()) {
+        logger.debug(
+          `sendFn reverted at simulation, retrying: attempt=${attempt} error=${(sendError as Error).message}`,
+        );
+        await beforeRetry?.();
+        await sleep(retryOnRevertDelayMs);
+        needsSend = true;
+        attempt++;
+        continue;
+      }
+
+      throw sendError;
+    }
+  }
+
+  throw new Error("sendTransactionWithGasPriceRetry: unreachable");
 }

--- a/e2e/src/common/utils/retry.ts
+++ b/e2e/src/common/utils/retry.ts
@@ -46,6 +46,34 @@ export type GasPriceFeeOverrides = {
 
 export type SendTransactionWithGasPriceRetryOptions = SendTransactionWithRetryOptions;
 
+type FeeState<TFees> = {
+  fees: TFees;
+  baseFees: TFees;
+};
+
+type FeeBumpResult<TFees> = {
+  fees: TFees;
+  wasCapped: boolean;
+};
+
+type FeeBumpLogContext<TFees> = {
+  hash: Hash;
+  attempt: number;
+  bumpFactor: bigint;
+  previousFees: TFees;
+  nextFees: TFees;
+  baseFees: TFees;
+  wasCapped: boolean;
+};
+
+type FeeRetryStrategy<TFees> = {
+  errorPrefix: string;
+  getInitialFeeState: (client: Client, hash: Hash) => Promise<FeeState<TFees>>;
+  getNextFeeState: (fees: TFees, baseFees: TFees, bumpFactor: bigint) => FeeBumpResult<TFees>;
+  logInitialSend: (hash: Hash, fees: TFees) => void;
+  logBump: (context: FeeBumpLogContext<TFees>) => void;
+};
+
 const logger = createTestLogger();
 
 /* ---------------- helpers ---------------- */
@@ -137,8 +165,8 @@ function bumpGasPriceFromTx(tx: { gasPrice: bigint | undefined }, bumpFactor: bi
   return { gasPrice: (tx.gasPrice * bumpFactor) / 100n };
 }
 
-function capBumpedGasPrice(fees: GasPriceFeeOverrides, baseGasPrice: bigint): GasPriceFeeOverrides {
-  const maxAllowedGasPrice = baseGasPrice * MAX_FEE_MULTIPLIER;
+function capBumpedGasPrice(fees: GasPriceFeeOverrides, baseFees: GasPriceFeeOverrides): GasPriceFeeOverrides {
+  const maxAllowedGasPrice = baseFees.gasPrice * MAX_FEE_MULTIPLIER;
   return { gasPrice: fees.gasPrice > maxAllowedGasPrice ? maxAllowedGasPrice : fees.gasPrice };
 }
 
@@ -195,10 +223,96 @@ async function assertReceiptSuccess(
 
 /* ---------------- final wrapper ---------------- */
 
-export async function sendTransactionWithRetry(
+async function getEip1559FeeState(client: Client, hash: Hash): Promise<FeeState<FeeOverrides>> {
+  const tx = await getTransaction(client, { hash });
+  const fees = {
+    maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+    maxFeePerGas: tx.maxFeePerGas,
+  };
+  return { fees, baseFees: fees };
+}
+
+function getNextEip1559FeeState(
+  fees: FeeOverrides,
+  baseFees: FeeOverrides,
+  bumpFactor: bigint,
+): FeeBumpResult<FeeOverrides> {
+  const nextFees = bumpFeesFromTx(fees, bumpFactor);
+  const cappedFees = capBumpedFees(nextFees, baseFees);
+  return {
+    fees: cappedFees,
+    wasCapped:
+      cappedFees.maxFeePerGas !== nextFees.maxFeePerGas ||
+      cappedFees.maxPriorityFeePerGas !== nextFees.maxPriorityFeePerGas,
+  };
+}
+
+function logEip1559InitialSend(hash: Hash, fees: FeeOverrides): void {
+  logger.debug(
+    `tx sent hash=${hash} maxFeePerGas=${fees.maxFeePerGas} maxPriorityFeePerGas=${fees.maxPriorityFeePerGas}`,
+  );
+}
+
+function logEip1559Bump(context: FeeBumpLogContext<FeeOverrides>): void {
+  const { hash, attempt, bumpFactor, previousFees, nextFees, baseFees, wasCapped } = context;
+  logger.debug(
+    `bumping fees hash=${hash} attempt=${attempt + 1} bumpFactor=${bumpFactor} ` +
+      `prevMaxFeePerGas=${previousFees.maxFeePerGas} nextMaxFeePerGas=${nextFees.maxFeePerGas} ` +
+      `prevMaxPriorityFeePerGas=${previousFees.maxPriorityFeePerGas} nextMaxPriorityFeePerGas=${nextFees.maxPriorityFeePerGas}`,
+  );
+
+  if (wasCapped) {
+    logger.debug(
+      `fee cap reached hash=${hash} maxFeePerGasCap=${baseFees.maxFeePerGas! * MAX_FEE_MULTIPLIER} ` +
+        `maxPriorityFeePerGasCap=${baseFees.maxPriorityFeePerGas! * MAX_FEE_MULTIPLIER}`,
+    );
+  }
+}
+
+async function getGasPriceFeeState(client: Client, hash: Hash): Promise<FeeState<GasPriceFeeOverrides>> {
+  const tx = await getTransaction(client, { hash });
+  if (tx.gasPrice === undefined) {
+    throw new Error("sendTransactionWithGasPriceRetry: transaction has no gasPrice");
+  }
+
+  const fees = { gasPrice: tx.gasPrice };
+  return { fees, baseFees: fees };
+}
+
+function getNextGasPriceFeeState(
+  fees: GasPriceFeeOverrides,
+  baseFees: GasPriceFeeOverrides,
+  bumpFactor: bigint,
+): FeeBumpResult<GasPriceFeeOverrides> {
+  const nextFees = bumpGasPriceFromTx(fees, bumpFactor);
+  const cappedFees = capBumpedGasPrice(nextFees, baseFees);
+  return {
+    fees: cappedFees,
+    wasCapped: cappedFees.gasPrice !== nextFees.gasPrice,
+  };
+}
+
+function logGasPriceInitialSend(hash: Hash, fees: GasPriceFeeOverrides): void {
+  logger.debug(`tx sent hash=${hash} gasPrice=${fees.gasPrice}`);
+}
+
+function logGasPriceBump(context: FeeBumpLogContext<GasPriceFeeOverrides>): void {
+  const { hash, attempt, bumpFactor, previousFees, nextFees, baseFees, wasCapped } = context;
+  logger.debug(
+    `bumping gasPrice hash=${hash} attempt=${attempt + 1} bumpFactor=${bumpFactor} ` +
+      `prevGasPrice=${previousFees.gasPrice} nextGasPrice=${nextFees.gasPrice}`,
+  );
+
+  if (wasCapped) {
+    logger.debug(`gasPrice cap reached hash=${hash} cap=${baseFees.gasPrice * MAX_FEE_MULTIPLIER}`);
+  }
+}
+
+async function sendTransactionWithFeeRetry<TFees>(
   client: Client,
-  sendFn: (fees?: FeeOverrides) => Promise<Hash>,
+  sendFn: (fees?: TFees) => Promise<Hash>,
   options: SendTransactionWithRetryOptions = {},
+  strategy: FeeRetryStrategy<TFees>,
 ): Promise<TransactionResult> {
   const receiptTimeoutMs = options.receiptTimeoutMs ?? DEFAULT_RECEIPT_TIMEOUT_MS;
   const feeBumpFactor = options.feeBumpFactor ?? DEFAULT_FEE_BUMP_FACTOR;
@@ -212,8 +326,8 @@ export async function sendTransactionWithRetry(
 
   const startedAt = Date.now();
   let lastHash!: Hash;
-  let fees!: FeeOverrides;
-  let baseFees!: FeeOverrides;
+  let fees!: TFees;
+  let baseFees!: TFees;
   let attempt = 0;
   let needsSend = true;
 
@@ -223,12 +337,10 @@ export async function sendTransactionWithRetry(
 
   async function freshSend(): Promise<void> {
     lastHash = await sendFn();
-    const tx = await getTransaction(client, { hash: lastHash });
-    fees = { maxPriorityFeePerGas: tx.maxPriorityFeePerGas, maxFeePerGas: tx.maxFeePerGas };
-    baseFees = fees;
-    logger.debug(
-      `tx sent hash=${lastHash} maxFeePerGas=${fees.maxFeePerGas} maxPriorityFeePerGas=${fees.maxPriorityFeePerGas}`,
-    );
+    const feeState = await strategy.getInitialFeeState(client, lastHash);
+    fees = feeState.fees;
+    baseFees = feeState.baseFees;
+    strategy.logInitialSend(lastHash, fees);
   }
 
   async function handleRevertRetry(hash: Hash, receipt: TransactionReceipt): Promise<boolean> {
@@ -244,6 +356,19 @@ export async function sendTransactionWithRetry(
     return true;
   }
 
+  async function retryAfterSimulationRevert(error: unknown): Promise<boolean> {
+    if (!(retryOnRevert && isContractRevert(error) && withinLimits())) {
+      return false;
+    }
+
+    logger.debug(`sendFn reverted at simulation, retrying: attempt=${attempt} error=${(error as Error).message}`);
+    await beforeRetry?.();
+    await sleep(retryOnRevertDelayMs);
+    needsSend = true;
+    attempt++;
+    return true;
+  }
+
   while (attempt <= maxRetries) {
     /* ---------- (re)send ---------- */
     if (needsSend) {
@@ -251,12 +376,7 @@ export async function sendTransactionWithRetry(
       try {
         await freshSend();
       } catch (err) {
-        if (retryOnRevert && isContractRevert(err) && withinLimits()) {
-          logger.debug(`sendFn reverted at simulation, retrying: attempt=${attempt} error=${(err as Error).message}`);
-          await beforeRetry?.();
-          await sleep(retryOnRevertDelayMs);
-          needsSend = true;
-          attempt++;
+        if (await retryAfterSimulationRevert(err)) {
           continue;
         }
         throw err;
@@ -274,7 +394,7 @@ export async function sendTransactionWithRetry(
         return { hash: lastHash, receipt: txReceipt };
       }
 
-      throw new Error("sendTransactionWithRetry: overall timeout exceeded");
+      throw new Error(`${strategy.errorPrefix}: overall timeout exceeded`);
     }
 
     /* ---------- primary wait ---------- */
@@ -316,31 +436,24 @@ export async function sendTransactionWithRetry(
         return { hash: lastHash, receipt: receipt };
       }
 
-      throw new Error("sendTransactionWithRetry: max retries exceeded");
+      throw new Error(`${strategy.errorPrefix}: max retries exceeded`);
     }
 
     /* ---------- bump from actual tx ---------- */
     const bumpFactor = feeBumpFactor + BigInt(attempt) * DEFAULT_FEE_BUMP_STEP;
-    const nextFees = bumpFeesFromTx(fees, bumpFactor);
-    const cappedFees = capBumpedFees(nextFees, baseFees);
-    const wasCapped =
-      cappedFees.maxFeePerGas !== nextFees.maxFeePerGas ||
-      cappedFees.maxPriorityFeePerGas !== nextFees.maxPriorityFeePerGas;
+    const previousFees = fees;
+    const nextFeeState = strategy.getNextFeeState(previousFees, baseFees, bumpFactor);
+    strategy.logBump({
+      hash: lastHash,
+      attempt,
+      bumpFactor,
+      previousFees,
+      nextFees: nextFeeState.fees,
+      baseFees,
+      wasCapped: nextFeeState.wasCapped,
+    });
 
-    logger.debug(
-      `bumping fees hash=${lastHash} attempt=${attempt + 1} bumpFactor=${bumpFactor} ` +
-        `prevMaxFeePerGas=${fees.maxFeePerGas} nextMaxFeePerGas=${cappedFees.maxFeePerGas} ` +
-        `prevMaxPriorityFeePerGas=${fees.maxPriorityFeePerGas} nextMaxPriorityFeePerGas=${cappedFees.maxPriorityFeePerGas}`,
-    );
-
-    if (wasCapped) {
-      logger.debug(
-        `fee cap reached hash=${lastHash} maxFeePerGasCap=${baseFees.maxFeePerGas! * MAX_FEE_MULTIPLIER} ` +
-          `maxPriorityFeePerGasCap=${baseFees.maxPriorityFeePerGas! * MAX_FEE_MULTIPLIER}`,
-      );
-    }
-
-    fees = cappedFees;
+    fees = nextFeeState.fees;
     attempt++;
 
     try {
@@ -360,14 +473,7 @@ export async function sendTransactionWithRetry(
         continue;
       }
 
-      if (retryOnRevert && isContractRevert(sendError) && withinLimits()) {
-        logger.debug(
-          `sendFn reverted at simulation, retrying: attempt=${attempt} error=${(sendError as Error).message}`,
-        );
-        await beforeRetry?.();
-        await sleep(retryOnRevertDelayMs);
-        needsSend = true;
-        attempt++;
+      if (await retryAfterSimulationRevert(sendError)) {
         continue;
       }
 
@@ -375,7 +481,21 @@ export async function sendTransactionWithRetry(
     }
   }
 
-  throw new Error("sendTransactionWithRetry: unreachable");
+  throw new Error(`${strategy.errorPrefix}: unreachable`);
+}
+
+export async function sendTransactionWithRetry(
+  client: Client,
+  sendFn: (fees?: FeeOverrides) => Promise<Hash>,
+  options: SendTransactionWithRetryOptions = {},
+): Promise<TransactionResult> {
+  return sendTransactionWithFeeRetry(client, sendFn, options, {
+    errorPrefix: "sendTransactionWithRetry",
+    getInitialFeeState: getEip1559FeeState,
+    getNextFeeState: getNextEip1559FeeState,
+    logInitialSend: logEip1559InitialSend,
+    logBump: logEip1559Bump,
+  });
 }
 
 export async function sendTransactionWithGasPriceRetry(
@@ -383,170 +503,11 @@ export async function sendTransactionWithGasPriceRetry(
   sendFn: (fees?: GasPriceFeeOverrides) => Promise<Hash>,
   options: SendTransactionWithGasPriceRetryOptions = {},
 ): Promise<TransactionResult> {
-  const receiptTimeoutMs = options.receiptTimeoutMs ?? DEFAULT_RECEIPT_TIMEOUT_MS;
-  const feeBumpFactor = options.feeBumpFactor ?? DEFAULT_FEE_BUMP_FACTOR;
-  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
-  const overallTimeoutMs = options.overallTimeoutMs ?? DEFAULT_OVERALL_TIMEOUT_MS;
-  const rejectOnRevert = options.rejectOnRevert ?? true;
-  const abi = options.abi;
-  const retryOnRevert = options.retryOnRevert ?? false;
-  const retryOnRevertDelayMs = options.retryOnRevertDelayMs ?? DEFAULT_RETRY_ON_REVERT_DELAY_MS;
-  const beforeRetry = options.beforeRetry;
-
-  const startedAt = Date.now();
-  let lastHash!: Hash;
-  let gasPriceFees!: GasPriceFeeOverrides;
-  let baseGasPrice!: bigint;
-  let attempt = 0;
-  let needsSend = true;
-
-  function withinLimits(): boolean {
-    return attempt < maxRetries && Date.now() - startedAt <= overallTimeoutMs;
-  }
-
-  async function freshSendGasPrice(): Promise<void> {
-    lastHash = await sendFn();
-    const tx = await getTransaction(client, { hash: lastHash });
-    if (tx.gasPrice === undefined) {
-      throw new Error("sendTransactionWithGasPriceRetry: transaction has no gasPrice");
-    }
-    gasPriceFees = { gasPrice: tx.gasPrice };
-    baseGasPrice = tx.gasPrice;
-    logger.debug(`tx sent hash=${lastHash} gasPrice=${gasPriceFees.gasPrice}`);
-  }
-
-  async function handleRevertRetryGasPrice(hash: Hash, receipt: TransactionReceipt): Promise<boolean> {
-    if (receipt.status !== "reverted" || !retryOnRevert || !withinLimits()) return false;
-
-    const reason = await getRevertReason(client, hash, receipt, abi);
-    logger.debug(`tx reverted, will retry: hash=${hash} attempt=${attempt} reason=${reason}`);
-
-    await beforeRetry?.();
-    await sleep(retryOnRevertDelayMs);
-    needsSend = true;
-    attempt++;
-    return true;
-  }
-
-  while (attempt <= maxRetries) {
-    if (needsSend) {
-      needsSend = false;
-      try {
-        await freshSendGasPrice();
-      } catch (err) {
-        if (retryOnRevert && isContractRevert(err) && withinLimits()) {
-          logger.debug(`sendFn reverted at simulation, retrying: attempt=${attempt} error=${(err as Error).message}`);
-          await beforeRetry?.();
-          await sleep(retryOnRevertDelayMs);
-          needsSend = true;
-          attempt++;
-          continue;
-        }
-        throw err;
-      }
-    }
-
-    if (Date.now() - startedAt > overallTimeoutMs) {
-      logger.debug(`overall timeout exceeded hash=${lastHash} attempt=${attempt}; probing receipt`);
-
-      const txReceipt = await safeGetReceipt(client, lastHash);
-      if (txReceipt) {
-        logger.debug(`tx confirmed during final probe hash=${lastHash} blockNumber=${txReceipt.blockNumber}`);
-        await assertReceiptSuccess(client, lastHash, txReceipt, rejectOnRevert, abi);
-        return { hash: lastHash, receipt: txReceipt };
-      }
-
-      throw new Error("sendTransactionWithGasPriceRetry: overall timeout exceeded");
-    }
-
-    try {
-      logger.debug(`waiting for receipt hash=${lastHash} attempt=${attempt} timeoutMs=${receiptTimeoutMs}`);
-
-      const receipt = await waitForTransactionReceipt(client, {
-        hash: lastHash,
-        timeout: receiptTimeoutMs,
-      });
-
-      logger.debug(`tx confirmed hash=${lastHash} blockNumber=${receipt.blockNumber} status=${receipt.status}`);
-
-      if (await handleRevertRetryGasPrice(lastHash, receipt)) continue;
-      await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
-      return { hash: lastHash, receipt };
-    } catch (err) {
-      if (!isReceiptTimeout(err)) throw err;
-
-      logger.debug(`receipt timeout for hash=${lastHash} attempt=${attempt}`);
-    }
-
-    const raceConditionReceipt = await safeGetReceipt(client, lastHash);
-    if (raceConditionReceipt) {
-      logger.debug(`tx mined during timeout race hash=${lastHash} blockNumber=${raceConditionReceipt.blockNumber}`);
-
-      if (await handleRevertRetryGasPrice(lastHash, raceConditionReceipt)) continue;
-      await assertReceiptSuccess(client, lastHash, raceConditionReceipt, rejectOnRevert, abi);
-      return { hash: lastHash, receipt: raceConditionReceipt };
-    }
-
-    if (attempt === maxRetries) {
-      logger.debug(`max retries reached hash=${lastHash} attempt=${attempt}; probing receipt`);
-
-      const receipt = await safeGetReceipt(client, lastHash);
-      if (receipt) {
-        await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
-        return { hash: lastHash, receipt };
-      }
-
-      throw new Error("sendTransactionWithGasPriceRetry: max retries exceeded");
-    }
-
-    const bumpFactor = feeBumpFactor + BigInt(attempt) * DEFAULT_FEE_BUMP_STEP;
-    const nextFees = bumpGasPriceFromTx(gasPriceFees, bumpFactor);
-    const cappedFees = capBumpedGasPrice(nextFees, baseGasPrice);
-    const wasCapped = cappedFees.gasPrice !== nextFees.gasPrice;
-
-    logger.debug(
-      `bumping gasPrice hash=${lastHash} attempt=${attempt + 1} bumpFactor=${bumpFactor} ` +
-        `prevGasPrice=${gasPriceFees.gasPrice} nextGasPrice=${cappedFees.gasPrice}`,
-    );
-
-    if (wasCapped) {
-      logger.debug(`gasPrice cap reached hash=${lastHash} cap=${baseGasPrice * MAX_FEE_MULTIPLIER}`);
-    }
-
-    gasPriceFees = cappedFees;
-    attempt++;
-
-    try {
-      lastHash = await sendFn(gasPriceFees);
-
-      logger.debug(`replacement tx sent hash=${lastHash} attempt=${attempt}`);
-    } catch (sendError) {
-      if (isNonceTooLow(sendError)) {
-        logger.debug(`nonce too low while retrying hash=${lastHash}; original tx likely mined`);
-
-        const receipt = await safeGetReceipt(client, lastHash);
-        if (receipt) {
-          if (await handleRevertRetryGasPrice(lastHash, receipt)) continue;
-          await assertReceiptSuccess(client, lastHash, receipt, rejectOnRevert, abi);
-          return { hash: lastHash, receipt };
-        }
-        continue;
-      }
-
-      if (retryOnRevert && isContractRevert(sendError) && withinLimits()) {
-        logger.debug(
-          `sendFn reverted at simulation, retrying: attempt=${attempt} error=${(sendError as Error).message}`,
-        );
-        await beforeRetry?.();
-        await sleep(retryOnRevertDelayMs);
-        needsSend = true;
-        attempt++;
-        continue;
-      }
-
-      throw sendError;
-    }
-  }
-
-  throw new Error("sendTransactionWithGasPriceRetry: unreachable");
+  return sendTransactionWithFeeRetry(client, sendFn, options, {
+    errorPrefix: "sendTransactionWithGasPriceRetry",
+    getInitialFeeState: getGasPriceFeeState,
+    getNextFeeState: getNextGasPriceFeeState,
+    logInitialSend: logGasPriceInitialSend,
+    logBump: logGasPriceBump,
+  });
 }

--- a/e2e/src/eip7702.spec.ts
+++ b/e2e/src/eip7702.spec.ts
@@ -1,17 +1,11 @@
-import { describe, expect, it } from "@jest/globals";
-import { encodeFunctionData, getAddress, isAddress } from "viem";
+import { describe, it } from "@jest/globals";
+import { PrivateKeyAccount } from "viem";
 
-import {
-  addToDenyList,
-  expectBlockedTransaction,
-  reloadDenyList,
-  removeFromDenyList,
-  withDenyListAddresses,
-} from "./common/test-helpers";
-import { estimateLineaGas, expectSuccessfulTransaction, sendTransactionWithRetry } from "./common/utils";
+import { expectBlockedTransaction, withDenyListAddresses } from "./common/test-helpers";
+import { encodeEip7702InitializeData, deployTestEip7702Delegation } from "./common/test-helpers/eip7702-delegation";
+import { estimateLineaGas, expectSuccessfulTransaction } from "./common/utils";
 import { L2RpcEndpoint } from "./config/clients/l2-client";
 import { createTestContext } from "./config/setup";
-import { TestEIP7702DelegationAbi, TestEIP7702DelegationAbiBytecode } from "./generated";
 
 const context = createTestContext();
 const l2AccountManager = context.getL2AccountManager();
@@ -34,34 +28,11 @@ type CreateDelegationScenarioParams = {
 describe("EIP-7702 test suite", () => {
   const l2PublicClient = context.l2PublicClient({ type: L2RpcEndpoint.BesuNode });
   const sequencerClient = context.l2PublicClient({ type: L2RpcEndpoint.Sequencer });
-  const initializeData = encodeFunctionData({
-    abi: TestEIP7702DelegationAbi,
-    functionName: "initialize",
-  });
+  const initializeData = encodeEip7702InitializeData();
 
-  async function deployDelegationContract(deployer: { address: `0x${string}` }): Promise<`0x${string}`> {
+  async function deployDelegationContract(deployer: PrivateKeyAccount): Promise<`0x${string}`> {
     const deployerWalletClient = context.l2WalletClient({ account: deployer });
-    const deployNonce = await l2PublicClient.getTransactionCount({ address: deployer.address });
-
-    const deployEstimate = await estimateLineaGas(l2PublicClient, {
-      account: deployer,
-      data: TestEIP7702DelegationAbiBytecode,
-    });
-
-    const { receipt: deployReceipt } = await sendTransactionWithRetry(l2PublicClient, (fees) =>
-      deployerWalletClient.sendTransaction({
-        data: TestEIP7702DelegationAbiBytecode,
-        nonce: deployNonce,
-        ...deployEstimate,
-        ...fees,
-      }),
-    );
-
-    expect(deployReceipt.status).toEqual("success");
-    expect(deployReceipt.contractAddress).toBeDefined();
-    expect(isAddress(deployReceipt.contractAddress as `0x${string}`)).toBe(true);
-
-    const deployedContractAddress = getAddress(deployReceipt.contractAddress as `0x${string}`);
+    const deployedContractAddress = await deployTestEip7702Delegation(l2PublicClient, deployerWalletClient, deployer);
     logger.debug(`TestEIP7702Delegation deployed. address=${deployedContractAddress}`);
     return deployedContractAddress;
   }
@@ -199,17 +170,11 @@ describe("EIP-7702 test suite", () => {
         contractAddress,
       });
 
-      try {
-        await expectSuccessfulTransaction(l2PublicClient, scenario.sendDelegatedInitializeTx());
+      await expectSuccessfulTransaction(l2PublicClient, scenario.sendDelegatedInitializeTx());
 
-        addToDenyList([scenario.denyListAddress]);
-        await reloadDenyList(sequencerClient);
-
+      await withDenyListAddresses(sequencerClient, [scenario.denyListAddress], async () => {
         await expectBlockedTransaction(scenario.sendDelegatedInitializeTx());
-      } finally {
-        removeFromDenyList([scenario.denyListAddress]);
-        await reloadDenyList(sequencerClient);
-      }
+      });
     },
     120_000,
   );

--- a/e2e/src/l2.spec.ts
+++ b/e2e/src/l2.spec.ts
@@ -4,10 +4,12 @@ import { randomBytes } from "crypto";
 import { encodeFunctionData, serializeTransaction, toHex } from "viem";
 
 import { TRANSACTION_CALLDATA_LIMIT } from "./common/constants";
-import { estimateLineaGas, sendTransactionWithRetry } from "./common/utils";
+import { estimateLineaGas, sendTransactionWithGasPriceRetry, sendTransactionWithRetry } from "./common/utils";
 import { L2RpcEndpoint } from "./config/clients/l2-client";
 import { createTestContext } from "./config/setup";
 import { DummyContractAbi } from "./generated";
+
+import type { GasPriceFeeOverrides } from "./common/utils";
 
 const context = createTestContext();
 const l2AccountManager = context.getL2AccountManager();
@@ -59,22 +61,24 @@ describe("Layer 2 test suite", () => {
   it.concurrent("Should successfully send a legacy transaction", async () => {
     const account = await l2AccountManager.generateAccount();
     const l2PublicClient = context.l2PublicClient();
+    const walletClient = context.l2WalletClient({ account });
+    const nonce = await l2PublicClient.getTransactionCount({ address: account.address });
 
     const { gasPrice } = await l2PublicClient.estimateFeesPerGas();
     logger.debug(`Fetched gasPrice=${gasPrice}`);
 
-    const txHash = await context.l2WalletClient({ account }).sendTransaction({
-      type: "legacy",
-      to: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
-      gasPrice,
-      value: etherToWei("0.01"),
-      gas: 4612388n,
-    });
+    const { hash, receipt } = await sendTransactionWithGasPriceRetry(l2PublicClient, (fees?: GasPriceFeeOverrides) =>
+      walletClient.sendTransaction({
+        type: "legacy",
+        to: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
+        gasPrice: fees?.gasPrice ?? gasPrice,
+        value: etherToWei("0.01"),
+        gas: 4612388n,
+        nonce,
+      }),
+    );
 
-    logger.debug(`Legacy transaction sent. transactionHash=${txHash}`);
-
-    const receipt = await l2PublicClient.waitForTransactionReceipt({ hash: txHash, timeout: 60_000 });
-    logger.debug(`Legacy transaction receipt received. transactionHash=${txHash} status=${receipt.status}`);
+    logger.debug(`Legacy transaction receipt received. transactionHash=${hash} status=${receipt.status}`);
 
     expect(receipt.status).toEqual("success");
   });
@@ -115,22 +119,24 @@ describe("Layer 2 test suite", () => {
     const account = await l2AccountManager.generateAccount();
 
     const l2PublicClient = context.l2PublicClient();
+    const walletClient = context.l2WalletClient({ account });
+    const nonce = await l2PublicClient.getTransactionCount({ address: account.address });
     const { gasPrice } = await l2PublicClient.estimateFeesPerGas();
     logger.debug(`Fetched gasPrice=${gasPrice}`);
 
-    const txHash = await context.l2WalletClient({ account }).sendTransaction({
-      type: "eip2930",
-      to: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
-      gasPrice,
-      value: etherToWei("0.01"),
-      gas: 21000n,
-      chainId: context.getL2ChainId(),
-    });
+    const { hash, receipt } = await sendTransactionWithGasPriceRetry(l2PublicClient, (fees?: GasPriceFeeOverrides) =>
+      walletClient.sendTransaction({
+        type: "eip2930",
+        to: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
+        gasPrice: fees?.gasPrice ?? gasPrice,
+        value: etherToWei("0.01"),
+        gas: 21000n,
+        chainId: context.getL2ChainId(),
+        nonce,
+      }),
+    );
 
-    logger.debug(`Empty access list transaction sent. transactionHash=${txHash}`);
-
-    const receipt = await l2PublicClient.waitForTransactionReceipt({ hash: txHash, timeout: 60_000 });
-    logger.debug(`Empty access list transaction receipt received. transactionHash=${txHash} status=${receipt.status}`);
+    logger.debug(`Empty access list transaction receipt received. transactionHash=${hash} status=${receipt.status}`);
 
     expect(receipt.status).toEqual("success");
   });
@@ -139,6 +145,8 @@ describe("Layer 2 test suite", () => {
     const account = await l2AccountManager.generateAccount();
 
     const l2PublicClient = context.l2PublicClient();
+    const walletClient = context.l2WalletClient({ account });
+    const nonce = await l2PublicClient.getTransactionCount({ address: account.address });
     const { gasPrice } = await l2PublicClient.estimateFeesPerGas();
     logger.debug(`Fetched gasPrice=${gasPrice}`);
 
@@ -152,19 +160,19 @@ describe("Layer 2 test suite", () => {
       },
     ] as const;
 
-    const txHash = await context.l2WalletClient({ account }).sendTransaction({
-      type: "eip2930",
-      to: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
-      gasPrice,
-      value: etherToWei("0.01"),
-      gas: 200000n,
-      chainId: context.getL2ChainId(),
-      accessList,
-    });
-    logger.debug(`Access list transaction sent. transactionHash=${txHash}`);
-
-    const receipt = await context.l2PublicClient().waitForTransactionReceipt({ hash: txHash, timeout: 60_000 });
-    logger.debug(`Access list transaction receipt received. transactionHash=${txHash} status=${receipt.status}`);
+    const { hash, receipt } = await sendTransactionWithGasPriceRetry(l2PublicClient, (fees?: GasPriceFeeOverrides) =>
+      walletClient.sendTransaction({
+        type: "eip2930",
+        to: "0x8D97689C9818892B700e27F316cc3E41e17fBeb9",
+        gasPrice: fees?.gasPrice ?? gasPrice,
+        value: etherToWei("0.01"),
+        gas: 200000n,
+        chainId: context.getL2ChainId(),
+        accessList,
+        nonce,
+      }),
+    );
+    logger.debug(`Access list transaction receipt received. transactionHash=${hash} status=${receipt.status}`);
 
     expect(receipt.status).toEqual("success");
   });


### PR DESCRIPTION
add deny list locking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared E2E helpers for deny-list mutation and transaction retry logic; bugs here can cause widespread test flakiness or masking of real failures, though impact is limited to test infrastructure.
> 
> **Overview**
> **E2E deny-list mutations are now serialized and stateful** to avoid concurrent tests racing on the shared `deny-list.txt`. The helper tracks per-file base content plus dynamically-added addresses (with reference counts), writes the effective list deterministically, and ensures `reloadDenyList` runs as part of each queued mutation/`withDenyListAddresses` session.
> 
> **Transaction retry utilities were expanded** by introducing `sendTransactionWithGasPriceRetry` for legacy/`gasPrice` transactions, and enhancing `sendTransactionWithRetry` with optional revert-aware retries and richer revert diagnostics (including ABI-based decoding when provided). E2E specs were updated to use these helpers, and new unit tests cover revert detection and deny-list locking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a231661e0520877f7117cb8c25c8461fe956c036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->