### PR TITLE
fix(coordinator) - enhance review output handling and upload executio…

### DIFF
--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -30,7 +30,7 @@ jobs:
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: --model claude-opus-4-6
+          claude_args: --model claude-opus-4-7
           prompt: |
             You are reviewing the full Kotlin/JVM codebase in the `coordinator/` and
             `jvm-libs/` modules of the Linea monorepo.

--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -102,15 +102,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_BRANCH: ${{ github.ref_name }}
-          REVIEW_BODY: ${{ steps.review.outputs.result }}
+          EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
           BRANCH="${INPUT_BRANCH}"
           COMMIT=$(git rev-parse --short=7 HEAD)
           TITLE="Coordinator review ${DATE} ${BRANCH} ${COMMIT}"
 
+          REVIEW_BODY=""
+          if [ -n "${EXECUTION_FILE}" ] && [ -f "${EXECUTION_FILE}" ]; then
+            REVIEW_BODY=$(jq -r '[.[] | select(.type=="result") | .result] | last // ""' "${EXECUTION_FILE}")
+          fi
+
           if [ -z "${REVIEW_BODY}" ]; then
-            REVIEW_BODY="No review output — Claude may not have produced output."
+            REVIEW_BODY="No review output — Claude may not have produced output. See the \`claude-execution-output\` workflow artifact for debugging."
           fi
 
           printf '%s' "${REVIEW_BODY}" > /tmp/coordinator-review.md
@@ -126,3 +131,10 @@ jobs:
         with:
           name: coordinator-review
           path: /tmp/coordinator-review.md
+
+      - name: Upload Claude execution log
+        if: ${{ always() && steps.review.outputs.execution_file != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: claude-execution-output
+          path: ${{ steps.review.outputs.execution_file }}


### PR DESCRIPTION
…n log

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes affecting how review output is parsed and artifacts are uploaded; minimal product risk, with the main risk being potential issue-body formatting/`jq` parsing failures in CI.
> 
> **Overview**
> Updates the `claude-coordinator-review` GitHub Action to run with `claude-opus-4-7`.
> 
> Improves issue creation by reading the final `.type=="result"` output from the action’s `execution_file` (via `jq`) instead of relying solely on the direct `result` output, and provides a clearer fallback message when no review text is produced.
> 
> Adds a new always-on artifact upload step (`claude-execution-output`) to persist the Claude execution log when available, to aid debugging of missing/empty reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 101f19060f4443621a11068c5b8a6d06d11ea4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->