### PR TITLE
[ZkTracer] chore: update corset to 1.2.10

### DIFF
--- a/tracer/gradle/corset.gradle
+++ b/tracer/gradle/corset.gradle
@@ -27,7 +27,7 @@ tasks.register('corsetExists') {
 ext {
   corsetVersion = project.hasProperty('corsetVersion')
     ? project.property('corsetVersion')
-    : System.getenv().getOrDefault('LINEA_CORSET_VERSION', "v1.2.7")
+    : System.getenv().getOrDefault('LINEA_CORSET_VERSION', "v1.2.10")
 }
 
 tasks.register('installGoCorset') {


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple version default bump in build tooling; main risk is build or generated-trace differences if `go-corset` v1.2.10 changes behavior.
> 
> **Overview**
> Updates the default `go-corset` version used by the Gradle tracer build from `v1.2.7` to `v1.2.10` when `corsetVersion`/`LINEA_CORSET_VERSION` are not explicitly set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7cfba07980b6141ad732d51f5dab1d69d604947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->