### PR TITLE
Issue #2876: Changes from Claude

### DIFF
--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/GoBackedBlobShnarfCalculator.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/GoBackedBlobShnarfCalculator.kt
@@ -87,8 +87,8 @@ class GoBackedBlobShnarfCalculator(
           kzgProofContract = result.kzgProofContract.decodeHex(),
           kzgProofSideCar = result.kzgProofSideCar.decodeHex(),
         )
-      } catch (it: Exception) {
-        throw RuntimeException("Error while decoding Shnarf calculation response from Go: ${it.message}")
+      } catch (e: Exception) {
+        throw RuntimeException("Error while decoding Shnarf calculation response from Go: ${e.message}")
       }
 
     return domainResult


### PR DESCRIPTION
This PR addresses issue #2876

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a cosmetic variable rename in a `catch` block with no behavior change.
> 
> **Overview**
> Renames the exception variable in `GoBackedBlobShnarfCalculator`’s `catch` block (`it` → `e`) while preserving the same runtime error message when Go shnarf calculation results fail to decode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222d7229c42c38a38eec44e41684b80b4c8af44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->