### PR TITLE
fix(coordinator) conflation cutoff by forced transacions

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationCalculator.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationCalculator.kt
@@ -50,13 +50,13 @@ fun interface AggregationTriggerHandler {
 }
 
 /**
- * The aggregation proof can be triggered by 2 conditions:
- *  - Number of batches - if number of all batches combined for all subsequent blobs above a given threshold;
+ * The proof aggregation can be triggered by the following conditions:
+ *  - proof limit: when (batches + blobs) reach a certain limit configured;
+ *  - blob limit: when (blobs) reach a certain limit configured;
+ *  - forced transaction was rejected: when an invalid (BadNonce) forced transaction is detected at block B, we need to
+ *      make aggregation boundary at B-1, to include invalidity proof a beginning of next aggregation;
  *  - Finalization deadline: the time elapsed between first block’s timestamp in the first submitted blob and
  *     current time is greater than a finalization deadline configured.
- *
- *   Sum(blob.numberOfBatches) < prover_batches_limit
- *   blob.firstBlockTimestamp < current_time - submission_deadline;
  */
 interface AggregationCalculator {
   fun newBlob(blobCounters: BlobCounters)

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationTriggerCalculatorByTargetBlockNumbers.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationTriggerCalculatorByTargetBlockNumbers.kt
@@ -15,6 +15,11 @@ class AggregationTriggerCalculatorByTargetBlockNumbers(
   private var inFlightAggregation: BlobsToAggregate? = null
 
   internal fun <T : BlockInterval> checkAggregationTrigger(blob: T): AggregationTrigger? {
+    log.debug(
+      "checking aggregation trigger: blockNumber={} targetEndBlockNumbers={}",
+      blob.intervalString(),
+      targetEndBlockNumbers.toList().sorted(),
+    )
     val endBlockNumbers = targetEndBlockNumbers.sorted()
 
     if (endBlockNumbers.isEmpty()) {

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationServiceImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationServiceImpl.kt
@@ -119,7 +119,7 @@ class ConflationServiceImpl(
       if (!safeBlockNumberProvider.isBlockSafeToConflate(nextBlockNumberToConflate)) {
         log.info(
           "conflation temporarily paused: blockNumber={} (likely paused by forced transactions)",
-          nextBlockNumberToConflate,
+          nextBlockNumberToConflate - 1UL,
         )
         break
       }

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlockConflationCalculator.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlockConflationCalculator.kt
@@ -73,10 +73,17 @@ class GlobalBlockConflationCalculator(
       inflightConflation.counters,
     )
     val triggers =
-      calculators.mapNotNull {
-        val overflowTrigger = it.checkOverflow(blockCounters)
-        log.trace("CHECK: calculator={}, blockNumber={}, trigger={}", it.id, blockCounters.blockNumber, overflowTrigger)
-        overflowTrigger
+      calculators.mapNotNull { calculator ->
+        calculator
+          .checkOverflow(blockCounters)
+          .also { overflowTrigger ->
+            log.trace(
+              "CHECK: calculator={}, blockNumber={}, trigger={}",
+              calculator.id,
+              blockCounters.blockNumber,
+              overflowTrigger,
+            )
+          }
       }.sortedBy { it.trigger.triggerPriority }
 
     if (triggers.isNotEmpty()) {

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByTargetBlockNumbersTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByTargetBlockNumbersTest.kt
@@ -20,16 +20,15 @@ class ConflationCalculatorByTargetBlockNumbersTest {
 
   @Test
   fun `checkOverflow should return overflow trigger for targetBlockNumber + 1`() {
-    for (i in 1uL..targetBlockNumber1) {
-      assertThat(calculator.checkOverflow(blockCounters(i))).isNull()
-    }
+    assertThat(calculator.checkOverflow(blockCounters(targetBlockNumber1))).isNull()
     assertThat(calculator.checkOverflow(blockCounters(targetBlockNumber1 + 1uL)))
-      .isEqualTo((ConflationCalculator.OverflowTrigger(ConflationTrigger.TARGET_BLOCK_NUMBER, false)))
-    for (i in targetBlockNumber1 + 2uL..targetBlockNumber2) {
-      assertThat(calculator.checkOverflow(blockCounters(i))).isNull()
-    }
+      .isEqualTo(ConflationCalculator.OverflowTrigger(ConflationTrigger.TARGET_BLOCK_NUMBER, false))
+    assertThat(calculator.checkOverflow(blockCounters(targetBlockNumber1 + 2UL))).isNull()
+
+    assertThat(calculator.checkOverflow(blockCounters(targetBlockNumber2))).isNull()
     assertThat(calculator.checkOverflow(blockCounters(targetBlockNumber2 + 1uL)))
-      .isEqualTo((ConflationCalculator.OverflowTrigger(ConflationTrigger.TARGET_BLOCK_NUMBER, false)))
+      .isEqualTo(ConflationCalculator.OverflowTrigger(ConflationTrigger.TARGET_BLOCK_NUMBER, false))
+    assertThat(calculator.checkOverflow(blockCounters(targetBlockNumber2 + 2UL))).isNull()
   }
 
   private fun blockCounters(blockNumber: ULong): BlockCounters {

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
@@ -11,6 +11,7 @@ import net.consensys.zkevm.ethereum.coordination.aggregation.SyncAggregationTrig
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.util.Queue
+import kotlin.collections.map
 
 /**
  * Synchronous aggregation trigger calculator that creates aggregation boundaries at FTX execution blocks
@@ -83,10 +84,9 @@ class AggregationCalculatorByForcedTransaction(
     if (newTriggerBlocks.isNotEmpty()) {
       val failedFtxs = processedFtxs.filter { it.inclusionResult != ForcedTransactionInclusionResult.Included }
       log.info(
-        "added {} FTX aggregation trigger blocks for {} non-included FTXs. ftxs={} total pending triggers: {}",
-        newTriggerBlocks.size,
-        failedFtxs.size,
-        failedFtxs.map { "ftx=${it.ftxNumber} result=${it.inclusionResult}" },
+        "appended new aggregation trigger of non-included FTXs: blockNumbers={} ftxs={}, total pending triggers {}",
+        newTriggerBlocks,
+        failedFtxs.map(ForcedTransactionInclusionStatus::toStringShortForLogging),
         pendingTriggerBlocks.sorted(),
       )
     } else {
@@ -105,6 +105,12 @@ class AggregationCalculatorByForcedTransaction(
 
   @Synchronized
   override fun checkAggregationTrigger(blobCounters: BlobCounters): AggregationTrigger? {
+    log.trace(
+      "checking ftx aggregation trigger: blob={} pendingTriggerBlocks={} processedFtxQueue={}",
+      blobCounters.intervalString(),
+      pendingTriggerBlocks.sorted(),
+      processedFtxQueue.toList().map(ForcedTransactionInclusionStatus::toStringShortForLogging),
+    )
     // First, consume all available processed FTXs from the queue
     consumeProcessedFtxs()
     // Delegate to the target block numbers calculator

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -105,10 +105,7 @@ class ConflationCalculatorByForcedTransaction(
     processedFtxs: List<ForcedTransactionInclusionStatus>,
   ) {
     if (actuallyNewBlocks.isNotEmpty()) {
-      val newFailedFtxs = processedFtxs.filter {
-        it.inclusionResult != ForcedTransactionInclusionResult.Included &&
-          actuallyNewBlocks.contains(if (it.blockNumber > 0UL) it.blockNumber - 1UL else null)
-      }
+      val newFailedFtxs = processedFtxs.filter { actuallyNewBlocks.contains(it.blockNumber) }
       log.info(
         "appended new conflation triggers {} of non-included ftxs={}, all pending triggers {}",
         actuallyNewBlocks,

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -46,14 +46,21 @@ class ConflationCalculatorByForcedTransaction(
   @Synchronized
   override fun checkOverflow(blockCounters: BlockCounters): ConflationCalculator.OverflowTrigger? {
     // First, read all available processed FTXs from the queue (without consuming)
+    log.debug(
+      "checking ftx conflation trigger: blockNumber={} ftxProcessed={}",
+      blockCounters.blockNumber,
+      processedFtxQueue.toList().map { it.toStringShortForLogging() },
+    )
+
     readProcessedFtxs()
 
     // Check if this block should trigger conflation
     return if (pendingTriggerBlocks.contains(blockCounters.blockNumber)) {
       log.info(
-        "FTX conflation overflow detected at block {} (will seal before FTX execution block {})",
+        "FTX conflation detected at block={} ftxExecuted={}",
         blockCounters.blockNumber,
-        blockCounters.blockNumber + 1UL,
+        processedFtxQueue.toList()
+          .map { it.toStringShortForLogging() },
       )
       ConflationCalculator.OverflowTrigger(
         trigger = ConflationTrigger.FORCED_TRANSACTION,
@@ -74,22 +81,23 @@ class ConflationCalculatorByForcedTransaction(
     }
 
     // Only add trigger blocks for FTXs that were NOT successfully included
+    val highestPendingTrigger = pendingTriggerBlocks.maxOrNull() ?: 0UL
     val newTriggerBlocks = processedFtxs
       .filter { ftx ->
-        ftx.inclusionResult != ForcedTransactionInclusionResult.Included
+        ftx.inclusionResult != ForcedTransactionInclusionResult.Included &&
+          ftx.blockNumber > highestPendingTrigger
       }
       .map { ftx ->
         // ftx.blockNumber is always greater than 0 (0 is genesis block),
         // In practice, greater than 2 most of the cases because network bootstrapping
         // takes a few blocks to deploy L2 protocol contracts
-        ftx.blockNumber - 1UL
+        ftx.blockNumber
       }
       .toSet()
 
     // Only update if we have new trigger blocks not already tracked
-    val actuallyNewBlocks = newTriggerBlocks - pendingTriggerBlocks
-    pendingTriggerBlocks.addAll(actuallyNewBlocks)
-    logNewFtxConflationTriggers(actuallyNewBlocks, processedFtxs)
+    pendingTriggerBlocks.addAll(newTriggerBlocks)
+    logNewFtxConflationTriggers(newTriggerBlocks, processedFtxs)
   }
 
   fun logNewFtxConflationTriggers(
@@ -102,10 +110,9 @@ class ConflationCalculatorByForcedTransaction(
           actuallyNewBlocks.contains(if (it.blockNumber > 0UL) it.blockNumber - 1UL else null)
       }
       log.info(
-        "added {} new FTX conflation trigger blocks for {} non-included FTXs. ftxs={} total pending triggers: {}",
-        actuallyNewBlocks.size,
-        newFailedFtxs.size,
-        newFailedFtxs.map { "ftx=${it.ftxNumber} result=${it.inclusionResult}" },
+        "appended new conflation triggers {} of non-included ftxs={}, all pending triggers {}",
+        actuallyNewBlocks,
+        newFailedFtxs.map { it.toStringShortForLogging() },
         pendingTriggerBlocks.sorted(),
       )
     }

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -37,7 +37,7 @@ class ConflationCalculatorByForcedTransaction(
 ) : ConflationCalculator {
   override val id: String = ConflationTrigger.FORCED_TRANSACTION.name
 
-  // Track pending trigger blocks (blockNumber - 1) for non-included FTXs
+  // Track pending trigger blocks (blockNumber) for non-included FTXs
   private val pendingTriggerBlocks = mutableSetOf<ULong>()
 
   @Volatile
@@ -49,7 +49,7 @@ class ConflationCalculatorByForcedTransaction(
     log.debug(
       "checking ftx conflation trigger: blockNumber={} ftxProcessed={}",
       blockCounters.blockNumber,
-      processedFtxQueue.toList().map { it.toStringShortForLogging() },
+      processedFtxQueue.toList().map(ForcedTransactionInclusionStatus::toStringShortForLogging),
     )
 
     readProcessedFtxs()
@@ -59,8 +59,7 @@ class ConflationCalculatorByForcedTransaction(
       log.info(
         "FTX conflation detected at block={} ftxExecuted={}",
         blockCounters.blockNumber,
-        processedFtxQueue.toList()
-          .map { it.toStringShortForLogging() },
+        processedFtxQueue.toList().map(ForcedTransactionInclusionStatus::toStringShortForLogging),
       )
       ConflationCalculator.OverflowTrigger(
         trigger = ConflationTrigger.FORCED_TRANSACTION,

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
@@ -4,6 +4,10 @@ import linea.contract.events.ForcedTransactionAddedEvent
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 
+/**
+ * Tracks the highest safe block number (inclusive) that can be conflated.
+ *
+ */
 internal class ForcedTransactionsSafeBlockNumberManager(
   private val listener: SafeBlockNumberUpdateListener,
 ) {
@@ -53,20 +57,20 @@ internal class ForcedTransactionsSafeBlockNumberManager(
           "simulatedExecutionBlockNumber=$simulatedExecutionBlockNumber, safeBlockNumber=$safeBlockNumber",
       )
     }
-    log.info(
-      "locking conflation: ftxNumber={} at blockNumber={}",
-      ftxNumber,
-      simulatedExecutionBlockNumber,
-    )
-    safeBlockNumber = simulatedExecutionBlockNumber
 
     this.ftxInSequencerForProcessing.removeIf { it <= ftxNumber }
     if (ftxInSequencerForProcessing.isEmpty() && startUpScanFinished) {
-      log.info("all ftx sent to sequencer were processed, releasing Safe Block Number lock")
+      log.info(
+        "all ftx sent to sequencer were processed, releasing lock: safeBlockNumber={} --> null",
+        safeBlockNumber,
+      )
       updateSafeBlockNumber(null)
     } else {
       log.info(
-        "ftx={} processed at safeBlockNumber={}, ftx in the sequencer {}",
+        "updating safeBlockNumber={}-->{} by processed ftx={} at blockNumber={}, " +
+          "ftx in the sequencer {}",
+        safeBlockNumber,
+        simulatedExecutionBlockNumber,
         ftxNumber,
         simulatedExecutionBlockNumber,
         ftxInSequencerForProcessing,

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -720,7 +720,7 @@ class ForcedTransactionsAppTest {
         l2DeadLine = 100UL,
       ),
       createFtxAddedEvent(
-        l1BlockNumber = 200UL,
+        l1BlockNumber = 101UL,
         ftxNumber = 2UL,
         l2DeadLine = 200UL,
       ),
@@ -762,8 +762,8 @@ class ForcedTransactionsAppTest {
     )
     this.ftxClient.setFtxInclusionResultAfterReception(
       ftxNumber = 2UL,
-      l2BlockNumber = 200UL,
-      inclusionResult = ForcedTransactionInclusionResult.Included,
+      l2BlockNumber = 101UL,
+      inclusionResult = ForcedTransactionInclusionResult.BadNonce,
     )
     this.ftxClient.setFtxInclusionResultAfterReception(
       ftxNumber = 3UL,
@@ -820,13 +820,15 @@ class ForcedTransactionsAppTest {
     }
     assertThat(conflationTriggers).isEqualTo(
       listOf(
-        99UL to ConflationTrigger.FORCED_TRANSACTION,
-        499UL to ConflationTrigger.FORCED_TRANSACTION,
+        100UL to ConflationTrigger.FORCED_TRANSACTION,
+        101UL to ConflationTrigger.FORCED_TRANSACTION,
+        500UL to ConflationTrigger.FORCED_TRANSACTION,
       ),
     )
     assertThat(aggregationTriggers).isEqualTo(
       listOf(
         99UL to AggregationTriggerType.FORCED_TRANSACTION,
+        100UL to AggregationTriggerType.FORCED_TRANSACTION,
         499UL to AggregationTriggerType.FORCED_TRANSACTION,
       ),
     )

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
@@ -1,0 +1,204 @@
+package linea.ftx.conflation
+
+import linea.forcedtx.ForcedTransactionInclusionResult
+import linea.forcedtx.ForcedTransactionInclusionStatus
+import net.consensys.linea.traces.TracesCountersV4
+import net.consensys.zkevm.domain.BlockCounters
+import net.consensys.zkevm.domain.ConflationTrigger
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCounters
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.util.LinkedList
+import java.util.Queue
+import kotlin.time.Instant
+
+class ConflationCalculatorByForcedTransactionTest {
+
+  private lateinit var queue: Queue<ForcedTransactionInclusionStatus>
+  private lateinit var calculator: ConflationCalculatorByForcedTransaction
+
+  private val timestamp = Instant.parse("2024-01-01T00:00:00Z")
+  private val ftxOverflowTrigger = ConflationCalculator.OverflowTrigger(
+    trigger = ConflationTrigger.FORCED_TRANSACTION,
+    singleBlockOverSized = false,
+  )
+
+  @BeforeEach
+  fun setUp() {
+    queue = LinkedList()
+    calculator = ConflationCalculatorByForcedTransaction(queue)
+  }
+
+  private fun ftx(
+    ftx: ULong,
+    blockNumber: ULong,
+    inclusionResult: ForcedTransactionInclusionResult,
+  ) = ForcedTransactionInclusionStatus(
+    ftxNumber = ftx,
+    blockNumber = blockNumber,
+    blockTimestamp = timestamp,
+    inclusionResult = inclusionResult,
+    ftxHash = ByteArray(32),
+    from = ByteArray(20),
+  )
+
+  private fun blockCounters(blockNumber: ULong) = BlockCounters(
+    blockNumber = blockNumber,
+    blockTimestamp = timestamp,
+    tracesCounters = TracesCountersV4.EMPTY_TRACES_COUNT,
+    blockRLPEncoded = ByteArray(0),
+  )
+
+  @Test
+  fun `id should be FORCED_TRANSACTION`() {
+    assertThat(calculator.id).isEqualTo(ConflationTrigger.FORCED_TRANSACTION.name)
+  }
+
+  @Test
+  fun `does not consume items from the queue`() {
+    queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
+
+    calculator.checkOverflow(blockCounters(blockNumber = 9UL))
+    calculator.appendBlock(blockCounters(blockNumber = 9UL))
+
+    assertThat(queue).hasSize(1)
+  }
+
+  @Test
+  fun `copyCountersTo is a no-op`() {
+    queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
+    val counters = ConflationCounters(tracesCounters = TracesCountersV4.EMPTY_TRACES_COUNT)
+
+    calculator.copyCountersTo(counters)
+
+    assertThat(counters.blockCount).isEqualTo(0u)
+    assertThat(counters.dataSize).isEqualTo(0u)
+  }
+
+  @Nested
+  inner class CheckOverflow {
+    @Test
+    fun `returns null when the queue is empty`() {
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
+    }
+
+    @Test
+    fun `returns null when all FTXs are Included`() {
+      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.Included))
+      queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.Included))
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 9UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 11UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 19UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 21UL))).isNull()
+    }
+
+    @ParameterizedTest(name = "inclusionResult={0}")
+    @EnumSource(
+      value = ForcedTransactionInclusionResult::class,
+      names = ["Included"],
+      mode = EnumSource.Mode.EXCLUDE,
+    )
+    fun `triggers conflation at ftxBlockNumber for all non-Included results`(
+      result: ForcedTransactionInclusionResult,
+    ) {
+      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = result))
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 9UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isEqualTo(ftxOverflowTrigger)
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 11UL))).isNull()
+    }
+
+    @Test
+    fun `triggers once per non-Included FTX at its respective boundary block`() {
+      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
+      queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadBalance))
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isEqualTo(ftxOverflowTrigger)
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
+    }
+
+    @Test
+    fun `only triggers for non-Included FTXs when mixed with Included ones`() {
+      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.Included))
+      queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
+    }
+
+    @Test
+    fun `picks up FTXs added to the queue between calls`() {
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
+
+      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isEqualTo(ftxOverflowTrigger)
+    }
+  }
+
+  @Nested
+  inner class AppendBlock {
+
+    @Test
+    fun `clears pending triggers at or below the appended block number`() {
+      queue.add(
+        ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce),
+      ) // trigger at 10
+      queue.add(
+        ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadBalance),
+      ) // trigger at 20
+
+      // Populate pendingTriggerBlocks: {10, 20}
+      calculator.checkOverflow(blockCounters(blockNumber = 5UL))
+
+      // Append block 10 - clears triggers <= 10 from pendingTriggerBlocks
+      calculator.appendBlock(blockCounters(blockNumber = 10UL))
+
+      // Clear queue so readProcessedFtxs won't re-add triggers on next checkOverflow
+      queue.clear()
+
+      // Trigger at 10 was cleared from pendingTriggerBlocks
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
+      // Trigger at 20 is still in pendingTriggerBlocks
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
+    }
+
+    @Test
+    fun `does not clear pending triggers for future blocks`() {
+      queue.add(
+        ftx(ftx = 1UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce),
+      ) // trigger at 20
+
+      calculator.checkOverflow(blockCounters(blockNumber = 5UL))
+      calculator.appendBlock(blockCounters(blockNumber = 10UL))
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
+    }
+  }
+
+  @Nested
+  inner class Reset {
+
+    @Test
+    fun `does not clear pending trigger blocks`() {
+      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
+
+      // Populate pendingTriggerBlocks
+      calculator.checkOverflow(blockCounters(blockNumber = 5UL))
+      // Remove from queue so the trigger can only come from pendingTriggerBlocks state
+      queue.clear()
+
+      calculator.reset()
+
+      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isEqualTo(ftxOverflowTrigger)
+    }
+  }
+}

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/forcedtx/ForcedTransactionsClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/forcedtx/ForcedTransactionsClient.kt
@@ -56,6 +56,10 @@ data class ForcedTransactionInclusionStatus(
       "blockTimestamp=$blockTimestamp, " +
       "inclusionResult=$inclusionResult, ftxHash=${ftxHash.encodeHex()}, from=${from.encodeHex()})"
   }
+
+  fun toStringShortForLogging(): String {
+    return "ftx=$ftxNumber blockNumber=$blockNumber result=$inclusionResult"
+  }
 }
 
 data class ForcedTransactionRequest(


### PR DESCRIPTION
relates to issue(s) #2103 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batching boundaries in the conflation path for forced transactions, which can affect proof segmentation and downstream processing. Risk is mitigated by updated integration/unit tests but still impacts core coordinator flow.
> 
> **Overview**
> **Fixes forced-transaction-driven conflation cutoffs** by moving the `FORCED_TRANSACTION` conflation trigger boundary to the FTX execution `blockNumber` (instead of `blockNumber - 1`) and preventing duplicate/old triggers from being re-added.
> 
> Adds richer debug/trace logging around aggregation/conflation trigger checks (including compact FTX status logging via `ForcedTransactionInclusionStatus.toStringShortForLogging()`), updates `ForcedTransactionsSafeBlockNumberManager` and `ConflationServiceImpl` log output, and adjusts/extends tests (new `ConflationCalculatorByForcedTransactionTest`, updated `ForcedTransactionsAppTest` expectations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3474c1220996bf569f1c7da7ec6aacd063536c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->