### PR TITLE
fix(coordinator) - correct invalidity reason enums to match Prover and Sequencer

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/InvalidtyProofRequestResponse.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/coordinator/clients/InvalidtyProofRequestResponse.kt
@@ -10,8 +10,8 @@ enum class InvalidityReason {
   BadBalance,
   BadPrecompile,
   TooManyLogs,
-  FilteredAddressesFrom,
-  FilteredAddressesTo,
+  FilteredAddressFrom,
+  FilteredAddressTo,
 }
 
 data class InvalidityProofRequest(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/domain/ForcedTransactionRecord.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/domain/ForcedTransactionRecord.kt
@@ -11,7 +11,7 @@ import kotlin.time.Instant
  *     "from": "0x6221a9c005f6e47eb398fd867784cacfdcfff4e7",
  *     // inclusion result / the type of invalidity for each forced transaction;
  *     // for the executed valid transaction it is set to [invalidity.BadNonce]
- *     // cases: Included, BadNonce, BadBalance, BadPrecompile, TooManyLogs, FilteredAddressesFrom, FilteredAddressesTo, Phylax)
+ *     // cases: Included, BadNonce, BadBalance, BadPrecompile, TooManyLogs, FilteredAddressFrom, FilteredAddressTo, Phylax)
  *     "inclusionResult": "BadNonce"
  *     "transactionHash": "0xTRANSACTION_HASH",
  *   }

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
@@ -4,7 +4,6 @@ import build.linea.clients.GetZkEVMStateMerkleProofResponse
 import build.linea.clients.LineaAccountProof
 import build.linea.clients.StateManagerAccountProofClient
 import build.linea.clients.StateManagerClientV1
-import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOrThrow
 import linea.contract.events.ForcedTransactionAddedEvent
 import linea.domain.BlockInterval
@@ -117,8 +116,8 @@ class InvalidityProofAssembler(
       ForcedTransactionInclusionResult.BadBalance -> InvalidityReason.BadBalance
       ForcedTransactionInclusionResult.BadPrecompile -> InvalidityReason.BadPrecompile
       ForcedTransactionInclusionResult.TooManyLogs -> InvalidityReason.TooManyLogs
-      ForcedTransactionInclusionResult.FilteredAddressFrom -> InvalidityReason.FilteredAddressesFrom
-      ForcedTransactionInclusionResult.FilteredAddressTo -> InvalidityReason.FilteredAddressesTo
+      ForcedTransactionInclusionResult.FilteredAddressFrom -> InvalidityReason.FilteredAddressFrom
+      ForcedTransactionInclusionResult.FilteredAddressTo -> InvalidityReason.FilteredAddressTo
       ForcedTransactionInclusionResult.Phylax ->
         throw IllegalArgumentException("Phylax invalidity proofs are not supported yet")
     }


### PR DESCRIPTION
This PR implements issue(s) #2103

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enum values used in invalidity-proof request generation; mismatched versions across services could break serialization/mapping for filtered-address cases.
> 
> **Overview**
> Aligns forced-transaction invalidity proof reasons with prover/sequencer naming by renaming `InvalidityReason.FilteredAddressesFrom/To` to `FilteredAddressFrom/To` and updating the inclusion-result mapping used when assembling invalidity proof requests.
> 
> Also updates related documentation/comments and removes an unused import in `InvalidityProofAssembler`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8e04bcf84ab057e58bc6820680429be2b3c48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->