### PR TITLE
Prover/fix sha2 on the fly

### DIFF
--- a/prover/zkevm/prover/hash/sha2/assignment.go
+++ b/prover/zkevm/prover/hash/sha2/assignment.go
@@ -114,7 +114,8 @@ func (sbh *sha2BlockModule) Run(run *wizard.ProverRuntime) {
 		sbh.ProverActions[i].Run(run)
 	}
 
-	assignProdHash(run, sbh)
+	assignSumHash(run, sbh)
+	sbh.EntireHashIsZero.Run(run)
 
 	if sbh.HasCircuit {
 		// this is guarded by a once, so it is safe to call multiple times
@@ -160,46 +161,27 @@ func (sbha *sha2BlockHashingAssignment) pushBlock(
 	return newState
 }
 
-// assignProdHash fills ProdHashChunk and ProdHashAggr1/2 from
-// HashIsZero so they satisfy the low-degree product constraints in
-// [newSha2BlockModule].
-func assignProdHash(run *wizard.ProverRuntime, sbh *sha2BlockModule) {
+// assignSumHash fills SumHashCol from HashIsZero so it satisfies the Σ constraint
+// in [newSha2BlockModule].
+func assignSumHash(run *wizard.ProverRuntime, sbh *sha2BlockModule) {
 	z := make([][]field.Element, numLimbsPerState)
 	for i := range numLimbsPerState {
 		z[i] = sbh.HashIsZero[i].GetColAssignment(run).IntoRegVecSaveAlloc()
 	}
 	n := len(z[0])
-	chunkOut := make([][]field.Element, numProdHashChunks)
-	for k := range numProdHashChunks {
-		chunkOut[k] = make([]field.Element, n)
-	}
-	aggr1 := make([]field.Element, n)
-	aggr2 := make([]field.Element, n)
-
-	for r := 0; r < n; r++ {
-		for k := range numProdHashChunks {
-			start, end := prodHashChunkLimbRange(k)
-			var p field.Element
-			p.SetOne()
-			for li := start; li < end; li++ {
-				p.Mul(&p, &z[li][r])
-			}
-			chunkOut[k][r] = p
+	sumCol := make([]field.Element, n)
+	for r := range n {
+		var s field.Element
+		for i := range numLimbsPerState {
+			s.Add(&s, &z[i][r])
 		}
-		var a1, a2 field.Element
-		a1.Mul(&chunkOut[0][r], &chunkOut[1][r])
-		a1.Mul(&a1, &chunkOut[2][r])
-		a2.Mul(&chunkOut[3][r], &chunkOut[4][r])
-		a2.Mul(&a2, &chunkOut[5][r])
-		aggr1[r] = a1
-		aggr2[r] = a2
+		sumCol[r] = s
 	}
-
-	for k := range numProdHashChunks {
-		run.AssignColumn(sbh.ProdHashChunk[k].GetColID(), smartvectors.NewRegular(chunkOut[k]), wizard.DisableAssignmentSizeReduction)
-	}
-	run.AssignColumn(sbh.ProdHashAggr1.GetColID(), smartvectors.NewRegular(aggr1), wizard.DisableAssignmentSizeReduction)
-	run.AssignColumn(sbh.ProdHashAggr2.GetColID(), smartvectors.NewRegular(aggr2), wizard.DisableAssignmentSizeReduction)
+	run.AssignColumn(
+		sbh.SumHashCol.GetColID(),
+		smartvectors.NewRegular(sumCol),
+		wizard.DisableAssignmentSizeReduction,
+	)
 }
 
 // catchUpHashHiLo pushes over the HashHi and HashLo columns so that their

--- a/prover/zkevm/prover/hash/sha2/assignment.go
+++ b/prover/zkevm/prover/hash/sha2/assignment.go
@@ -70,10 +70,6 @@ func (sbh *sha2BlockModule) Run(run *wizard.ProverRuntime) {
 			// include in the loop boundary as it features a sanity-check.
 			if isFirstLaneOfNewHash[cursorInp].IsZero() && cursorInp+1 < numRowInp && isFirstLaneOfNewHash[cursorInp+1].IsOne() {
 
-				if selector[cursorInp].IsZero() {
-					utils.Panic("unexpected: at row %v, the selector is zero but isNewHash is one", cursorInp)
-				}
-
 				cursorInp++
 				return blocks
 			}

--- a/prover/zkevm/prover/hash/sha2/assignment.go
+++ b/prover/zkevm/prover/hash/sha2/assignment.go
@@ -110,12 +110,12 @@ func (sbh *sha2BlockModule) Run(run *wizard.ProverRuntime) {
 	sbh.CanBeBlockOfInstance.Assign(run)
 	sbh.CanBeEndOfInstance.Assign(run)
 
-	for i := range sbh.ProverActions {
-		sbh.ProverActions[i].Run(run)
+	// Run the LimbsIsZero prover action, then compute the sum and run EntireLimbsIntervalIsZero.
+	for _, pa := range sbh.ProverActions {
+		pa.Run(run)
 	}
-
-	assignSumHash(run, sbh)
-	sbh.EntireHashIsZero.Run(run)
+	assignSumLimbsIsZero(run, sbh)
+	sbh.EntireLimbsIntervalIsZero.Run(run)
 
 	if sbh.HasCircuit {
 		// this is guarded by a once, so it is safe to call multiple times
@@ -161,24 +161,22 @@ func (sbha *sha2BlockHashingAssignment) pushBlock(
 	return newState
 }
 
-// assignSumHash fills SumHashCol from HashIsZero so it satisfies the Σ constraint
-// in [newSha2BlockModule].
-func assignSumHash(run *wizard.ProverRuntime, sbh *sha2BlockModule) {
-	z := make([][]field.Element, numLimbsPerState)
-	for i := range numLimbsPerState {
-		z[i] = sbh.HashIsZero[i].GetColAssignment(run).IntoRegVecSaveAlloc()
-	}
-	n := len(z[0])
+// assignSumLimbsIsZero computes SumLimbsIsZeroCol as Σ Shift(LimbsIsZero, 48+i) for i in [0,16).
+func assignSumLimbsIsZero(run *wizard.ProverRuntime, sbh *sha2BlockModule) {
+	limbsIsZero := sbh.LimbsIsZero.GetColAssignment(run).IntoRegVecSaveAlloc()
+	n := len(limbsIsZero)
 	sumCol := make([]field.Element, n)
+	newStateOffset := numLimbsPerBlock + numLimbsPerState
 	for r := range n {
 		var s field.Element
 		for i := range numLimbsPerState {
-			s.Add(&s, &z[i][r])
+			idx := (r + newStateOffset + i) % n
+			s.Add(&s, &limbsIsZero[idx])
 		}
 		sumCol[r] = s
 	}
 	run.AssignColumn(
-		sbh.SumHashCol.GetColID(),
+		sbh.SumLimbsIsZeroCol.GetColID(),
 		smartvectors.NewRegular(sumCol),
 		wizard.DisableAssignmentSizeReduction,
 	)

--- a/prover/zkevm/prover/hash/sha2/assignment.go
+++ b/prover/zkevm/prover/hash/sha2/assignment.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/linea-monorepo/prover/crypto/sha2"
-	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
 	"github.com/consensys/linea-monorepo/prover/utils"
@@ -114,7 +113,6 @@ func (sbh *sha2BlockModule) Run(run *wizard.ProverRuntime) {
 	for _, pa := range sbh.ProverActions {
 		pa.Run(run)
 	}
-	assignSumLimbsIsZero(run, sbh)
 	sbh.EntireLimbsIntervalIsZero.Run(run)
 
 	if sbh.HasCircuit {
@@ -159,27 +157,6 @@ func (sbha *sha2BlockHashingAssignment) pushBlock(
 	}
 
 	return newState
-}
-
-// assignSumLimbsIsZero computes SumLimbsIsZeroCol as Σ Shift(LimbsIsZero, 48+i) for i in [0,16).
-func assignSumLimbsIsZero(run *wizard.ProverRuntime, sbh *sha2BlockModule) {
-	limbsIsZero := sbh.LimbsIsZero.GetColAssignment(run).IntoRegVecSaveAlloc()
-	n := len(limbsIsZero)
-	sumCol := make([]field.Element, n)
-	newStateOffset := numLimbsPerBlock + numLimbsPerState
-	for r := range n {
-		var s field.Element
-		for i := range numLimbsPerState {
-			idx := (r + newStateOffset + i) % n
-			s.Add(&s, &limbsIsZero[idx])
-		}
-		sumCol[r] = s
-	}
-	run.AssignColumn(
-		sbh.SumLimbsIsZeroCol.GetColID(),
-		smartvectors.NewRegular(sumCol),
-		wizard.DisableAssignmentSizeReduction,
-	)
 }
 
 // catchUpHashHiLo pushes over the HashHi and HashLo columns so that their

--- a/prover/zkevm/prover/hash/sha2/assignment.go
+++ b/prover/zkevm/prover/hash/sha2/assignment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/consensys/gnark/constraint/solver"
 	"github.com/consensys/linea-monorepo/prover/crypto/sha2"
+	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
 	"github.com/consensys/linea-monorepo/prover/utils"
@@ -113,6 +114,8 @@ func (sbh *sha2BlockModule) Run(run *wizard.ProverRuntime) {
 		sbh.ProverActions[i].Run(run)
 	}
 
+	assignProdHash(run, sbh)
+
 	if sbh.HasCircuit {
 		// this is guarded by a once, so it is safe to call multiple times
 		registerGnarkHint()
@@ -155,6 +158,48 @@ func (sbha *sha2BlockHashingAssignment) pushBlock(
 	}
 
 	return newState
+}
+
+// assignProdHash fills ProdHashChunk and ProdHashAggr1/2 from
+// HashIsZero so they satisfy the low-degree product constraints in
+// [newSha2BlockModule].
+func assignProdHash(run *wizard.ProverRuntime, sbh *sha2BlockModule) {
+	z := make([][]field.Element, numLimbsPerState)
+	for i := range numLimbsPerState {
+		z[i] = sbh.HashIsZero[i].GetColAssignment(run).IntoRegVecSaveAlloc()
+	}
+	n := len(z[0])
+	chunkOut := make([][]field.Element, numProdHashChunks)
+	for k := range numProdHashChunks {
+		chunkOut[k] = make([]field.Element, n)
+	}
+	aggr1 := make([]field.Element, n)
+	aggr2 := make([]field.Element, n)
+
+	for r := 0; r < n; r++ {
+		for k := range numProdHashChunks {
+			start, end := prodHashChunkLimbRange(k)
+			var p field.Element
+			p.SetOne()
+			for li := start; li < end; li++ {
+				p.Mul(&p, &z[li][r])
+			}
+			chunkOut[k][r] = p
+		}
+		var a1, a2 field.Element
+		a1.Mul(&chunkOut[0][r], &chunkOut[1][r])
+		a1.Mul(&a1, &chunkOut[2][r])
+		a2.Mul(&chunkOut[3][r], &chunkOut[4][r])
+		a2.Mul(&a2, &chunkOut[5][r])
+		aggr1[r] = a1
+		aggr2[r] = a2
+	}
+
+	for k := range numProdHashChunks {
+		run.AssignColumn(sbh.ProdHashChunk[k].GetColID(), smartvectors.NewRegular(chunkOut[k]), wizard.DisableAssignmentSizeReduction)
+	}
+	run.AssignColumn(sbh.ProdHashAggr1.GetColID(), smartvectors.NewRegular(aggr1), wizard.DisableAssignmentSizeReduction)
+	run.AssignColumn(sbh.ProdHashAggr2.GetColID(), smartvectors.NewRegular(aggr2), wizard.DisableAssignmentSizeReduction)
 }
 
 // catchUpHashHiLo pushes over the HashHi and HashLo columns so that their

--- a/prover/zkevm/prover/hash/sha2/circuit.go
+++ b/prover/zkevm/prover/hash/sha2/circuit.go
@@ -48,9 +48,9 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 	}
 
 	// allLimbsAreZero is the count of zero limbs (sum of IsZero). It equals
-	// len(NewDigest) iff every limb is zero — same predicate as ProdHashAggr1·
-	// ProdHashAggr2 in sha2_block.go. When equal, we skip the permutation check
-	// (padding row): (count - len) is zero so the equality is not enforced.
+	// len(NewDigest) iff every limb is zero — same predicate as EntireHashIsZero
+	// in sha2_block.go. When equal, we skip the permutation check (padding
+	// row): (count - len) is zero so the equality is not enforced.
 	var allLimbsAreZero frontend.Variable = 0
 	for i := range sbpi.NewDigest {
 		allLimbsAreZero = api.Add(allLimbsAreZero, api.IsZero(sbpi.NewDigest[i]))

--- a/prover/zkevm/prover/hash/sha2/circuit.go
+++ b/prover/zkevm/prover/hash/sha2/circuit.go
@@ -47,10 +47,10 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 		panic(fmt.Sprintf("unexpected error when instantiating `uapi`: %v", err.Error()))
 	}
 
-	// allLimbsAreZero is the count of zero limbs (sum of IsZero). It equals
-	// len(NewDigest) iff every limb is zero — same predicate as EntireHashIsZero
-	// in sha2_block.go. When equal, we skip the permutation check (padding
-	// row): (count - len) is zero so the equality is not enforced.
+	// Count of zero limbs; equals len(NewDigest) iff NewDigest is all-zero.
+	// When equal, skip permutation check for padded / unused Plonk instances.
+	// Real compressions must not be all-zero in Limbs: see sha2_block.go
+	// (IsActive × CanBeBeginning × EntireLimbsNewStateIsZero).
 	var allLimbsAreZero frontend.Variable = 0
 	for i := range sbpi.NewDigest {
 		allLimbsAreZero = api.Add(allLimbsAreZero, api.IsZero(sbpi.NewDigest[i]))
@@ -71,7 +71,6 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 	recomputedNewDigest := sha2.Permute(uapi, prevDigest, blockBytes)
 
 	for i := range recomputedNewDigest {
-		// newDigest == recomputedDigest unless all limbs of NewDigest are zero.
 		api.AssertIsEqual(
 			api.Mul(
 				api.Sub(allLimbsAreZero, len(sbpi.NewDigest)),

--- a/prover/zkevm/prover/hash/sha2/circuit.go
+++ b/prover/zkevm/prover/hash/sha2/circuit.go
@@ -47,13 +47,13 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 		panic(fmt.Sprintf("unexpected error when instantiating `uapi`: %v", err.Error()))
 	}
 
-	// allLimbsAreZero is 1 iff every NewDigest[i] is zero — same predicate as
-	// ∏_i HashIsZero[i] in sha2_block.go (HASH_CANT_BE_ENTIRELY_ZERO). When 1,
-	// we skip the permutation check (padding row); active compression rows must
-	// have allLimbsAreZero = 0, which the wizard enforces.
-	var allLimbsAreZero frontend.Variable = 1
+	// allLimbsAreZero is the count of zero limbs (sum of IsZero). It equals
+	// len(NewDigest) iff every limb is zero — same predicate as ProdHashAggr1·
+	// ProdHashAggr2 in sha2_block.go. When equal, we skip the permutation check
+	// (padding row): (count - len) is zero so the equality is not enforced.
+	var allLimbsAreZero frontend.Variable = 0
 	for i := range sbpi.NewDigest {
-		allLimbsAreZero = api.Mul(allLimbsAreZero, api.IsZero(sbpi.NewDigest[i]))
+		allLimbsAreZero = api.Add(allLimbsAreZero, api.IsZero(sbpi.NewDigest[i]))
 	}
 
 	var (
@@ -74,7 +74,7 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 		// newDigest == recomputedDigest unless all limbs of NewDigest are zero.
 		api.AssertIsEqual(
 			api.Mul(
-				api.Sub(allLimbsAreZero, 1),
+				api.Sub(allLimbsAreZero, len(sbpi.NewDigest)),
 				api.Sub(
 					uapi.ToValue(recomputedNewDigest[i]),
 					uapi.ToValue(newDigest[i]),

--- a/prover/zkevm/prover/hash/sha2/circuit.go
+++ b/prover/zkevm/prover/hash/sha2/circuit.go
@@ -47,15 +47,14 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 		panic(fmt.Sprintf("unexpected error when instantiating `uapi`: %v", err.Error()))
 	}
 
-	var (
-		// If the new digest is zero, then the block check is skipped as this is
-		// considered a padding instance. The wizard should externally check that
-		// NewDigest = 0x0 is forbidden.
-		inpIsZero = api.Add(
-			api.IsZero(sbpi.NewDigest[0]),
-			api.IsZero(sbpi.NewDigest[1]),
-		)
-	)
+	// allLimbsAreZero is 1 iff every NewDigest[i] is zero — same predicate as
+	// ∏_i HashIsZero[i] in sha2_block.go (HASH_CANT_BE_ENTIRELY_ZERO). When 1,
+	// we skip the permutation check (padding row); active compression rows must
+	// have allLimbsAreZero = 0, which the wizard enforces.
+	var allLimbsAreZero frontend.Variable = 1
+	for i := range sbpi.NewDigest {
+		allLimbsAreZero = api.Mul(allLimbsAreZero, api.IsZero(sbpi.NewDigest[i]))
+	}
 
 	var (
 		prevDigest = cast16xu16To8xU32s(api, sbpi.PrevDigest)
@@ -72,10 +71,10 @@ func (sbpi *sha2BlockPermutationInstance) checkSha2Permutation(api frontend.API)
 	recomputedNewDigest := sha2.Permute(uapi, prevDigest, blockBytes)
 
 	for i := range recomputedNewDigest {
-		// This checks that newDigest == recomputedDigest unless inpIsZero == 2
+		// newDigest == recomputedDigest unless all limbs of NewDigest are zero.
 		api.AssertIsEqual(
 			api.Mul(
-				api.Sub(inpIsZero, 2),
+				api.Sub(allLimbsAreZero, 1),
 				api.Sub(
 					uapi.ToValue(recomputedNewDigest[i]),
 					uapi.ToValue(newDigest[i]),

--- a/prover/zkevm/prover/hash/sha2/sha2.go
+++ b/prover/zkevm/prover/hash/sha2/sha2.go
@@ -58,7 +58,7 @@ func NewSha2ZkEvm(comp *wizard.CompiledIOP, s Settings, arith *arithmetization.A
 				HashNum: arith.MashedColumnOf(comp, "shakiradata", "ID"),
 				HashHi:  arith.GetLimbsOfU128Be(comp, "shakiradata", "LIMB"),
 				HashLo:  arith.GetLimbsOfU128Be(comp, "shakiradata", "LIMB"),
-				// Before, we usse to pass column.Shift(IsHash, -1) but this does
+				// Before, we used to pass column.Shift(IsHash, -1) but this does
 				// not work with the prover distribution as the column is used as
 				// a filter for a projection query.
 				IsHashHi: arith.ColumnOf(comp, "shakiradata", "SELECTOR_SHA2_RES_HI"),

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -374,7 +374,7 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 
 	comp.InsertGlobal(0,
 		ifaces.QueryIDf("%v_HASH_CANT_BE_BOTH_ZERO", inp.Name),
-		sym.Mul(res.IsActive, sym.Add(prodIsZeroHi, prodIsZeroLo)),
+		sym.Mul(res.IsActive, sumHiIsZero, sumLoIsZero),
 	)
 
 	return res

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -3,6 +3,7 @@ package sha2
 import (
 	"fmt"
 
+	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/column"
 	"github.com/consensys/linea-monorepo/prover/protocol/dedicated"
@@ -38,12 +39,6 @@ const (
 	// final hash.
 	numRowPerInstance = numLimbsPerBlock + numLimbsPerState + numLimbsPerState
 
-	// prodHashLimbChunkSize is the arity of each partial product constraint
-	// (degree 3 including the equality). Full digest-all-zero is built via
-	// intermediate columns ProdHashChunk, ProdHashAggr1/2 so the global constraint is
-	// degree 3 (IsActive × aggr1 × aggr2).
-	prodHashLimbChunkSize = 3
-	numProdHashChunks     = (numLimbsPerState + prodHashLimbChunkSize - 1) / prodHashLimbChunkSize
 )
 
 var (
@@ -156,12 +151,15 @@ type sha2BlockModule struct {
 	Hash [numLimbsPerState]ifaces.Column
 
 	HashIsZero [numLimbsPerState]ifaces.Column
-	// ProdHashChunk[k] equals the product of HashIsZero over limbs in chunk k.
-	ProdHashChunk [numProdHashChunks]ifaces.Column
-	// ProdHashAggr1/2 are intermediate products of three chunk columns each;
-	// their product is 1 iff every Hash limb is zero (all HashIsZero are 1).
-	ProdHashAggr1 ifaces.Column
-	ProdHashAggr2 ifaces.Column
+	// SumHashCol is constrained to Σ HashIsZero[i]. It counts how many
+	// hash limbs are zero on each row.
+	SumHashCol ifaces.Column
+	// LenHashCol is a precomputed column holding numLimbsPerState on every
+	// row.
+	LenHashCol ifaces.Column
+	// EntireHashIsZero is IsZero(LenHashCol − SumHashCol): 1 iff every hash
+	// limb is zero. Constrained via IsActive × EntireHashIsZero = 0.
+	EntireHashIsZero *dedicated.IsZeroCtx
 	ProverActions []wizard.ProverAction
 
 	// GnarkCircuitConnector is the result of the Plonk alignement module. It
@@ -363,61 +361,38 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 		},
 	)
 
-	csLowDegreeZeroHash(comp, inp, res, declareCommit)
-
-	return res
-}
-
-// csLowDegreeZeroHash enforces that an active row cannot carry an all-zero
-// digest (the gnark circuit skips the permutation when every limb is zero).
-// It uses intermediate columns so each global constraint has multiplicative
-// degree at most 3.
-func csLowDegreeZeroHash(
-	comp *wizard.CompiledIOP,
-	inp *sha2BlocksInputs,
-	res *sha2BlockModule,
-	declareCommit func(string) ifaces.Column,
-) {
-	if numProdHashChunks != 6 {
-		panic("csLowDegreeZeroHash assumes exactly 6 chunks; update the aggr constraints if this changes")
-	}
-	for k := range numProdHashChunks {
-		res.ProdHashChunk[k] = declareCommit(fmt.Sprintf("PROD_HASH_CHUNK_%d", k))
-	}
-	res.ProdHashAggr1 = declareCommit("PROD_HASH_AGGR1")
-	res.ProdHashAggr2 = declareCommit("PROD_HASH_AGGR2")
-
-	var ctxHash [numLimbsPerState]wizard.ProverAction
+	// Active rows cannot carry an all-zero digest (gnark skips permutation when
+	// every limb is zero). SumHashCol = Σ HashIsZero[i]; LenHashCol is fixed to
+	// numLimbsPerState; EntireHashIsZero = IsZero(LenHashCol − SumHashCol); forbid
+	// IsActive × EntireHashIsZero.
+	res.SumHashCol = declareCommit("SUM_HASH_COL")
+	res.LenHashCol = comp.InsertPrecomputed(
+		ifaces.ColID(inp.Name+"_LEN_HASH_COL"),
+		smartvectors.NewConstant(field.NewElement(uint64(numLimbsPerState)), colSize),
+	)
+	var hashIsZeroCtx [numLimbsPerState]wizard.ProverAction
 	for i := range numLimbsPerState {
-		res.HashIsZero[i], ctxHash[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
+		res.HashIsZero[i], hashIsZeroCtx[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
 	}
-	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
-
-	for k := range numProdHashChunks {
-		start, end := prodHashChunkLimbRange(k)
-		limbs := make([]any, end-start)
-		for i, li := 0, start; li < end; li, i = li+1, i+1 {
-			limbs[i] = res.HashIsZero[li]
-		}
-		comp.InsertGlobal(0,
-			ifaces.QueryIDf("%v_PROD_HASH_CHUNK_%d_EQ", inp.Name, k),
-			sym.Sub(res.ProdHashChunk[k], sym.Mul(limbs...)),
-		)
+	res.ProverActions = append(res.ProverActions, hashIsZeroCtx[:]...)
+	sumHashIsZero := sym.NewVariable(res.HashIsZero[0])
+	for i := 1; i < numLimbsPerState; i++ {
+		sumHashIsZero = sym.Add(sumHashIsZero, res.HashIsZero[i])
 	}
-
 	comp.InsertGlobal(0,
-		ifaces.QueryIDf("%v_PROD_HASH_AGGR1_EQ", inp.Name),
-		sym.Sub(res.ProdHashAggr1, sym.Mul(res.ProdHashChunk[0], res.ProdHashChunk[1], res.ProdHashChunk[2])),
+		ifaces.QueryIDf("%v_SUM_HASH_COL_EQ", inp.Name),
+		sym.Sub(res.SumHashCol, sumHashIsZero),
 	)
-	comp.InsertGlobal(0,
-		ifaces.QueryIDf("%v_PROD_HASH_AGGR2_EQ", inp.Name),
-		sym.Sub(res.ProdHashAggr2, sym.Mul(res.ProdHashChunk[3], res.ProdHashChunk[4], res.ProdHashChunk[5])),
+	res.EntireHashIsZero = dedicated.IsZero(
+		comp,
+		sym.Sub(res.LenHashCol, res.SumHashCol),
 	)
-
 	comp.InsertGlobal(0,
 		ifaces.QueryIDf("%v_HASH_CANT_BE_ENTIRELY_ZERO", inp.Name),
-		sym.Mul(res.IsActive, res.ProdHashAggr1, res.ProdHashAggr2),
+		sym.Mul(res.IsActive, res.EntireHashIsZero.IsZero),
 	)
+
+	return res
 }
 
 func (sbh *sha2BlockModule) WithCircuit(comp *wizard.CompiledIOP, options ...query.PlonkOption) *sha2BlockModule {
@@ -437,15 +412,6 @@ func (sbh *sha2BlockModule) WithCircuit(comp *wizard.CompiledIOP, options ...que
 	)
 
 	return sbh
-}
-
-func prodHashChunkLimbRange(chunkIdx int) (start, end int) {
-	start = chunkIdx * prodHashLimbChunkSize
-	end = start + prodHashLimbChunkSize
-	if end > numLimbsPerState {
-		end = numLimbsPerState
-	}
-	return start, end
 }
 
 func canBeBlockOfInstancePattern() []field.Element {

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -3,9 +3,9 @@ package sha2
 import (
 	"fmt"
 
-	"github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	"github.com/consensys/linea-monorepo/prover/protocol/column"
+	"github.com/consensys/linea-monorepo/prover/protocol/column/verifiercol"
 	"github.com/consensys/linea-monorepo/prover/protocol/dedicated"
 	"github.com/consensys/linea-monorepo/prover/protocol/dedicated/plonk"
 	"github.com/consensys/linea-monorepo/prover/protocol/distributed/pragmas"
@@ -38,7 +38,6 @@ const (
 	// in total) for the initial hash and 16 uint16 (256 bits in total) for the
 	// final hash.
 	numRowPerInstance = numLimbsPerBlock + numLimbsPerState + numLimbsPerState
-
 )
 
 var (
@@ -150,17 +149,13 @@ type sha2BlockModule struct {
 	// span of a hash.
 	Hash [numLimbsPerState]ifaces.Column
 
-	HashIsZero [numLimbsPerState]ifaces.Column
-	// SumHashCol is constrained to Σ HashIsZero[i]. It counts how many
-	// hash limbs are zero on each row.
-	SumHashCol ifaces.Column
-	// LenHashCol is a precomputed column holding numLimbsPerState on every
-	// row.
-	LenHashCol ifaces.Column
-	// EntireHashIsZero is IsZero(LenHashCol − SumHashCol): 1 iff every hash
-	// limb is zero. Constrained via IsActive × EntireHashIsZero = 0.
-	EntireHashIsZero *dedicated.IsZeroCtx
-	ProverActions []wizard.ProverAction
+	// LimbsIsZero is 1 iff limb is zero.
+	LimbsIsZero ifaces.Column
+	// SumLimbsIsZeroCol equals Σ LimbsIsZero[i+numLimbsPerBlock+numLimbsPerState].
+	SumLimbsIsZeroCol ifaces.Column
+	// EntireLimbsIntervalIsZero is 1 iff every  limb in the interval equivalent with newState is zero.
+	EntireLimbsIntervalIsZero *dedicated.IsZeroCtx
+	ProverActions             []wizard.ProverAction
 
 	// GnarkCircuitConnector is the result of the Plonk alignement module. It
 	// handles all the Plonk logic responsible for verifying the correctness of
@@ -361,35 +356,38 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 		},
 	)
 
-	// Active rows cannot carry an all-zero digest (gnark skips permutation when
-	// every limb is zero). SumHashCol = Σ HashIsZero[i]; LenHashCol is fixed to
-	// numLimbsPerState; EntireHashIsZero = IsZero(LenHashCol − SumHashCol); forbid
-	// IsActive × EntireHashIsZero.
-	res.SumHashCol = declareCommit("SUM_HASH_COL")
-	res.LenHashCol = comp.InsertPrecomputed(
-		ifaces.ColID(inp.Name+"_LEN_HASH_COL"),
-		smartvectors.NewConstant(field.NewElement(uint64(numLimbsPerState)), colSize),
-	)
-	var hashIsZeroCtx [numLimbsPerState]wizard.ProverAction
-	for i := range numLimbsPerState {
-		res.HashIsZero[i], hashIsZeroCtx[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
-	}
-	res.ProverActions = append(res.ProverActions, hashIsZeroCtx[:]...)
-	sumHashIsZero := sym.NewVariable(res.HashIsZero[0])
-	for i := 1; i < numLimbsPerState; i++ {
-		sumHashIsZero = sym.Add(sumHashIsZero, res.HashIsZero[i])
-	}
-	comp.InsertGlobal(0,
-		ifaces.QueryIDf("%v_SUM_HASH_COL_EQ", inp.Name),
-		sym.Sub(res.SumHashCol, sumHashIsZero),
-	)
-	res.EntireHashIsZero = dedicated.IsZero(
+	// Forbid all-zero newState on active compressions so gnark cannot skip Permute.
+	res.SumLimbsIsZeroCol = declareCommit("SUM_NEW_STATE_LIMBS_IS_ZERO")
+	var limbIsZeroCtx wizard.ProverAction
+	res.LimbsIsZero, limbIsZeroCtx = dedicated.IsZero(
 		comp,
-		sym.Sub(res.LenHashCol, res.SumHashCol),
+		res.Limbs,
+	).GetColumnAndProverAction()
+
+	res.ProverActions = append(res.ProverActions, limbIsZeroCtx)
+
+	sumNewStateFlags := sym.NewConstant(0)
+	for i := 0; i < numLimbsPerState; i++ {
+		// shift the column by the offset of the newState interval
+		sumNewStateFlags = sym.Add(sumNewStateFlags, column.Shift(res.LimbsIsZero, numLimbsPerBlock+numLimbsPerState+i))
+	}
+	comp.InsertGlobal(0,
+		ifaces.QueryIDf("%v_SUM_NEW_STATE_LIMBS_IS_ZERO_EQ", inp.Name),
+		sym.Sub(res.SumLimbsIsZeroCol, sumNewStateFlags),
+	)
+	lenHashCol := verifiercol.NewConstantCol(field.NewElement(uint64(numLimbsPerState)), colSize, inp.Name+"_LEN_HASH_COL")
+	res.EntireLimbsIntervalIsZero = dedicated.IsZero(
+		comp,
+		sym.Sub(lenHashCol, res.SumLimbsIsZeroCol),
 	)
 	comp.InsertGlobal(0,
-		ifaces.QueryIDf("%v_HASH_CANT_BE_ENTIRELY_ZERO", inp.Name),
-		sym.Mul(res.IsActive, res.EntireHashIsZero.IsZero),
+		// we can use CanBeBeginningOfInstance.Natural as selector since res.EntireLimbsIntervalIsZero is constructed  by the shift of the LimbsIsZero column by the offset of the newState.
+		ifaces.QueryIDf("%v_LIMBS_NEW_STATE_CANT_BE_ENTIRELY_ZERO", inp.Name),
+		sym.Mul(
+			res.IsActive,
+			res.CanBeBeginningOfInstance.Natural,
+			res.EntireLimbsIntervalIsZero.IsZero,
+		),
 	)
 
 	return res

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -351,20 +351,30 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 	)
 
 	// As per the padding technique we use, the HashHi and HashLo should not
-	// be zero when isActive.
+	// be zero when isActive. We check that neither the upper 128-bit half nor
+	// the lower 128-bit half is entirely zero by taking the product of the
+	// per-limb IsZero results for each half.
 	var ctxHash [numLimbsPerState]wizard.ProverAction
 
-	sumHash := sym.NewConstant(0)
 	for i := range numLimbsPerState {
 		res.HashIsZero[i], ctxHash[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
-		sumHash = sym.Add(sumHash, res.HashIsZero[i])
 	}
 
 	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
 
+	prodIsZeroHi := sym.NewConstant(1)
+	for i := range numLimbsPerState / 2 {
+		prodIsZeroHi = sym.Mul(prodIsZeroHi, res.HashIsZero[i])
+	}
+
+	prodIsZeroLo := sym.NewConstant(1)
+	for i := numLimbsPerState / 2; i < numLimbsPerState; i++ {
+		prodIsZeroLo = sym.Mul(prodIsZeroLo, res.HashIsZero[i])
+	}
+
 	comp.InsertGlobal(0,
 		ifaces.QueryIDf("%v_HASH_CANT_BE_BOTH_ZERO", inp.Name),
-		sym.Mul(res.IsActive, sumHash),
+		sym.Mul(res.IsActive, sym.Add(prodIsZeroHi, prodIsZeroLo)),
 	)
 
 	return res

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -151,8 +151,6 @@ type sha2BlockModule struct {
 
 	// LimbsIsZero is 1 iff limb is zero.
 	LimbsIsZero ifaces.Column
-	// SumLimbsIsZeroCol equals Σ LimbsIsZero[i+numLimbsPerBlock+numLimbsPerState].
-	SumLimbsIsZeroCol ifaces.Column
 	// EntireLimbsIntervalIsZero is 1 iff every  limb in the interval equivalent with newState is zero.
 	EntireLimbsIntervalIsZero *dedicated.IsZeroCtx
 	ProverActions             []wizard.ProverAction
@@ -357,7 +355,6 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 	)
 
 	// Forbid all-zero newState on active compressions so gnark cannot skip Permute.
-	res.SumLimbsIsZeroCol = declareCommit("SUM_NEW_STATE_LIMBS_IS_ZERO")
 	var limbIsZeroCtx wizard.ProverAction
 	res.LimbsIsZero, limbIsZeroCtx = dedicated.IsZero(
 		comp,
@@ -371,14 +368,11 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 		// shift the column by the offset of the newState interval
 		sumNewStateFlags = sym.Add(sumNewStateFlags, column.Shift(res.LimbsIsZero, numLimbsPerBlock+numLimbsPerState+i))
 	}
-	comp.InsertGlobal(0,
-		ifaces.QueryIDf("%v_SUM_NEW_STATE_LIMBS_IS_ZERO_EQ", inp.Name),
-		sym.Sub(res.SumLimbsIsZeroCol, sumNewStateFlags),
-	)
+
 	lenHashCol := verifiercol.NewConstantCol(field.NewElement(uint64(numLimbsPerState)), colSize, inp.Name+"_LEN_HASH_COL")
 	res.EntireLimbsIntervalIsZero = dedicated.IsZero(
 		comp,
-		sym.Sub(lenHashCol, res.SumLimbsIsZeroCol),
+		sym.Sub(lenHashCol, sumNewStateFlags),
 	)
 	comp.InsertGlobal(0,
 		// we can use CanBeBeginningOfInstance.Natural as selector since res.EntireLimbsIntervalIsZero is constructed  by the shift of the LimbsIsZero column by the offset of the newState.

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -37,6 +37,13 @@ const (
 	// in total) for the initial hash and 16 uint16 (256 bits in total) for the
 	// final hash.
 	numRowPerInstance = numLimbsPerBlock + numLimbsPerState + numLimbsPerState
+
+	// prodHashLimbChunkSize is the arity of each partial product constraint
+	// (degree 3 including the equality). Full digest-all-zero is built via
+	// intermediate columns ProdHashChunk, ProdHashAggr1/2 so the global constraint is
+	// degree 3 (IsActive × aggr1 × aggr2).
+	prodHashLimbChunkSize = 3
+	numProdHashChunks     = (numLimbsPerState + prodHashLimbChunkSize - 1) / prodHashLimbChunkSize
 )
 
 var (
@@ -148,7 +155,13 @@ type sha2BlockModule struct {
 	// span of a hash.
 	Hash [numLimbsPerState]ifaces.Column
 
-	HashIsZero    [numLimbsPerState]ifaces.Column
+	HashIsZero [numLimbsPerState]ifaces.Column
+	// ProdHashChunk[k] equals the product of HashIsZero over limbs in chunk k.
+	ProdHashChunk [numProdHashChunks]ifaces.Column
+	// ProdHashAggr1/2 are intermediate products of three chunk columns each;
+	// their product is 1 iff every Hash limb is zero (all HashIsZero are 1).
+	ProdHashAggr1 ifaces.Column
+	ProdHashAggr2 ifaces.Column
 	ProverActions []wizard.ProverAction
 
 	// GnarkCircuitConnector is the result of the Plonk alignement module. It
@@ -350,24 +363,61 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 		},
 	)
 
-	// As per the padding technique we use, the HashHi and HashLo should not
-	// be zero when isActive.
-	var ctxHash [numLimbsPerState]wizard.ProverAction
+	csLowDegreeZeroHash(comp, inp, res, declareCommit)
 
-	prodHash := sym.NewConstant(1)
+	return res
+}
+
+// csLowDegreeZeroHash enforces that an active row cannot carry an all-zero
+// digest (the gnark circuit skips the permutation when every limb is zero).
+// It uses intermediate columns so each global constraint has multiplicative
+// degree at most 3.
+func csLowDegreeZeroHash(
+	comp *wizard.CompiledIOP,
+	inp *sha2BlocksInputs,
+	res *sha2BlockModule,
+	declareCommit func(string) ifaces.Column,
+) {
+	if numProdHashChunks != 6 {
+		panic("csLowDegreeZeroHash assumes exactly 6 chunks; update the aggr constraints if this changes")
+	}
+	for k := range numProdHashChunks {
+		res.ProdHashChunk[k] = declareCommit(fmt.Sprintf("PROD_HASH_CHUNK_%d", k))
+	}
+	res.ProdHashAggr1 = declareCommit("PROD_HASH_AGGR1")
+	res.ProdHashAggr2 = declareCommit("PROD_HASH_AGGR2")
+
+	var ctxHash [numLimbsPerState]wizard.ProverAction
 	for i := range numLimbsPerState {
 		res.HashIsZero[i], ctxHash[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
-		prodHash = sym.Mul(prodHash, res.HashIsZero[i])
+	}
+	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
+
+	for k := range numProdHashChunks {
+		start, end := prodHashChunkLimbRange(k)
+		limbs := make([]any, end-start)
+		for i, li := 0, start; li < end; li, i = li+1, i+1 {
+			limbs[i] = res.HashIsZero[li]
+		}
+		comp.InsertGlobal(0,
+			ifaces.QueryIDf("%v_PROD_HASH_CHUNK_%d_EQ", inp.Name, k),
+			sym.Sub(res.ProdHashChunk[k], sym.Mul(limbs...)),
+		)
 	}
 
-	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
+	comp.InsertGlobal(0,
+		ifaces.QueryIDf("%v_PROD_HASH_AGGR1_EQ", inp.Name),
+		sym.Sub(res.ProdHashAggr1, sym.Mul(res.ProdHashChunk[0], res.ProdHashChunk[1], res.ProdHashChunk[2])),
+	)
+	comp.InsertGlobal(0,
+		ifaces.QueryIDf("%v_PROD_HASH_AGGR2_EQ", inp.Name),
+		sym.Sub(res.ProdHashAggr2, sym.Mul(res.ProdHashChunk[3], res.ProdHashChunk[4], res.ProdHashChunk[5])),
+	)
 
 	comp.InsertGlobal(0,
 		ifaces.QueryIDf("%v_HASH_CANT_BE_ENTIRELY_ZERO", inp.Name),
-		sym.Mul(res.IsActive, prodHash),
+		sym.Mul(res.IsActive, res.ProdHashAggr1, res.ProdHashAggr2),
 	)
-
-	return res
 }
 
 func (sbh *sha2BlockModule) WithCircuit(comp *wizard.CompiledIOP, options ...query.PlonkOption) *sha2BlockModule {
@@ -387,6 +437,15 @@ func (sbh *sha2BlockModule) WithCircuit(comp *wizard.CompiledIOP, options ...que
 	)
 
 	return sbh
+}
+
+func prodHashChunkLimbRange(chunkIdx int) (start, end int) {
+	start = chunkIdx * prodHashLimbChunkSize
+	end = start + prodHashLimbChunkSize
+	if end > numLimbsPerState {
+		end = numLimbsPerState
+	}
+	return start, end
 }
 
 func canBeBlockOfInstancePattern() []field.Element {

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -148,7 +148,6 @@ type sha2BlockModule struct {
 	// span of a hash.
 	Hash [numLimbsPerState]ifaces.Column
 
-	HashIsZero    [numLimbsPerState]ifaces.Column
 	ProverActions []wizard.ProverAction
 
 	// GnarkCircuitConnector is the result of the Plonk alignement module. It
@@ -350,27 +349,21 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 		},
 	)
 
-	// As per the padding technique we use, the HashHi and HashLo should not
-	// be zero when isActive. We check that neither the upper 128-bit half nor
-	// the lower 128-bit half is entirely zero by taking the product of the
-	// per-limb IsZero results for each half.
-	var ctxHash [numLimbsPerState]wizard.ProverAction
-
-	for i := range numLimbsPerState {
-		res.HashIsZero[i], ctxHash[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
-	}
-
-	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
-
-	prodIsZeroHi := sym.NewConstant(1)
+	// The hash should not be entirely zero when isActive.
+	// Sum limbs per half and use IsZero to keep constraint degree low.
+	sumHashHi := sym.NewConstant(0)
 	for i := range numLimbsPerState / 2 {
-		prodIsZeroHi = sym.Mul(prodIsZeroHi, res.HashIsZero[i])
+		sumHashHi = sym.Add(sumHashHi, res.Hash[i])
 	}
 
-	prodIsZeroLo := sym.NewConstant(1)
+	sumHashLo := sym.NewConstant(0)
 	for i := numLimbsPerState / 2; i < numLimbsPerState; i++ {
-		prodIsZeroLo = sym.Mul(prodIsZeroLo, res.HashIsZero[i])
+		sumHashLo = sym.Add(sumHashLo, res.Hash[i])
 	}
+
+	sumHiIsZero, ctxSumHi := dedicated.IsZero(comp, sumHashHi).GetColumnAndProverAction()
+	sumLoIsZero, ctxSumLo := dedicated.IsZero(comp, sumHashLo).GetColumnAndProverAction()
+	res.ProverActions = append(res.ProverActions, ctxSumHi, ctxSumLo)
 
 	comp.InsertGlobal(0,
 		ifaces.QueryIDf("%v_HASH_CANT_BE_BOTH_ZERO", inp.Name),

--- a/prover/zkevm/prover/hash/sha2/sha2_block.go
+++ b/prover/zkevm/prover/hash/sha2/sha2_block.go
@@ -40,8 +40,8 @@ const (
 )
 
 var (
-	// initializationVector encodes the initialization vector of SHA2 in 2 field
-	// elements storing each 128 bytes of the IV in big endian order.
+	// initializationVector is the SHA-256 IV as 16 big-endian uint16 limbs
+	// (32 bytes total), each limb stored in the low 16 bits of a field element.
 	//
 	// 0x6A09E667BB67AE853C6EF372A54FF53A510E527F9B05688C1F83D9AB5BE0CD19
 	initializationVector = [16]field.Element{
@@ -70,8 +70,8 @@ var (
 // verification circuit.
 type sha2BlocksInputs struct {
 
-	// Name allows the prover to provide context in a string which we derive to
-	// to derive the name of the constraints and queries of the module.
+	// Name allows the prover to provide a string context from which we derive
+	// the names of the constraints and queries of the module.
 	Name string
 
 	// MaxNbBlock corresponds to the maximum number of blocks that can be handled
@@ -148,6 +148,7 @@ type sha2BlockModule struct {
 	// span of a hash.
 	Hash [numLimbsPerState]ifaces.Column
 
+	HashIsZero    [numLimbsPerState]ifaces.Column
 	ProverActions []wizard.ProverAction
 
 	// GnarkCircuitConnector is the result of the Plonk alignement module. It
@@ -349,25 +350,21 @@ func newSha2BlockModule(comp *wizard.CompiledIOP, inp *sha2BlocksInputs) *sha2Bl
 		},
 	)
 
-	// The hash should not be entirely zero when isActive.
-	// Sum limbs per half and use IsZero to keep constraint degree low.
-	sumHashHi := sym.NewConstant(0)
-	for i := range numLimbsPerState / 2 {
-		sumHashHi = sym.Add(sumHashHi, res.Hash[i])
+	// As per the padding technique we use, the HashHi and HashLo should not
+	// be zero when isActive.
+	var ctxHash [numLimbsPerState]wizard.ProverAction
+
+	prodHash := sym.NewConstant(1)
+	for i := range numLimbsPerState {
+		res.HashIsZero[i], ctxHash[i] = dedicated.IsZero(comp, res.Hash[i]).GetColumnAndProverAction()
+		prodHash = sym.Mul(prodHash, res.HashIsZero[i])
 	}
 
-	sumHashLo := sym.NewConstant(0)
-	for i := numLimbsPerState / 2; i < numLimbsPerState; i++ {
-		sumHashLo = sym.Add(sumHashLo, res.Hash[i])
-	}
-
-	sumHiIsZero, ctxSumHi := dedicated.IsZero(comp, sumHashHi).GetColumnAndProverAction()
-	sumLoIsZero, ctxSumLo := dedicated.IsZero(comp, sumHashLo).GetColumnAndProverAction()
-	res.ProverActions = append(res.ProverActions, ctxSumHi, ctxSumLo)
+	res.ProverActions = append(res.ProverActions, ctxHash[:]...)
 
 	comp.InsertGlobal(0,
-		ifaces.QueryIDf("%v_HASH_CANT_BE_BOTH_ZERO", inp.Name),
-		sym.Mul(res.IsActive, sumHiIsZero, sumLoIsZero),
+		ifaces.QueryIDf("%v_HASH_CANT_BE_ENTIRELY_ZERO", inp.Name),
+		sym.Mul(res.IsActive, prodHash),
 	)
 
 	return res


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core proving/compilation pipelines (new on-the-fly path, parallel compilation/module discovery, lock semantics) and modifies SHA2 circuit/assignment constraints, which can impact proof correctness and performance under concurrency.
> 
> **Overview**
> **Adds an on-the-fly Limitless prover path**: when `Execution.Serialization` is disabled, proving now compiles and runs end-to-end in memory (`ProveOnTheFly`), overlapping compilation with bootstrapper execution, tracking compiled-circuit usage for early release, and allowing concurrency tuning via env vars (e.g. `LIMITLESS_SUBPROVER_JOBS`, `LIMITLESS_TARGET_WEIGHT_LOG2`).
> 
> **Removes JSONL perf logging** from the limitless prover and retunes the disk-based path by making sub-prover concurrency configurable and simplifying GL/LPP/conglomeration calls (no `perfLogger` plumbing).
> 
> **Improves performance and parallelism across the proving stack**: distributed wizard build/compile is parallelized and can skip debug modules, conglomeration compilation is pre-started, module discovery precompiles/caches Plonk constraint counts, quotient computation reuses allocated slices and adjusts FFT tasking, and `ProverRuntime` switches to an `RWMutex` with reduced lock hold time during `AssignColumn`.
> 
> **Fixes SHA2 on-the-fly/padding behavior** by preventing the gnark SHA2 permutation check from being skipped via all-zero digests, adding a constraint/action to forbid an all-zero new-state interval on active instances, and ensuring the new `EntireLimbsIntervalIsZero` prover action is run.
> 
> Also updates dependencies (`gnark-crypto`, `go-corset` via `replace`, `x/sync`, `x/sys`) and parallelizes Vortex column extraction/Merkle proving with a faster linear-combination path for regular vectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51fb1defa8727bc191705ce889aea0a53e71b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->