### PR TITLE
docs(get-started): target checkpoints, wait flags, and resume curl

### DIFF
--- a/docs/conflation-target-checkpoints.md
+++ b/docs/conflation-target-checkpoints.md
@@ -1,0 +1,78 @@
+# Target checkpoints, L1 finalization, and API resume
+
+Configure `[conflation.proof-aggregation]` in the coordinator TOML (for example `config/coordinator/coordinator-config-v2.toml` or
+your Docker-mounted coordinator config). Optionally set `[api]` for JSON-RPC (default path `/`; `json-rpc-port` is often
+`9546` in Docker, and that port is usually not published to the host).
+
+## Block number targets: `target-end-blocks`
+
+Example: `target-end-blocks = [4, 9]`, assuming other limits (deadline, traces, data size) do not cut batches earlier.
+
+| Checkpoint (listed value) | Inclusive end of the conflated batch, blob, and aggregation |
+|----------------------------|-------------------------------------------------------------|
+| **4** | **4**                                                       |
+| **9** | **9**                                                       |
+
+```toml
+[conflation.proof-aggregation]
+target-end-blocks = [4, 9]
+```
+
+## Timestamp hard forks: `timestamp-based-hard-forks`
+
+The list must be strictly ascending, with no duplicate timestamps. For example, `timestamp-based-hard-forks = [1700000100, 1700001000]` is two thresholds expressed as Unix seconds, or the same
+instants as ISO-8601 strings in TOML.
+
+| L2 block (example) | Block timestamp (example) | Inclusive end of the conflated batch, blob, and aggregation                                                       |
+|----------------------|---------------------------|-------------------------------------------------------------------------------------------------------------------|
+| 6 | `1700000000` | — |
+| 7 | `1700000100` | The first threshold is crossed at block **7**, so the batch, blob, and aggregation are cut off with end block number **6**. |
+| … | … | … |
+| 15 | `1700001000` | The second threshold is crossed at block **15**, so the batch, blob, and aggregation are cut off with end block number **14**. |
+
+```toml
+[conflation.proof-aggregation]
+timestamp-based-hard-forks = [1700000100, 1700001000]
+# Or e.g. ["2023-11-14T22:15:00Z", "2023-11-14T22:30:00Z"] (same two instants) — must stay strictly ascending, no duplicates
+```
+
+## Block number targets and timestamp hard forks
+
+Both can be set. The batch, blob, and aggregation are cut off at whichever target is hit first: a **block** end from `target-end-blocks` or a **time** threshold from `timestamp-based-hard-forks`. For
+example, with `target-end-blocks = [4, 9]` and `timestamp-based-hard-forks = [1700000100, 1700001000]`:
+
+- **Block 4** (the first **block** target) has timestamp `1700000000`, so the batch, blob, and aggregation in progress are cut off with end block number **4**.
+- **Block 7** has timestamp `1700000100` (the first **time** threshold), so the cut-off is at end block number **6**.
+- **Block 9** (the second **block** target) has timestamp `1700000500` (between the two time thresholds), so the cut-off is at end block number **9**.
+- **Block 15** has timestamp `1700001000` (the second time threshold), so the cut-off is at end block number **14**.
+
+## Wait on L1 finalization and on API: `wait-target-block-l1-finalization`, `wait-api-resume-after-target-block`
+
+| Setting | If `true` |
+|--------|------------|
+| `wait-target-block-l1-finalization` | Do not import past the checkpoint until the L1-finalized L2 block height is high enough. |
+| `wait-api-resume-after-target-block` | Before resuming, require the JSON-RPC call below. |
+| Both `true` | Both conditions must pass before resuming. |
+| Both `false` | No import pause from these options (all other behavior unchanged). |
+
+```toml
+[conflation.proof-aggregation]
+wait-target-block-l1-finalization = true
+wait-api-resume-after-target-block = true
+```
+
+## Resume: `conflation_signalTargetCheckpointResume`
+
+```bash
+docker compose -f docker/compose-tracing-v2.yml exec coordinator \
+  curl -sS -X POST "http://127.0.0.1:9546/" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"conflation_signalTargetCheckpointResume","params":[]}'
+```
+
+`result: true` means the signal was applied (the API gate is on and a pause was waiting for it).
+
+## See also
+
+- [Get Started](get-started.md)
+- [Local development guide](local-development-guide.md)

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -80,59 +80,10 @@ For local testing and development conflation deadline is set to 6s `conflation-d
 Hence, only a two-block conflation.
 If you want bigger conflations, increase the deadline accordingly.
 
-### Target checkpoints, L1 finalization, and API resume
-
-Under `[conflation.proof-aggregation]` in the coordinator TOML configuration,
-you can define **target checkpoints** and optional **gates** that pause L2 block import / conflation until release
-conditions are met.
-
-**`target-end-blocks`** — Block numbers that mark checkpoints. The coordinator uses the same target set across the
-conflation pipeline so that, for each configured **`N`**, work is **cut off with end block number `N`**: an execution
-**batch** ends at **`N`**, the enclosing **blob** is closed so its range ends at **`N`**, and **proof aggregation** is
-triggered so that aggregation’s block range also ends at **`N`**. When the wait flags below are enabled, **import /
-conflation then pauses** at that boundary: the pause is recognized when block **`N + 1`** is handed to conflation—that
-is, after the batch/blob/aggregation slice through **`N`** has been completed and the coordinator is about to progress
-past **`N`**.
-
-**`timestamp-based-hard-forks`** — Ordered list of L2 block timestamp thresholds (ISO-8601 strings or Unix epoch
-seconds, as in other coordinator TOML `Instant` fields). The list must be **strictly ascending** with **no
-duplicates**. Conflation uses the same crossing rule as `TimestampHardForkConflationCalculator`: the **first** L2 block
-whose timestamp is **at or above** a threshold **T**, while the previous block’s timestamp was **strictly below** **T**,
-is the block **`N + 1`** for that fork. The coordinator closes conflation so that the execution **batch**,
-enclosing **blob**, and **aggregation** all have **end block number `N`** (the last block still strictly before the
-fork in time). The crossing block **`N + 1`** starts the next batch after the boundary. For the optional checkpoint
-**pause** (when the wait flags below are enabled), the same **`N` / `N + 1`** split applies as for `target-end-blocks`:
-the pause is tied to handing **`N + 1`** into conflation once the work through **`N`** has been completed.
-
-**`wait-target-block-l1-finalization`** — When `true`, after a checkpoint the coordinator waits until the
-**L1-finalized** L2 block number reported by the rollup is at least the checkpoint height before it may resume
-importing.
-
-**`wait-api-resume-after-target-block`** — When `true`, after a checkpoint the coordinator also waits for an operator
-**JSON-RPC** call before resuming. If both wait flags are `true`, **both** the L1-finalization condition and the API
-signal must be satisfied before the pause clears. If only one flag is `true`, only that gate applies.
-
-The pause machinery is active when **either** wait flag is `true`. If both are `false`, `target-end-blocks` and
-`timestamp-based-hard-forks` do not trigger this import pause (they can still affect proof aggregation layout
-elsewhere).
-
-**Resume API** — JSON-RPC method name: `conflation_signalTargetCheckpointResume`. The body is standard JSON-RPC 2.0;
-`params` may be an empty array. The `result` is a boolean: `true` if the resume signal was accepted (API gate enabled
-and a checkpoint pause was actually waiting on the API), `false` otherwise.
-
-Coordinator API settings live under `[api]` (`json-rpc-port`, optional `json-rpc-path`; default path is `/`). In the
-default Docker tracing stack, `json-rpc-port` is **9546** and is **not** published to the host; call it from inside the
-`coordinator` container or add a port mapping if you need host access.
-
-Example:
-
-```bash
-curl -sS -X POST "http://127.0.0.1:9546/" \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"conflation_signalTargetCheckpointResume","params":[]}'
-```
-
-If you set a non-default `json-rpc-path` (for example `/jsonrpc`), append that path to the URL instead of `/`.
+For **target block / timestamp checkpoints**, L1 finalization and API **resume** (`target-end-blocks`,
+`timestamp-based-hard-forks`, `wait-target-block-l1-finalization`, `wait-api-resume-after-target-block`, and
+`conflation_signalTargetCheckpointResume`), see
+[Target checkpoints, L1 finalization, and API resume](conflation-target-checkpoints.md).
 
 ## Next steps
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -27,7 +27,7 @@ pnpm -F e2e run test:local
 To stop the stack:
 
 ```
