### PR TITLE
chore: Fix shomei frontend node healthcheck

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -479,7 +479,7 @@ services:
     ports:
       - "8889:8888"
     healthcheck:
-      test: [ "CMD-SHELL", "bash -c \"[ -f /data/shomei/LOCK ]\"" ]
+      test: [ "CMD-SHELL", "bash -c \"[ -f /data/shomei-frontend/LOCK ]\"" ]
       interval: 1s
       timeout: 1s
       retries: 60

--- a/docker/config/postman/env
+++ b/docker/config/postman/env
@@ -15,7 +15,7 @@ L2_RPC_URL=http://l2-node-besu:8545
 L2_CONTRACT_ADDRESS=0xe537D669CA013d86EBeF1D64e40fC74CADC91987
 # WARNING=FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
 L2_SIGNER_PRIVATE_KEY=0xfcf854e0a0bc6fd7e97d7050e61a362c915cecd6767a32267b22e8b7af572e58
-L2_LISTENER_INTERVAL=2000
+L2_LISTENER_INTERVAL=500
 # Starting block for L2 event fetching. Controls from which block the Postman service starts fetching events.
 # Options: -1 = current latest block (default), 0 = from genesis (all historical events),
 # specific number = custom starting block (e.g., 1000000)

--- a/docker/config/postman/env
+++ b/docker/config/postman/env
@@ -2,7 +2,7 @@ L1_RPC_URL=http://l1-el-node:8545
 L1_CONTRACT_ADDRESS=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
 # WARNING=FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
 L1_SIGNER_PRIVATE_KEY=0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba
-L1_LISTENER_INTERVAL=2000
+L1_LISTENER_INTERVAL=500
 # Starting block for L1 event fetching. Controls from which block the Postman service starts fetching events.
 # Options: -1 = current latest block (default), 0 = from genesis (all historical events),
 # specific number = custom starting block (e.g., 18500000)

--- a/e2e/src/bridge-tokens.spec.ts
+++ b/e2e/src/bridge-tokens.spec.ts
@@ -144,7 +144,7 @@ describe("Bridge ERC20 Tokens L1 -> L2 and L2 -> L1", () => {
             _messageHash: messageHash,
           },
           strict: true,
-          timeoutMs: 200_000,
+          timeoutMs: 150_000,
         }),
         waitForEvents(l2PublicClient, {
           abi: TokenBridgeV1_1Abi,
@@ -157,13 +157,13 @@ describe("Bridge ERC20 Tokens L1 -> L2 and L2 -> L1", () => {
           criteria: async (events) => {
             return events.filter((event) => event.args.amount === bridgeAmount);
           },
-          timeoutMs: 200_000,
+          timeoutMs: 150_000,
         }),
       ]);
 
       logger.debug(`Message claimed on L2. event=${serialize(claimedEvent)}.`);
     },
-    250_000,
+    200_000,
   );
 
   it.concurrent(

--- a/e2e/src/bridge-tokens.spec.ts
+++ b/e2e/src/bridge-tokens.spec.ts
@@ -144,7 +144,7 @@ describe("Bridge ERC20 Tokens L1 -> L2 and L2 -> L1", () => {
             _messageHash: messageHash,
           },
           strict: true,
-          timeoutMs: 150_000,
+          timeoutMs: 200_000,
         }),
         waitForEvents(l2PublicClient, {
           abi: TokenBridgeV1_1Abi,
@@ -157,13 +157,13 @@ describe("Bridge ERC20 Tokens L1 -> L2 and L2 -> L1", () => {
           criteria: async (events) => {
             return events.filter((event) => event.args.amount === bridgeAmount);
           },
-          timeoutMs: 150_000,
+          timeoutMs: 200_000,
         }),
       ]);
 
       logger.debug(`Message claimed on L2. event=${serialize(claimedEvent)}.`);
     },
-    200_000,
+    250_000,
   );
 
   it.concurrent(


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only local docker configuration tweaks; main impact is faster polling that could increase load/noise in dev environments.
> 
> **Overview**
> Fixes the `shomei-frontend` Docker healthcheck to look for the correct lockfile (`/data/shomei-frontend/LOCK`), preventing false-unhealthy status.
> 
> Updates Postman local dev env defaults to poll L1/L2 events more frequently by reducing `L1_LISTENER_INTERVAL` and `L2_LISTENER_INTERVAL` from `2000`ms to `500`ms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8236688091c26d1fcbafa0c4f3c2863ab4f0a3d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->