### PR TITLE
security(ci): disable KICS — Checkmarx supply chain compromise

### DIFF
--- a/.github/workflows/dockerfile-security-scan.yml
+++ b/.github/workflows/dockerfile-security-scan.yml
@@ -1,8 +1,16 @@
 name: Weekly Dockerfile Security Scan
 
+# DISABLED 2026-04-22: Checkmarx KICS supply chain compromise.
+# Malicious artifacts found in KICS Docker images (v2.1.20, v2.1.21, alpine)
+# and VS Code extensions (v1.17.0, v1.19.0). Poisoned binaries exfiltrate
+# scanned IaC secrets. Although we pin v2.1.19 by SHA, we are disabling this
+# workflow as a precaution until Checkmarx confirms the incident is fully resolved.
+# Reference: https://socket.dev/blog/checkmarx-supply-chain-compromise
+# TODO: Re-enable once Checkmarx publishes a post-mortem and verified-clean release.
+
 on:
-  schedule:
-    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+  # schedule:
+  #   - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -11,8 +19,9 @@ permissions:
 
 jobs:
   kics-scan:
-    name: KICS Dockerfile Scan
+    name: KICS Dockerfile Scan (disabled)
     runs-on: ubuntu-latest
+    if: false # Disabled — Checkmarx KICS supply chain compromise (2026-04-22)
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- **Temporarily disables** the weekly KICS Dockerfile security scan (`dockerfile-security-scan.yml`) due to a potential [supply chain compromise of Checkmarx KICS](https://socket.dev/blog/checkmarx-supply-chain-compromise) discovered on 2026-04-22
- Malicious artifacts were injected into KICS Docker images (tags `v2.1.20`, `v2.1.21`, `alpine`) and VS Code extensions (`v1.17.0`, `v1.19.0`); poisoned binaries exfiltrate secrets from scanned IaC files (Terraform, CloudFormation, Kubernetes)
- Although we pin `v2.1.19` by commit SHA (`4063ea7`), the workflow is disabled as a precaution — the full scope of the compromise is still under investigation

## What changed

- Commented out the `schedule` trigger (cron) so the scan no longer runs automatically
- Added `if: false` guard on the job as a belt-and-suspenders measure
- Preserved `workflow_dispatch` trigger so the workflow can be manually re-enabled for testing once a clean release is available
- Added inline comments documenting the reason, date, reference URL, and re-enablement criteria

## Re-enablement criteria

- [ ] Checkmarx publishes a post-mortem confirming root cause and remediation
- [ ] A verified-clean KICS release is available (new SHA to pin)
- [ ] Remove `if: false`, uncomment `schedule`, update the action SHA

## Test plan

- [ ] Verify CI passes (no functional workflows depend on KICS)
- [ ] Confirm the workflow no longer appears in scheduled runs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it turns off an automated security scan, reducing ongoing detection/visibility until it’s re-enabled.
> 
> **Overview**
> Disables the weekly `dockerfile-security-scan.yml` KICS Dockerfile scan by commenting out the cron trigger and adding an `if: false` guard, while leaving `workflow_dispatch` available.
> 
> Adds inline documentation noting the Checkmarx KICS supply-chain compromise (date, reference link) and re-enable guidance, and updates the job label to indicate it’s disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17522e59a062210ced6f4daa9420e1a9f85ee24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->