-make clean-enviroment
+make clean-environment
 ```
 
 While running the end-to-end tests, you should observe files being generated in `tmp/local/` directory.
@@ -76,9 +76,63 @@ docker system prune --volumes
 ## Tuning in conflation
 
 For local testing and development conflation deadline is set to 6s `conflation-deadline=PT6S` in
-`config/coordinator/coordinator-docker.config.toml` file.
+`config/coordinator/coordinator-config-v2.toml` (Docker-based `make start-env*` stacks often mount a different file from `docker/config/`).
 Hence, only a two-block conflation.
 If you want bigger conflations, increase the deadline accordingly.
+
+### Target checkpoints, L1 finalization, and API resume
+
+Under `[conflation.proof-aggregation]` in the coordinator TOML configuration,
+you can define **target checkpoints** and optional **gates** that pause L2 block import / conflation until release
+conditions are met.
+
+**`target-end-blocks`** — Block numbers that mark checkpoints. The coordinator uses the same target set across the
+conflation pipeline so that, for each configured **`N`**, work is **cut off with end block number `N`**: an execution
+**batch** ends at **`N`**, the enclosing **blob** is closed so its range ends at **`N`**, and **proof aggregation** is
+triggered so that aggregation’s block range also ends at **`N`**. When the wait flags below are enabled, **import /
+conflation then pauses** at that boundary: the pause is recognized when block **`N + 1`** is handed to conflation—that
+is, after the batch/blob/aggregation slice through **`N`** has been completed and the coordinator is about to progress
+past **`N`**.
+
+**`timestamp-based-hard-forks`** — Ordered list of L2 block timestamp thresholds (ISO-8601 strings or Unix epoch
+seconds, as in other coordinator TOML `Instant` fields). The list must be **strictly ascending** with **no
+duplicates**. Conflation uses the same crossing rule as `TimestampHardForkConflationCalculator`: the **first** L2 block
+whose timestamp is **at or above** a threshold **T**, while the previous block’s timestamp was **strictly below** **T**,
+is the block **`N + 1`** for that fork. The coordinator closes conflation so that the execution **batch**,
+enclosing **blob**, and **aggregation** all have **end block number `N`** (the last block still strictly before the
+fork in time). The crossing block **`N + 1`** starts the next batch after the boundary. For the optional checkpoint
+**pause** (when the wait flags below are enabled), the same **`N` / `N + 1`** split applies as for `target-end-blocks`:
+the pause is tied to handing **`N + 1`** into conflation once the work through **`N`** has been completed.
+
+**`wait-target-block-l1-finalization`** — When `true`, after a checkpoint the coordinator waits until the
+**L1-finalized** L2 block number reported by the rollup is at least the checkpoint height before it may resume
+importing.
+
+**`wait-api-resume-after-target-block`** — When `true`, after a checkpoint the coordinator also waits for an operator
+**JSON-RPC** call before resuming. If both wait flags are `true`, **both** the L1-finalization condition and the API
+signal must be satisfied before the pause clears. If only one flag is `true`, only that gate applies.
+
+The pause machinery is active when **either** wait flag is `true`. If both are `false`, `target-end-blocks` and
+`timestamp-based-hard-forks` do not trigger this import pause (they can still affect proof aggregation layout
+elsewhere).
+
+**Resume API** — JSON-RPC method name: `conflation_signalTargetCheckpointResume`. The body is standard JSON-RPC 2.0;
+`params` may be an empty array. The `result` is a boolean: `true` if the resume signal was accepted (API gate enabled
+and a checkpoint pause was actually waiting on the API), `false` otherwise.
+
+Coordinator API settings live under `[api]` (`json-rpc-port`, optional `json-rpc-path`; default path is `/`). In the
+default Docker tracing stack, `json-rpc-port` is **9546** and is **not** published to the host; call it from inside the
+`coordinator` container or add a port mapping if you need host access.
+
+Example:
+
+```bash
+curl -sS -X POST "http://127.0.0.1:9546/" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"conflation_signalTargetCheckpointResume","params":[]}'
+```
+
+If you set a non-default `json-rpc-path` (for example `/jsonrpc`), append that path to the URL instead of `/`.
 
 ## Next steps
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new guide plus minor wording/typo fixes) with no runtime behavior impact.
> 
> **Overview**
> Adds new documentation (`docs/conflation-target-checkpoints.md`) describing how to configure conflation target checkpoints via `target-end-blocks` and `timestamp-based-hard-forks`, optionally gating progress on L1 finalization and a manual JSON-RPC resume (`conflation_signalTargetCheckpointResume`).
> 
> Updates `docs/get-started.md` to fix the `make clean-environment` command, clarify which coordinator config file is used in Docker setups, and link to the new target-checkpoint/resume guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a33e6382deb96e518d6e1c7cc5daacfde1bc3b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->