### PR TITLE
Prover-ray: port the range checks

### DIFF
--- a/prover-ray/wiop/compilers/rangecheck/rangecheck.go
+++ b/prover-ray/wiop/compilers/rangecheck/rangecheck.go
@@ -1,0 +1,75 @@
+// Package rangecheck implements the RangeCheck compiler pass for the wiop
+// protocol framework.
+//
+// It reduces every [wiop.RangeCheck] query to an [wiop.TableRelation] inclusion:
+// the checked column must be a subset of a precomputed column that enumerates
+// [0, B). A single precomputed range column is shared across all RangeChecks
+// with the same bound B, keeping the number of precomputed columns minimal.
+package rangecheck
+
+import (
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/utils"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+)
+
+// Compile reduces all [wiop.RangeCheck] queries in sys to [wiop.TableRelation]
+// inclusion constraints against precomputed range tables.
+//
+// For each unique bound B, one new module of size NextPowerOfTwo(B) is created
+// with a precomputed column containing [0, 1, …, B-1, 0, …, 0]. Each
+// RangeCheck is then replaced by an Inclusion asserting that the checked
+// column is contained in the range column. Already-reduced queries are skipped.
+func Compile(sys *wiop.System) {
+	rangeColumns := make(map[int]*wiop.Column)
+	compCtx := sys.Context.Childf("rangecheck")
+
+	for mIdx, m := range sys.Modules {
+		for rcIdx, rc := range m.RangeChecks {
+			if rc.IsReduced() {
+				continue
+			}
+
+			b := rc.B
+			rangeCol, ok := rangeColumns[b]
+			if !ok {
+				rangeCol = createRangeColumn(sys, compCtx, b)
+				rangeColumns[b] = rangeCol
+			}
+
+			included := []wiop.Table{wiop.NewTable(rc.Handle.View())}
+			including := []wiop.Table{wiop.NewTable(rangeCol.View())}
+			sys.NewInclusion(
+				compCtx.Childf("inc-m%d-rc%d", mIdx, rcIdx),
+				included,
+				including,
+			)
+			rc.MarkAsReduced()
+		}
+	}
+}
+
+// createRangeColumn creates a new module of size NextPowerOfTwo(b) and a
+// precomputed column containing [0, 1, …, b-1, 0, …, 0].
+func createRangeColumn(sys *wiop.System, ctx *wiop.ContextFrame, b int) *wiop.Column {
+	size := utils.NextPowerOfTwo(b)
+	mod := sys.NewSizedModule(
+		ctx.Childf("range-mod-b%d", b),
+		size,
+		wiop.PaddingDirectionNone,
+	)
+
+	elems := make([]field.Element, size)
+	for i := range b {
+		elems[i].SetUint64(uint64(i))
+	}
+
+	cv := &wiop.ConcreteVector{
+		Plain: []field.Vec{field.VecFromBase(elems)},
+	}
+	return mod.NewPrecomputedColumn(
+		ctx.Childf("range-col-b%d", b),
+		wiop.VisibilityOracle,
+		cv,
+	)
+}

--- a/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
+++ b/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
@@ -1,0 +1,171 @@
+package rangecheck_test
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop/compilers/rangecheck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRC builds a minimal system with one RangeCheck and calls Compile.
+// Returns the system, the checked column, the RangeCheck, and (after Compile)
+// the single Inclusion TableRelation.
+func newRC(t *testing.T, b int) (sys *wiop.System, col *wiop.Column, rc *wiop.RangeCheck) {
+	t.Helper()
+	sys = wiop.NewSystemf("rc-test")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 8, wiop.PaddingDirectionNone)
+	col = mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	rc = mod.NewRangeCheck(sys.Context.Childf("rc"), col, b)
+	return
+}
+
+func makeVec(vals ...uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, len(vals))
+	for i, v := range vals {
+		elems[i].SetUint64(v)
+	}
+	return &wiop.ConcreteVector{Plain: []field.Vec{field.VecFromBase(elems)}}
+}
+
+// ---- Structural tests ----
+
+func TestCompile_CreatesInclusion(t *testing.T) {
+	sys, _, rc := newRC(t, 8)
+	rangecheck.Compile(sys)
+
+	assert.True(t, rc.IsReduced(), "RangeCheck must be marked reduced after Compile")
+	require.Len(t, sys.TableRelations, 1)
+	assert.Equal(t, wiop.TableRelationInclusion, sys.TableRelations[0].Kind)
+}
+
+func TestCompile_SharedRangeColumn(t *testing.T) {
+	sys := wiop.NewSystemf("rc-shared")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 8, wiop.PaddingDirectionNone)
+	colA := mod.NewColumn(sys.Context.Childf("colA"), wiop.VisibilityOracle, r0)
+	colB := mod.NewColumn(sys.Context.Childf("colB"), wiop.VisibilityOracle, r0)
+	mod.NewRangeCheck(sys.Context.Childf("rcA"), colA, 4)
+	mod.NewRangeCheck(sys.Context.Childf("rcB"), colB, 4)
+	modulesBeforeCompile := len(sys.Modules) // 1
+
+	rangecheck.Compile(sys)
+
+	// One range module for B=4 shared across both RangeChecks.
+	assert.Len(t, sys.Modules, modulesBeforeCompile+1)
+	require.Len(t, sys.TableRelations, 2)
+}
+
+func TestCompile_DistinctBoundsDistinctModules(t *testing.T) {
+	sys := wiop.NewSystemf("rc-distinct")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 8, wiop.PaddingDirectionNone)
+	colA := mod.NewColumn(sys.Context.Childf("colA"), wiop.VisibilityOracle, r0)
+	colB := mod.NewColumn(sys.Context.Childf("colB"), wiop.VisibilityOracle, r0)
+	mod.NewRangeCheck(sys.Context.Childf("rcA"), colA, 4)
+	mod.NewRangeCheck(sys.Context.Childf("rcB"), colB, 8)
+	modulesBeforeCompile := len(sys.Modules)
+
+	rangecheck.Compile(sys)
+
+	// Two distinct bounds → two distinct range modules.
+	assert.Len(t, sys.Modules, modulesBeforeCompile+2)
+	require.Len(t, sys.TableRelations, 2)
+}
+
+func TestCompile_Idempotent(t *testing.T) {
+	sys, _, _ := newRC(t, 4)
+	rangecheck.Compile(sys)
+	relationsAfterFirst := len(sys.TableRelations)
+	modulesAfterFirst := len(sys.Modules)
+
+	rangecheck.Compile(sys)
+
+	assert.Len(t, sys.TableRelations, relationsAfterFirst,
+		"second Compile must not add new relations")
+	assert.Len(t, sys.Modules, modulesAfterFirst,
+		"second Compile must not add new modules")
+}
+
+func TestCompile_DynamicModule_Completeness(t *testing.T) {
+	sys := wiop.NewSystemf("rc-dyn-complete")
+	r0 := sys.NewRound()
+	mod := sys.NewDynamicModule(sys.Context.Childf("mod"), wiop.PaddingDirectionRight)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	mod.NewRangeCheck(sys.Context.Childf("rc"), col, 4)
+	rangecheck.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, makeVec(0, 1, 2, 3, 0, 1)) // 6 rows, all in [0, 4)
+
+	require.Len(t, sys.TableRelations, 1)
+	require.NoError(t, sys.TableRelations[0].Check(rt))
+}
+
+func TestCompile_DynamicModule_Soundness(t *testing.T) {
+	sys := wiop.NewSystemf("rc-dyn-sound")
+	r0 := sys.NewRound()
+	mod := sys.NewDynamicModule(sys.Context.Childf("mod"), wiop.PaddingDirectionRight)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	mod.NewRangeCheck(sys.Context.Childf("rc"), col, 4)
+	rangecheck.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, makeVec(0, 1, 2, 5)) // 5 >= 4 → out of range
+
+	require.Len(t, sys.TableRelations, 1)
+	assert.Error(t, sys.TableRelations[0].Check(rt),
+		"value above bound must be rejected by the compiled Inclusion")
+}
+
+func TestCompile_NoRangeChecks(t *testing.T) {
+	sys := wiop.NewSystemf("rc-none")
+	sys.NewRound()
+	sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
+
+	rangecheck.Compile(sys) // must not panic
+
+	assert.Empty(t, sys.TableRelations)
+}
+
+// ---- Soundness tests ----
+
+func TestCompile_Completeness(t *testing.T) {
+	sys, col, _ := newRC(t, 8)
+	rangecheck.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, makeVec(0, 1, 2, 3, 4, 5, 6, 7))
+
+	require.Len(t, sys.TableRelations, 1)
+	require.NoError(t, sys.TableRelations[0].Check(rt),
+		"all values in [0,8) must be accepted by the compiled Inclusion")
+}
+
+func TestCompile_Soundness_ValueAtBound(t *testing.T) {
+	sys, col, _ := newRC(t, 4)
+	rangecheck.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	// Value 4 == B is out of the range [0, 4).
+	rt.AssignColumn(col, makeVec(0, 1, 2, 4, 0, 0, 0, 0))
+
+	require.Len(t, sys.TableRelations, 1)
+	assert.Error(t, sys.TableRelations[0].Check(rt),
+		"value at bound must be rejected by the compiled Inclusion")
+}
+
+func TestCompile_Soundness_ValueAboveBound(t *testing.T) {
+	sys, col, _ := newRC(t, 4)
+	rangecheck.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, makeVec(0, 1, 2, 7, 0, 0, 0, 0)) // 7 >= 4
+
+	require.Len(t, sys.TableRelations, 1)
+	assert.Error(t, sys.TableRelations[0].Check(rt),
+		"value above bound must be rejected by the compiled Inclusion")
+}

