### PR TITLE
fix: printf in interpreter for instruction_type

### DIFF
--- a/arithmetization/src/main/riscv/interpreter.zkc
+++ b/arithmetization/src/main/riscv/interpreter.zkc
@@ -16,7 +16,7 @@ fn interpreter<ram,registers>(instruction:u32, pc:Address) -> (new_pc:Address) {
     printf "instruction %b\n", instruction
     printf "opcode:     %b\n", opcode
     printf "parameters: %b\n", instruction_parameters
-    printf "parameters: %b\n", instruction_parameters
+    printf "type:       %b\n", instruction_type
 
     // TODO: handle the case where rd = 0: we will handle this in RAM itself, likely by adding an extra read-write pair
     // to reset the value in registers[rd] to 0


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-output-only change that doesn’t affect instruction execution logic or state transitions.
> 
> **Overview**
> Fixes a debug-print typo in `riscv/interpreter.zkc` by removing a duplicate `printf` of `instruction_parameters` and adding a `printf` for the decoded `instruction_type`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ee3a030c779462430ea6c5b2629d6066d96be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->