### PR TITLE
enable KOALABEAR_16 on unit & replay tests

### DIFF
--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -78,7 +78,7 @@ jobs:
         timeout-minutes: 360
         env:
           JUNIT_TESTS_PARALLELISM: 2
-          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --field=KOALABEAR_16 --report --air
           FAILED_TEST_JSON_DIRECTORY: ${{ github.workspace }}/tmp/${{ github.head_ref || github.ref_name }}/
           FAILED_MODULE: ${{ inputs.failed_module || '' }}
           FAILED_CONSTRAINT: ${{ inputs.failed_constraint || '' }}

--- a/.github/workflows/reusable-tracer-nightly-tests.yml
+++ b/.github/workflows/reusable-tracer-nightly-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:arithmetization:nightlyTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          GOCORSET_FLAGS: -v --ansi-escapes=false --report --mir
+          GOCORSET_FLAGS: -v --ansi-escapes=false --field=KOALABEAR_16 --report --mir
           JUNIT_TESTS_PARALLELISM: 2
           ZKEVM_FORK: ${{ inputs.zkevm_fork }}
 
@@ -75,7 +75,7 @@ jobs:
         run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:arithmetization:nightlyModexpTests
         env:
           JUNIT_TESTS_PARALLELISM: 2
-          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --mir
+          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --field=KOALABEAR_16 --report --mir
           ZKEVM_FORK: ${{ inputs.zkevm_fork }}
 
       - name: Upload test report

--- a/.github/workflows/reusable-tracer-unit-tests.yml
+++ b/.github/workflows/reusable-tracer-unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
         run: GOMEMLIMIT=26GiB ./gradlew :tracer:arithmetization:test
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --field=KOALABEAR_16 --report --air
           JUNIT_TESTS_PARALLELISM: 4
           PARAMETERIZED_TESTS_SAMPLE_SIZE: 0.2
           ZKEVM_FORK: ${{ inputs.zkevm_fork }}

--- a/.github/workflows/reusable-tracer-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-prc-tests.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           JUNIT_TESTS_PARALLELISM: 24
-          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --mir
+          GOCORSET_FLAGS: -v -b1024 --field=KOALABEAR_16 --ansi-escapes=false --report --mir
           ZKEVM_FORK: ${{ inputs.zkevm_fork }}
 
       - name: Upload prc calls test report

--- a/.github/workflows/reusable-tracer-weekly-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:arithmetization:weeklyTest
         env:
           JUNIT_TESTS_PARALLELISM: 2
-          GOCORSET_FLAGS: -v -b1024 --ansi-escapes=false --report --mir
+          GOCORSET_FLAGS: -v -b1024 --field=KOALABEAR_16 --ansi-escapes=false --report --mir
           ZKEVM_FORK: ${{ inputs.zkevm_fork }}
 
       - name: Upload test report

--- a/.github/workflows/tracer-gradle-nightly-tests.yml
+++ b/.github/workflows/tracer-gradle-nightly-tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:arithmetization:nightlyReplayTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          GOCORSET_FLAGS: -v --ansi-escapes=false --report --mir
+          GOCORSET_FLAGS: -v --ansi-escapes=false --field=KOALABEAR_16 --report --mir
           JUNIT_TESTS_PARALLELISM: 2
 
       - name: Upload test report

--- a/.github/workflows/tracer-gradle-tests.yml
+++ b/.github/workflows/tracer-gradle-tests.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
           JUNIT_TESTS_PARALLELISM: 4
-          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -b1024 -v --ansi-escapes=false --field=KOALABEAR_16 --report --air
 
       - name: Upload test report
         if: ${{ always() }}

--- a/.github/workflows/tracer-gradle-weekly-tests.yml
+++ b/.github/workflows/tracer-gradle-weekly-tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: GOMAXPROCS=10 GOMEMLIMIT=20GiB ./gradlew :tracer:arithmetization:weeklyReplayTests
         env:
           JAVA_OPTS: -Dorg.gradle.daemon=false
-          GOCORSET_FLAGS: -v --ansi-escapes=false --report --air
+          GOCORSET_FLAGS: -v --ansi-escapes=false --field=KOALABEAR_16 --report --air
           JUNIT_TESTS_PARALLELISM: 2
 
       - name: Upload test report


### PR DESCRIPTION
This enables KOALABEAR_16 on the unit & replay tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that just adjust test runner flags, with the main impact being potential CI behavior/test-result differences rather than production code changes.
> 
> **Overview**
> **CI-only change:** updates multiple Tracer GitHub Actions workflows to pass `--field=KOALABEAR_16` via `GOCORSET_FLAGS` when running unit, replay, nightly, weekly, PRC-call, and blockchain reference tests.
> 
> No application code changes; this primarily standardizes the field configuration used during CI test execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2d1190a2eb4fcbfa49c417a4f946a9627a0355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->