### PR TITLE
fix(e2e): ensure L2 traffic generation stops reliably on teardown

### DIFF
--- a/e2e/src/common/utils/traffic.ts
+++ b/e2e/src/common/utils/traffic.ts
@@ -1,4 +1,4 @@
-import { wait, serialize, etherToWei } from "@consensys/linea-shared-utils";
+import { serialize, etherToWei } from "@consensys/linea-shared-utils";
 import { Account, Chain, Client, Hash, SendTransactionErrorType, Transport } from "viem";
 import { getTransactionCount, sendTransaction, SendTransactionParameters } from "viem/actions";
 import { EstimateGasParameters } from "viem/linea";
@@ -40,6 +40,7 @@ export class TrafficGenerator<
   private txSinceRefresh = 0;
   private isRunning = false;
   private loopPromise: Promise<void> | null = null;
+  private abortController: AbortController | null = null;
 
   private readonly address: `0x${string}`;
   private readonly gasParams: EstimateGasParameters;
@@ -62,17 +63,20 @@ export class TrafficGenerator<
     this.baseFees = this.fees;
     this.txSinceRefresh = 0;
     this.isRunning = true;
+    this.abortController = new AbortController();
 
     this.loopPromise = this.loop();
   }
 
   async stop(): Promise<void> {
     this.isRunning = false;
+    this.abortController?.abort();
+
     if (this.loopPromise) {
       await this.loopPromise;
       this.loopPromise = null;
     }
-    logger.debug("Stopped generating traffic on L2");
+    logger.info("Stopped generating traffic on L2");
   }
 
   private async loop(): Promise<void> {
@@ -92,8 +96,32 @@ export class TrafficGenerator<
         await this.recover(error);
       }
 
-      await wait(this.pollingInterval);
+      await this.abortableWait(this.pollingInterval);
     }
+  }
+
+  /**
+   * Resolves after `ms` milliseconds, or immediately when the abort signal
+   * fires. Allows `stop()` to interrupt the loop's polling delay without
+   * waiting for the full interval to pass.
+   */
+  private abortableWait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      const signal = this.abortController?.signal;
+      if (signal?.aborted) return resolve();
+
+      const timeoutId = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+        resolve();
+      };
+
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
 
   private async sendTx(txNonce: number, txFees: GasFees): Promise<Hash> {

--- a/e2e/src/config/jest/global-teardown.ts
+++ b/e2e/src/config/jest/global-teardown.ts
@@ -6,7 +6,6 @@ const logger = createTestLogger();
 export default async (): Promise<void> => {
   try {
     await stopL2TrafficGeneration();
-    logger.debug("Stopped L2 traffic generation");
   } catch (error) {
     logger.error(`Error stopping L2 traffic generation: ${error}`);
     // Don't throw - teardown failures shouldn't mask test failures

--- a/e2e/src/config/jest/traffic-state.ts
+++ b/e2e/src/config/jest/traffic-state.ts
@@ -1,14 +1,17 @@
 type StopTrafficFn = () => Promise<void>;
 
-let stopTrafficFn: StopTrafficFn | null = null;
+declare global {
+  var __stopL2TrafficFn: StopTrafficFn | null;
+}
 
 export function setStopL2TrafficGeneration(fn: StopTrafficFn) {
-  stopTrafficFn = fn;
+  globalThis.__stopL2TrafficFn = fn;
 }
 
 export async function stopL2TrafficGeneration(): Promise<void> {
-  if (stopTrafficFn) {
-    await stopTrafficFn();
-    stopTrafficFn = null;
+  const stopFn = globalThis.__stopL2TrafficFn;
+  if (stopFn) {
+    await stopFn();
+    globalThis.__stopL2TrafficFn = null;
   }
 }


### PR DESCRIPTION
The L2 traffic generation stop function was sometimes not triggered when e2e tests finished because:

1. The stop function was stored in a module-level variable, which is isolated per Jest worker. Global teardown runs in a different worker than global setup, so the function was null in teardown context.

2. The TrafficGenerator loop had no way to interrupt its polling delay, leading to slow or inconsistent shutdown.

Changes:
- traffic-state.ts: store the stop function on globalThis so it is shared across Jest worker boundaries.
- traffic.ts: add an AbortController and an abortable wait so stop() interrupts the polling interval immediately instead of waiting for the full delay to elapse. In-flight HTTP calls still complete gracefully.
- global-teardown.ts: remove redundant debug log (already logged by the generator itself).

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to e2e test harness shutdown behavior, mainly affecting teardown timing and shared state rather than production logic.
> 
> **Overview**
> Improves reliability of stopping background L2 traffic generation after e2e runs.
> 
> The stop callback is now stored on `globalThis` (via `__stopL2TrafficFn`) so Jest `global-teardown` can access it even when setup/teardown execute in different workers. The traffic loop can now be interrupted immediately on `stop()` using an `AbortController` + `abortableWait`, and teardown logging is simplified by removing a redundant message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe3c0de54d579c5a8eae87897ff0fa41f2eddcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->