### PR TITLE
fix(coordinator) - adjust ftx conflation logic to make aggregation cu…

### DIFF
--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
@@ -65,10 +65,6 @@ class AggregationCalculatorByForcedTransaction(
     // Only add trigger blocks for FTXs that were NOT successfully included
     // Trigger at (blockNumber - 1) to seal aggregation before failed FTX execution block
     val newTriggerBlocks = processedFtxs
-      // FIXME: tmp make cut off at Included, suboptimal but will fix correctnes issue
-      // .filter { ftx ->
-      //   ftx.inclusionResult != ForcedTransactionInclusionResult.Included
-      // }
       .map { ftx ->
         // ftx.blockNumber is always greater than 0 (0 is genesis block),
         // In practice, greater than 2 most of the cases because network bootstrapping

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/AggregationCalculatorByForcedTransaction.kt
@@ -65,9 +65,10 @@ class AggregationCalculatorByForcedTransaction(
     // Only add trigger blocks for FTXs that were NOT successfully included
     // Trigger at (blockNumber - 1) to seal aggregation before failed FTX execution block
     val newTriggerBlocks = processedFtxs
-      .filter { ftx ->
-        ftx.inclusionResult != ForcedTransactionInclusionResult.Included
-      }
+      // FIXME: tmp make cut off at Included, suboptimal but will fix correctnes issue
+      // .filter { ftx ->
+      //   ftx.inclusionResult != ForcedTransactionInclusionResult.Included
+      // }
       .map { ftx ->
         // ftx.blockNumber is always greater than 0 (0 is genesis block),
         // In practice, greater than 2 most of the cases because network bootstrapping

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -83,8 +83,9 @@ class ConflationCalculatorByForcedTransaction(
     val highestPendingTrigger = pendingTriggerBlocks.maxOrNull() ?: 0UL
     val newTriggerBlocks = processedFtxs
       .filter { ftx ->
-        ftx.inclusionResult != ForcedTransactionInclusionResult.Included &&
-          ftx.blockNumber > highestPendingTrigger
+        // FIXME: tmp make cut off at Included, suboptimal but will fix correctnes issue
+        // ftx.inclusionResult != ForcedTransactionInclusionResult.Included &&
+        ftx.blockNumber > highestPendingTrigger
       }
       .map { ftx ->
         // ftx.blockNumber is always greater than 0 (0 is genesis block),

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -82,8 +82,6 @@ class ConflationCalculatorByForcedTransaction(
     val highestPendingTrigger = pendingTriggerBlocks.maxOrNull() ?: 0UL
     val newTriggerBlocks = processedFtxs
       .filter { ftx ->
-        // FIXME: tmp make cut off at Included, suboptimal but will fix correctnes issue
-        // ftx.inclusionResult != ForcedTransactionInclusionResult.Included &&
         ftx.blockNumber > highestPendingTrigger
       }
       .map { ftx ->

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransaction.kt
@@ -2,7 +2,6 @@ package linea.ftx.conflation
 
 import linea.domain.BlockCounters
 import linea.domain.ConflationTrigger
-import linea.forcedtx.ForcedTransactionInclusionResult
 import linea.forcedtx.ForcedTransactionInclusionStatus
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCounters

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/ForcedTransactionsSafeBlockNumberManager.kt
@@ -17,8 +17,13 @@ internal class ForcedTransactionsSafeBlockNumberManager(
   private val ftxInSequencerForProcessing: MutableList<ULong> = mutableListOf()
 
   private fun updateSafeBlockNumber(value: ULong?) {
-    safeBlockNumber = value
-    listener.onSafeBlockNumberUpdate(safeBlockNumber)
+    if (safeBlockNumber != value) {
+      if (value == null) {
+        log.info("releasing safeBlockNumber lock: safeBlockNumber={} --> null", safeBlockNumber)
+      }
+      safeBlockNumber = value
+      listener.onSafeBlockNumberUpdate(safeBlockNumber)
+    }
   }
 
   @Synchronized
@@ -85,7 +90,6 @@ internal class ForcedTransactionsSafeBlockNumberManager(
     if (!startUpScanFinished) {
       return
     }
-    log.info("releasing Safe Block Number lock")
     updateSafeBlockNumber(null)
   }
 

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.concurrent.CopyOnWriteArrayList
@@ -711,7 +712,7 @@ class ForcedTransactionsAppTest {
     app.stop().get()
   }
 
-  @Test
+  @Disabled
   fun `should trigger conflation and aggregation when sequencer processes ftxs`() {
     val ftxAddedEvents = listOf(
       createFtxAddedEvent(

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.concurrent.CopyOnWriteArrayList
@@ -712,7 +711,7 @@ class ForcedTransactionsAppTest {
     app.stop().get()
   }
 
-  @Disabled
+  @Test
   fun `should trigger conflation and aggregation when sequencer processes ftxs`() {
     val ftxAddedEvents = listOf(
       createFtxAddedEvent(
@@ -823,6 +822,8 @@ class ForcedTransactionsAppTest {
       listOf(
         100UL to ConflationTrigger.FORCED_TRANSACTION,
         101UL to ConflationTrigger.FORCED_TRANSACTION,
+        300UL to ConflationTrigger.FORCED_TRANSACTION,
+        400UL to ConflationTrigger.FORCED_TRANSACTION,
         500UL to ConflationTrigger.FORCED_TRANSACTION,
       ),
     )
@@ -830,6 +831,8 @@ class ForcedTransactionsAppTest {
       listOf(
         99UL to AggregationTriggerType.FORCED_TRANSACTION,
         100UL to AggregationTriggerType.FORCED_TRANSACTION,
+        299UL to AggregationTriggerType.FORCED_TRANSACTION,
+        399UL to AggregationTriggerType.FORCED_TRANSACTION,
         499UL to AggregationTriggerType.FORCED_TRANSACTION,
       ),
     )

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
@@ -9,6 +9,7 @@ import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCounters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -87,7 +88,7 @@ class ConflationCalculatorByForcedTransactionTest {
       assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
     }
 
-    @Test
+    @Disabled
     fun `returns null when all FTXs are Included`() {
       queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.Included))
       queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.Included))
@@ -125,7 +126,7 @@ class ConflationCalculatorByForcedTransactionTest {
       assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
     }
 
-    @Test
+    @Disabled
     fun `only triggers for non-Included FTXs when mixed with Included ones`() {
       queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.Included))
       queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/conflation/ConflationCalculatorByForcedTransactionTest.kt
@@ -9,7 +9,6 @@ import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCounters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -88,24 +87,9 @@ class ConflationCalculatorByForcedTransactionTest {
       assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
     }
 
-    @Disabled
-    fun `returns null when all FTXs are Included`() {
-      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.Included))
-      queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.Included))
-
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 9UL))).isNull()
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 11UL))).isNull()
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 19UL))).isNull()
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isNull()
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 21UL))).isNull()
-    }
-
     @ParameterizedTest(name = "inclusionResult={0}")
     @EnumSource(
       value = ForcedTransactionInclusionResult::class,
-      names = ["Included"],
-      mode = EnumSource.Mode.EXCLUDE,
     )
     fun `triggers conflation at ftxBlockNumber for all non-Included results`(
       result: ForcedTransactionInclusionResult,
@@ -123,15 +107,6 @@ class ConflationCalculatorByForcedTransactionTest {
       queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadBalance))
 
       assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isEqualTo(ftxOverflowTrigger)
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
-    }
-
-    @Disabled
-    fun `only triggers for non-Included FTXs when mixed with Included ones`() {
-      queue.add(ftx(ftx = 1UL, blockNumber = 10UL, inclusionResult = ForcedTransactionInclusionResult.Included))
-      queue.add(ftx(ftx = 2UL, blockNumber = 20UL, inclusionResult = ForcedTransactionInclusionResult.BadNonce))
-
-      assertThat(calculator.checkOverflow(blockCounters(blockNumber = 10UL))).isNull()
       assertThat(calculator.checkOverflow(blockCounters(blockNumber = 20UL))).isEqualTo(ftxOverflowTrigger)
     }
 


### PR DESCRIPTION
…toff on included transactions

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when conflation/aggregation boundaries are created around forced-transaction execution blocks, which can impact batching behavior and proof generation; test updates cover expected new trigger points but behavior change is core coordination logic.
> 
> **Overview**
> FTX conflation/aggregation boundary calculation is changed to **also schedule triggers for successfully `Included` forced transactions**, by removing the inclusion-result filter in both `ConflationCalculatorByForcedTransaction` and `AggregationCalculatorByForcedTransaction`.
> 
> `ForcedTransactionsSafeBlockNumberManager` now only emits `onSafeBlockNumberUpdate` when the value actually changes (and logs lock release details), reducing duplicate notifications. Tests are updated to expect conflation/aggregation triggers for included FTX execution blocks and to drop assertions that `Included` results never trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c4b39a7488d82f7df297578a22118025a6c4a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->