### PR TITLE
fix(coordinator): enforce l2 blocks fetch limit for conflation backtesting

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -54,6 +54,7 @@ import org.apache.logging.log4j.LogManager
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.nio.file.Path
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
@@ -82,7 +83,7 @@ class ConflationBacktestingApp(
       ?.let { require(!it) { "Cannot use same traces endpoint for backtesting and main conflation" } }
   }
 
-  private val log = LogManager.getLogger("conflation_backtesting.job_${conflationBacktestingAppConfig.jobId()}")
+  private val log = LogManager.getLogger("conflation_backtesting_job_${conflationBacktestingAppConfig.jobId()}")
 
   private val conflationBacktestingComplete = AtomicBoolean(false)
 
@@ -105,7 +106,6 @@ class ConflationBacktestingApp(
 
   val backtestingCoordinatorConfig: CoordinatorConfig = mainCoordinatorConfig.copy(
     conflation = mainCoordinatorConfig.conflation.copy(
-      l2FetchBlocksLimit = UInt.MAX_VALUE,
       blocksLimit = conflationBacktestingAppConfig.batchesFixedSize,
       forceStopConflationAtBlockInclusive = conflationBacktestingAppConfig.endBlockNumber,
       conflationDeadline = null,
@@ -219,6 +219,7 @@ class ConflationBacktestingApp(
     logger = log,
   )
 
+  val lastProcessedBatchEndBlockNumber = AtomicLong(conflationBacktestingAppConfig.startBlockNumber.toLong() - 1)
   val proofGeneratingConflationHandlerImpl = run {
     val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient(log = log)
 
@@ -240,6 +241,13 @@ class ConflationBacktestingApp(
         log = log,
       ),
       batchProofHandler = { _ -> SafeFuture.completedFuture(Unit) },
+      batchProofRequestHandler = { proofIndex, unProvenBatch ->
+        log.info(
+          "Backtesting execution proof request produced: batch={}",
+          unProvenBatch.intervalString(),
+        )
+        lastProcessedBatchEndBlockNumber.store(proofIndex.endBlockNumber.toLong())
+      },
       vertx = vertx,
       config = ProofGeneratingConflationHandlerImpl.Config(
         conflationAndProofGenerationRetryBackoffDelay = 5.seconds,
@@ -381,7 +389,7 @@ class ConflationBacktestingApp(
     blockCreationListener = blockToBatchSubmissionCoordinator,
     lastProvenBlockNumberProviderSync = object : LastProvenBlockNumberProviderSync {
       override fun getLastKnownProvenBlockNumber(): Long {
-        return conflationBacktestingAppConfig.startBlockNumber.toLong() - 1
+        return lastProcessedBatchEndBlockNumber.load()
       }
     },
     config = BlockCreationMonitor.Config(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/ProofGeneratingConflationHandlerImpl.kt
@@ -18,6 +18,7 @@ import linea.timer.VertxPeriodicPollingService
 import net.consensys.linea.async.AsyncRetryer
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.zkevm.ethereum.coordination.proofcreation.BatchProofHandler
+import net.consensys.zkevm.ethereum.coordination.proofcreation.BatchProofRequestHandler
 import net.consensys.zkevm.ethereum.coordination.proofcreation.ZkProofCreationCoordinator
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -29,6 +30,7 @@ class ProofGeneratingConflationHandlerImpl(
   private val tracesProductionCoordinator: TracesConflationCoordinator,
   private val zkProofProductionCoordinator: ZkProofCreationCoordinator,
   private val batchProofHandler: BatchProofHandler,
+  private val batchProofRequestHandler: BatchProofRequestHandler? = null,
   private val vertx: Vertx,
   private val config: Config,
   private val log: Logger = LogManager.getLogger(ProofGeneratingConflationHandlerImpl::class.java),
@@ -160,7 +162,11 @@ class ProofGeneratingConflationHandlerImpl(
                   .createZkProofRequest(conflation, blocksTracesConflated)
                   .thenApply { proofIndex ->
                     log.info("execution proof request generated: proofIndex={}", proofIndex)
-                    proofRequestsInProgress.addLast(proofIndex)
+                    try {
+                      batchProofRequestHandler?.acceptNewBatchProofRequest(proofIndex, batch)
+                    } finally {
+                      proofRequestsInProgress.addLast(proofIndex)
+                    }
                   }
                   .whenException { th ->
                     log.debug(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/BatchProofHandler.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/BatchProofHandler.kt
@@ -1,6 +1,7 @@
 package net.consensys.zkevm.ethereum.coordination.proofcreation
 
 import linea.domain.Batch
+import linea.domain.ExecutionProofIndex
 import linea.error.DuplicatedRecordException
 import linea.persistence.BatchesRepository
 import org.apache.logging.log4j.LogManager
@@ -8,6 +9,10 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 fun interface BatchProofHandler {
   fun acceptNewBatch(batch: Batch): SafeFuture<*>
+}
+
+fun interface BatchProofRequestHandler {
+  fun acceptNewBatchProofRequest(proofIndex: ExecutionProofIndex, unProvenBatch: Batch)
 }
 
 class BatchProofHandlerImpl(


### PR DESCRIPTION

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core proof-request flow by adding an optional callback hook and slightly changes when proof requests are recorded; while backward-compatible, it could affect execution proof request tracking if misused. Backtesting behavior also changes by enforcing the configured L2 block fetch limit and advancing the monitor’s last-proven cursor as proof requests are produced.
> 
> **Overview**
> Backtesting no longer overrides `l2FetchBlocksLimit` to `UInt.MAX_VALUE`, so L2 block fetching is now constrained by the configured limit.
> 
> Adds a new optional `BatchProofRequestHandler` callback to `ProofGeneratingConflationHandlerImpl`, invoked when an execution proof request is generated. `ConflationBacktestingApp` uses this to track the last requested batch end block and feeds it into `BlockCreationMonitor`’s `LastProvenBlockNumberProviderSync`, improving backtesting progress/cursor behavior. Also tweaks the backtesting logger name format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b91365f82412403efa7d19fc9ae468cd787e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->