--- a/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
+++ b/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
@@ -53,7 +53,7 @@ func TestCompile_SharedRangeColumn(t *testing.T) {
 	rangecheck.Compile(sys)
 
 	// One range module for B=4 shared across both RangeChecks.
-	assert.Equal(t, modulesBeforeCompile+1, len(sys.Modules))
+	assert.Len(t, sys.Modules, modulesBeforeCompile+1)
 	require.Len(t, sys.TableRelations, 2)
 }
 
@@ -70,7 +70,7 @@ func TestCompile_DistinctBoundsDistinctModules(t *testing.T) {
 	rangecheck.Compile(sys)
 
 	// Two distinct bounds → two distinct range modules.
-	assert.Equal(t, modulesBeforeCompile+2, len(sys.Modules))
+	assert.Len(t, sys.Modules, modulesBeforeCompile+2)
 	require.Len(t, sys.TableRelations, 2)
 }
 
@@ -82,9 +82,9 @@ func TestCompile_Idempotent(t *testing.T) {
 
 	rangecheck.Compile(sys)
 
-	assert.Equal(t, relationsAfterFirst, len(sys.TableRelations),
+	assert.Len(t, sys.TableRelations, relationsAfterFirst,
 		"second Compile must not add new relations")
-	assert.Equal(t, modulesAfterFirst, len(sys.Modules),
+	assert.Len(t, sys.Modules, modulesAfterFirst,
 		"second Compile must not add new modules")
 }
 

--- a/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
+++ b/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newRC builds a minimal system with one RangeCheck and calls Compile.
-// Returns the system, the checked column, the RangeCheck, and (after Compile)
-// the single Inclusion TableRelation.
+// newRC builds a minimal system with one sized module and one RangeCheck.
 func newRC(t *testing.T, b int) (sys *wiop.System, col *wiop.Column, rc *wiop.RangeCheck) {
 	t.Helper()
 	sys = wiop.NewSystemf("rc-test")
@@ -55,7 +53,7 @@ func TestCompile_SharedRangeColumn(t *testing.T) {
 	rangecheck.Compile(sys)
 
 	// One range module for B=4 shared across both RangeChecks.
-	assert.Len(t, sys.Modules, modulesBeforeCompile+1)
+	assert.Equal(t, modulesBeforeCompile+1, len(sys.Modules))
 	require.Len(t, sys.TableRelations, 2)
 }
 
@@ -72,7 +70,7 @@ func TestCompile_DistinctBoundsDistinctModules(t *testing.T) {
 	rangecheck.Compile(sys)
 
 	// Two distinct bounds → two distinct range modules.
-	assert.Len(t, sys.Modules, modulesBeforeCompile+2)
+	assert.Equal(t, modulesBeforeCompile+2, len(sys.Modules))
 	require.Len(t, sys.TableRelations, 2)
 }
 
@@ -84,41 +82,10 @@ func TestCompile_Idempotent(t *testing.T) {
 
 	rangecheck.Compile(sys)
 
-	assert.Len(t, sys.TableRelations, relationsAfterFirst,
+	assert.Equal(t, relationsAfterFirst, len(sys.TableRelations),
 		"second Compile must not add new relations")
-	assert.Len(t, sys.Modules, modulesAfterFirst,
+	assert.Equal(t, modulesAfterFirst, len(sys.Modules),
 		"second Compile must not add new modules")
-}
-
-func TestCompile_DynamicModule_Completeness(t *testing.T) {
-	sys := wiop.NewSystemf("rc-dyn-complete")
-	r0 := sys.NewRound()
-	mod := sys.NewDynamicModule(sys.Context.Childf("mod"), wiop.PaddingDirectionRight)
-	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
-	mod.NewRangeCheck(sys.Context.Childf("rc"), col, 4)
-	rangecheck.Compile(sys)
-
-	rt := wiop.NewRuntime(sys)
-	rt.AssignColumn(col, makeVec(0, 1, 2, 3, 0, 1)) // 6 rows, all in [0, 4)
-
-	require.Len(t, sys.TableRelations, 1)
-	require.NoError(t, sys.TableRelations[0].Check(rt))
-}
-
-func TestCompile_DynamicModule_Soundness(t *testing.T) {
-	sys := wiop.NewSystemf("rc-dyn-sound")
-	r0 := sys.NewRound()
-	mod := sys.NewDynamicModule(sys.Context.Childf("mod"), wiop.PaddingDirectionRight)
-	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
-	mod.NewRangeCheck(sys.Context.Childf("rc"), col, 4)
-	rangecheck.Compile(sys)
-
-	rt := wiop.NewRuntime(sys)
-	rt.AssignColumn(col, makeVec(0, 1, 2, 5)) // 5 >= 4 → out of range
-
-	require.Len(t, sys.TableRelations, 1)
-	assert.Error(t, sys.TableRelations[0].Check(rt),
-		"value above bound must be rejected by the compiled Inclusion")
 }
 
 func TestCompile_NoRangeChecks(t *testing.T) {

--- a/prover-ray/wiop/query_range_check.go
+++ b/prover-ray/wiop/query_range_check.go
@@ -1,0 +1,79 @@
+package wiop
+
+import (
+	"fmt"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+)
+
+// RangeCheck is a [Query] asserting that every row of a column lies in [0, B).
+// A compiler pass must reduce this query before proof generation by converting
+// it to an Inclusion relation against a precomputed range table.
+type RangeCheck struct {
+	baseQuery
+	// Handle is the column whose values must all lie in [0, B).
+	Handle *Column
+	// B is the exclusive upper bound of the valid range.
+	B int
+}
+
+// Round implements [Query]. Returns the round of the checked column.
+func (rc *RangeCheck) Round() *Round { return rc.Handle.Round() }
+
+// Check implements [Query]. Verifies that every row of Handle lies in [0, B).
+func (rc *RangeCheck) Check(rt Runtime) error {
+	m := rc.Handle.Module
+	n := m.Size()
+	cv := rt.GetColumnAssignment(rc.Handle)
+	for row := range n {
+		elem := cv.ElementAt(m, row)
+		if !elem.IsBase() {
+			return fmt.Errorf(
+				"wiop: RangeCheck(%s).Check: extension-field value at row %d",
+				rc.context.Path(), row,
+			)
+		}
+		base := elem.AsBase()
+		v := field.ToInt(&base)
+		if v >= rc.B {
+			return fmt.Errorf(
+				"wiop: RangeCheck(%s).Check: value %d at row %d is out of range [0, %d)",
+				rc.context.Path(), v, row, rc.B,
+			)
+		}
+	}
+	return nil
+}
+
+// String returns a human-readable description of the RangeCheck for debugging.
+func (rc *RangeCheck) String() string {
+	return fmt.Sprintf("RangeCheck(%s, B=%d)", rc.context.Path(), rc.B)
+}
+
+// NewRangeCheck registers a new RangeCheck on module m asserting that every
+// value in col lies in [0, B).
+//
+// Panics if ctx or col is nil, or if B is not positive.
+func (m *Module) NewRangeCheck(ctx *ContextFrame, col *Column, b int) *RangeCheck {
+	if ctx == nil {
+		panic("wiop: Module.NewRangeCheck requires a non-nil ContextFrame")
+	}
+	if col == nil {
+		panic("wiop: Module.NewRangeCheck requires a non-nil Column")
+	}
+	if b <= 0 {
+		panic(fmt.Sprintf(
+			"wiop: Module.NewRangeCheck requires a positive bound, got %d", b,
+		))
+	}
+	rc := &RangeCheck{
+		baseQuery: baseQuery{
+			context:     ctx,
+			Annotations: make(Annotations),
+		},
+		Handle: col,
+		B:      b,
+	}
+	m.RangeChecks = append(m.RangeChecks, rc)
+	return rc
+}

--- a/prover-ray/wiop/query_range_check_test.go
+++ b/prover-ray/wiop/query_range_check_test.go
@@ -1,0 +1,115 @@
+package wiop_test
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop/wioptest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRangeCheck_Soundness_Completeness(t *testing.T) {
+	sc := wioptest.NewRangeCheckScenario()
+	rt := wiop.NewRuntime(sc.Sys)
+	sc.RunHonest(&rt)
+	require.NoError(t, sc.Query.Check(rt), "honest witness must pass Check")
+}
+
+func TestRangeCheck_Soundness_InvalidWitness(t *testing.T) {
+	sc := wioptest.NewRangeCheckScenario()
+	rt := wiop.NewRuntime(sc.Sys)
+	sc.RunInvalid(&rt)
+	assert.Error(t, sc.Query.Check(rt), "invalid witness must be rejected by Check")
+}
+
+func TestRangeCheck_Round(t *testing.T) {
+	sys, r0, r1, mod := newTestSystem(t)
+	col0 := mod.NewColumn(sys.Context.Childf("rc-r0"), wiop.VisibilityOracle, r0)
+	col1 := mod.NewColumn(sys.Context.Childf("rc-r1"), wiop.VisibilityOracle, r1)
+	rc0 := mod.NewRangeCheck(sys.Context.Childf("rc0"), col0, 4)
+	rc1 := mod.NewRangeCheck(sys.Context.Childf("rc1"), col1, 4)
+	assert.Equal(t, r0, rc0.Round())
+	assert.Equal(t, r1, rc1.Round())
+}
+
+func TestRangeCheck_String(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("rc-col"), wiop.VisibilityOracle, r0)
+	rc := mod.NewRangeCheck(sys.Context.Childf("rc"), col, 16)
+	s := rc.String()
+	assert.Contains(t, s, "RangeCheck")
+	assert.Contains(t, s, "16")
+}
+
+func TestRangeCheck_Check_BoundaryValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		vals    []uint64
+		b       int
+		wantErr bool
+	}{
+		{"zero is valid", []uint64{0, 0, 0, 0}, 4, false},
+		{"b-1 is valid", []uint64{3, 3, 3, 3}, 4, false},
+		{"b is invalid", []uint64{0, 1, 2, 4}, 4, true},
+		{"b+1 is invalid", []uint64{0, 1, 2, 5}, 4, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sys := wiop.NewSystemf("rc-bnd")
+			r0 := sys.NewRound()
+			mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
+			col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+			rc := mod.NewRangeCheck(sys.Context.Childf("rc"), col, tc.b)
+			rt := wiop.NewRuntime(sys)
+			rt.AssignColumn(col, makeVecU64(tc.vals...))
+			if tc.wantErr {
+				assert.Error(t, rc.Check(rt))
+			} else {
+				assert.NoError(t, rc.Check(rt))
+			}
+		})
+	}
+}
+
+func TestRangeCheck_NewRangeCheck_NilCtxPanic(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("rc-nil-col"), wiop.VisibilityOracle, r0)
+	assert.Panics(t, func() { mod.NewRangeCheck(nil, col, 4) })
+}
+
+func TestRangeCheck_NewRangeCheck_NilColPanic(t *testing.T) {
+	sys, _, _, mod := newTestSystem(t)
+	assert.Panics(t, func() { mod.NewRangeCheck(sys.Context.Childf("rc"), nil, 4) })
+}
+
+func TestRangeCheck_NewRangeCheck_ZeroBoundPanic(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	assert.Panics(t, func() { mod.NewRangeCheck(sys.Context.Childf("rc"), col, 0) })
+}
+
+func TestRangeCheck_NewRangeCheck_NegativeBoundPanic(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	assert.Panics(t, func() { mod.NewRangeCheck(sys.Context.Childf("rc"), col, -1) })
+}
+
+func TestRangeCheck_IsReduced(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	rc := mod.NewRangeCheck(sys.Context.Childf("rc"), col, 4)
+	assert.False(t, rc.IsReduced())
+	rc.MarkAsReduced()
+	assert.True(t, rc.IsReduced())
+}
+
+// makeVecU64 builds a PaddingDirectionNone ConcreteVector from explicit uint64 values.
+func makeVecU64(vals ...uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, len(vals))
+	for i, v := range vals {
+		elems[i].SetUint64(v)
+	}
+	return &wiop.ConcreteVector{Plain: []field.Vec{field.VecFromBase(elems)}}
+}

