### PR TITLE
Update Maru node image version to v1.2.1

### DIFF
--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -57,7 +57,7 @@ services:
   maru-node:
     hostname: linea-maru
     container_name: linea-maru
-    image: consensys/maru:v1.1.0-20260204153030-00cd762
+    image: consensys/maru:v1.2.1-20260410142843-d326b73
     restart: unless-stopped
     ports:
       - "8080:8080" # Beacon/REST API

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -57,7 +57,7 @@ services:
   maru-node:
     hostname: linea-maru
     container_name: linea-maru
-    image: consensys/maru:v1.1.0-20260204153030-00cd762
+    image: consensys/maru:v1.2.1-20260410142843-d326b73
     restart: unless-stopped
     ports:
       - "8080:8080" # Beacon/REST API


### PR DESCRIPTION
update Maru to v1.2.1-20260410142843-d326b73 for mainnet and Sepolia

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that bumps a container image tag; risk is limited to users who follow these compose files and may see behavior changes from the newer Maru release.
> 
> **Overview**
> Updates the getting-started Docker Compose configs for Linea mainnet and Sepolia to pull `consensys/maru` `v1.2.1-20260410142843-d326b73` instead of the previous `v1.1.0` image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b268ca4101148060439be317829ce393daad4d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->