### PR TITLE
Prover/smaller benchmark

### DIFF
--- a/prover/protocol/compiler/standard_benchmark_test.go
+++ b/prover/protocol/compiler/standard_benchmark_test.go
@@ -179,6 +179,17 @@ func BenchmarkCompilerWithSelfRecursionAndGnarkVerifier(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkProfileSelfRecursion allows running benchmark experiments of the
+// prover with medium memory requirement. Experiments have shown that this
+// can run on a 64 GiB machine.
+func BenchmarkProfileSelfRecursion(b *testing.B) {
+	BenchmarkProfileSelfRecursionRealistic(b)
+}
+
+// BenchmarkProfileSelfRecursion allows running benchmark experiments of the
+// prover with medium memory requirement. Experiments have shown that this
+// can run on a 64 GiB machine.
 func BenchmarkProfileSelfRecursionRealistic(b *testing.B) {
 	for _, bc := range benchCases {
 		if bc.Name != realisticSegmentName {
@@ -190,6 +201,9 @@ func BenchmarkProfileSelfRecursionRealistic(b *testing.B) {
 	}
 }
 
+// BenchmarkProfileSelfRecursionSmaller allows running benchmark experiments of
+// the prover with low memory requirement. Experiments have shown that this
+// could run under 14 GiB on a laptop.
 func BenchmarkProfileSelfRecursionSmaller(b *testing.B) {
 	for _, bc := range benchCases {
 		if bc.Name != smallerSegmentName {

--- a/prover/protocol/compiler/standard_benchmark_test.go
+++ b/prover/protocol/compiler/standard_benchmark_test.go
@@ -64,6 +64,11 @@ type SubModuleParameters struct {
 	NumRowAux int
 }
 
+const (
+	smallerSegmentName   string = "smaller-segment"
+	realisticSegmentName string = "realistic-segment"
+)
+
 var (
 	benchCases = []StdBenchmarkCase{
 		// {
@@ -96,7 +101,36 @@ var (
 			// cat /sys/kernel/mm/transparent_hugepage/enabled
 			// if not:
 			// echo always | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
-			Name: "realistic-segment",
+			Name: smallerSegmentName,
+			Permutations: SubModuleParameters{
+				Count:  5,
+				NumCol: 3,
+				NumRow: 1 << 17,
+			},
+			Lookup: SubModuleParameters{
+				Count:     50,
+				NumCol:    3,
+				NumRow:    1 << 17,
+				NumRowAux: 1 << 17,
+			},
+			Projection: SubModuleParameters{
+				Count:     5,
+				NumCol:    3,
+				NumRow:    1 << 17,
+				NumRowAux: 1 << 17,
+			},
+			Fibo: SubModuleParameters{
+				Count:  200,
+				NumRow: 1 << 17,
+			},
+		},
+		{
+			// run with GOGC=200 and
+			// ensure THP is enabled:
+			// cat /sys/kernel/mm/transparent_hugepage/enabled
+			// if not:
+			// echo always | sudo tee /sys/kernel/mm/transparent_hugepage/enabled
+			Name: realisticSegmentName,
 			Permutations: SubModuleParameters{
 				Count:  5,
 				NumCol: 3,
@@ -119,30 +153,6 @@ var (
 				NumRow: 1 << 20,
 			},
 		},
-		// {
-		// 	Name: "smaller-segment",
-		// 	Permutations: SubModuleParameters{
-		// 		Count:  1,
-		// 		NumCol: 3,
-		// 		NumRow: 1 << 19,
-		// 	},
-		// 	Lookup: SubModuleParameters{
-		// 		Count:     5,
-		// 		NumCol:    3,
-		// 		NumRow:    1 << 19,
-		// 		NumRowAux: 1 << 19,
-		// 	},
-		// 	Projection: SubModuleParameters{
-		// 		Count:     1,
-		// 		NumCol:    3,
-		// 		NumRow:    1 << 19,
-		// 		NumRowAux: 1 << 19,
-		// 	},
-		// 	Fibo: SubModuleParameters{
-		// 		Count:  20,
-		// 		NumRow: 1 << 19,
-		// 	},
-		// },
 	}
 )
 
@@ -169,8 +179,22 @@ func BenchmarkCompilerWithSelfRecursionAndGnarkVerifier(b *testing.B) {
 		})
 	}
 }
-func BenchmarkProfileSelfRecursion(b *testing.B) {
+func BenchmarkProfileSelfRecursionRealistic(b *testing.B) {
 	for _, bc := range benchCases {
+		if bc.Name != realisticSegmentName {
+			continue
+		}
+		b.Run(bc.Name, func(b *testing.B) {
+			profileSelfRecursionCompilation(b, bc)
+		})
+	}
+}
+
+func BenchmarkProfileSelfRecursionSmaller(b *testing.B) {
+	for _, bc := range benchCases {
+		if bc.Name != smallerSegmentName {
+			continue
+		}
 		b.Run(bc.Name, func(b *testing.B) {
 			profileSelfRecursionCompilation(b, bc)
 		})
@@ -301,7 +325,7 @@ func benchmarkCompilerWithSelfRecursion(b *testing.B, sbc StdBenchmarkCase) {
 		),
 	)
 
-	nbIteration := 2
+	nbIteration := 1
 
 	for i := 0; i < nbIteration; i++ {
 		applySelfRecursionThenArcane(comp, params)


### PR DESCRIPTION
This PR creates an ad-hoc benchmark that can be run with low memory requirement.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to benchmark/test code and mainly adjust benchmark parameters and selection logic, with no production-path behavior changes.
> 
> **Overview**
> Adds a new `smaller-segment` standard benchmark configuration (reduced row sizes) alongside the existing `realistic-segment`, using shared constants for case names.
> 
> Splits `BenchmarkProfileSelfRecursion` into `BenchmarkProfileSelfRecursionRealistic` (default) and `BenchmarkProfileSelfRecursionSmaller`, each filtering to a single benchmark case to allow profiling on lower-memory machines.
> 
> Tweaks the self-recursion benchmark loop to run a single recursion iteration (`nbIteration` from 2 to 1) to reduce benchmark cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f233ef6cd11a90fc7cb13f68605236bde8c042b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->