--- a/prover-ray/wiop/wiop_column.go
+++ b/prover-ray/wiop/wiop_column.go
@@ -30,6 +30,9 @@ type Module struct {
 	// LocalOpenings holds all [LocalOpening] queries registered with this
 	// system via [System.NewLocalOpening], in declaration order.
 	LocalOpenings []*LocalOpening
+	// RangeChecks holds all [RangeCheck] queries registered on this module
+	// via [Module.NewRangeCheck], in declaration order.
+	RangeChecks []*RangeCheck
 	// size is zero when the module has not yet been sized. Use [Module.Size]
 	// and [Module.SetSize] rather than accessing this field directly.
 	size int

--- a/prover-ray/wiop/wioptest/query_scenarios.go
+++ b/prover-ray/wiop/wioptest/query_scenarios.go
@@ -131,6 +131,30 @@ func NewPermutationScenario() *Scenario {
 	}
 }
 
+// NewRangeCheckScenario returns a scenario for a RangeCheck query.
+//
+//   - Valid: column [0, 1, 2, 3]; bound B = 8.
+//   - Invalid: column [0, 1, 2, 9]; 9 ≥ 8.
+func NewRangeCheckScenario() *Scenario {
+	sys := wiop.NewSystemf("rc-sc")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	rc := mod.NewRangeCheck(sys.Context.Childf("rc"), col, 8)
+
+	return &Scenario{
+		Name:  "RangeCheck",
+		Sys:   sys,
+		Query: rc,
+		RunHonest: func(rt *wiop.Runtime) {
+			rt.AssignColumn(col, makeVec(0, 1, 2, 3))
+		},
+		RunInvalid: func(rt *wiop.Runtime) {
+			rt.AssignColumn(col, makeVec(0, 1, 2, 9)) // 9 ≥ B=8
+		},
+	}
+}
+
 // NewInclusionScenario returns a scenario for an Inclusion TableRelation.
 //
 //   - Valid: A = [1, 1, 2, 2], B = [1, 2, 3, 4] (every A value is in B).

