### PR TITLE
Prover/Fix Theta of Keccakf

### DIFF
--- a/prover/zkevm/prover/hash/keccak/keccakf/theta.go
+++ b/prover/zkevm/prover/hash/keccak/keccakf/theta.go
@@ -198,6 +198,36 @@ func (theta *theta) computationStepConstraints(comp *wizard.CompiledIOP) {
 			}
 		}
 	}
+	// Booleanity and decomposition constraints for StateNext bits.
+	// StateNext[x][y][z*8+j] must be binary (0 or 1) and must recompose
+	// in base 4 to equal StateInternalClean[x][y][z].
+	for x := 0; x < 5; x++ {
+		for y := 0; y < 5; y++ {
+			for z := 0; z < 8; z++ {
+				// Booleanity: bit * (1 - bit) == 0
+				for j := 0; j < 8; j++ {
+					bit := theta.StateNext[x][y][z*8+j]
+					exprBool := sym.Mul(bit, sym.Sub(field.One(), bit))
+					comp.InsertGlobal(0,
+						ifaces.QueryIDf("THETA_BIT_BOOL_%v_%v_%v_%v", x, y, z, j),
+						exprBool,
+					)
+				}
+				// Decomposition: StateInternalClean[x][y][z] == sum(StateNext[x][y][z*8+j] * 4^j, j=0..7)
+				pow4j := 1
+				recomposed := sym.Mul(theta.StateNext[x][y][z*8], pow4j)
+				for j := 1; j < 8; j++ {
+					pow4j *= thetaBase
+					recomposed = sym.Add(recomposed, sym.Mul(theta.StateNext[x][y][z*8+j], pow4j))
+				}
+				exprDecomp := sym.Sub(theta.StateInternalClean[x][y][z], recomposed)
+				comp.InsertGlobal(0,
+					ifaces.QueryIDf("THETA_DECOMP_%v_%v_%v", x, y, z),
+					exprDecomp,
+				)
+			}
+		}
+	}
 }
 
 // lookupConstraints use inclusion query to validate the dirty and clean versions


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Keccak/theta prover constraints; incorrect booleanity or recomposition logic could make proofs unsound or break existing witnesses despite the change being localized.
> 
> **Overview**
> Adds new constraints in `keccakf/theta.go` to enforce that `StateNext` is a valid bit-level representation of the theta output: each `StateNext` entry must be boolean, and each 8-bit slice must recompose (base-`4`) to match `StateInternalClean`.
> 
> This tightens the theta step circuit by explicitly linking the committed bit columns back to the cleaned state, reducing the chance of inconsistent witnesses slipping through without being checked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b60a8f3d3f940943c749b14eb7e1adcff9f844b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->