### PR TITLE
chore(misc): remove docker/* from coordinator ci trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,6 @@ jobs:
               - '.github/workflows/build-and-publish.yml'
               - '.github/workflows/main.yml'
               - '.github/workflows/reuse-*.yml'
-              - 'docker/compose-*.yml'
             staterecovery:
               - 'state-recovery/**'
               - 'buildSrc/**'


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only adjusts path filters; the main risk is missing coordinator builds when Docker Compose files change and should have triggered them.
> 
> **Overview**
> Updates `.github/workflows/main.yml` path filtering so the `coordinator` workflow no longer treats `docker/compose-*.yml` changes as requiring coordinator-related CI runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66fd802e0e6932cfffb7ae5ea1c422eebb99e776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->