### PR TITLE
Misc/chore claude gha

### DIFF
--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -80,21 +80,42 @@ jobs:
             ## Output Format
 
             Format your response as a GitHub issue body. Prefix EACH individual finding with
-            `- [ ]` (an unchecked checkbox) so team members can tick them off as addressed.
+            a plain list marker `- ` (NO checkbox on the finding itself) and append exactly
+            these four triage sub-items, indented two spaces, all left unchecked:
+
+              - [ ] ❌ won't fix
+              - [ ] ❌ false positive
+              - [ ] 🤖 to be fixed
+              - [ ] ✅ addressed/fixed
+
+            Reviewers will later tick exactly one of those sub-items to record the triage
+            decision. Do NOT put `- [ ]` on the finding line itself.
 
             Example format:
 
             ## Dead Code
-            - [ ] `coordinator/src/.../Foo.kt:42` — `unusedParam` is never read. Remove the parameter and update all call sites.
+            - `coordinator/src/.../Foo.kt:42` — `unusedParam` is never read. Remove the parameter and update all call sites.
+              - [ ] ❌ won't fix
+              - [ ] ❌ false positive
+              - [ ] 🤖 to be fixed
+              - [ ] ✅ addressed/fixed
 
             ## Duplicated / Similar Code
             No issues found.
 
             ## Anti-patterns and Code Smells
-            - [ ] `coordinator/src/.../Bar.kt:17` — Uses `!!` on a nullable result from `findOrNull` with no justification. Replace with `?: error("...")` or a safe alternative.
+            - `coordinator/src/.../Bar.kt:17` — Uses `!!` on a nullable result from `findOrNull` with no justification. Replace with `?: error("...")` or a safe alternative.
+              - [ ] ❌ won't fix
+              - [ ] ❌ false positive
+              - [ ] 🤖 to be fixed
+              - [ ] ✅ addressed/fixed
 
             ## Concurrency Issues
-            - [ ] `coordinator/src/.../Baz.kt:88` — `.get()` called on a `CompletableFuture` on the event-loop thread, which will block it. Use `.thenApply` instead.
+            - `coordinator/src/.../Baz.kt:88` — `.get()` called on a `CompletableFuture` on the event-loop thread, which will block it. Use `.thenApply` instead.
+              - [ ] ❌ won't fix
+              - [ ] ❌ false positive
+              - [ ] 🤖 to be fixed
+              - [ ] ✅ addressed/fixed
 
             Output ONLY the review content, nothing else.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'issues' && github.event.action == 'assigned' && github.event.assignee.login == 'claude[bot]')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Required for Claude to push its claude/* branches
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates GitHub Actions permissions (granting `contents: write`), which increases the blast radius if the workflow/action is compromised, though changes are limited to CI configuration.
> 
> **Overview**
> Updates the `claude-coordinator-review` workflow prompt to change how findings are formatted: each finding is now a plain bullet followed by a fixed set of four *triage* checkboxes (won’t fix / false positive / to be fixed / addressed) instead of a checkbox on the finding line.
> 
> Adjusts the main `claude.yml` workflow to grant `contents: write` so Claude can push `claude/*` branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff29ddc7801e38636d46e19ad4549282dd829c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->