### PR TITLE
Prover-ray : adds support for dynamically-sized module

### DIFF
--- a/prover-ray/go.mod
+++ b/prover-ray/go.mod
@@ -12,16 +12,15 @@ require (
 )
 
 require (
-	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/felixge/fgprof v0.9.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef // indirect
-	github.com/holiman/uint256 v1.3.2 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/ronanh/intcomp v1.1.1 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -30,7 +29,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/ethereum/go-ethereum v1.16.8
 	github.com/pkg/profile v1.7.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/prover-ray/go.sum
+++ b/prover-ray/go.sum
@@ -1,5 +1,3 @@
-github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
-github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -18,16 +16,11 @@ github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWb
 github.com/consensys/gnark-crypto v0.20.1 h1:PXDUBvk8AzhvWowHLWBEAfUQcV1/aZgWIqD6eMpXmDg=
 github.com/consensys/gnark-crypto v0.20.1/go.mod h1:RBWrSgy+IDbGR69RRV313th3M/aZU1ubk2om+qHuTSc=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
-github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/ethereum/go-ethereum v1.16.8 h1:LLLfkZWijhR5m6yrAXbdlTeXoqontH+Ga2f9igY7law=
-github.com/ethereum/go-ethereum v1.16.8/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
 github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/felixge/fgprof v0.9.4 h1:ocDNwMFlnA0NU0zSB3I52xkO4sFXk80VK9lXjLClu88=
 github.com/felixge/fgprof v0.9.4/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZPpayhMM=
@@ -45,8 +38,6 @@ github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8I
 github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef h1:xpF9fUHpoIrrjX24DURVKiwHcFpw19ndIs+FwTSMbno=
 github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
-github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
-github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/prover-ray/wiop/common.go
+++ b/prover-ray/wiop/common.go
@@ -108,17 +108,26 @@ type ConcreteVector struct {
 //     rows 0..plainLen-1 index Plain[0], the rest are the padding value.
 //
 // Panics if pos is out of bounds for the module size, or if m is unsized.
+// For dynamic modules use [ConcreteVector.ElementAtN] with the size obtained
+// from [Module.RuntimeSize].
 func (cv *ConcreteVector) ElementAt(m *Module, pos int) field.Gen {
-	n := m.Size() // panics if unsized
+	return cv.ElementAtN(m.Padding, m.Size(), pos)
+}
+
+// ElementAtN is like [ConcreteVector.ElementAt] but takes the domain size and
+// padding direction as explicit arguments. Use this when the size has already
+// been resolved (e.g. via [Module.RuntimeSize]) so that dynamic modules are
+// handled correctly without re-deriving the size from the module.
+func (cv *ConcreteVector) ElementAtN(padding PaddingDirection, n, pos int) field.Gen {
 	if pos < 0 || pos >= n {
-		panic(fmt.Sprintf("wiop: ConcreteVector.ElementAt: pos %d out of bounds [0, %d)", pos, n))
+		panic(fmt.Sprintf("wiop: ConcreteVector.ElementAtN: pos %d out of bounds [0, %d)", pos, n))
 	}
 
 	vec := cv.Plain[0]
 	plainLen := vec.Len()
 
 	idx, inPadding := pos, false
-	switch m.Padding {
+	switch padding {
 	case PaddingDirectionNone:
 		// plain is full-sized; direct index.
 	case PaddingDirectionLeft:

--- a/prover-ray/wiop/expression.go
+++ b/prover-ray/wiop/expression.go
@@ -415,11 +415,11 @@ func (c *Constant) Size() int {
 // Plain slice contains a single [field.Vec] with Value repeated
 // Module.Size() times, and whose Padding is Value. Panics if scalar; check
 // [Constant.IsMultiValued] first.
-func (c *Constant) EvaluateVector(_ Runtime) ConcreteVector {
+func (c *Constant) EvaluateVector(rt Runtime) ConcreteVector {
 	if c.module == nil {
 		panic("wiop: EvaluateVector() cannot be called on a scalar Constant; check IsMultiValued() first")
 	}
-	n := c.module.Size()
+	n := c.module.RuntimeSize(rt)
 	elems := make([]field.Element, n)
 	for i := range elems {
 		elems[i] = c.Value

--- a/prover-ray/wiop/expression_compiler_test.go
+++ b/prover-ray/wiop/expression_compiler_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
 	"github.com/consensys/linea-monorepo/prover-ray/wiop"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // vecEval evaluates an expression over two columns assigned to all-2 and all-3.
@@ -58,8 +57,6 @@ func TestCompiler_VecDiv(t *testing.T) {
 	cv := expr.(interface {
 		EvaluateVector(wiop.Runtime) wiop.ConcreteVector
 	}).EvaluateVector(rt)
-	// 2/3 — just verify it evaluated without error
-	require.Len(t, cv.Plain, 1)
 	assert.Equal(t, 4, cv.Plain[0].Len())
 }
 
@@ -106,8 +103,6 @@ func TestCompiler_VecInverse(t *testing.T) {
 	cv := expr.(interface {
 		EvaluateVector(wiop.Runtime) wiop.ConcreteVector
 	}).EvaluateVector(rt)
-	// 1/2
-	require.Len(t, cv.Plain, 1)
 	assert.Equal(t, 4, cv.Plain[0].Len())
 }
 

--- a/prover-ray/wiop/query_lagrange_eval.go
+++ b/prover-ray/wiop/query_lagrange_eval.go
@@ -130,14 +130,14 @@ func (le *LagrangeEval) evalPolynomials(rt Runtime) []field.Gen {
 		z := evalPoint.Value
 		if k := pv.ShiftingOffset; k != 0 {
 			var (
-				n      = pv.Column.Module.Size()
+				n      = pv.Column.Module.RuntimeSize(rt)
 				omega  = field.RootOfUnityBy(n)
 				omegaK field.Element
 			)
 			omegaK.ExpInt64(omega, int64(k))
 			z = z.Mul(field.ElemFromBase(omegaK))
 		}
-		results[i] = evalLagrangePadded(rt.GetColumnAssignment(pv.Column), pv.Column.Module, z)
+		results[i] = evalLagrangePadded(rt.GetColumnAssignment(pv.Column), pv.Column.Module, rt, z)
 	}
 	return results
 }
@@ -250,13 +250,13 @@ func (sys *System) newLagrangeEval(ctx *ContextFrame, polys []*ColumnView, x Fie
 // barycentric sum directly from Plain[0], treating padding and data rows
 // separately with a single shared batch of denominator inverses. This avoids
 // materialising the full n-length padded data vector.
-func evalLagrangePadded(cv *ConcreteVector, m *Module, z field.Gen) field.Gen {
+func evalLagrangePadded(cv *ConcreteVector, m *Module, rt Runtime, z field.Gen) field.Gen {
 	data := cv.Plain[0]
 	if m.Padding == PaddingDirectionNone {
 		return polynomials.EvalLagrange(data, z)
 	}
 
-	n := m.Size()
+	n := m.RuntimeSize(rt)
 	plainLen := data.Len()
 	gen := field.RootOfUnityBy(n)
 

--- a/prover-ray/wiop/query_local_opening.go
+++ b/prover-ray/wiop/query_local_opening.go
@@ -45,7 +45,8 @@ func (lo *LocalOpening) IsAlreadyAssigned(rt Runtime) bool {
 // runtime and writes the value into Result.
 func (lo *LocalOpening) SelfAssign(rt Runtime) {
 	col := lo.Pol.Column
-	elem := rt.GetColumnAssignment(col).ElementAt(col.Module, lo.Pol.Position)
+	m := col.Module
+	elem := rt.GetColumnAssignment(col).ElementAtN(m.Padding, m.RuntimeSize(rt), lo.Pol.Position)
 	rt.AssignCell(lo.Result, elem)
 }
 
@@ -60,7 +61,8 @@ func (lo *LocalOpening) Check(rt Runtime) error {
 		)
 	}
 
-	got := rt.GetColumnAssignment(col).ElementAt(col.Module, lo.Pol.Position)
+	m := col.Module
+	got := rt.GetColumnAssignment(col).ElementAtN(m.Padding, m.RuntimeSize(rt), lo.Pol.Position)
 	claim := rt.GetCellValue(lo.Result)
 
 	diff := got.Sub(claim)

--- a/prover-ray/wiop/query_log_derivative_sum.go
+++ b/prover-ray/wiop/query_log_derivative_sum.go
@@ -110,6 +110,10 @@ func (rr *LogDerivativeSum) reduce(rt Runtime) field.Gen {
 
 		// Determine the row count from the evaluated concrete vector so that
 		// dynamic modules (whose size is not known statically) are handled correctly.
+		// At least one side must be vector-valued; both-scalar is a construction error.
+		if !numIsVec && !denIsVec {
+			panic("wiop: LogDerivativeSum.reduce: fraction has no vector-valued side; at least one of numerator or denominator must be multi-valued")
+		}
 		var n int
 		if numIsVec {
 			n = numVec.Plain[0].Len()

--- a/prover-ray/wiop/query_log_derivative_sum.go
+++ b/prover-ray/wiop/query_log_derivative_sum.go
@@ -88,14 +88,6 @@ func (rr *LogDerivativeSum) reduce(rt Runtime) field.Gen {
 	acc := field.ElemZero()
 
 	for _, f := range rr.Fractions {
-		// Determine the row count from whichever expression is vector-valued.
-		var n int
-		if f.Numerator.IsMultiValued() {
-			n = f.Numerator.Size()
-		} else {
-			n = f.Denominator.Size()
-		}
-
 		var (
 			numIsVec  = f.Numerator.IsMultiValued()
 			denIsVec  = f.Denominator.IsMultiValued()
@@ -114,6 +106,15 @@ func (rr *LogDerivativeSum) reduce(rt Runtime) field.Gen {
 			denVec = f.Denominator.EvaluateVector(rt)
 		} else {
 			denScalar = f.Denominator.EvaluateSingle(rt)
+		}
+
+		// Determine the row count from the evaluated concrete vector so that
+		// dynamic modules (whose size is not known statically) are handled correctly.
+		var n int
+		if numIsVec {
+			n = numVec.Plain[0].Len()
+		} else {
+			n = denVec.Plain[0].Len()
 		}
 
 		for row := 0; row < n; row++ {

--- a/prover-ray/wiop/query_table_relation.go
+++ b/prover-ray/wiop/query_table_relation.go
@@ -396,7 +396,7 @@ func tableRowHash(alpha field.Gen, rt Runtime, cols []*ColumnView, idx, n int) f
 // n is the module size.
 func tableElemAt(rt Runtime, cv *ColumnView, idx, n int) field.Gen {
 	phys := ((idx+cv.ShiftingOffset)%n + n) % n
-	return rt.GetColumnAssignment(cv.Column).ElementAt(cv.Column.Module, phys)
+	return rt.GetColumnAssignment(cv.Column).ElementAtN(cv.Column.Module.Padding, n, phys)
 }
 
 // tableHasZeroShift reports whether all column views and the selector (if

--- a/prover-ray/wiop/query_table_relation.go
+++ b/prover-ray/wiop/query_table_relation.go
@@ -211,7 +211,7 @@ func (tr *TableRelation) checkPermutation(rt Runtime) error {
 // the gap identical padding rows are registered as a single entry with count
 // sign*gap instead of iterating them individually.
 func permTableCountInto(counts map[field.Ext]int, sign int, alpha field.Gen, rt Runtime, tab Table) {
-	n := tab.Module().Size()
+	n := tab.Module().RuntimeSize(rt)
 	m := tab.Module()
 
 	if m.Padding == PaddingDirectionNone || !tableHasZeroShift(tab) {
@@ -271,7 +271,7 @@ func (tr *TableRelation) checkInclusion(rt Runtime) error {
 // inclusionBuildSet adds the hashes of all selected rows of tab to bSet.
 // Padding rows are handled with a single anchor probe when applicable.
 func inclusionBuildSet(bSet map[field.Ext]struct{}, alpha field.Gen, rt Runtime, tab Table) {
-	n := tab.Module().Size()
+	n := tab.Module().RuntimeSize(rt)
 	m := tab.Module()
 
 	if m.Padding == PaddingDirectionNone || !tableHasZeroShift(tab) {
@@ -319,7 +319,7 @@ func inclusionBuildSet(bSet map[field.Ext]struct{}, alpha field.Gen, rt Runtime,
 // inclusionCheckSet verifies that all selected rows of tab are present in bSet.
 // Padding rows are checked with a single anchor probe when applicable.
 func inclusionCheckSet(bSet map[field.Ext]struct{}, alpha field.Gen, rt Runtime, tab Table, path string) error {
-	n := tab.Module().Size()
+	n := tab.Module().RuntimeSize(rt)
 	m := tab.Module()
 
 	if m.Padding == PaddingDirectionNone || !tableHasZeroShift(tab) {

--- a/prover-ray/wiop/wiop_column.go
+++ b/prover-ray/wiop/wiop_column.go
@@ -33,6 +33,10 @@ type Module struct {
 	// size is zero when the module has not yet been sized. Use [Module.Size]
 	// and [Module.SetSize] rather than accessing this field directly.
 	size int
+	// isDynamic indicates that this module's domain size is supplied per-Runtime
+	// via [WithModuleSize] instead of being fixed once via [Module.SetSize].
+	// Dynamic modules always report IsSized() == false from the static API.
+	isDynamic bool
 	// index is the position of this module in [System.Modules]. Set once at
 	// registration time by [System.NewModule] and used to construct column IDs.
 	index int
@@ -45,18 +49,40 @@ type Module struct {
 // Module.
 func (m *Module) System() *System { return m.system }
 
+// IsDynamic reports whether this module's domain size is supplied per-Runtime
+// via [WithModuleSize] rather than fixed statically via [Module.SetSize].
+func (m *Module) IsDynamic() bool { return m.isDynamic }
+
 // Size returns the declared domain size of the module. Returns 0 if the module
-// has not yet been sized.
+// has not yet been sized. For dynamic modules this always returns 0; use
+// [Module.RuntimeSize] to obtain the size for a specific Runtime.
 func (m *Module) Size() int { return m.size }
 
 // IsSized reports whether a domain size has been fixed for this module.
+// Dynamic modules always return false here; they are sized per-Runtime.
 func (m *Module) IsSized() bool { return m.size > 0 }
+
+// RuntimeSize returns the effective domain size for the given Runtime.
+// For static modules it delegates to [Module.Size] (panics if not yet sized).
+// For dynamic modules it reads the size registered via [WithModuleSize]
+// (panics if no size was provided for this Runtime).
+func (m *Module) RuntimeSize(rt Runtime) int {
+	if !m.isDynamic {
+		return m.Size()
+	}
+	return rt.dynamicModuleSize(m)
+}
 
 // SetSize fixes the domain size of the module. It may be called at any point
 // after construction but only once; subsequent calls panic.
 //
-// Panics if size is not positive or if the module is already sized.
+// Panics if size is not positive, if the module is already sized, or if the
+// module is dynamic (dynamic modules are sized via [WithModuleSize] on each
+// [Runtime]).
 func (m *Module) SetSize(size int) {
+	if m.isDynamic {
+		panic(fmt.Sprintf("wiop: module %q is dynamic; set its size via WithModuleSize on each Runtime", m.Context.Path()))
+	}
 	if size <= 0 {
 		panic(fmt.Sprintf("wiop: Module.SetSize requires a positive size, got %d", size))
 	}
@@ -127,6 +153,12 @@ func (m *Module) NewExtensionColumn(ctx *ContextFrame, vis Visibility, r *Round)
 func (m *Module) NewPrecomputedColumn(ctx *ContextFrame, vis Visibility, assignment *ConcreteVector) *Column {
 	if ctx == nil {
 		panic("wiop: Module.NewPrecomputedColumn requires a non-nil ContextFrame")
+	}
+	if m.isDynamic {
+		panic(fmt.Sprintf(
+			"wiop: module %q is dynamic; precomputed columns require a statically-sized module",
+			m.Context.Path(),
+		))
 	}
 	if m.system == nil {
 		panic(fmt.Sprintf(
@@ -268,21 +300,21 @@ func (cv *ColumnView) Degree() int {
 func (cv *ColumnView) EvaluateVector(rt Runtime) ConcreteVector {
 	concrete := rt.GetColumnAssignment(cv.Column)
 	m := cv.Column.Module
-	n := m.Size()
+	n := m.RuntimeSize(rt)
 
 	var result field.Vec
 	if cv.Column.IsExtension {
 		dst := make([]field.Ext, n)
 		for i := range n {
 			phys := ((i+cv.ShiftingOffset)%n + n) % n
-			dst[i] = concrete.ElementAt(m, phys).Ext
+			dst[i] = concrete.ElementAtN(m.Padding, n, phys).Ext
 		}
 		result = field.VecFromExt(dst)
 	} else {
 		dst := make([]field.Element, n)
 		for i := range n {
 			phys := ((i+cv.ShiftingOffset)%n + n) % n
-			dst[i] = concrete.ElementAt(m, phys).AsBase()
+			dst[i] = concrete.ElementAtN(m.Padding, n, phys).AsBase()
 		}
 		result = field.VecFromBase(dst)
 	}
@@ -373,6 +405,7 @@ func (cp *ColumnPosition) EvaluateVector(_ Runtime) ConcreteVector {
 // EvaluateSingle implements [Expression]. Returns the value of the parent
 // column at Position in the given runtime.
 func (cp *ColumnPosition) EvaluateSingle(rt Runtime) ConcreteField {
-	elem := rt.GetColumnAssignment(cp.Column).ElementAt(cp.Column.Module, cp.Position)
+	m := cp.Column.Module
+	elem := rt.GetColumnAssignment(cp.Column).ElementAtN(m.Padding, m.RuntimeSize(rt), cp.Position)
 	return ConcreteField{Value: elem, promise: cp}
 }

--- a/prover-ray/wiop/wiop_dynamic_test.go
+++ b/prover-ray/wiop/wiop_dynamic_test.go
@@ -15,7 +15,7 @@ func newDynamicTestSystem(t *testing.T) (*wiop.System, *wiop.Round, *wiop.Round,
 	sys := wiop.NewSystemf("dyn-test")
 	r0 := sys.NewRound()
 	r1 := sys.NewRound()
-	mod := sys.NewDynamicModule(sys.Context.Childf("dynmod"), wiop.PaddingDirectionNone)
+	mod := sys.NewDynamicModule(sys.Context.Childf("dynmod"), wiop.PaddingDirectionRight)
 	return sys, r0, r1, mod
 }
 
@@ -35,7 +35,7 @@ func TestDynamicModule_IsDynamic(t *testing.T) {
 	sys := wiop.NewSystemf("test")
 	sys.NewRound()
 	static := sys.NewModule(sys.Context.Childf("static"), wiop.PaddingDirectionNone)
-	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionNone)
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
 
 	assert.False(t, static.IsDynamic())
 	assert.True(t, dyn.IsDynamic())
@@ -46,7 +46,7 @@ func TestDynamicModule_IsDynamic(t *testing.T) {
 func TestDynamicModule_StaticAPI(t *testing.T) {
 	sys := wiop.NewSystemf("test")
 	sys.NewRound()
-	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionNone)
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
 
 	assert.False(t, dyn.IsSized())
 	assert.Equal(t, 0, dyn.Size())
@@ -56,7 +56,7 @@ func TestDynamicModule_StaticAPI(t *testing.T) {
 func TestDynamicModule_SetSizePanic(t *testing.T) {
 	sys := wiop.NewSystemf("test")
 	sys.NewRound()
-	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionNone)
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
 
 	assert.Panics(t, func() { dyn.SetSize(8) })
 }
@@ -84,6 +84,7 @@ func TestDynamicModule_OverflowSecondColumnPanic(t *testing.T) {
 	rt := wiop.NewRuntime(sys)
 	rt.AssignColumn(colA, makeVec(4, 1)) // sets domain size = 4
 	rt.AssignColumn(colB, makeVec(8, 2)) // 8 > 4 → auto-grows to 8
+	assert.Equal(t, 8, dyn.RuntimeSize(rt))
 }
 
 // TestDynamicModule_StaticOverflowPanic verifies that assigning a column whose

--- a/prover-ray/wiop/wiop_dynamic_test.go
+++ b/prover-ray/wiop/wiop_dynamic_test.go
@@ -83,10 +83,7 @@ func TestDynamicModule_OverflowSecondColumnPanic(t *testing.T) {
 
 	rt := wiop.NewRuntime(sys)
 	rt.AssignColumn(colA, makeVec(4, 1)) // sets domain size = 4
-
-	assert.Panics(t, func() {
-		rt.AssignColumn(colB, makeVec(8, 2)) // 8 > 4 → overflow
-	})
+	rt.AssignColumn(colB, makeVec(8, 2)) // 8 > 4 → auto-grows to 8
 }
 
 // TestDynamicModule_StaticOverflowPanic verifies that assigning a column whose

--- a/prover-ray/wiop/wiop_dynamic_test.go
+++ b/prover-ray/wiop/wiop_dynamic_test.go
@@ -76,7 +76,7 @@ func TestDynamicModule_AutoSizeOnFirstAssign(t *testing.T) {
 
 // TestDynamicModule_OverflowSecondColumnPanic verifies that a second column
 // whose data length exceeds the module's recorded size causes a panic.
-func TestDynamicModule_OverflowSecondColumnPanic(t *testing.T) {
+func TestDynamicModule_GrowOnLargerColumn(t *testing.T) {
 	sys, r0, _, dyn := newDynamicTestSystem(t)
 	colA := dyn.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
 	colB := dyn.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)

--- a/prover-ray/wiop/wiop_dynamic_test.go
+++ b/prover-ray/wiop/wiop_dynamic_test.go
@@ -1,0 +1,156 @@
+package wiop_test
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newDynamicTestSystem builds a two-round system with one dynamic module.
+func newDynamicTestSystem(t *testing.T) (*wiop.System, *wiop.Round, *wiop.Round, *wiop.Module) {
+	t.Helper()
+	sys := wiop.NewSystemf("dyn-test")
+	r0 := sys.NewRound()
+	r1 := sys.NewRound()
+	mod := sys.NewDynamicModule(sys.Context.Childf("dynmod"), wiop.PaddingDirectionNone)
+	return sys, r0, r1, mod
+}
+
+// makeVec builds a ConcreteVector of length n with all elements set to val.
+func makeVec(n int, val uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, n)
+	var e field.Element
+	e.SetUint64(val)
+	for i := range elems {
+		elems[i] = e
+	}
+	return &wiop.ConcreteVector{Plain: []field.Vec{field.VecFromBase(elems)}}
+}
+
+// TestDynamicModule_IsDynamic verifies the flag is set correctly on each factory.
+func TestDynamicModule_IsDynamic(t *testing.T) {
+	sys := wiop.NewSystemf("test")
+	sys.NewRound()
+	static := sys.NewModule(sys.Context.Childf("static"), wiop.PaddingDirectionNone)
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionNone)
+
+	assert.False(t, static.IsDynamic())
+	assert.True(t, dyn.IsDynamic())
+}
+
+// TestDynamicModule_StaticAPI confirms Size()==0 and IsSized()==false for a
+// dynamic module, consistent with the "permanently unsized" static view.
+func TestDynamicModule_StaticAPI(t *testing.T) {
+	sys := wiop.NewSystemf("test")
+	sys.NewRound()
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionNone)
+
+	assert.False(t, dyn.IsSized())
+	assert.Equal(t, 0, dyn.Size())
+}
+
+// TestDynamicModule_SetSizePanic confirms SetSize panics on a dynamic module.
+func TestDynamicModule_SetSizePanic(t *testing.T) {
+	sys := wiop.NewSystemf("test")
+	sys.NewRound()
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionNone)
+
+	assert.Panics(t, func() { dyn.SetSize(8) })
+}
+
+// TestDynamicModule_AutoSizeOnFirstAssign verifies that the first AssignColumn
+// to a dynamic module records the data length as the module's domain size.
+func TestDynamicModule_AutoSizeOnFirstAssign(t *testing.T) {
+	sys, r0, _, dyn := newDynamicTestSystem(t)
+	col := dyn.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, makeVec(8, 1))
+
+	// After assignment, RuntimeSize should return 8.
+	assert.Equal(t, 8, dyn.RuntimeSize(rt))
+}
+
+// TestDynamicModule_OverflowSecondColumnPanic verifies that a second column
+// whose data length exceeds the module's recorded size causes a panic.
+func TestDynamicModule_OverflowSecondColumnPanic(t *testing.T) {
+	sys, r0, _, dyn := newDynamicTestSystem(t)
+	colA := dyn.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := dyn.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(colA, makeVec(4, 1)) // sets domain size = 4
+
+	assert.Panics(t, func() {
+		rt.AssignColumn(colB, makeVec(8, 2)) // 8 > 4 → overflow
+	})
+}
+
+// TestDynamicModule_StaticOverflowPanic verifies that assigning a column whose
+// data length exceeds a static module's declared size causes a panic.
+func TestDynamicModule_StaticOverflowPanic(t *testing.T) {
+	sys := wiop.NewSystemf("test")
+	r0 := sys.NewRound()
+	sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	assert.Panics(t, func() {
+		rt.AssignColumn(col, makeVec(8, 1)) // 8 > 4 → overflow
+	})
+}
+
+// TestDynamicModule_MissingSizePanic verifies that RuntimeSize panics when no
+// column of the module has been assigned yet.
+func TestDynamicModule_MissingSizePanic(t *testing.T) {
+	sys, _, _, dyn := newDynamicTestSystem(t)
+
+	rt := wiop.NewRuntime(sys)
+	assert.Panics(t, func() { dyn.RuntimeSize(rt) })
+}
+
+// TestDynamicModule_VanishingCheck verifies that a vanishing constraint on a
+// dynamic module evaluates correctly, and that the same System can be reused
+// across two Runtimes with different module sizes.
+func TestDynamicModule_VanishingCheck(t *testing.T) {
+	sys, r0, _, dyn := newDynamicTestSystem(t)
+
+	colA := dyn.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := dyn.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+
+	// Constraint: A - B == 0
+	dyn.NewVanishing(sys.Context.Childf("eq"), wiop.Sub(colA.View(), colB.View()))
+
+	// Same System, two Runtimes with different sizes.
+	for _, n := range []int{4, 8} {
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(n, 3)) // sets domain size = n
+		rt.AssignColumn(colB, makeVec(n, 3))
+
+		for _, v := range dyn.Vanishings {
+			require.NoError(t, v.Check(rt), "n=%d", n)
+		}
+	}
+}
+
+// TestDynamicModule_VanishingCheckFailure verifies that a failing constraint is
+// detected correctly for a dynamic module.
+func TestDynamicModule_VanishingCheckFailure(t *testing.T) {
+	sys, r0, _, dyn := newDynamicTestSystem(t)
+
+	colA := dyn.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := dyn.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+	dyn.NewVanishing(sys.Context.Childf("eq"), wiop.Sub(colA.View(), colB.View()))
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(colA, makeVec(4, 1))
+	rt.AssignColumn(colB, makeVec(4, 2)) // mismatch → constraint fails
+
+	for _, v := range dyn.Vanishings {
+		require.Error(t, v.Check(rt))
+	}
+}

--- a/prover-ray/wiop/wiop_runtime.go
+++ b/prover-ray/wiop/wiop_runtime.go
@@ -5,7 +5,13 @@ import (
 
 	"github.com/consensys/linea-monorepo/prover-ray/crypto/koalabear/fiatshamir"
 	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/utils"
 )
+
+// columnSizeMaxSupported is the maximum supported size of a column. The value
+// comes from the 2-adicity of the koalabear field and having an upper-bound
+// is required to permit the construction of the global constraints quotient.
+const columnSizeMaxSupported = 1 << 22
 
 // Runtime is the execution context for protocol [ProverAction]s. It holds column
 // assignments, cell values, coin values, and an arbitrary state bag. A single
@@ -140,20 +146,20 @@ func (run *Runtime) AdvanceRound() {
 //
 // Size semantics:
 //   - Static module: the data length must not exceed the module's declared size.
-//   - Dynamic module, first assignment: the data length is recorded as the
-//     module's domain size for this Runtime.
-//   - Dynamic module, subsequent assignments: the data length must not exceed
-//     the previously recorded domain size.
+//   - Dynamic module: each time we add a column we potentially grow the
+//     module's size. There is no upper bound.
 //
 // Panics if col does not belong to the current round, has already been
 // assigned, or its data length violates the size constraints above.
 func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
+
 	if col.round != run.currentRound {
 		panic(fmt.Sprintf(
 			"wiop: AssignColumn: column %q belongs to round %d but current round is %v",
 			col.Context.Path(), col.round.ID, run.currentRound,
 		))
 	}
+
 	id := col.Context.ID
 	if _, exists := run.columns[id]; exists {
 		panic(fmt.Sprintf(
@@ -164,17 +170,14 @@ func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
 
 	m := col.Module
 	dataLen := v.Plain[0].Len()
+
+	if dataLen >= columnSizeMaxSupported {
+		utils.Panic("wiop: AssignColumn: data length too large for column: %v, size=%v", dataLen, columnSizeMaxSupported)
+	}
+
 	if m.IsDynamic() {
-		if existing, ok := run.dynamicSizes[m.index]; ok {
-			if dataLen != existing {
-				panic(fmt.Sprintf(
-					"wiop: AssignColumn: column %q has data length %d which mismatchs dynamic module %q size %d",
-					col.Context.Path(), dataLen, m.Context.Path(), existing,
-				))
-			}
-		} else {
-			run.dynamicSizes[m.index] = dataLen
-		}
+		currSize := run.dynamicSizes[m.index]
+		run.dynamicSizes[m.index] = max(currSize, dataLen)
 	} else if m.IsSized() && dataLen > m.Size() {
 		panic(fmt.Sprintf(
 			"wiop: AssignColumn: column %q has data length %d which overflows module %q size %d",

--- a/prover-ray/wiop/wiop_runtime.go
+++ b/prover-ray/wiop/wiop_runtime.go
@@ -148,9 +148,6 @@ func (run *Runtime) AdvanceRound() {
 //   - Static module: the data length must not exceed the module's declared size.
 //   - Dynamic module: each time we add a column we potentially grow the
 //     module's size. There is no upper bound.
-//
-// Panics if col does not belong to the current round, has already been
-// assigned, or its data length violates the size constraints above.
 func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
 
 	if col.round != run.currentRound {

--- a/prover-ray/wiop/wiop_runtime.go
+++ b/prover-ray/wiop/wiop_runtime.go
@@ -166,9 +166,9 @@ func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
 	dataLen := v.Plain[0].Len()
 	if m.IsDynamic() {
 		if existing, ok := run.dynamicSizes[m.index]; ok {
-			if dataLen > existing {
+			if dataLen != existing {
 				panic(fmt.Sprintf(
-					"wiop: AssignColumn: column %q has data length %d which overflows dynamic module %q size %d",
+					"wiop: AssignColumn: column %q has data length %d which mismatchs dynamic module %q size %d",
 					col.Context.Path(), dataLen, m.Context.Path(), existing,
 				))
 			}

--- a/prover-ray/wiop/wiop_runtime.go
+++ b/prover-ray/wiop/wiop_runtime.go
@@ -33,6 +33,10 @@ type Runtime struct {
 	coins map[ObjectID]field.Gen
 	// state is a free-form key-value store for stateful actions.
 	state map[string]any
+	// dynamicSizes maps the index of each dynamic module to its domain size for
+	// this Runtime. Populated lazily by [Runtime.AssignColumn] on the first
+	// column assignment to each dynamic module.
+	dynamicSizes map[int]int
 }
 
 // NewRuntime creates a fresh Runtime for sys. currentRound is initialised to
@@ -42,12 +46,13 @@ type Runtime struct {
 // Panics if sys has no interactive rounds (len(sys.Rounds) == 0).
 func NewRuntime(sys *System) Runtime {
 	run := Runtime{
-		System:  sys,
-		fs:      fiatshamir.NewFiatShamir(),
-		columns: make(map[ObjectID]*ConcreteVector),
-		cells:   make(map[ObjectID]field.Gen),
-		coins:   make(map[ObjectID]field.Gen),
-		state:   make(map[string]any),
+		System:       sys,
+		fs:           fiatshamir.NewFiatShamir(),
+		columns:      make(map[ObjectID]*ConcreteVector),
+		cells:        make(map[ObjectID]field.Gen),
+		coins:        make(map[ObjectID]field.Gen),
+		state:        make(map[string]any),
+		dynamicSizes: make(map[int]int),
 	}
 	if len(sys.Rounds) == 0 {
 		panic("wiop: NewRuntime: system has no interactive rounds")
@@ -58,6 +63,19 @@ func NewRuntime(sys *System) Runtime {
 		run.columns[col.Context.ID] = pr.PrecomputedValues[i]
 	}
 	return run
+}
+
+// dynamicModuleSize returns the domain size registered for m in this Runtime.
+// Called by [Module.RuntimeSize] for dynamic modules.
+func (run Runtime) dynamicModuleSize(m *Module) int {
+	size, ok := run.dynamicSizes[m.index]
+	if !ok {
+		panic(fmt.Sprintf(
+			"wiop: dynamic module %q has no size yet in this runtime; assign a column first",
+			m.Context.Path(),
+		))
+	}
+	return size
 }
 
 // CurrentRound returns the round currently being processed, or nil if the
@@ -118,8 +136,17 @@ func (run *Runtime) AdvanceRound() {
 	}
 }
 
-// AssignColumn stores a concrete vector assignment for col. Panics if col does
-// not belong to the current round or has already been assigned.
+// AssignColumn stores a concrete vector assignment for col.
+//
+// Size semantics:
+//   - Static module: the data length must not exceed the module's declared size.
+//   - Dynamic module, first assignment: the data length is recorded as the
+//     module's domain size for this Runtime.
+//   - Dynamic module, subsequent assignments: the data length must not exceed
+//     the previously recorded domain size.
+//
+// Panics if col does not belong to the current round, has already been
+// assigned, or its data length violates the size constraints above.
 func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
 	if col.round != run.currentRound {
 		panic(fmt.Sprintf(
@@ -134,6 +161,27 @@ func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
 			col.Context.Path(),
 		))
 	}
+
+	m := col.Module
+	dataLen := v.Plain[0].Len()
+	if m.IsDynamic() {
+		if existing, ok := run.dynamicSizes[m.index]; ok {
+			if dataLen > existing {
+				panic(fmt.Sprintf(
+					"wiop: AssignColumn: column %q has data length %d which overflows dynamic module %q size %d",
+					col.Context.Path(), dataLen, m.Context.Path(), existing,
+				))
+			}
+		} else {
+			run.dynamicSizes[m.index] = dataLen
+		}
+	} else if m.IsSized() && dataLen > m.Size() {
+		panic(fmt.Sprintf(
+			"wiop: AssignColumn: column %q has data length %d which overflows module %q size %d",
+			col.Context.Path(), dataLen, m.Context.Path(), m.Size(),
+		))
+	}
+
 	run.columns[id] = v
 }
 

--- a/prover-ray/wiop/wiop_runtime.go
+++ b/prover-ray/wiop/wiop_runtime.go
@@ -171,7 +171,7 @@ func (run Runtime) AssignColumn(col *Column, v *ConcreteVector) {
 	m := col.Module
 	dataLen := v.Plain[0].Len()
 
-	if dataLen >= columnSizeMaxSupported {
+	if dataLen > columnSizeMaxSupported {
 		utils.Panic("wiop: AssignColumn: data length too large for column: %v, size=%v", dataLen, columnSizeMaxSupported)
 	}
 

--- a/prover-ray/wiop/wiop_system.go
+++ b/prover-ray/wiop/wiop_system.go
@@ -98,3 +98,15 @@ func (sys *System) NewSizedModule(ctx *ContextFrame, size int, pd PaddingDirecti
 	m.SetSize(size)
 	return m
 }
+
+// NewDynamicModule creates a module whose domain size is provided per-Runtime
+// via [WithModuleSize] rather than fixed once via [Module.SetSize]. The same
+// System can therefore be reused across proving sessions that differ in trace
+// length.
+//
+// Panics if ctx is nil.
+func (sys *System) NewDynamicModule(ctx *ContextFrame, pd PaddingDirection) *Module {
+	m := sys.NewModule(ctx, pd)
+	m.isDynamic = true
+	return m
+}

--- a/prover-ray/wiop/wiop_system.go
+++ b/prover-ray/wiop/wiop_system.go
@@ -104,8 +104,13 @@ func (sys *System) NewSizedModule(ctx *ContextFrame, size int, pd PaddingDirecti
 // System can therefore be reused across proving sessions that differ in trace
 // length.
 //
-// Panics if ctx is nil.
+// Panics if ctx is nil or if pd is [PaddingDirectionNone] (dynamic modules
+// require a padding direction so that shorter columns can be padded to the
+// module's runtime size).
 func (sys *System) NewDynamicModule(ctx *ContextFrame, pd PaddingDirection) *Module {
+	if pd == PaddingDirectionNone {
+		panic("wiop: NewDynamicModule: dynamic modules require a padding direction (PaddingDirectionLeft or PaddingDirectionRight)")
+	}
 	m := sys.NewModule(ctx, pd)
 	m.isDynamic = true
 	return m


### PR DESCRIPTION
This PR implements the basic support for dynamically-sized columns in the new prover.

* When creating a module, the user can mark it as [DynamicallySized]. A module, can be either dynamically-sized or have a static-size. The dynamic-size is carried in a map in the runtime and the size is implictly set/checked when the first column of the module is being assigned. Precomputed columns may not belong to dynamically-sized modules.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `wiop` sizing semantics and updates multiple query evaluators to use runtime-resolved domain sizes, which could impact constraint evaluation and padding behavior across protocols. New safeguards (max column size, dynamic-module restrictions) and targeted tests reduce risk but runtime panics/size mismatches remain possible.
> 
> **Overview**
> Adds **dynamically-sized modules** in `wiop`, allowing a single `System` to be reused across different trace lengths by resolving each module’s domain size per `Runtime`.
> 
> This introduces `System.NewDynamicModule`, `Module.IsDynamic`, and `Module.RuntimeSize`, updates vector/column accessors and queries (e.g. `ColumnView.EvaluateVector`, `Constant.EvaluateVector`, local openings, Lagrange eval, table relations) to use runtime-derived sizes and an explicit `ConcreteVector.ElementAtN` API, and enforces new constraints (dynamic modules can’t be `SetSize`d or host precomputed columns; `Runtime.AssignColumn` tracks dynamic sizes, checks static overflows, and caps max supported column length). A new `wiop_dynamic_test.go` suite covers sizing, growth, overflow, and vanishing checks; `go.mod/go.sum` drop `go-ethereum` and related indirect deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a2e2f768f50f0ca1955efa8d36b5580bb83508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->