--- a/prover-ray/wiop/wioptest/scenario.go
+++ b/prover-ray/wiop/wioptest/scenario.go
@@ -44,5 +44,6 @@ func All() []func() *Scenario {
 		NewLogDerivativeSumScenario,
 		NewPermutationScenario,
 		NewInclusionScenario,
+		NewRangeCheckScenario,
 	}
 }


### PR DESCRIPTION
Here is a PR for the port of the range-checks in the new ray framework. The handling mechanism is the same as the previous one. It has been tested against dynamically-size modules as well.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new constraint/query semantics and a compiler rewrite that affect proof-system soundness if bounds or table construction are incorrect, though changes are well-covered by new unit tests.
> 
> **Overview**
> Adds a new `wiop.RangeCheck` query type to assert column values lie in `[0,B)` (with runtime `Check`, constructor validation, and module storage).
> 
> Introduces a `rangecheck` compiler pass that reduces each unreduced `RangeCheck` into an Inclusion `TableRelation` against a shared precomputed range column per bound (sized to `NextPowerOfTwo(B)`), and marks queries reduced for idempotent compilation.
> 
> Adds unit tests for both the query and compiler pass (structural/idempotency + basic soundness), and registers a new `NewRangeCheckScenario` in `wioptest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615da761815a5da662c2dc0edb8a83ce6eb219bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->