### PR TITLE
Fixing prover response shape and the parent zk state root hash

### DIFF
--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
@@ -30,6 +30,8 @@ data class InvalidityProofRequestDto(
   val simulatedExecutionBlockTimestamp: Long,
 ) {
   companion object {
+    private val objectMapper = jacksonObjectMapper()
+
     fun fromDomainObject(invalidityProofRequest: InvalidityProofRequest): InvalidityProofRequestDto {
       return InvalidityProofRequestDto(
         ftxRLP = invalidityProofRequest.ftxRlp.encodeHex(),
@@ -40,7 +42,7 @@ data class InvalidityProofRequestDto(
         zkParentStateRootHash = invalidityProofRequest.zkParentStateRootHash.encodeHex(),
         conflatedExecutionTracesFile = invalidityProofRequest.tracesResponse,
         accountMerkleProof = invalidityProofRequest.accountProof?.accountProof?.let {
-          jacksonObjectMapper().readTree(it)
+          objectMapper.readTree(it)
         },
         zkStateMerkleProof = invalidityProofRequest.zkStateMerkleProof?.zkStateMerkleProof,
         simulatedExecutionBlockNumber = invalidityProofRequest.simulatedExecutionBlockNumber.toLong(),

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/net/consensys/zkevm/coordinator/clients/prover/FileBasedInvalidityProverClient.kt
@@ -1,6 +1,5 @@
 package net.consensys.zkevm.coordinator.clients.prover
 
-import build.linea.clients.LineaAccountProof
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
@@ -25,7 +24,7 @@ data class InvalidityProofRequestDto(
   val invalidityType: String,
   val zkParentStateRootHash: String,
   val conflatedExecutionTracesFile: String?,
-  val accountMerkleProof: AccountProofDto?,
+  val accountMerkleProof: JsonNode?,
   val zkStateMerkleProof: ArrayNode?,
   val simulatedExecutionBlockNumber: Long,
   val simulatedExecutionBlockTimestamp: Long,
@@ -40,23 +39,13 @@ data class InvalidityProofRequestDto(
         invalidityType = invalidityProofRequest.invalidityReason.name,
         zkParentStateRootHash = invalidityProofRequest.zkParentStateRootHash.encodeHex(),
         conflatedExecutionTracesFile = invalidityProofRequest.tracesResponse,
-        accountMerkleProof = AccountProofDto.fromDomainObject(invalidityProofRequest.accountProof),
+        accountMerkleProof = invalidityProofRequest.accountProof?.accountProof?.let {
+          jacksonObjectMapper().readTree(it)
+        },
         zkStateMerkleProof = invalidityProofRequest.zkStateMerkleProof?.zkStateMerkleProof,
         simulatedExecutionBlockNumber = invalidityProofRequest.simulatedExecutionBlockNumber.toLong(),
         simulatedExecutionBlockTimestamp = invalidityProofRequest.simulatedExecutionBlockTimestamp.epochSeconds,
       )
-    }
-  }
-}
-
-data class AccountProofDto(val accountProof: JsonNode) {
-  companion object {
-    fun fromDomainObject(lineaAccountProof: LineaAccountProof?): AccountProofDto? {
-      return lineaAccountProof
-        ?.accountProof
-        ?.let {
-          AccountProofDto(accountProof = jacksonObjectMapper().readTree(it))
-        }
     }
   }
 }

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
@@ -196,7 +196,7 @@ class InvalidityProofAssembler(
       .thenApply {
         RequiredInvalidityProofData(
           prevFtxRollingHash = prevFtxRollingHashFuture.get(),
-          zkParentStateRootHash = zkParentStateRootHashFuture.get().zkEndStateRootHash,
+          zkParentStateRootHash = zkParentStateRootHashFuture.get().zkParentStateRootHash,
           tracesFile = tracesFuture.get()?.tracesFileName,
           accountProof = accountProofFuture.get(),
           zkStateMerkleProof = stateProofFuture.get(),

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
@@ -129,15 +129,40 @@ class InvalidityProofAssembler(
     val tracesFile: String? = null,
     val accountProof: LineaAccountProof? = null,
     val zkStateMerkleProof: GetZkEVMStateMerkleProofResponse? = null,
-  )
+  ) {
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (javaClass != other?.javaClass) return false
+
+      other as RequiredInvalidityProofData
+
+      if (!prevFtxRollingHash.contentEquals(other.prevFtxRollingHash)) return false
+      if (!zkParentStateRootHash.contentEquals(other.zkParentStateRootHash)) return false
+      if (tracesFile != other.tracesFile) return false
+      if (accountProof != other.accountProof) return false
+      if (zkStateMerkleProof != other.zkStateMerkleProof) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      var result = prevFtxRollingHash.contentHashCode()
+      result = 31 * result + zkParentStateRootHash.contentHashCode()
+      result = 31 * result + (tracesFile?.hashCode() ?: 0)
+      result = 31 * result + (accountProof?.hashCode() ?: 0)
+      result = 31 * result + (zkStateMerkleProof?.hashCode() ?: 0)
+      return result
+    }
+  }
 
   private fun fetchRequiredDataForInvalidityProof(
     invalidityReason: InvalidityReason,
     ftx: ForcedTransactionRecord,
   ): SafeFuture<RequiredInvalidityProofData> {
     val prevFtxRollingHashFuture = getPrevFtxRollingHash(ftx.ftxNumber)
+    val parentBlockNumber = ftx.simulatedExecutionBlockNumber - 1uL
     val zkParentStateRootHashFuture = stateManagerClient
-      .rollupGetStateMerkleProof(BlockInterval(ftx.simulatedExecutionBlockNumber, ftx.simulatedExecutionBlockNumber))
+      .rollupGetStateMerkleProof(BlockInterval(parentBlockNumber, parentBlockNumber))
     var accountProofFuture: SafeFuture<LineaAccountProof?> = SafeFuture.completedFuture(null)
     var stateProofFuture: SafeFuture<GetZkEVMStateMerkleProofResponse?> = SafeFuture.completedFuture(null)
     var tracesFuture: SafeFuture<GenerateTracesResponse?> = SafeFuture.completedFuture(null)
@@ -172,7 +197,7 @@ class InvalidityProofAssembler(
       .thenApply {
         RequiredInvalidityProofData(
           prevFtxRollingHash = prevFtxRollingHashFuture.get(),
-          zkParentStateRootHash = zkParentStateRootHashFuture.get().zkParentStateRootHash,
+          zkParentStateRootHash = zkParentStateRootHashFuture.get().zkEndStateRootHash,
           tracesFile = tracesFuture.get()?.tracesFileName,
           accountProof = accountProofFuture.get(),
           zkStateMerkleProof = stateProofFuture.get(),

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
@@ -160,9 +160,8 @@ class InvalidityProofAssembler(
     ftx: ForcedTransactionRecord,
   ): SafeFuture<RequiredInvalidityProofData> {
     val prevFtxRollingHashFuture = getPrevFtxRollingHash(ftx.ftxNumber)
-    val parentBlockNumber = ftx.simulatedExecutionBlockNumber - 1uL
     val zkParentStateRootHashFuture = stateManagerClient
-      .rollupGetStateMerkleProof(BlockInterval(parentBlockNumber, parentBlockNumber))
+      .rollupGetStateMerkleProof(BlockInterval(ftx.simulatedExecutionBlockNumber, ftx.simulatedExecutionBlockNumber))
     var accountProofFuture: SafeFuture<LineaAccountProof?> = SafeFuture.completedFuture(null)
     var stateProofFuture: SafeFuture<GetZkEVMStateMerkleProofResponse?> = SafeFuture.completedFuture(null)
     var tracesFuture: SafeFuture<GenerateTracesResponse?> = SafeFuture.completedFuture(null)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the JSON shape/typing of `accountMerkleProof` sent to the invalidity prover and adjusts equality semantics for proof-assembly data, which could affect integrations and any caching/dedup logic relying on comparisons.
> 
> **Overview**
> Fixes invalidity proof request serialization by sending `accountMerkleProof` as raw parsed JSON (`JsonNode`) instead of wrapping it in an `AccountProofDto`, and removes the now-unused DTO/type import.
> 
> Updates `InvalidityProofAssembler.RequiredInvalidityProofData` to use content-based `equals`/`hashCode` for `ByteArray` fields so comparisons reflect actual hash/root values rather than array identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3462b91d50165cd055117840f040f9c833a4287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->