### PR TITLE
Fix/aggregation boundaries

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -389,6 +389,7 @@ class ConflationApp(
         aggregationL2StateProvider = AggregationL2StateProviderImpl(
           ethApiClient = l2EthClient,
           messageService = l2MessageService,
+          aggregationsRepository = aggregationsRepository,
           forcedTransactionsDao = forcedTransactionsDao,
         ),
         consecutiveProvenBlobsProvider = maxBlobEndBlockNumberTracker,

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationL2StateProvider.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationL2StateProvider.kt
@@ -4,6 +4,7 @@ import linea.contract.l2.L2MessageServiceSmartContractClientReadOnly
 import linea.domain.BlockParameter.Companion.toBlockParameter
 import linea.ethapi.EthApiClient
 import linea.persistence.ftx.ForcedTransactionsDao
+import net.consensys.zkevm.persistence.AggregationsRepository
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Instant
 
@@ -14,6 +15,7 @@ interface AggregationL2StateProvider {
 class AggregationL2StateProviderImpl(
   private val ethApiClient: EthApiClient,
   private val messageService: L2MessageServiceSmartContractClientReadOnly,
+  private val aggregationsRepository: AggregationsRepository,
   private val forcedTransactionsDao: ForcedTransactionsDao,
 ) : AggregationL2StateProvider {
   private data class AnchoredMessage(
@@ -58,13 +60,30 @@ class AggregationL2StateProviderImpl(
       return SafeFuture.completedFuture(FtxRollingInfo.GENESIS)
     }
 
-    return forcedTransactionsDao
-      .findHighestForcedTransaction(
-        upToSimulatedExecutionBlockNumberInclusive = aggEndBlockNumber.minus(1uL),
-      ).thenApply { highestFtx ->
-        highestFtx
-          ?.let { FtxRollingInfo(it.ftxNumber, it.ftxRollingHash) }
-          ?: FtxRollingInfo.GENESIS
+    val highestFtxFuture =
+      forcedTransactionsDao
+        .findHighestForcedTransaction(
+          // The parent finalized state is taken at the end of aggEndBlockNumber itself.
+          upToSimulatedExecutionBlockNumberInclusive = aggEndBlockNumber,
+        )
+    val latestProvenAggregationFuture =
+      aggregationsRepository.findLatestProvenAggregationProofUpToEndBlockNumber(aggEndBlockNumber.toLong())
+
+    return SafeFuture.allOf(highestFtxFuture, latestProvenAggregationFuture)
+      .thenApply {
+        val highestFtx = highestFtxFuture.get()
+        val latestProvenAggregation = latestProvenAggregationFuture.get()
+        when {
+          latestProvenAggregation != null && latestProvenAggregation.finalBlockNumber.toULong() == aggEndBlockNumber ->
+            FtxRollingInfo(latestProvenAggregation.finalFtxNumber, latestProvenAggregation.finalFtxRollingHash)
+          latestProvenAggregation != null && highestFtx != null && highestFtx.ftxNumber > latestProvenAggregation.finalFtxNumber ->
+            FtxRollingInfo(highestFtx.ftxNumber, highestFtx.ftxRollingHash)
+          latestProvenAggregation != null ->
+            FtxRollingInfo(latestProvenAggregation.finalFtxNumber, latestProvenAggregation.finalFtxRollingHash)
+          highestFtx != null ->
+            FtxRollingInfo(highestFtx.ftxNumber, highestFtx.ftxRollingHash)
+          else -> FtxRollingInfo.GENESIS
+        }
       }
   }
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/InvalidityProofProvider.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/InvalidityProofProvider.kt
@@ -7,7 +7,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 fun interface InvalidityProofProvider {
   fun getInvalidityProofs(
     ftxStartingNumber: ULong,
-    aggregationStartingBlockNumber: ULong,
+    aggregationEndBlockNumber: ULong,
   ): SafeFuture<List<InvalidityProofIndex>>
 }
 
@@ -16,12 +16,12 @@ class InvalidityProofProviderImpl(
 ) : InvalidityProofProvider {
   override fun getInvalidityProofs(
     ftxStartingNumber: ULong,
-    aggregationStartingBlockNumber: ULong,
+    aggregationEndBlockNumber: ULong,
   ): SafeFuture<List<InvalidityProofIndex>> {
     return forcedTransactionsDao
       .findByStartingNumber(
         ftxStartingNumberInclusive = ftxStartingNumber,
-        endSimulatedExecutionBlockNumberInclusive = aggregationStartingBlockNumber,
+        endSimulatedExecutionBlockNumberInclusive = aggregationEndBlockNumber,
       ).thenApply { forcedTransactions ->
         forcedTransactions.map { forcedTransaction ->
           InvalidityProofIndex(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
@@ -231,7 +231,7 @@ class ProofAggregationCoordinatorService(
       .thenCompose { rollingInfo ->
         invalidityProofProvider.getInvalidityProofs(
           ftxStartingNumber = rollingInfo.parentAggregationLastFtxNumber.inc(),
-          aggregationStartingBlockNumber = blobsToAggregate.startBlockNumber,
+          aggregationEndBlockNumber = blobsToAggregate.endBlockNumber,
         ).thenApply { invalidityProofIndexes ->
           ProofsToAggregate(
             compressionProofIndexes = compressionProofIndexes,

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/persistence/AggregationsRepository.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/persistence/AggregationsRepository.kt
@@ -36,6 +36,8 @@ interface AggregationsRepository {
 
   fun findAggregationProofByEndBlockNumber(endBlockNumber: Long): SafeFuture<ProofToFinalize?>
 
+  fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<ProofToFinalize?>
+
   fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<Int>
 
   fun deleteAggregationsAfterBlockNumber(startingBlockNumberInclusive: Long): SafeFuture<Int>

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationL2StateProviderTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationL2StateProviderTest.kt
@@ -1,0 +1,304 @@
+package net.consensys.zkevm.ethereum.coordination.aggregation
+
+import linea.contract.l2.FakeL2MessageService
+import linea.ethapi.FakeEthApiClient
+import linea.forcedtx.ForcedTransactionInclusionResult
+import linea.persistence.ftx.ForcedTransactionsDao
+import net.consensys.zkevm.domain.BlobAndBatchCounters
+import net.consensys.zkevm.domain.ForcedTransactionRecord
+import net.consensys.zkevm.domain.ProofToFinalize
+import net.consensys.zkevm.domain.createProofToFinalize
+import net.consensys.zkevm.persistence.AggregationsRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Instant
+
+class AggregationL2StateProviderTest {
+  @Test
+  fun `uses previous aggregation finalized ftx state instead of latest processed ftx`() {
+    val rollingHash = byteArrayOf(0x11)
+    val finalizedFtxRollingHash = byteArrayOf(0x22)
+    val unfinalizedFtxRollingHash = byteArrayOf(0x33)
+    val fakeEthApiClient = FakeEthApiClient().apply {
+      setLatestBlockTag(42uL)
+    }
+    val fakeMessageService = FakeL2MessageService(contractDeployBlock = 0uL).apply {
+      setLastAnchoredL1Message(7uL, rollingHash)
+    }
+    val previousAggregation =
+      createProofToFinalize(
+        firstBlockNumber = 41,
+        finalBlockNumber = 42,
+        parentAggregationFtxNumber = 0uL,
+        parentAggregationFtxRollingHash = ByteArray(32),
+        finalFtxNumber = 1uL,
+        finalFtxRollingHash = finalizedFtxRollingHash,
+      )
+    val aggregationsRepository =
+      object : AggregationsRepository {
+        override fun findConsecutiveProvenBlobs(fromBlockNumber: Long) =
+          SafeFuture.completedFuture(emptyList<BlobAndBatchCounters>())
+
+        override fun saveNewAggregation(aggregation: net.consensys.zkevm.domain.Aggregation) =
+          SafeFuture.failedFuture<Unit>(IllegalStateException("not implemented"))
+
+        override fun getProofsToFinalize(
+          fromBlockNumber: Long,
+          finalEndBlockCreatedBefore: Instant,
+          maximumNumberOfProofs: Int,
+        ) = SafeFuture.completedFuture(emptyList<ProofToFinalize>())
+
+        override fun findHighestConsecutiveEndBlockNumber(fromBlockNumber: Long?) =
+          SafeFuture.completedFuture<Long?>(null)
+
+        override fun findAggregationProofByEndBlockNumber(endBlockNumber: Long) =
+          SafeFuture.completedFuture<ProofToFinalize?>(if (endBlockNumber == 42L) previousAggregation else null)
+
+        override fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture<ProofToFinalize?>(if (endBlockNumberInclusive >= 42L) previousAggregation else null)
+
+        override fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture(0)
+
+        override fun deleteAggregationsAfterBlockNumber(startingBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture(0)
+      }
+    val forcedTransactionsDao =
+      object : ForcedTransactionsDao {
+        private val records =
+          listOf(
+            ForcedTransactionRecord(
+              ftxNumber = 1uL,
+              inclusionResult = ForcedTransactionInclusionResult.Included,
+              simulatedExecutionBlockNumber = 41uL,
+              simulatedExecutionBlockTimestamp = Instant.fromEpochSeconds(41),
+              ftxBlockNumberDeadline = 50uL,
+              ftxRollingHash = byteArrayOf(0x01),
+              ftxRlp = byteArrayOf(0x01),
+              proofStatus = ForcedTransactionRecord.ProofStatus.UNREQUESTED,
+            ),
+            ForcedTransactionRecord(
+              ftxNumber = 2uL,
+              inclusionResult = ForcedTransactionInclusionResult.Included,
+              simulatedExecutionBlockNumber = 42uL,
+              simulatedExecutionBlockTimestamp = Instant.fromEpochSeconds(42),
+              ftxBlockNumberDeadline = 51uL,
+              ftxRollingHash = unfinalizedFtxRollingHash,
+              ftxRlp = byteArrayOf(0x02),
+              proofStatus = ForcedTransactionRecord.ProofStatus.UNREQUESTED,
+            ),
+          )
+
+        override fun save(ftx: ForcedTransactionRecord): SafeFuture<Unit> =
+          SafeFuture.failedFuture(IllegalStateException("not implemented"))
+
+        override fun findByNumber(ftxNumber: ULong): SafeFuture<ForcedTransactionRecord?> {
+          return SafeFuture.completedFuture(records.find { it.ftxNumber == ftxNumber })
+        }
+
+        override fun list(): SafeFuture<List<ForcedTransactionRecord>> = SafeFuture.completedFuture(records)
+
+        override fun deleteFtxUpToInclusive(ftxNumber: ULong): SafeFuture<Int> = SafeFuture.completedFuture(0)
+      }
+
+    val aggregationL2StateProvider =
+      AggregationL2StateProviderImpl(
+        ethApiClient = fakeEthApiClient,
+        messageService = fakeMessageService,
+        aggregationsRepository = aggregationsRepository,
+        forcedTransactionsDao = forcedTransactionsDao,
+      )
+
+    val aggregationL2State = aggregationL2StateProvider.getAggregationL2State(42).get()
+
+    assertThat(aggregationL2State.parentAggregationLastL1RollingHashMessageNumber).isEqualTo(7uL)
+    assertThat(aggregationL2State.parentAggregationLastL1RollingHash).isEqualTo(rollingHash)
+    assertThat(aggregationL2State.parentAggregationLastFtxNumber).isEqualTo(1uL)
+    assertThat(aggregationL2State.parentAggregationLastFtxRollingHash).isEqualTo(finalizedFtxRollingHash)
+  }
+
+  @Test
+  fun `prefers higher dao ftx when latest proven aggregation is older than parent block`() {
+    val rollingHash = byteArrayOf(0x11)
+    val latestProvenFtxRollingHash = byteArrayOf(0x22)
+    val processedFtxRollingHash = byteArrayOf(0x33)
+    val fakeEthApiClient = FakeEthApiClient().apply {
+      setLatestBlockTag(36uL)
+    }
+    val fakeMessageService = FakeL2MessageService(contractDeployBlock = 0uL).apply {
+      setLastAnchoredL1Message(7uL, rollingHash)
+    }
+    val latestProvenAggregation =
+      createProofToFinalize(
+        firstBlockNumber = 33,
+        finalBlockNumber = 34,
+        parentAggregationFtxNumber = 0uL,
+        parentAggregationFtxRollingHash = ByteArray(32),
+        finalFtxNumber = 1uL,
+        finalFtxRollingHash = latestProvenFtxRollingHash,
+      )
+    val aggregationsRepository =
+      object : AggregationsRepository {
+        override fun findConsecutiveProvenBlobs(fromBlockNumber: Long) =
+          SafeFuture.completedFuture(emptyList<BlobAndBatchCounters>())
+
+        override fun saveNewAggregation(aggregation: net.consensys.zkevm.domain.Aggregation) =
+          SafeFuture.failedFuture<Unit>(IllegalStateException("not implemented"))
+
+        override fun getProofsToFinalize(
+          fromBlockNumber: Long,
+          finalEndBlockCreatedBefore: Instant,
+          maximumNumberOfProofs: Int,
+        ) = SafeFuture.completedFuture(emptyList<ProofToFinalize>())
+
+        override fun findHighestConsecutiveEndBlockNumber(fromBlockNumber: Long?) =
+          SafeFuture.completedFuture<Long?>(null)
+
+        override fun findAggregationProofByEndBlockNumber(endBlockNumber: Long) =
+          SafeFuture.completedFuture<ProofToFinalize?>(null)
+
+        override fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture<ProofToFinalize?>(
+            if (endBlockNumberInclusive >= 34L) latestProvenAggregation else null,
+          )
+
+        override fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture(0)
+
+        override fun deleteAggregationsAfterBlockNumber(startingBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture(0)
+      }
+    val forcedTransactionsDao =
+      object : ForcedTransactionsDao {
+        private val records =
+          listOf(
+            ForcedTransactionRecord(
+              ftxNumber = 1uL,
+              inclusionResult = ForcedTransactionInclusionResult.Included,
+              simulatedExecutionBlockNumber = 33uL,
+              simulatedExecutionBlockTimestamp = Instant.fromEpochSeconds(33),
+              ftxBlockNumberDeadline = 50uL,
+              ftxRollingHash = byteArrayOf(0x01),
+              ftxRlp = byteArrayOf(0x01),
+              proofStatus = ForcedTransactionRecord.ProofStatus.PROVEN,
+            ),
+            ForcedTransactionRecord(
+              ftxNumber = 2uL,
+              inclusionResult = ForcedTransactionInclusionResult.Included,
+              simulatedExecutionBlockNumber = 34uL,
+              simulatedExecutionBlockTimestamp = Instant.fromEpochSeconds(34),
+              ftxBlockNumberDeadline = 51uL,
+              ftxRollingHash = processedFtxRollingHash,
+              ftxRlp = byteArrayOf(0x02),
+              proofStatus = ForcedTransactionRecord.ProofStatus.PROVEN,
+            ),
+          )
+
+        override fun save(ftx: ForcedTransactionRecord): SafeFuture<Unit> =
+          SafeFuture.failedFuture(IllegalStateException("not implemented"))
+
+        override fun findByNumber(ftxNumber: ULong): SafeFuture<ForcedTransactionRecord?> {
+          return SafeFuture.completedFuture(records.find { it.ftxNumber == ftxNumber })
+        }
+
+        override fun list(): SafeFuture<List<ForcedTransactionRecord>> = SafeFuture.completedFuture(records)
+
+        override fun deleteFtxUpToInclusive(ftxNumber: ULong): SafeFuture<Int> = SafeFuture.completedFuture(0)
+      }
+
+    val aggregationL2StateProvider =
+      AggregationL2StateProviderImpl(
+        ethApiClient = fakeEthApiClient,
+        messageService = fakeMessageService,
+        aggregationsRepository = aggregationsRepository,
+        forcedTransactionsDao = forcedTransactionsDao,
+      )
+
+    val aggregationL2State = aggregationL2StateProvider.getAggregationL2State(36).get()
+
+    assertThat(aggregationL2State.parentAggregationLastL1RollingHashMessageNumber).isEqualTo(7uL)
+    assertThat(aggregationL2State.parentAggregationLastL1RollingHash).isEqualTo(rollingHash)
+    assertThat(aggregationL2State.parentAggregationLastFtxNumber).isEqualTo(2uL)
+    assertThat(aggregationL2State.parentAggregationLastFtxRollingHash).isEqualTo(processedFtxRollingHash)
+  }
+
+  @Test
+  fun `falls back to latest proven aggregation when dao no longer retains finalized ftx`() {
+    val rollingHash = byteArrayOf(0x11)
+    val finalizedFtxRollingHash = byteArrayOf(0x22)
+    val fakeEthApiClient = FakeEthApiClient().apply {
+      setLatestBlockTag(58uL)
+    }
+    val fakeMessageService = FakeL2MessageService(contractDeployBlock = 0uL).apply {
+      setLastAnchoredL1Message(7uL, rollingHash)
+    }
+    val latestProvenAggregation =
+      createProofToFinalize(
+        firstBlockNumber = 55,
+        finalBlockNumber = 56,
+        parentAggregationFtxNumber = 1uL,
+        parentAggregationFtxRollingHash = finalizedFtxRollingHash,
+        finalFtxNumber = 1uL,
+        finalFtxRollingHash = finalizedFtxRollingHash,
+      )
+    val aggregationsRepository =
+      object : AggregationsRepository {
+        override fun findConsecutiveProvenBlobs(fromBlockNumber: Long) =
+          SafeFuture.completedFuture(emptyList<BlobAndBatchCounters>())
+
+        override fun saveNewAggregation(aggregation: net.consensys.zkevm.domain.Aggregation) =
+          SafeFuture.failedFuture<Unit>(IllegalStateException("not implemented"))
+
+        override fun getProofsToFinalize(
+          fromBlockNumber: Long,
+          finalEndBlockCreatedBefore: Instant,
+          maximumNumberOfProofs: Int,
+        ) = SafeFuture.completedFuture(emptyList<ProofToFinalize>())
+
+        override fun findHighestConsecutiveEndBlockNumber(fromBlockNumber: Long?) =
+          SafeFuture.completedFuture<Long?>(null)
+
+        override fun findAggregationProofByEndBlockNumber(endBlockNumber: Long) =
+          SafeFuture.completedFuture<ProofToFinalize?>(null)
+
+        override fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture<ProofToFinalize?>(
+            if (endBlockNumberInclusive >= 56L) latestProvenAggregation else null,
+          )
+
+        override fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture(0)
+
+        override fun deleteAggregationsAfterBlockNumber(startingBlockNumberInclusive: Long) =
+          SafeFuture.completedFuture(0)
+      }
+    val forcedTransactionsDao =
+      object : ForcedTransactionsDao {
+        override fun save(ftx: ForcedTransactionRecord): SafeFuture<Unit> =
+          SafeFuture.failedFuture(IllegalStateException("not implemented"))
+
+        override fun findByNumber(ftxNumber: ULong): SafeFuture<ForcedTransactionRecord?> =
+          SafeFuture.completedFuture(null)
+
+        override fun list(): SafeFuture<List<ForcedTransactionRecord>> = SafeFuture.completedFuture(emptyList())
+
+        override fun deleteFtxUpToInclusive(ftxNumber: ULong): SafeFuture<Int> = SafeFuture.completedFuture(0)
+      }
+
+    val aggregationL2StateProvider =
+      AggregationL2StateProviderImpl(
+        ethApiClient = fakeEthApiClient,
+        messageService = fakeMessageService,
+        aggregationsRepository = aggregationsRepository,
+        forcedTransactionsDao = forcedTransactionsDao,
+      )
+
+    val aggregationL2State = aggregationL2StateProvider.getAggregationL2State(58).get()
+
+    assertThat(aggregationL2State.parentAggregationLastL1RollingHashMessageNumber).isEqualTo(7uL)
+    assertThat(aggregationL2State.parentAggregationLastL1RollingHash).isEqualTo(rollingHash)
+    assertThat(aggregationL2State.parentAggregationLastFtxNumber).isEqualTo(1uL)
+    assertThat(aggregationL2State.parentAggregationLastFtxRollingHash).isEqualTo(finalizedFtxRollingHash)
+  }
+}

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/InvalidityProofProviderTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/InvalidityProofProviderTest.kt
@@ -1,0 +1,68 @@
+package net.consensys.zkevm.ethereum.coordination.aggregation
+
+import linea.forcedtx.ForcedTransactionInclusionResult
+import linea.persistence.ftx.ForcedTransactionsDao
+import net.consensys.zkevm.domain.ForcedTransactionRecord
+import net.consensys.zkevm.domain.InvalidityProofIndex
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Instant
+
+class InvalidityProofProviderTest {
+  @Test
+  fun `includes forced transaction simulated on aggregation end block`() {
+    val forcedTransactionsDao =
+      object : ForcedTransactionsDao {
+        private val records =
+          listOf(
+            ForcedTransactionRecord(
+              ftxNumber = 1uL,
+              inclusionResult = ForcedTransactionInclusionResult.Included,
+              simulatedExecutionBlockNumber = 38uL,
+              simulatedExecutionBlockTimestamp = Instant.fromEpochSeconds(123),
+              ftxBlockNumberDeadline = 100uL,
+              ftxRollingHash = byteArrayOf(0x11),
+              ftxRlp = byteArrayOf(0x22),
+              proofStatus = ForcedTransactionRecord.ProofStatus.UNREQUESTED,
+            ),
+            ForcedTransactionRecord(
+              ftxNumber = 2uL,
+              inclusionResult = ForcedTransactionInclusionResult.Included,
+              simulatedExecutionBlockNumber = 39uL,
+              simulatedExecutionBlockTimestamp = Instant.fromEpochSeconds(124),
+              ftxBlockNumberDeadline = 101uL,
+              ftxRollingHash = byteArrayOf(0x33),
+              ftxRlp = byteArrayOf(0x44),
+              proofStatus = ForcedTransactionRecord.ProofStatus.UNREQUESTED,
+            ),
+          )
+
+        override fun save(ftx: ForcedTransactionRecord): SafeFuture<Unit> =
+          SafeFuture.failedFuture(IllegalStateException("not implemented"))
+
+        override fun findByNumber(ftxNumber: ULong): SafeFuture<ForcedTransactionRecord?> =
+          SafeFuture.completedFuture(records.find { it.ftxNumber == ftxNumber })
+
+        override fun list(): SafeFuture<List<ForcedTransactionRecord>> = SafeFuture.completedFuture(records)
+
+        override fun deleteFtxUpToInclusive(ftxNumber: ULong): SafeFuture<Int> = SafeFuture.completedFuture(0)
+      }
+
+    val invalidityProofProvider = InvalidityProofProviderImpl(forcedTransactionsDao)
+
+    val invalidityProofs =
+      invalidityProofProvider.getInvalidityProofs(
+        ftxStartingNumber = 1uL,
+        aggregationEndBlockNumber = 38uL,
+      ).get()
+
+    assertThat(invalidityProofs).containsExactly(
+      InvalidityProofIndex(
+        ftxNumber = 1uL,
+        simulatedExecutionBlockNumber = 38uL,
+        startBlockTimestamp = Instant.fromEpochSeconds(123),
+      ),
+    )
+  }
+}

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
@@ -1,6 +1,5 @@
 package linea.ftx.conflation
 
-import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.forcedtx.ForcedTransactionInclusionStatus
 import net.consensys.zkevm.domain.BlobCounters
 import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
@@ -17,28 +16,27 @@ import java.util.Queue
  * that require invalidity proofs.
  *
  * Consumes from processedFtxQueue (shared with ConflationCalculatorByForcedTransaction)
- * to detect processed FTXs with non-Included results and returns INVALIDITY_PROOF
+ * to detect processed FTXs that require invalidity proofs and returns FORCED_TRANSACTION
  * aggregation triggers at (ftx.blockNumber - 1) to isolate the FTX block for invalidity proof generation.
  *
  * Rules:
- * - Trigger aggregation at (ftx.blockNumber - 1) when inclusionResult != Included
- * - Do NOT trigger if inclusionResult == Included (successfully executed FTXs)
+ * - Trigger aggregation at (ftx.blockNumber - 1) for every processed FTX
  *
  * Note: This calculator is responsible for consuming items from the shared queue.
  * ConflationCalculatorByForcedTransaction reads from the queue without consuming.
  * Queue cleanup happens on reset() to ensure all FTXs are processed before clearing.
  *
  * This ensures that:
- * 1. Aggregations are sealed before failed FTX execution blocks
- * 2. Failed FTX blocks are isolated in their own aggregation for invalidity proof generation
- * 3. Successfully included FTXs don't create unnecessary aggregation boundaries
+ * 1. Aggregations are sealed before processed FTX execution blocks
+ * 2. FTX execution blocks are isolated in their own aggregation for invalidity proof generation
+ * 3. Aggregation requests never mix invalidity proofs from different simulated execution blocks
  */
 class AggregationCalculatorByForcedTransaction(
   private val processedFtxQueue: Queue<ForcedTransactionInclusionStatus>,
   private val log: Logger = LogManager.getLogger(AggregationCalculatorByForcedTransaction::class.java),
 ) : SyncAggregationTriggerCalculator {
 
-  // Track pending trigger blocks (blockNumber - 1) for non-included FTXs
+  // Track pending trigger blocks (blockNumber - 1) for processed FTXs.
   private val pendingTriggerBlocks = DynamicBlockNumberSet()
 
   // Delegate to AggregationTriggerCalculatorByTargetBlockNumbers for actual triggering logic
@@ -61,12 +59,10 @@ class AggregationCalculatorByForcedTransaction(
       return
     }
 
-    // Only add trigger blocks for FTXs that were NOT successfully included
-    // Trigger at (blockNumber - 1) to seal aggregation before failed FTX execution block
+    // Trigger at (blockNumber - 1) to seal aggregation before the FTX execution block.
+    // Included FTXs also require invalidity proofs, and the prover rejects aggregations
+    // that mix invalidity proofs from different simulated execution blocks.
     val newTriggerBlocks = processedFtxs
-      .filter { ftx ->
-        ftx.inclusionResult != ForcedTransactionInclusionResult.Included
-      }
       .map { ftx ->
         // ftx.blockNumber is always greater than 0 (0 is genesis block),
         // In practice, greater than 2 most of the cases because network bootstrapping
@@ -76,24 +72,16 @@ class AggregationCalculatorByForcedTransaction(
       .toSet()
 
     pendingTriggerBlocks.addBlockNumbers(newTriggerBlocks)
-    logFtxPendingAggregation(processedFtxs, newTriggerBlocks)
-  }
-
-  fun logFtxPendingAggregation(processedFtxs: List<ForcedTransactionInclusionStatus>, newTriggerBlocks: Set<ULong>) {
     if (newTriggerBlocks.isNotEmpty()) {
-      val failedFtxs = processedFtxs.filter { it.inclusionResult != ForcedTransactionInclusionResult.Included }
       log.info(
-        "added {} FTX aggregation trigger blocks for {} non-included FTXs. ftxs={} total pending triggers: {}",
+        "added {} FTX aggregation trigger blocks for {} processed FTXs. ftxs={} total pending triggers: {}",
         newTriggerBlocks.size,
-        failedFtxs.size,
-        failedFtxs.map { "ftx=${it.ftxNumber} result=${it.inclusionResult}" },
+        processedFtxs.size,
+        processedFtxs.map { "ftx=${it.ftxNumber} result=${it.inclusionResult}" },
         pendingTriggerBlocks.sorted(),
       )
     } else {
-      log.debug(
-        "processed {} FTXs, all were successfully included (no aggregation triggers needed)",
-        processedFtxs.size,
-      )
+      log.debug("processed {} FTXs (no new aggregation trigger blocks needed)", processedFtxs.size)
     }
   }
 
@@ -112,7 +100,7 @@ class AggregationCalculatorByForcedTransaction(
 
     if (trigger != null) {
       log.info(
-        "FTX aggregation trigger detected: sealing aggregation at block {} (before failed FTX execution at block {})",
+        "FTX aggregation trigger detected: sealing aggregation at block {} (before FTX execution at block {})",
         blobCounters.endBlockNumber,
         blobCounters.endBlockNumber + 1UL,
       )

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -1,6 +1,5 @@
 package linea.ftx.conflation
 
-import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.forcedtx.ForcedTransactionInclusionStatus
 import net.consensys.zkevm.domain.BlockCounters
 import net.consensys.zkevm.domain.ConflationTrigger
@@ -9,27 +8,25 @@ import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCounters
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.util.Queue
-import kotlin.collections.map
 
 /**
  * Deferred trigger calculator that creates conflation boundaries at FTX execution blocks
  * that require invalidity proofs.
  *
  * Reads from processedFtxQueue (shared with AggregationCalculatorByForcedTransaction)
- * to detect processed FTXs with non-Included results and triggers FORCED_TRANSACTION
- * conflation at (blockNumber - 1) to isolate the FTX block for invalidity proof generation.
+ * to detect processed FTXs that require invalidity proofs and triggers FORCED_TRANSACTION
+ * conflation at the FTX execution block to isolate that block for invalidity proof generation.
  *
  * Rules:
- * - Trigger conflation at (ftx.blockNumber - 1) when inclusionResult != Included
- * - Do NOT trigger if inclusionResult == Included (successfully executed FTXs)
+ * - Trigger conflation at ftx.blockNumber for every processed FTX
  *
  * Note: This calculator reads from the queue without consuming.
  * AggregationCalculatorByForcedTransaction is responsible for consuming items.
  *
  * This ensures that:
- * 1. Failed FTXs are isolated in their own conflation for invalidity proof generation
- * 2. Successfully included FTXs don't create unnecessary conflation boundaries
- * 3. The conflation before the failed FTX block is sealed at (blockNumber - 1)
+ * 1. Processed FTXs are isolated in their own conflation for invalidity proof generation
+ * 2. Mixed invalidity proofs from consecutive simulated execution blocks are avoided
+ * 3. The conflation before the FTX execution block is sealed when that block is processed
  */
 class ConflationCalculatorByForcedTransaction(
   private val processedFtxQueue: Queue<ForcedTransactionInclusionStatus>,
@@ -37,7 +34,7 @@ class ConflationCalculatorByForcedTransaction(
 ) : ConflationCalculator {
   override val id: String = ConflationTrigger.FORCED_TRANSACTION.name
 
-  // Track pending trigger blocks (blockNumber - 1) for non-included FTXs
+  // Track pending trigger blocks keyed by the FTX execution block number.
   private val pendingTriggerBlocks = mutableSetOf<ULong>()
 
   @Volatile
@@ -51,9 +48,8 @@ class ConflationCalculatorByForcedTransaction(
     // Check if this block should trigger conflation
     return if (pendingTriggerBlocks.contains(blockCounters.blockNumber)) {
       log.info(
-        "FTX conflation overflow detected at block {} (will seal before FTX execution block {})",
+        "FTX conflation overflow detected at block {} (will seal before processing this FTX execution block)",
         blockCounters.blockNumber,
-        blockCounters.blockNumber + 1UL,
       )
       ConflationCalculator.OverflowTrigger(
         trigger = ConflationTrigger.FORCED_TRANSACTION,
@@ -73,39 +69,24 @@ class ConflationCalculatorByForcedTransaction(
       return
     }
 
-    // Only add trigger blocks for FTXs that were NOT successfully included
     val newTriggerBlocks = processedFtxs
-      .filter { ftx ->
-        ftx.inclusionResult != ForcedTransactionInclusionResult.Included
-      }
       .map { ftx ->
-        // ftx.blockNumber is always greater than 0 (0 is genesis block),
-        // In practice, greater than 2 most of the cases because network bootstrapping
-        // takes a few blocks to deploy L2 protocol contracts
-        ftx.blockNumber - 1UL
+        ftx.blockNumber
       }
       .toSet()
 
     // Only update if we have new trigger blocks not already tracked
     val actuallyNewBlocks = newTriggerBlocks - pendingTriggerBlocks
     pendingTriggerBlocks.addAll(actuallyNewBlocks)
-    logNewFtxConflationTriggers(actuallyNewBlocks, processedFtxs)
-  }
-
-  fun logNewFtxConflationTriggers(
-    actuallyNewBlocks: Set<ULong>,
-    processedFtxs: List<ForcedTransactionInclusionStatus>,
-  ) {
     if (actuallyNewBlocks.isNotEmpty()) {
-      val newFailedFtxs = processedFtxs.filter {
-        it.inclusionResult != ForcedTransactionInclusionResult.Included &&
-          actuallyNewBlocks.contains(if (it.blockNumber > 0UL) it.blockNumber - 1UL else null)
+      val newProcessedFtxs = processedFtxs.filter {
+        actuallyNewBlocks.contains(it.blockNumber)
       }
       log.info(
-        "added {} new FTX conflation trigger blocks for {} non-included FTXs. ftxs={} total pending triggers: {}",
+        "added {} new FTX conflation trigger blocks for {} processed FTXs. ftxs={} total pending triggers: {}",
         actuallyNewBlocks.size,
-        newFailedFtxs.size,
-        newFailedFtxs.map { "ftx=${it.ftxNumber} result=${it.inclusionResult}" },
+        newProcessedFtxs.size,
+        newProcessedFtxs.map { "ftx=${it.ftxNumber} result=${it.inclusionResult}" },
         pendingTriggerBlocks.sorted(),
       )
     }

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -712,7 +712,7 @@ class ForcedTransactionsAppTest {
   }
 
   @Test
-  fun `should trigger conflation and aggregation when sequencer processes ftxs`() {
+  fun `should trigger conflation and aggregation for every processed ftx block`() {
     val ftxAddedEvents = listOf(
       createFtxAddedEvent(
         l1BlockNumber = 100UL,
@@ -820,13 +820,19 @@ class ForcedTransactionsAppTest {
     }
     assertThat(conflationTriggers).isEqualTo(
       listOf(
-        99UL to ConflationTrigger.FORCED_TRANSACTION,
-        499UL to ConflationTrigger.FORCED_TRANSACTION,
+        100UL to ConflationTrigger.FORCED_TRANSACTION,
+        200UL to ConflationTrigger.FORCED_TRANSACTION,
+        300UL to ConflationTrigger.FORCED_TRANSACTION,
+        400UL to ConflationTrigger.FORCED_TRANSACTION,
+        500UL to ConflationTrigger.FORCED_TRANSACTION,
       ),
     )
     assertThat(aggregationTriggers).isEqualTo(
       listOf(
         99UL to AggregationTriggerType.FORCED_TRANSACTION,
+        199UL to AggregationTriggerType.FORCED_TRANSACTION,
+        299UL to AggregationTriggerType.FORCED_TRANSACTION,
+        399UL to AggregationTriggerType.FORCED_TRANSACTION,
         499UL to AggregationTriggerType.FORCED_TRANSACTION,
       ),
     )

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransactionTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransactionTest.kt
@@ -1,0 +1,71 @@
+package linea.ftx.conflation
+
+import linea.forcedtx.ForcedTransactionInclusionResult
+import linea.forcedtx.ForcedTransactionInclusionStatus
+import net.consensys.zkevm.domain.blobCounters
+import net.consensys.zkevm.ethereum.coordination.aggregation.AggregationTrigger
+import net.consensys.zkevm.ethereum.coordination.aggregation.AggregationTriggerType
+import net.consensys.zkevm.domain.BlobsToAggregate
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.util.LinkedList
+import java.util.Queue
+import kotlin.time.Instant
+
+class AggregationCalculatorByForcedTransactionTest {
+  @Test
+  fun `creates adjacent aggregation boundaries for consecutive processed ftx blocks`() {
+    val processedFtxQueue: Queue<ForcedTransactionInclusionStatus> = LinkedList()
+    processedFtxQueue.add(
+      forcedTransactionInclusionStatus(
+        ftxNumber = 3uL,
+        blockNumber = 46uL,
+        inclusionResult = ForcedTransactionInclusionResult.Included,
+        blockTimestamp = Instant.fromEpochSeconds(1_776_183_262),
+      ),
+    )
+    processedFtxQueue.add(
+      forcedTransactionInclusionStatus(
+        ftxNumber = 4uL,
+        blockNumber = 47uL,
+        inclusionResult = ForcedTransactionInclusionResult.BadNonce,
+        blockTimestamp = Instant.fromEpochSeconds(1_776_183_264),
+      ),
+    )
+
+    val calculator = AggregationCalculatorByForcedTransaction(processedFtxQueue = processedFtxQueue, log = mock())
+
+    assertThat(calculator.checkAggregationTrigger(blobCounters(startBlockNumber = 45uL, endBlockNumber = 45uL)))
+      .isEqualTo(
+        AggregationTrigger(
+          aggregationTriggerType = AggregationTriggerType.FORCED_TRANSACTION,
+          aggregation = BlobsToAggregate(45uL, 45uL),
+        ),
+      )
+
+    calculator.reset()
+
+    assertThat(calculator.checkAggregationTrigger(blobCounters(startBlockNumber = 46uL, endBlockNumber = 46uL)))
+      .isEqualTo(
+        AggregationTrigger(
+          aggregationTriggerType = AggregationTriggerType.FORCED_TRANSACTION,
+          aggregation = BlobsToAggregate(46uL, 46uL),
+        ),
+      )
+  }
+
+  private fun forcedTransactionInclusionStatus(
+    ftxNumber: ULong,
+    blockNumber: ULong,
+    inclusionResult: ForcedTransactionInclusionResult,
+    blockTimestamp: Instant,
+  ) = ForcedTransactionInclusionStatus(
+    ftxNumber = ftxNumber,
+    blockNumber = blockNumber,
+    blockTimestamp = blockTimestamp,
+    inclusionResult = inclusionResult,
+    ftxHash = byteArrayOf(0x01),
+    from = byteArrayOf(0x02),
+  )
+}

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
@@ -1,0 +1,67 @@
+package linea.ftx.conflation
+
+import linea.forcedtx.ForcedTransactionInclusionResult
+import linea.forcedtx.ForcedTransactionInclusionStatus
+import net.consensys.zkevm.domain.BlockCounters
+import net.consensys.zkevm.domain.ConflationTrigger
+import net.consensys.linea.traces.TracesCountersV4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.util.LinkedList
+import java.util.Queue
+import kotlin.time.Instant
+
+class ConflationCalculatorByForcedTransactionTest {
+  @Test
+  fun `creates adjacent conflation boundaries for consecutive processed ftx blocks`() {
+    val processedFtxQueue: Queue<ForcedTransactionInclusionStatus> = LinkedList()
+    processedFtxQueue.add(
+      forcedTransactionInclusionStatus(
+        ftxNumber = 1uL,
+        blockNumber = 27uL,
+        inclusionResult = ForcedTransactionInclusionResult.BadNonce,
+        blockTimestamp = Instant.fromEpochSeconds(1_776_184_667),
+      ),
+    )
+    processedFtxQueue.add(
+      forcedTransactionInclusionStatus(
+        ftxNumber = 2uL,
+        blockNumber = 28uL,
+        inclusionResult = ForcedTransactionInclusionResult.Included,
+        blockTimestamp = Instant.fromEpochSeconds(1_776_184_668),
+      ),
+    )
+
+    val calculator = ConflationCalculatorByForcedTransaction(processedFtxQueue = processedFtxQueue, log = mock())
+
+    assertThat(calculator.checkOverflow(blockCounters(27uL))?.trigger)
+      .isEqualTo(ConflationTrigger.FORCED_TRANSACTION)
+
+    calculator.reset()
+
+    assertThat(calculator.checkOverflow(blockCounters(28uL))?.trigger)
+      .isEqualTo(ConflationTrigger.FORCED_TRANSACTION)
+  }
+
+  private fun blockCounters(blockNumber: ULong) = BlockCounters(
+    blockNumber = blockNumber,
+    blockTimestamp = Instant.fromEpochSeconds(blockNumber.toLong()),
+    tracesCounters = TracesCountersV4.EMPTY_TRACES_COUNT,
+    blockRLPEncoded = ByteArray(0),
+  )
+
+  private fun forcedTransactionInclusionStatus(
+    ftxNumber: ULong,
+    blockNumber: ULong,
+    inclusionResult: ForcedTransactionInclusionResult,
+    blockTimestamp: Instant,
+  ) = ForcedTransactionInclusionStatus(
+    ftxNumber = ftxNumber,
+    blockNumber = blockNumber,
+    blockTimestamp = blockTimestamp,
+    inclusionResult = inclusionResult,
+    ftxHash = byteArrayOf(0x01),
+    from = byteArrayOf(0x02),
+  )
+}

--- a/coordinator/persistence/aggregation/src/integrationTest/kotlin/net/consensys/zkevm/persistence/dao/aggregation/AggregationsPostgresDaoTest.kt
+++ b/coordinator/persistence/aggregation/src/integrationTest/kotlin/net/consensys/zkevm/persistence/dao/aggregation/AggregationsPostgresDaoTest.kt
@@ -696,6 +696,39 @@ class AggregationsPostgresDaoTest : CleanDbTestSuiteParallel() {
   }
 
   @Test
+  fun `findLatestProvenAggregationProofUpToEndBlockNumber returns latest proven proof only`() {
+    val provenAggregation1 = createAggregation(
+      startBlockNumber = 1,
+      endBlockNumber = 4,
+    )
+    val provingAggregation =
+      Aggregation(
+        startBlockNumber = 5uL,
+        endBlockNumber = 6uL,
+        batchCount = 1uL,
+        aggregationProof = null,
+      )
+    val provenAggregation2 = createAggregation(
+      startBlockNumber = 7,
+      endBlockNumber = 8,
+    )
+
+    SafeFuture.collectAll(
+      aggregationsPostgresDaoImpl.saveNewAggregation(provenAggregation1),
+      aggregationsPostgresDaoImpl.saveNewAggregation(provingAggregation),
+      aggregationsPostgresDaoImpl.saveNewAggregation(provenAggregation2),
+    ).get()
+
+    assertThat(aggregationsPostgresDaoImpl.findLatestProvenAggregationProofUpToEndBlockNumber(7))
+      .succeedsWithin(1, TimeUnit.SECONDS)
+      .isEqualTo(provenAggregation1.aggregationProof!!)
+
+    assertThat(aggregationsPostgresDaoImpl.findLatestProvenAggregationProofUpToEndBlockNumber(8))
+      .succeedsWithin(1, TimeUnit.SECONDS)
+      .isEqualTo(provenAggregation2.aggregationProof!!)
+  }
+
+  @Test
   fun `getProofsToFinalize deserializes record without ftx fields using defaults`() {
     // Simulates a legacy DB record that was persisted before finalFtxNumber,
     // finalFtxRollingHash, and filteredAddresses were added to the proof JSON.

--- a/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/AggregationsDao.kt
+++ b/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/AggregationsDao.kt
@@ -43,6 +43,8 @@ interface AggregationsDao {
 
   fun findAggregationProofByEndBlockNumber(endBlockNumber: Long): SafeFuture<ProofToFinalize?>
 
+  fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<ProofToFinalize?>
+
   fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<Int>
 
   fun deleteAggregationsAfterBlockNumber(startingBlockNumberInclusive: Long): SafeFuture<Int>

--- a/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/AggregationsRepositoryImpl.kt
+++ b/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/AggregationsRepositoryImpl.kt
@@ -46,6 +46,10 @@ class AggregationsRepositoryImpl(
     return aggregationsPostgresDao.findAggregationProofByEndBlockNumber(endBlockNumber)
   }
 
+  override fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<ProofToFinalize?> {
+    return aggregationsPostgresDao.findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive)
+  }
+
   override fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<Int> {
     return aggregationsPostgresDao.deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive)
   }

--- a/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/PostgresAggregationsDao.kt
+++ b/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/PostgresAggregationsDao.kt
@@ -156,6 +156,18 @@ class PostgresAggregationsDao(
       """.trimIndent(),
     )
 
+  private val findLatestProvenAggregationByEndBlockNumber =
+    connection.preparedQuery(
+      """
+        select * from $aggregationsTable
+        where end_block_number <= $1
+          and status = $2
+          and aggregation_proof is not null
+        order by end_block_number desc
+        limit 1
+      """.trimIndent(),
+    )
+
   private val findFirstAggregation =
     connection.preparedQuery(
       """
@@ -374,6 +386,20 @@ class PostgresAggregationsDao(
         } else {
           aggregationProofs.firstOrNull()
         }
+      }
+  }
+
+  override fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<ProofToFinalize?> {
+    return findLatestProvenAggregationByEndBlockNumber
+      .execute(
+        Tuple.of(
+          endBlockNumberInclusive,
+          aggregationStatusToDbValue(Aggregation.Status.Proven),
+        ),
+      )
+      .toSafeFuture()
+      .thenApply { rowSet ->
+        rowSet.firstOrNull()?.let(::parseAggregationProofs)
       }
   }
 

--- a/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RetryingPostgresAggregationsDao.kt
+++ b/coordinator/persistence/aggregation/src/main/kotlin/net/consensys/zkevm/persistence/dao/aggregation/RetryingPostgresAggregationsDao.kt
@@ -49,6 +49,12 @@ class RetryingPostgresAggregationsDao(
     return persistenceRetryer.retryQuery({ delegate.findAggregationProofByEndBlockNumber(endBlockNumber) })
   }
 
+  override fun findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<ProofToFinalize?> {
+    return persistenceRetryer.retryQuery({
+      delegate.findLatestProvenAggregationProofUpToEndBlockNumber(endBlockNumberInclusive)
+    })
+  }
+
   override fun deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive: Long): SafeFuture<Int> {
     return persistenceRetryer.retryQuery({ delegate.deleteAggregationsUpToEndBlockNumber(endBlockNumberInclusive) })
   }

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -37,12 +37,9 @@ describe("Forced transaction test suite", () => {
       const gateway = context.l1Contracts.forcedTransactionGateway(l1WalletClient);
       const gatewayRead = context.l1Contracts.forcedTransactionGateway(l1PublicClient);
 
-      // Read gateway configuration
       const destinationChainId = await gatewayRead.read.DESTINATION_CHAIN_ID();
-
       logger.debug(`Gateway config — destinationChainId=${destinationChainId}`);
 
-      // Resolve finalized state and fee
       let lastFinalizedState = await resolveLastFinalizedState(
         lineaRollup,
         l1PublicClient,
@@ -70,7 +67,6 @@ describe("Forced transaction test suite", () => {
       const [, , , , feeAmount] = await lineaRollup.read.getRequiredForcedTransactionFields();
       const { maxPriorityFeePerGas, maxFeePerGas } = await l1PublicClient.estimateFeesPerGas();
 
-      // Submit the forced transaction
       const { hash: txHash, receipt } = await sendTransactionWithRetry(
         l1PublicClient,
         (fees) =>
@@ -97,7 +93,6 @@ describe("Forced transaction test suite", () => {
       logger.debug(
         `submitForcedTransaction confirmed. txHash=${txHash} status=${receipt.status} blockNumber=${receipt.blockNumber}`,
       );
-
       expect(receipt.status).toEqual("success");
 
       const [forcedTxEvent] = await getEvents(l1PublicClient, {
@@ -110,15 +105,12 @@ describe("Forced transaction test suite", () => {
       });
 
       expect(forcedTxEvent).toBeDefined();
-
       logger.debug(
         `ForcedTransactionAdded — forcedTransactionNumber=${forcedTxEvent.args.forcedTransactionNumber} from=${forcedTxEvent.args.from} blockNumberDeadline=${forcedTxEvent.args.blockNumberDeadline} forcedTransactionRollingHash=${forcedTxEvent.args.forcedTransactionRollingHash}`,
       );
-
-      // Wait for the forced transaction to be executed on L2 by polling for its receipt
-      const l2PublicClient = context.l2PublicClient();
       const submittedForcedTransactionNumber = forcedTxEvent.args.forcedTransactionNumber;
 
+      const l2PublicClient = context.l2PublicClient();
       logger.debug(`Waiting for forced transaction receipt on L2. l2TxHash=${l2TxHash}`);
 
       const l2Receipt = await l2PublicClient.waitForTransactionReceipt({ hash: l2TxHash, timeout: 120_000 });
@@ -128,7 +120,6 @@ describe("Forced transaction test suite", () => {
         `Forced transaction executed on L2. l2TxHash=${l2TxHash} blockNumber=${l2Receipt.blockNumber} status=${l2Receipt.status}`,
       );
 
-      // Wait for L1 finalization that includes the forced transaction
       logger.debug(
         `Waiting for FinalizedStateUpdated with forcedTransactionNumber >= ${submittedForcedTransactionNumber}`,
       );
@@ -141,7 +132,7 @@ describe("Forced transaction test suite", () => {
         toBlock: "latest",
         pollingIntervalMs: 2_000,
         strict: true,
-        timeoutMs: 300_000,
+        timeoutMs: 200_000,
         criteria: async (events) =>
           events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
       });
@@ -150,7 +141,7 @@ describe("Forced transaction test suite", () => {
         `Finalization includes forced transaction. blockNumber=${finalizedEvent.args.blockNumber} forcedTransactionNumber=${finalizedEvent.args.forcedTransactionNumber}`,
       );
     },
-    300_000,
+    200_000,
   );
 
   it.concurrent(
@@ -168,12 +159,9 @@ describe("Forced transaction test suite", () => {
       const gateway = context.l1Contracts.forcedTransactionGateway(l1WalletClient);
       const gatewayRead = context.l1Contracts.forcedTransactionGateway(l1PublicClient);
 
-      // Read gateway configuration
       const destinationChainId = await gatewayRead.read.DESTINATION_CHAIN_ID();
-
       logger.debug(`Gateway config — destinationChainId=${destinationChainId}`);
 
-      // Resolve finalized state and fee
       let lastFinalizedState = await resolveLastFinalizedState(
         lineaRollup,
         l1PublicClient,
@@ -201,7 +189,6 @@ describe("Forced transaction test suite", () => {
       const [, , , , feeAmount] = await lineaRollup.read.getRequiredForcedTransactionFields();
       const { maxPriorityFeePerGas, maxFeePerGas } = await l1PublicClient.estimateFeesPerGas();
 
-      // Submit the forced transaction
       const { hash: txHash, receipt } = await sendTransactionWithRetry(
         l1PublicClient,
         (fees) =>
@@ -228,7 +215,6 @@ describe("Forced transaction test suite", () => {
       logger.debug(
         `submitForcedTransaction confirmed. txHash=${txHash} status=${receipt.status} blockNumber=${receipt.blockNumber}`,
       );
-
       expect(receipt.status).toEqual("success");
 
       const [forcedTxEvent] = await getEvents(l1PublicClient, {
@@ -241,14 +227,11 @@ describe("Forced transaction test suite", () => {
       });
 
       expect(forcedTxEvent).toBeDefined();
-
       logger.debug(
         `ForcedTransactionAdded — forcedTransactionNumber=${forcedTxEvent.args.forcedTransactionNumber} from=${forcedTxEvent.args.from} blockNumberDeadline=${forcedTxEvent.args.blockNumberDeadline} forcedTransactionRollingHash=${forcedTxEvent.args.forcedTransactionRollingHash}`,
       );
 
       const submittedForcedTransactionNumber = forcedTxEvent.args.forcedTransactionNumber;
-
-      // Wait for L1 finalization that includes the forced transaction
       logger.debug(
         `Waiting for FinalizedStateUpdated with forcedTransactionNumber >= ${submittedForcedTransactionNumber}`,
       );
@@ -260,7 +243,7 @@ describe("Forced transaction test suite", () => {
         fromBlock: receipt.blockNumber,
         toBlock: "latest",
         pollingIntervalMs: 2_000,
-        timeoutMs: 300_000,
+        timeoutMs: 200_000,
         strict: true,
         criteria: async (events) =>
           events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
@@ -275,8 +258,6 @@ describe("Forced transaction test suite", () => {
 
       try {
         await l2PublicClient.getTransactionReceipt({ hash: l2TxHash });
-        // This code path should not be reached; the getTransactionReceipt call is expected to throw.
-        // If it does not throw, the test should fail.
         throw new Error(
           "Test failed: Expected getTransactionReceipt to throw TransactionReceiptNotFoundError, but it did not.",
         );
@@ -289,7 +270,7 @@ describe("Forced transaction test suite", () => {
 
       logger.debug("Checked for forced transaction receipt on L2; confirmed that receipt was not found as expected.");
     },
-    300_000,
+    200_000,
   );
 
   it.skip("Should reject a forced transaction that calls an excluded precompile (BadPrecompile)", async () => {

--- a/e2e/src/shomei-get-proof.spec.ts
+++ b/e2e/src/shomei-get-proof.spec.ts
@@ -10,7 +10,7 @@ import { createTestContext } from "./config/setup";
 const context = createTestContext();
 
 describe("Shomei Linea get proof test suite", () => {
-  const lineaRollupV6 = context.l1Contracts.lineaRollup(context.l1PublicClient());
+  const lineaRollupV8 = context.l1Contracts.lineaRollup(context.l1PublicClient());
   const lineaShomeiFrontendClient = context.l2PublicClient({ type: L2RpcEndpoint.ShomeiFrontend });
   const lineaShomeiClient = context.l2PublicClient({ type: L2RpcEndpoint.Shomei });
 
@@ -23,7 +23,7 @@ describe("Shomei Linea get proof test suite", () => {
       let targetL2BlockNumber = await awaitUntil(
         async () => {
           try {
-            return await lineaRollupV6.read.currentL2BlockNumber({ blockTag: "latest" });
+            return await lineaRollupV8.read.currentL2BlockNumber({ blockTag: "latest" });
           } catch (err) {
             if (err instanceof ContractFunctionExecutionError) {
               if (err.shortMessage.includes(`returned no data ("0x")`)) {
@@ -60,7 +60,7 @@ describe("Shomei Linea get proof test suite", () => {
             }
           }
           if (!getProofResponse) {
-            const latestFinalizedL2BlockNumber = await lineaRollupV6.read.currentL2BlockNumber({
+            const latestFinalizedL2BlockNumber = await lineaRollupV8.read.currentL2BlockNumber({
               blockTag: "latest",
             });
             if (!finalizedL2BlockNumbers.includes(latestFinalizedL2BlockNumber)) {

--- a/e2e/src/submission-finalization.spec.ts
+++ b/e2e/src/submission-finalization.spec.ts
@@ -7,7 +7,7 @@ import { createTestContext } from "./config/setup";
 const context = createTestContext();
 
 describe("Submission and finalization test suite", () => {
-  describe("Contracts v6", () => {
+  describe("Contracts v8", () => {
     it.concurrent(
       "Check L1 data submission and finalization",
       async () => {


### PR DESCRIPTION
For review @fluentcrafter 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes aggregation/conflation boundary logic around forced transactions and adjusts how parent FTX rolling state is derived, which can affect proof inputs and aggregation slicing. Adds a new DB query path for selecting the latest proven aggregation proof, so correctness depends on data consistency and status handling.
> 
> **Overview**
> **Adjusts forced-transaction boundaries to avoid mixing invalidity proofs across simulated execution blocks.** Forced-transaction conflation now triggers on *every* processed FTX execution block (not only non-included ones), and forced-transaction aggregation triggers seal at `ftx.blockNumber - 1` for every processed FTX, updating logs and tests accordingly.
> 
> **Fixes proof inputs for parent FTX rolling state and invalidity-proof selection.** `AggregationL2StateProviderImpl` now consults `AggregationsRepository.findLatestProvenAggregationProofUpToEndBlockNumber` (new repo/DAO method + Postgres query) and the forced-tx DAO to choose the correct finalized `finalFtxNumber`/rolling-hash at an aggregation boundary; invalidity proof fetching is updated to use the aggregation *end* block inclusively.
> 
> **Test/infra updates.** Adds focused unit/integration tests for the new selection logic and query, and tweaks e2e specs (reduced timeouts; naming updates to contracts v8).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6870c013ed51f3311b6e7954d7b6ae140f92f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->