### PR TITLE
chore(coordinator): refactor conflation calculator to help with ftx t…

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -27,7 +27,6 @@ import linea.web3j.ethapi.createEthApiClient
 import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.cleanupDbDataAfterBlockNumbers
-import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.createCalculatorsForBlobsAndConflation
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.createDeadlineConflationCalculatorRunner
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resumeAggregationFrom
 import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper.resumeConflationFrom
@@ -51,18 +50,14 @@ import net.consensys.zkevm.ethereum.coordination.aggregation.InvalidityProofProv
 import net.consensys.zkevm.ethereum.coordination.aggregation.ProofAggregationCoordinatorService
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
-import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProviderImpl
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.BlockToBatchSubmissionCoordinator
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByDataCompressed
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorFactory
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationService
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationServiceImpl
-import net.consensys.zkevm.ethereum.coordination.conflation.GlobalBlobAwareConflationCalculator
-import net.consensys.zkevm.ethereum.coordination.conflation.GlobalBlockConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.ProofGeneratingConflationHandlerImpl
-import net.consensys.zkevm.ethereum.coordination.conflation.TimestampHardForkConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.TracesConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.TracesConflationCoordinatorImpl
 import net.consensys.zkevm.ethereum.coordination.proofcreation.BatchProofHandlerImpl
@@ -237,53 +232,21 @@ class ConflationApp(
     }
   }
 
-  private val conflationCalculator: TracesConflationCalculator = run {
-    val logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java)
-
-    // To fail faster for JNA reasons
-    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
-      compressorVersion = configs.conflation.blobCompression.blobCompressorVersion,
-      dataLimit = configs.conflation.blobCompression.blobSizeLimit,
-      metricsFacade = metricsFacade,
-    )
-
-    val compressedBlobCalculator = ConflationCalculatorByDataCompressed(
-      blobCompressor = blobCompressor,
-    )
-    val syncCalculators = createCalculatorsForBlobsAndConflation(
-      configs = configs,
-      compressedBlobCalculator = compressedBlobCalculator,
-      lastProcessedTimestamp = lastProcessedTimestamp,
-      dynamicTargetEndBlockNumberSet = dynamicTargetEndBlockNumberSet,
-      logger = logger,
-      metricsFacade = metricsFacade,
-    ).also {
-      it.filterIsInstance<TimestampHardForkConflationCalculator>().forEach { calculator ->
-        log.info(
-          "Added timestamp-based hard fork calculator={} ",
-          calculator,
-        )
-      }
-    }
-
-    val globalCalculator = GlobalBlockConflationCalculator(
-      lastBlockNumber = lastProcessedBlockNumber,
-      syncCalculators = syncCalculators + forcedTransactionsApp.conflationCalculator,
-      deferredTriggerConflationCalculators = listOfNotNull(deadlineConflationCalculatorRunner),
-      emptyTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
-      log = logger,
-    )
-
-    val batchesLimit = configs.conflation.blobCompression.batchesLimit
-      ?: (configs.conflation.proofAggregation.proofsLimit - 1U)
-    GlobalBlobAwareConflationCalculator(
-      conflationCalculator = globalCalculator,
-      blobCalculator = compressedBlobCalculator,
-      metricsFacade = metricsFacade,
-      batchesLimit = batchesLimit,
-      dynamicBlockNumberSet = dynamicTargetEndBlockNumberSet,
-    )
-  }
+  private val conflationCalculator: TracesConflationCalculator = ConflationCalculatorFactory.conflationCalculator(
+    blobCompressorVersion = configs.conflation.blobCompression.blobCompressorVersion,
+    blobSizeLimit = configs.conflation.blobCompression.blobSizeLimit,
+    tracesCountersLimit = configs.conflation.tracesLimits,
+    blocksLimit = configs.conflation.blocksLimit,
+    timestampBasedHardForks = configs.conflation.proofAggregation.timestampBasedHardForks,
+    lastProcessedBlockNumber = lastProcessedBlockNumber,
+    lastProcessedTimestamp = lastProcessedTimestamp,
+    blobBatchesLimit = configs.conflation.blobCompression.batchesLimit,
+    aggregationProofsLimit = configs.conflation.proofAggregation.proofsLimit,
+    dynamicBlockNumberSet = dynamicTargetEndBlockNumberSet,
+    extraSyncCalculators = listOf(forcedTransactionsApp.conflationCalculator),
+    deferredTriggerConflationCalculators = listOfNotNull(deadlineConflationCalculatorRunner),
+    metricsFacade = metricsFacade,
+  )
 
   private val conflationService: ConflationService =
     ConflationServiceImpl(

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -50,6 +50,7 @@ import net.consensys.zkevm.ethereum.coordination.aggregation.InvalidityProofProv
 import net.consensys.zkevm.ethereum.coordination.aggregation.ProofAggregationCoordinatorService
 import net.consensys.zkevm.ethereum.coordination.blob.BlobCompressionProofCoordinator
 import net.consensys.zkevm.ethereum.coordination.blob.BlobZkStateProviderImpl
+import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProviderImpl
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
@@ -232,21 +233,27 @@ class ConflationApp(
     }
   }
 
