### PR TITLE
fix: ecpair pairID and Index consistency

### DIFF
--- a/prover/zkevm/prover/ecpair/ecpair_constraints.go
+++ b/prover/zkevm/prover/ecpair/ecpair_constraints.go
@@ -126,7 +126,7 @@ func (ec *ECPair) csConstantWhenIsComputing(comp *wizard.CompiledIOP) {
 		),
 	)
 
-	// IF IS_COMPUTING AND IS_ACTIVE AND NOT FIRST_LINE => TOTAL_PAIRINGS_{i} = TOTAL_PAIRINGS_{i-1}
+	// IF IS_COMPUTING AND IS_ACTIVE AND NOT FIRST_LINE => TOTAL_PAIRS_{i} = TOTAL_PAIRS_{i-1}
 	comp.InsertGlobal(
 		roundNr,
 		ifaces.QueryIDf("%v_TOTAL_PAIRS_CONSISTENCY", nameECPair),

--- a/prover/zkevm/prover/ecpair/ecpair_constraints.go
+++ b/prover/zkevm/prover/ecpair/ecpair_constraints.go
@@ -113,15 +113,27 @@ func (ec *ECPair) csConstantWhenIsComputing(comp *wizard.CompiledIOP) {
 	// we want to ensure that when we compute lines then PAIRING_ID and
 	// TOTAL_PAIRINGS is consistent with the projected values
 
-	// IF IS_COMPUTING AND IS_ACTIVE AND NOT FIRST_LINE => PAIRING_ID_{i} = PAIRING_ID_{i-1} AND TOTAL_PAIRINGS_{i} = TOTAL_PAIRINGS_{i-1}
+	// PairID may only change on the first computed row of a new pair.
 	comp.InsertGlobal(
 		roundNr,
-		ifaces.QueryIDf("%v_COUNTERS_CONSISTENCY", nameECPair),
+		ifaces.QueryIDf("%v_PAIR_ID_CONSISTENCY", nameECPair),
 		sym.Mul(
 			ec.UnalignedPairingData.IsActive,
 			ec.UnalignedPairingData.IsComputed,
 			sym.Sub(1, ec.UnalignedPairingData.IsFirstLineOfInstance),
+			sym.Sub(1, ec.UnalignedPairingData.IsFirstLineOfPrevAccumulator),
 			sym.Sub(ec.UnalignedPairingData.PairID, column.Shift(ec.UnalignedPairingData.PairID, -1)),
+		),
+	)
+
+	// IF IS_COMPUTING AND IS_ACTIVE AND NOT FIRST_LINE => TOTAL_PAIRINGS_{i} = TOTAL_PAIRINGS_{i-1}
+	comp.InsertGlobal(
+		roundNr,
+		ifaces.QueryIDf("%v_TOTAL_PAIRS_CONSISTENCY", nameECPair),
+		sym.Mul(
+			ec.UnalignedPairingData.IsActive,
+			ec.UnalignedPairingData.IsComputed,
+			sym.Sub(1, ec.UnalignedPairingData.IsFirstLineOfInstance),
 			sym.Sub(ec.UnalignedPairingData.TotalPairs, column.Shift(ec.UnalignedPairingData.TotalPairs, -1)),
 		),
 	)


### PR DESCRIPTION
In the ECPAIR module we send the input pairs into MillerLoopAndMul circuit except for the last pair, which goes into MillerLoopAndFinalExpCircuit. For this filtering to work we need to ensure that the pairID and TotalPairs stay consistent over the instance of a pairing input.

Previously, we checked the conditions at the same time:
```go
comp.InsertGlobal(
		roundNr,
		ifaces.QueryIDf("%v_COUNTERS_CONSISTENCY", nameECPair),
		sym.Mul(
			ec.UnalignedPairingData.IsActive,
			ec.UnalignedPairingData.IsComputed,
			sym.Sub(1, ec.UnalignedPairingData.IsFirstLineOfInstance),
			sym.Sub(ec.UnalignedPairingData.PairID, column.Shift(ec.UnalignedPairingData.PairID, -1)),
			sym.Sub(ec.UnalignedPairingData.TotalPairs, column.Shift(ec.UnalignedPairingData.TotalPairs, -1)),
		),
	)
```
However, this is effectively an OR-condition instead of AND-condition which is necessary. The fix is to separate the single constraint into two separate constraints checking PairID and TotalPairs separately.

Now, fixing that, it surfaced an actual completeness issue -- when we had `TotalPairs[i] == TotalPairs[i-1]` then it effectively disabled check on PairID, which can genuinely update on every new pair. So we had to also filter the condition on `IsFirstLineOfPrevAccumulator` to fix completeness.

Tested on:
- locally on a regression test
- on test suite included in the repository
- additional generated test-suite in `zkevm/prover/ecpair/testdata/generated` generated using the fixture generator (up to two pairs per pairing)

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches proof-system-critical hashing, commitment layouts, and recursion verification paths; any padding/layout mismatch can break soundness or cause widespread verification failures across circuits.
> 
> **Overview**
> **Fixes and hardens Vortex non-SIS hashing/recursion consistency.** No-SIS column hashing (MiMC and Poseidon2/koalabear) is now *right-zero-padded to the next power-of-two* so commitments, verifier checks, and self-recursion `CheckLinearHash`/`EvalCoeffBivariate` agree on the same period.
> 
> Self-recursion’s non-SIS preimage handling is reworked to use the *same committed opened columns directly* (round-indexed layouts: MiMC uses `colChunksPad=nextPow2(Pi)`; Poseidon2 uses per-round **8-lane** columns with `colChunksPad=nextPow2(ceil(Pi/8))`). This removes separate “concatenated preimage” commitments/assignments and closes a gap where a prover could satisfy Merkle/linear-hash checks with inconsistent preimage data.
> 
> Separately tightens constraints across modules: ECPAIR splits the previous combined PairID/TotalPairs check into two constraints and adds `IsFirstLineOfPrevAccumulator` gating; KeccakF adds an `IsBlockActive` column to drive cyclic counters/patterns and Theta now enforces bit booleanity + base-4 decomposition; state-manager accumulator adds binding constraints anchoring pointer/path columns to Merkle openings/positions and removes synthetic ReadZero injection; `FlattenColumn` drops the precomputed projection-mask approach in favor of a multi-ary projection query (and updates limitless sizing advice accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a7be8a2d09e86a6386bc2ceba1be98f757aafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->