### PR TITLE
chore(e2e) - add test:local-core script with extended ignore patterns

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -307,7 +307,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-7c850f2}
+    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-37e5396}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "eslint --fix .",
     "test:local:run": "TEST_ENV=local npx jest",
     "test:local": "pnpm run test:local:run --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts && pnpm run test:liveness:local",
+    "test:local-core": "pnpm run test:local:run --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts --testPathIgnorePatterns=messaging.spec.ts --testPathIgnorePatterns=bridge-tokens.spec.ts --testPathIgnorePatterns=shomei-get-proof.spec.ts --testPathIgnorePatterns=transaction-exclusion.spec.ts",
     "test:fleet:local": "TEST_ENV=local npx jest linea-besu-fleet.spec.ts",
     "test:liveness:local": "TEST_ENV=local npx jest liveness.spec.ts",
     "test:sendbundle:local": "TEST_ENV=local npx jest send-bundle.spec.ts",


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only changes: a docker image tag bump and an additional test runner script with more ignored specs, with no production code changes.
> 
> **Overview**
> Updates local dev infra by bumping the `linea-coordinator` image default tag in `docker/compose-spec-l2-services.yml`.
> 
> Adds `test:local-core` to `e2e/package.json`, running local Jest while ignoring additional non-core spec files (e.g., messaging/bridge/shomei/transaction-exclusion) to speed up a core-only local run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8034debebc6222e2caa852c347014a8117e27bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->