-  private val conflationCalculator: TracesConflationCalculator = ConflationCalculatorFactory.conflationCalculator(
-    blobCompressorVersion = configs.conflation.blobCompression.blobCompressorVersion,
-    blobSizeLimit = configs.conflation.blobCompression.blobSizeLimit,
-    tracesCountersLimit = configs.conflation.tracesLimits,
-    blocksLimit = configs.conflation.blocksLimit,
-    timestampBasedHardForks = configs.conflation.proofAggregation.timestampBasedHardForks,
-    lastProcessedBlockNumber = lastProcessedBlockNumber,
-    lastProcessedTimestamp = lastProcessedTimestamp,
-    blobBatchesLimit = configs.conflation.blobCompression.batchesLimit,
-    aggregationProofsLimit = configs.conflation.proofAggregation.proofsLimit,
-    dynamicBlockNumberSet = dynamicTargetEndBlockNumberSet,
-    extraSyncCalculators = listOf(forcedTransactionsApp.conflationCalculator),
-    deferredTriggerConflationCalculators = listOfNotNull(deadlineConflationCalculatorRunner),
-    metricsFacade = metricsFacade,
-  )
+  private val conflationCalculator: TracesConflationCalculator = run {
+    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
+      compressorVersion = configs.conflation.blobCompression.blobCompressorVersion,
+      dataLimit = configs.conflation.blobCompression.blobSizeLimit,
+      metricsFacade = metricsFacade,
+    )
+    ConflationCalculatorFactory.conflationCalculator(
+      blobCompressor = blobCompressor,
+      tracesCountersLimit = configs.conflation.tracesLimits,
+      blocksLimit = configs.conflation.blocksLimit,
+      timestampBasedHardForks = configs.conflation.proofAggregation.timestampBasedHardForks,
+      lastProcessedBlockNumber = lastProcessedBlockNumber,
+      lastProcessedTimestamp = lastProcessedTimestamp,
+      blobBatchesLimit = configs.conflation.blobCompression.batchesLimit,
+      aggregationProofsLimit = configs.conflation.proofAggregation.proofsLimit,
+      dynamicBlockNumberSet = dynamicTargetEndBlockNumberSet,
+      extraSyncCalculators = listOf(forcedTransactionsApp.conflationCalculator),
+      deferredTriggerConflationCalculators = listOfNotNull(deadlineConflationCalculatorRunner),
+      metricsFacade = metricsFacade,
+    )
+  }
 
   private val conflationService: ConflationService =
     ConflationServiceImpl(

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationAppHelper.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationAppHelper.kt
@@ -6,21 +6,11 @@ import linea.ethapi.EthApiClient
 import linea.persistence.AggregationsRepository
 import linea.persistence.BatchesRepository
 import linea.persistence.BlobsRepository
-import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.coordinator.blockcreation.FixedLaggingHeadSafeBlockProvider
-import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculator
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByBlockLimit
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByDataCompressed
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByExecutionTraces
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByTargetBlockNumbers
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByTimeDeadline
 import net.consensys.zkevm.ethereum.coordination.conflation.DeadlineConflationCalculatorRunner
-import net.consensys.zkevm.ethereum.coordination.conflation.TimestampHardForkConflationCalculator
-import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Clock
-import kotlin.time.Instant
 
 object ConflationAppHelper {
   /**
@@ -68,62 +58,6 @@ object ConflationAppHelper {
         .deleteAggregationsAfterBlockNumber((lastConsecutiveAggregatedBlockNumber + 1u).toLong())
 
     return SafeFuture.allOf(cleanupBatches, cleanupBlobs, cleanupAggregations)
-  }
-
-  fun addBlocksLimitCalculatorIfDefined(
-    configs: CoordinatorConfig,
-    calculators: MutableList<ConflationCalculator>,
-  ) {
-    if (configs.conflation.blocksLimit != null) {
-      calculators.add(
-        ConflationCalculatorByBlockLimit(
-          blockLimit = configs.conflation.blocksLimit,
-        ),
-      )
-    }
-  }
-
-  fun addTimestampHardForkCalculatorIfDefined(
-    configs: CoordinatorConfig,
-    lastProcessedTimestamp: Instant,
-    calculators: MutableList<ConflationCalculator>,
-  ) {
-    if (configs.conflation.proofAggregation.timestampBasedHardForks.isNotEmpty()) {
-      calculators.add(
-        TimestampHardForkConflationCalculator(
-          hardForkTimestamps = configs.conflation.proofAggregation.timestampBasedHardForks,
-          initialTimestamp = lastProcessedTimestamp,
-        ),
-      )
-    }
-  }
-
-  fun createCalculatorsForBlobsAndConflation(
-    configs: CoordinatorConfig,
-    compressedBlobCalculator: ConflationCalculatorByDataCompressed,
-    lastProcessedTimestamp: Instant,
-    dynamicTargetEndBlockNumberSet: DynamicBlockNumberSet,
-    logger: Logger,
-    metricsFacade: MetricsFacade,
-  ): List<ConflationCalculator> {
-    val calculators: MutableList<ConflationCalculator> =
-      mutableListOf(
-        ConflationCalculatorByExecutionTraces(
-          tracesCountersLimit = configs.conflation.tracesLimits,
-          emptyTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
-          metricsFacade = metricsFacade,
-          log = logger,
-        ),
-        ConflationCalculatorByTargetBlockNumbers(targetEndBlockNumbers = dynamicTargetEndBlockNumberSet),
-        compressedBlobCalculator,
-      )
-    addBlocksLimitCalculatorIfDefined(configs = configs, calculators = calculators)
-    addTimestampHardForkCalculatorIfDefined(
-      configs = configs,
-      calculators = calculators,
-      lastProcessedTimestamp = lastProcessedTimestamp,
-    )
-    return calculators
   }
 
   fun createDeadlineConflationCalculatorRunner(

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -43,7 +43,6 @@ import net.consensys.zkevm.ethereum.coordination.blob.ParentBlobDataProvider
 import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculator
 import net.consensys.zkevm.ethereum.coordination.blockcreation.AlwaysSafeBlockNumberProvider
 import net.consensys.zkevm.ethereum.coordination.conflation.BlockToBatchSubmissionCoordinator
-import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByDataCompressed
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorFactory
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationService
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationServiceImpl
@@ -175,7 +174,7 @@ class ConflationBacktestingApp(
   )
 
   private val conflationCalculator: TracesConflationCalculator = ConflationCalculatorFactory.conflationCalculator(
-    compressedBlobCalculator = ConflationCalculatorByDataCompressed(blobCompressor = blobCompressor),
+    blobCompressor = blobCompressor,
     tracesCountersLimit = backtestingCoordinatorConfig.conflation.tracesLimits,
     blocksLimit = backtestingCoordinatorConfig.conflation.blocksLimit,
     timestampBasedHardForks = backtestingCoordinatorConfig.conflation.proofAggregation.timestampBasedHardForks,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -23,7 +23,6 @@ import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
 import net.consensys.linea.metrics.MetricsFacade
-import net.consensys.zkevm.coordinator.app.conflation.ConflationAppHelper
 import net.consensys.zkevm.coordinator.app.conflation.TracesClientFactory
 import net.consensys.zkevm.coordinator.blockcreation.BlockCreationMonitor
 import net.consensys.zkevm.coordinator.blockcreation.FixedLaggingHeadSafeBlockProvider
@@ -45,10 +44,9 @@ import net.consensys.zkevm.ethereum.coordination.blob.RollingBlobShnarfCalculato
 import net.consensys.zkevm.ethereum.coordination.blockcreation.AlwaysSafeBlockNumberProvider
 import net.consensys.zkevm.ethereum.coordination.conflation.BlockToBatchSubmissionCoordinator
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorByDataCompressed
+import net.consensys.zkevm.ethereum.coordination.conflation.ConflationCalculatorFactory
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationService
 import net.consensys.zkevm.ethereum.coordination.conflation.ConflationServiceImpl
-import net.consensys.zkevm.ethereum.coordination.conflation.GlobalBlobAwareConflationCalculator
-import net.consensys.zkevm.ethereum.coordination.conflation.GlobalBlockConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.ProofGeneratingConflationHandlerImpl
 import net.consensys.zkevm.ethereum.coordination.conflation.TracesConflationCalculator
 import net.consensys.zkevm.ethereum.coordination.conflation.TracesConflationCoordinatorImpl
@@ -176,40 +174,19 @@ class ConflationBacktestingApp(
     dataLimit = backtestingCoordinatorConfig.conflation.blobCompression.blobSizeLimit.toInt(),
   )
 
-  private val conflationCalculator: TracesConflationCalculator = run {
-    // To fail faster for JNA reasons
-
-    val compressedBlobCalculator = ConflationCalculatorByDataCompressed(
-      blobCompressor = blobCompressor,
-    )
-
-    val globalCalculator = GlobalBlockConflationCalculator(
-      lastBlockNumber = lastProcessedBlockNumber,
-      syncCalculators = ConflationAppHelper.createCalculatorsForBlobsAndConflation(
-        configs = backtestingCoordinatorConfig,
-        compressedBlobCalculator = compressedBlobCalculator,
-        lastProcessedTimestamp = lastProcessedTimestamp,
-        dynamicTargetEndBlockNumberSet = dynamicTargetEndBlockNumberSet,
-        logger = log,
-        metricsFacade = metricsFacade,
-      ),
-      deferredTriggerConflationCalculators = emptyList(),
-      emptyTracesCounters = backtestingCoordinatorConfig.conflation.tracesLimits.emptyTracesCounters,
-      log = log,
-    )
-
-    val batchesLimit = backtestingCoordinatorConfig.conflation.blobCompression.batchesLimit
-      ?: (backtestingCoordinatorConfig.conflation.proofAggregation.proofsLimit - 1U)
-
-    GlobalBlobAwareConflationCalculator(
-      conflationCalculator = globalCalculator,
-      blobCalculator = compressedBlobCalculator,
-      metricsFacade = metricsFacade,
-      batchesLimit = batchesLimit,
-      dynamicBlockNumberSet = dynamicTargetEndBlockNumberSet,
-      log = log,
-    )
-  }
+  private val conflationCalculator: TracesConflationCalculator = ConflationCalculatorFactory.conflationCalculator(
+    compressedBlobCalculator = ConflationCalculatorByDataCompressed(blobCompressor = blobCompressor),
+    tracesCountersLimit = backtestingCoordinatorConfig.conflation.tracesLimits,
+    blocksLimit = backtestingCoordinatorConfig.conflation.blocksLimit,
+    timestampBasedHardForks = backtestingCoordinatorConfig.conflation.proofAggregation.timestampBasedHardForks,
+    lastProcessedBlockNumber = lastProcessedBlockNumber,
+    lastProcessedTimestamp = lastProcessedTimestamp,
+    blobBatchesLimit = backtestingCoordinatorConfig.conflation.blobCompression.batchesLimit,
+    aggregationProofsLimit = backtestingCoordinatorConfig.conflation.proofAggregation.proofsLimit,
+    dynamicBlockNumberSet = dynamicTargetEndBlockNumberSet,
+    metricsFacade = metricsFacade,
+    log = log,
+  )
 
   private val conflationService: ConflationService =
     ConflationServiceImpl(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationCalculatorFactory.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/AggregationCalculatorFactory.kt
@@ -1,0 +1,46 @@
+package net.consensys.zkevm.ethereum.coordination.aggregation
+
+import net.consensys.linea.metrics.MetricsFacade
+import kotlin.time.Instant
+
+object AggregationCalculatorFactory {
+  fun createAggregationCalculator(
+    startBlockNumberInclusive: ULong,
+    maxProofsPerAggregation: UInt,
+    maxBlobsPerAggregation: UInt?,
+    targetEndBlockNumbers: Set<ULong>,
+    aggregationSizeMultipleOf: UInt,
+    hardForkTimestamps: List<Instant> = emptyList(),
+    initialTimestamp: Instant,
+    forcedTransactionTriggerAggCalculator: SyncAggregationTriggerCalculator,
+    deferredAggregationTriggerCalculators: List<DeferredAggregationTriggerCalculator> = emptyList(),
+    metricsFacade: MetricsFacade,
+  ): GlobalAggregationCalculator {
+    val syncAggregationTriggerCalculators = mutableListOf<SyncAggregationTriggerCalculator>(
+      forcedTransactionTriggerAggCalculator,
+      AggregationTriggerCalculatorByProofLimit(maxProofsPerAggregation = maxProofsPerAggregation),
+      AggregationTriggerCalculatorByTargetBlockNumbers(targetEndBlockNumbers = targetEndBlockNumbers),
+    )
+    if (maxBlobsPerAggregation != null) {
+      syncAggregationTriggerCalculators.add(
+        AggregationTriggerCalculatorByBlobLimit(maxBlobsPerAggregation = maxBlobsPerAggregation),
+      )
+    }
+    if (hardForkTimestamps.isNotEmpty()) {
+      syncAggregationTriggerCalculators.add(
+        AggregationTriggerCalculatorByTimestampHardFork(
+          hardForkTimestamps = hardForkTimestamps,
+          initialTimestamp = initialTimestamp,
+        ),
+      )
+    }
+
+    return GlobalAggregationCalculator(
+      lastBlockNumber = startBlockNumberInclusive - 1UL,
+      syncAggregationTrigger = syncAggregationTriggerCalculators,
+      deferredAggregationTrigger = deferredAggregationTriggerCalculators,
+      metricsFacade = metricsFacade,
+      aggregationSizeMultipleOf = aggregationSizeMultipleOf,
+    )
+  }
+}

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/ProofAggregationCoordinatorService.kt
@@ -305,35 +305,19 @@ class ProofAggregationCoordinatorService(
           clock = Clock.System,
           latestBlockProvider = latestBlockProvider,
         )
-      val syncAggregationTriggerCalculators = mutableListOf<SyncAggregationTriggerCalculator>(
-        forcedTransactionTriggerAggCalculator,
-        AggregationTriggerCalculatorByProofLimit(maxProofsPerAggregation = maxProofsPerAggregation),
-        AggregationTriggerCalculatorByTargetBlockNumbers(
-          targetEndBlockNumbers = targetEndBlockNumbers,
-        ),
+
+      val globalAggregationCalculator = AggregationCalculatorFactory.createAggregationCalculator(
+        startBlockNumberInclusive = startBlockNumberInclusive,
+        maxProofsPerAggregation = maxProofsPerAggregation,
+        maxBlobsPerAggregation = maxBlobsPerAggregation,
+        targetEndBlockNumbers = targetEndBlockNumbers,
+        aggregationSizeMultipleOf = aggregationSizeMultipleOf,
+        hardForkTimestamps = hardForkTimestamps,
+        initialTimestamp = initialTimestamp,
+        forcedTransactionTriggerAggCalculator = forcedTransactionTriggerAggCalculator,
+        deferredAggregationTriggerCalculators = listOf(aggregationCalculatorByDeadline),
+        metricsFacade = metricsFacade,
       )
-      if (maxBlobsPerAggregation != null) {
-        syncAggregationTriggerCalculators
-          .add(AggregationTriggerCalculatorByBlobLimit(maxBlobsPerAggregation = maxBlobsPerAggregation))
-      }
-
-      if (hardForkTimestamps.isNotEmpty()) {
-        syncAggregationTriggerCalculators.add(
-          AggregationTriggerCalculatorByTimestampHardFork(
-            hardForkTimestamps = hardForkTimestamps,
-            initialTimestamp = initialTimestamp,
-          ),
-        )
-      }
-
-      val globalAggregationCalculator =
-        GlobalAggregationCalculator(
-          lastBlockNumber = startBlockNumberInclusive - 1UL,
-          syncAggregationTrigger = syncAggregationTriggerCalculators,
-          deferredAggregationTrigger = listOf(aggregationCalculatorByDeadline),
-          metricsFacade = metricsFacade,
-          aggregationSizeMultipleOf = aggregationSizeMultipleOf,
-        )
 
       val deadlineCheckRunner =
         AggregationTriggerCalculatorByDeadlineRunner(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByExecutionTraces.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByExecutionTraces.kt
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger
 
 class ConflationCalculatorByExecutionTraces(
   val tracesCountersLimit: TracesCounters,
-  private val emptyTracesCounters: TracesCounters = tracesCountersLimit,
+  private val emptyTracesCounters: TracesCounters = tracesCountersLimit.emptyTracesCounters,
   metricsFacade: MetricsFacade,
   private val log: Logger = LogManager.getLogger(ConflationCalculatorByExecutionTraces::class.java),
 ) : ConflationCalculator {

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByExecutionTraces.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByExecutionTraces.kt
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger
 
 class ConflationCalculatorByExecutionTraces(
   val tracesCountersLimit: TracesCounters,
-  private val emptyTracesCounters: TracesCounters,
+  private val emptyTracesCounters: TracesCounters = tracesCountersLimit,
   metricsFacade: MetricsFacade,
   private val log: Logger = LogManager.getLogger(ConflationCalculatorByExecutionTraces::class.java),
 ) : ConflationCalculator {

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorFactory.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorFactory.kt
@@ -1,57 +1,17 @@
 package net.consensys.zkevm.ethereum.coordination.conflation
 
-import linea.blob.BlobCompressorVersion
+import linea.blob.BlobCompressor
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.traces.TracesCounters
 import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
-import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import kotlin.time.Instant
 
 object ConflationCalculatorFactory {
-  fun conflationCalculator(
-    blobCompressorVersion: BlobCompressorVersion,
-    blobSizeLimit: UInt,
-    tracesCountersLimit: TracesCounters,
-    blocksLimit: UInt?,
-    timestampBasedHardForks: List<Instant> = emptyList(),
-    lastProcessedBlockNumber: ULong,
-    lastProcessedTimestamp: Instant,
-    blobBatchesLimit: UInt? = null,
-    aggregationProofsLimit: UInt,
-    dynamicBlockNumberSet: DynamicBlockNumberSet,
-    extraSyncCalculators: List<ConflationCalculator> = emptyList(),
-    deferredTriggerConflationCalculators: List<DeferredTriggerConflationCalculator> = emptyList(),
-    metricsFacade: MetricsFacade,
-    log: Logger = LogManager.getLogger(GlobalBlobAwareConflationCalculator::class.java),
-  ): GlobalBlobAwareConflationCalculator {
-    // To fail faster for JNA reasons
-    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
-      compressorVersion = blobCompressorVersion,
-      dataLimit = blobSizeLimit,
-      metricsFacade = metricsFacade,
-    )
-
-    return conflationCalculator(
-      compressedBlobCalculator = ConflationCalculatorByDataCompressed(blobCompressor = blobCompressor),
-      tracesCountersLimit = tracesCountersLimit,
-      blocksLimit = blocksLimit,
-      timestampBasedHardForks = timestampBasedHardForks,
-      lastProcessedBlockNumber = lastProcessedBlockNumber,
-      lastProcessedTimestamp = lastProcessedTimestamp,
-      blobBatchesLimit = blobBatchesLimit,
-      aggregationProofsLimit = aggregationProofsLimit,
-      dynamicBlockNumberSet = dynamicBlockNumberSet,
-      extraSyncCalculators = extraSyncCalculators,
-      deferredTriggerConflationCalculators = deferredTriggerConflationCalculators,
-      metricsFacade = metricsFacade,
-      log = log,
-    )
-  }
 
   fun conflationCalculator(
-    compressedBlobCalculator: ConflationCalculatorByDataCompressed,
+    blobCompressor: BlobCompressor,
     tracesCountersLimit: TracesCounters,
     blocksLimit: UInt?,
     timestampBasedHardForks: List<Instant> = emptyList(),
@@ -65,11 +25,12 @@ object ConflationCalculatorFactory {
     metricsFacade: MetricsFacade,
     log: Logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java),
   ): GlobalBlobAwareConflationCalculator {
+    val blobCalculator = ConflationCalculatorByDataCompressed(blobCompressor = blobCompressor)
     val syncCalculators = createCalculatorsForBlobsAndConflation(
       tracesCountersLimit = tracesCountersLimit,
       blocksLimit = blocksLimit,
       timestampBasedHardForks = timestampBasedHardForks,
-      compressedBlobCalculator = compressedBlobCalculator,
+      compressedBlobCalculator = blobCalculator,
       lastProcessedTimestamp = lastProcessedTimestamp,
       dynamicTargetEndBlockNumberSet = dynamicBlockNumberSet,
       logger = log,
@@ -90,7 +51,7 @@ object ConflationCalculatorFactory {
 
     return GlobalBlobAwareConflationCalculator(
       conflationCalculator = globalCalculator,
-      blobCalculator = compressedBlobCalculator,
+      blobCalculator = blobCalculator,
       metricsFacade = metricsFacade,
       batchesLimit = blobBatchesLimit ?: (aggregationProofsLimit - 1U),
       dynamicBlockNumberSet = dynamicBlockNumberSet,

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorFactory.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorFactory.kt
@@ -24,7 +24,7 @@ object ConflationCalculatorFactory {
     extraSyncCalculators: List<ConflationCalculator> = emptyList(),
     deferredTriggerConflationCalculators: List<DeferredTriggerConflationCalculator> = emptyList(),
     metricsFacade: MetricsFacade,
-    log: Logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java),
+    log: Logger = LogManager.getLogger(GlobalBlobAwareConflationCalculator::class.java),
   ): GlobalBlobAwareConflationCalculator {
     // To fail faster for JNA reasons
     val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
@@ -94,6 +94,7 @@ object ConflationCalculatorFactory {
       metricsFacade = metricsFacade,
       batchesLimit = blobBatchesLimit ?: (aggregationProofsLimit - 1U),
       dynamicBlockNumberSet = dynamicBlockNumberSet,
+      log = log,
     )
   }
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorFactory.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorFactory.kt
@@ -1,0 +1,134 @@
+package net.consensys.zkevm.ethereum.coordination.conflation
+
+import linea.blob.BlobCompressorVersion
+import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.linea.traces.TracesCounters
+import net.consensys.zkevm.ethereum.coordination.DynamicBlockNumberSet
+import net.consensys.zkevm.ethereum.coordination.blob.GoBackedBlobCompressorAdapter
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import kotlin.time.Instant
+
+object ConflationCalculatorFactory {
+  fun conflationCalculator(
+    blobCompressorVersion: BlobCompressorVersion,
+    blobSizeLimit: UInt,
+    tracesCountersLimit: TracesCounters,
+    blocksLimit: UInt?,
+    timestampBasedHardForks: List<Instant> = emptyList(),
+    lastProcessedBlockNumber: ULong,
+    lastProcessedTimestamp: Instant,
+    blobBatchesLimit: UInt? = null,
+    aggregationProofsLimit: UInt,
+    dynamicBlockNumberSet: DynamicBlockNumberSet,
+    extraSyncCalculators: List<ConflationCalculator> = emptyList(),
+    deferredTriggerConflationCalculators: List<DeferredTriggerConflationCalculator> = emptyList(),
+    metricsFacade: MetricsFacade,
+    log: Logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java),
+  ): GlobalBlobAwareConflationCalculator {
+    // To fail faster for JNA reasons
+    val blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
+      compressorVersion = blobCompressorVersion,
+      dataLimit = blobSizeLimit,
+      metricsFacade = metricsFacade,
+    )
+
+    return conflationCalculator(
+      compressedBlobCalculator = ConflationCalculatorByDataCompressed(blobCompressor = blobCompressor),
+      tracesCountersLimit = tracesCountersLimit,
+      blocksLimit = blocksLimit,
+      timestampBasedHardForks = timestampBasedHardForks,
+      lastProcessedBlockNumber = lastProcessedBlockNumber,
+      lastProcessedTimestamp = lastProcessedTimestamp,
+      blobBatchesLimit = blobBatchesLimit,
+      aggregationProofsLimit = aggregationProofsLimit,
+      dynamicBlockNumberSet = dynamicBlockNumberSet,
+      extraSyncCalculators = extraSyncCalculators,
+      deferredTriggerConflationCalculators = deferredTriggerConflationCalculators,
+      metricsFacade = metricsFacade,
+      log = log,
+    )
+  }
+
+  fun conflationCalculator(
+    compressedBlobCalculator: ConflationCalculatorByDataCompressed,
+    tracesCountersLimit: TracesCounters,
+    blocksLimit: UInt?,
+    timestampBasedHardForks: List<Instant> = emptyList(),
+    lastProcessedBlockNumber: ULong,
+    lastProcessedTimestamp: Instant,
+    blobBatchesLimit: UInt? = null,
+    aggregationProofsLimit: UInt,
+    dynamicBlockNumberSet: DynamicBlockNumberSet,
+    extraSyncCalculators: List<ConflationCalculator> = emptyList(),
+    deferredTriggerConflationCalculators: List<DeferredTriggerConflationCalculator> = emptyList(),
+    metricsFacade: MetricsFacade,
+    log: Logger = LogManager.getLogger(GlobalBlockConflationCalculator::class.java),
+  ): GlobalBlobAwareConflationCalculator {
+    val syncCalculators = createCalculatorsForBlobsAndConflation(
+      tracesCountersLimit = tracesCountersLimit,
+      blocksLimit = blocksLimit,
+      timestampBasedHardForks = timestampBasedHardForks,
+      compressedBlobCalculator = compressedBlobCalculator,
+      lastProcessedTimestamp = lastProcessedTimestamp,
+      dynamicTargetEndBlockNumberSet = dynamicBlockNumberSet,
+      logger = log,
+      metricsFacade = metricsFacade,
+    ).also {
+      it.filterIsInstance<TimestampHardForkConflationCalculator>().forEach { calculator ->
+        log.info("Added timestamp-based hard fork calculator={} ", calculator)
+      }
+    }
+
+    val globalCalculator = GlobalBlockConflationCalculator(
+      lastBlockNumber = lastProcessedBlockNumber,
+      syncCalculators = syncCalculators + extraSyncCalculators,
+      deferredTriggerConflationCalculators = deferredTriggerConflationCalculators,
+      emptyTracesCounters = tracesCountersLimit.emptyTracesCounters,
+      log = log,
+    )
+
+    return GlobalBlobAwareConflationCalculator(
+      conflationCalculator = globalCalculator,
+      blobCalculator = compressedBlobCalculator,
+      metricsFacade = metricsFacade,
+      batchesLimit = blobBatchesLimit ?: (aggregationProofsLimit - 1U),
+      dynamicBlockNumberSet = dynamicBlockNumberSet,
+    )
+  }
+
+  fun createCalculatorsForBlobsAndConflation(
+    tracesCountersLimit: TracesCounters,
+    blocksLimit: UInt?,
+    timestampBasedHardForks: List<Instant> = emptyList(),
+    compressedBlobCalculator: ConflationCalculatorByDataCompressed,
+    lastProcessedTimestamp: Instant,
+    dynamicTargetEndBlockNumberSet: DynamicBlockNumberSet,
+    logger: Logger,
+    metricsFacade: MetricsFacade,
+  ): List<ConflationCalculator> {
+    val calculators: MutableList<ConflationCalculator> =
+      mutableListOf(
+        ConflationCalculatorByExecutionTraces(
+          tracesCountersLimit = tracesCountersLimit,
+          emptyTracesCounters = tracesCountersLimit.emptyTracesCounters,
+          metricsFacade = metricsFacade,
+          log = logger,
+        ),
+        ConflationCalculatorByTargetBlockNumbers(targetEndBlockNumbers = dynamicTargetEndBlockNumberSet),
+        compressedBlobCalculator,
+      )
+    if (blocksLimit != null) {
+      calculators.add(ConflationCalculatorByBlockLimit(blockLimit = blocksLimit))
+    }
+    if (timestampBasedHardForks.isNotEmpty()) {
+      calculators.add(
+        TimestampHardForkConflationCalculator(
+          hardForkTimestamps = timestampBasedHardForks,
+          initialTimestamp = lastProcessedTimestamp,
+        ),
+      )
+    }
+    return calculators
+  }
+}

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/GlobalAggregationCalculatorTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/aggregation/GlobalAggregationCalculatorTest.kt
@@ -62,21 +62,15 @@ class GlobalAggregationCalculatorTest {
     metricsFacade: MetricsFacade = mock<MetricsFacade>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS),
     aggregationHandler: AggregationHandler = AggregationHandler.NOOP_HANDLER,
   ): GlobalAggregationCalculator {
-    val syncAggregationTriggers = mutableListOf<SyncAggregationTriggerCalculator>()
-      .apply {
-        proofLimit?.also { add(AggregationTriggerCalculatorByProofLimit(maxProofsPerAggregation = it)) }
-        blobLimit?.also { add(AggregationTriggerCalculatorByBlobLimit(maxBlobsPerAggregation = it)) }
-        targetBlockNumbers?.also {
-          add(AggregationTriggerCalculatorByTargetBlockNumbers(targetBlockNumbers.map { it.toULong() }.toSet()))
-        }
-        hardForkTimestamps?.also {
-          aggregationTriggerCalculatorByTimestampHardFork = AggregationTriggerCalculatorByTimestampHardFork(
-            hardForkTimestamps = it,
-            initialTimestamp = initialTimestamp,
-          )
-          add(aggregationTriggerCalculatorByTimestampHardFork)
-        }
+    val fakeFtxCalculator = object : SyncAggregationTriggerCalculator {
+      override fun newBlob(blobCounters: BlobCounters) {
+        // no op
       }
+      override fun checkAggregationTrigger(blobCounters: BlobCounters): AggregationTrigger? = null
+      override fun reset() {
+        // no op
+      }
+    }
 
     val deferredAggregationTriggers = mutableListOf<DeferredAggregationTriggerCalculator>().apply {
       aggregationDeadline?.also {
@@ -93,12 +87,17 @@ class GlobalAggregationCalculatorTest {
       }
     }
 
-    return GlobalAggregationCalculator(
-      lastBlockNumber = lastBlockNumber,
-      syncAggregationTrigger = syncAggregationTriggers,
-      deferredAggregationTrigger = deferredAggregationTriggers,
-      metricsFacade = metricsFacade,
+    return AggregationCalculatorFactory.createAggregationCalculator(
+      startBlockNumberInclusive = lastBlockNumber + 1u,
+      maxProofsPerAggregation = proofLimit ?: UInt.MAX_VALUE,
+      maxBlobsPerAggregation = blobLimit,
+      targetEndBlockNumbers = targetBlockNumbers?.map { it.toULong() }?.toSet() ?: emptySet(),
       aggregationSizeMultipleOf = aggregationSizeMultipleOf.toUInt(),
+      hardForkTimestamps = hardForkTimestamps ?: emptyList(),
+      initialTimestamp = initialTimestamp,
+      forcedTransactionTriggerAggCalculator = fakeFtxCalculator,
+      deferredAggregationTriggerCalculators = deferredAggregationTriggers,
+      metricsFacade = metricsFacade,
     ).apply { onAggregation(aggregationHandler) }
   }
 

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByExecutionTracesTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ConflationCalculatorByExecutionTracesTest.kt
@@ -20,8 +20,7 @@ class ConflationCalculatorByExecutionTracesTest {
   private val testMeterRegistry = SimpleMeterRegistry()
   private val calculator =
     ConflationCalculatorByExecutionTraces(
-      tracesLimit,
-      TracesCountersV2.EMPTY_TRACES_COUNT,
+      tracesCountersLimit = tracesLimit,
       metricsFacade = MicrometerMetricsFacade(testMeterRegistry, "test"),
     )
   private lateinit var conflationTriggerConsumer: ConflationTriggerConsumer

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlobAwareConflationCalculatorTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlobAwareConflationCalculatorTest.kt
@@ -191,7 +191,6 @@ class GlobalBlobAwareConflationCalculatorTest {
     calculatorByTraces =
       ConflationCalculatorByExecutionTraces(
         tracesCountersLimit = fakeTracesCountersV2(100u),
-        emptyTracesCounters = TracesCountersV2.EMPTY_TRACES_COUNT,
         metricsFacade = mock(defaultAnswer = Mockito.RETURNS_DEEP_STUBS),
       )
     conflationTargetEndBlockNumbers.clear()

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlockConflationCalculatorIntTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/GlobalBlockConflationCalculatorIntTest.kt
@@ -76,7 +76,6 @@ class GlobalBlockConflationCalculatorIntTest {
     calculatorByTraces =
       ConflationCalculatorByExecutionTraces(
         tracesCountersLimit = fakeTracesCountersV2(100u),
-        emptyTracesCounters = TracesCountersV2.EMPTY_TRACES_COUNT,
         metricsFacade = mock<MetricsFacade>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS),
       )
     calculatorByHardFork =


### PR DESCRIPTION
…ests

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how conflation and aggregation trigger calculators are constructed in runtime and tests; while intended to be behavior-preserving, it touches core batching/aggregation boundary logic and could subtly change trigger ordering or limits.
> 
> **Overview**
> **Centralizes calculator construction** by introducing `ConflationCalculatorFactory` and `AggregationCalculatorFactory`, and updating `ConflationApp`, `ConflationBacktestingApp`, and `ProofAggregationCoordinatorService` to use these factories instead of assembling `Global*Calculator` graphs inline.
> 
> **Removes app-layer conflation calculator wiring helpers** from `ConflationAppHelper` and simplifies `ConflationCalculatorByExecutionTraces` by defaulting `emptyTracesCounters` from `tracesCountersLimit`, with corresponding test updates to match the new construction paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2858fa49329010fc363bd55999fc5fd488774b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->