### PR TITLE
feat(coordinator): optional traces conflation config for backtesting

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
@@ -15,6 +15,7 @@ data class ConflationCreateProverRequestJsonDto(
   val batchesFixedSize: Int?,
   val parentBlobShnarf: String?,
   val tracesApi: TracesApiDto,
+  val tracesConflationApi: TracesApiDto? = null,
   val shomeiApi: ShomeiApiDto,
 ) {
   constructor() : this(
@@ -35,6 +36,7 @@ data class ConflationCreateProverRequestJsonDto(
       batchesFixedSize = this.batchesFixedSize?.toUInt(),
       parentBlobShnarf = this.parentBlobShnarf,
       tracesApi = this.tracesApi.toDomainObject(),
+      tracesConflationApi = this.tracesConflationApi?.toDomainObject(),
       shomeiApi = this.shomeiApi.toDomainObject(),
     )
   }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -75,12 +75,25 @@ class ConflationBacktestingApp(
     require(conflationBacktestingAppConfig.blobCompressorVersion != BlobCompressorVersion.V2) {
       "Blob compressor version 2 is not supported for backtesting"
     }
-    mainCoordinatorConfig.traces.common?.endpoints?.contains(conflationBacktestingAppConfig.tracesApi.endpoint)
-      ?.let { require(!it) { "Cannot use same traces endpoint for backtesting and main conflation" } }
-    mainCoordinatorConfig.traces.counters?.endpoints?.contains(conflationBacktestingAppConfig.tracesApi.endpoint)
-      ?.let { require(!it) { "Cannot use same traces endpoint for backtesting and main conflation" } }
-    mainCoordinatorConfig.traces.conflation?.endpoints?.contains(conflationBacktestingAppConfig.tracesApi.endpoint)
-      ?.let { require(!it) { "Cannot use same traces endpoint for backtesting and main conflation" } }
+    val mainCoordinatorConfigTracesEndpoints = emptySet<String>()
+      .plus(mainCoordinatorConfig.traces.common?.endpoints ?: emptyList())
+      .plus(mainCoordinatorConfig.traces.counters?.endpoints ?: emptyList())
+      .plus(mainCoordinatorConfig.traces.conflation?.endpoints ?: emptyList())
+
+    val backtestingTracesEndpoints = setOf(
+      conflationBacktestingAppConfig.tracesApi.endpoint.toString(),
+      conflationBacktestingAppConfig.tracesConflationApi?.endpoint?.toString(),
+    ).filterNotNull().toSet()
+
+    require(mainCoordinatorConfigTracesEndpoints.intersect(backtestingTracesEndpoints).isEmpty()) {
+      "Cannot use same traces endpoint for backtesting and main conflation"
+    }
+    require(
+      conflationBacktestingAppConfig.tracesConflationApi == null ||
+        conflationBacktestingAppConfig.tracesConflationApi.version == conflationBacktestingAppConfig.tracesApi.version,
+    ) {
+      "When tracesConflationApi is set, its version must match tracesApi.version"
+    }
   }
 
   private val log = LogManager.getLogger("conflation_backtesting_job_${conflationBacktestingAppConfig.jobId()}")
@@ -131,15 +144,25 @@ class ConflationBacktestingApp(
         )
       },
     ),
-    traces = mainCoordinatorConfig.traces.copy(
-      expectedTracesApiVersion = conflationBacktestingAppConfig.tracesApi.version,
-      common = ClientApiConfig(
-        endpoints = listOf(conflationBacktestingAppConfig.tracesApi.endpoint),
-        requestLimitPerEndpoint = conflationBacktestingAppConfig.tracesApi.requestLimitPerEndpoint,
-      ),
-      counters = null,
-      conflation = null,
-    ),
+    traces = run {
+      val bt = conflationBacktestingAppConfig
+      val tracesApiClient = ClientApiConfig(
+        endpoints = listOf(bt.tracesApi.endpoint),
+        requestLimitPerEndpoint = bt.tracesApi.requestLimitPerEndpoint,
+      )
+      val conflationApiClient = bt.tracesConflationApi?.let { api ->
+        ClientApiConfig(
+          endpoints = listOf(api.endpoint),
+          requestLimitPerEndpoint = api.requestLimitPerEndpoint,
+        )
+      }
+      mainCoordinatorConfig.traces.copy(
+        expectedTracesApiVersion = bt.tracesApi.version,
+        common = if (conflationApiClient == null) tracesApiClient else null,
+        counters = if (conflationApiClient == null) null else tracesApiClient,
+        conflation = conflationApiClient,
+      )
+    },
     stateManager = mainCoordinatorConfig.stateManager.copy(
       endpoints = listOf(conflationBacktestingAppConfig.shomeiApi.endpoint),
       requestLimitPerEndpoint = conflationBacktestingAppConfig.shomeiApi.requestLimitPerEndpoint,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -81,8 +81,8 @@ class ConflationBacktestingApp(
       .plus(mainCoordinatorConfig.traces.conflation?.endpoints ?: emptyList())
 
     val backtestingTracesEndpoints = setOf(
-      conflationBacktestingAppConfig.tracesApi.endpoint.toString(),
-      conflationBacktestingAppConfig.tracesConflationApi?.endpoint?.toString(),
+      conflationBacktestingAppConfig.tracesApi.endpoint,
+      conflationBacktestingAppConfig.tracesConflationApi?.endpoint,
     ).filterNotNull().toSet()
 
     require(mainCoordinatorConfigTracesEndpoints.intersect(backtestingTracesEndpoints).isEmpty()) {

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingConfig.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingConfig.kt
@@ -10,6 +10,7 @@ data class ConflationBacktestingConfig(
   val batchesFixedSize: UInt? = null,
   val parentBlobShnarf: String? = null,
   val tracesApi: TracesApiConfig,
+  val tracesConflationApi: TracesApiConfig? = null,
   val shomeiApi: ShomeiApiConfig,
 ) {
   fun jobId(): String {
@@ -20,11 +21,11 @@ data class ConflationBacktestingConfig(
 data class TracesApiConfig(
   val endpoint: URL,
   val version: String,
-  val requestLimitPerEndpoint: UInt = 10u,
+  val requestLimitPerEndpoint: UInt = 1u,
 )
 
 data class ShomeiApiConfig(
   val endpoint: URL,
   val version: String,
-  val requestLimitPerEndpoint: UInt = 10u,
+  val requestLimitPerEndpoint: UInt = 1u,
 )

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDtoTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDtoTest.kt
@@ -9,16 +9,21 @@ import org.junit.jupiter.api.Test
 class ConflationCreateProverRequestJsonDtoTest {
 
   @Test
-  fun `parseFrom should correctly parse valid JSON RPC request params`() {
+  fun `parseFrom should correctly parse valid JSON RPC request params including optional tracesConflationApi`() {
     val expectedDtoList = listOf(
       ConflationCreateProverRequestJsonDto(
         startBlockNumber = 10,
         endBlockNumber = 20,
-        blobCompressorVersion = "V1_2",
+        blobCompressorVersion = "V3",
         batchesFixedSize = null,
         parentBlobShnarf = null,
         tracesApi = TracesApiDto(
-          endpoint = "https://example.com/traces",
+          endpoint = "https://example.com/traces/counters",
+          version = "v1",
+          requestLimitPerEndpoint = 100,
+        ),
+        tracesConflationApi = TracesApiDto(
+          endpoint = "https://example.com/traces/conflation",
           version = "v1",
           requestLimitPerEndpoint = 100,
         ),
@@ -44,7 +49,6 @@ class ConflationCreateProverRequestJsonDtoTest {
           version = "v2",
           requestLimitPerEndpoint = 50,
         ),
-
       ),
     )
     val jsonRpcRequest = JsonRpcRequestListParams(
@@ -55,9 +59,14 @@ class ConflationCreateProverRequestJsonDtoTest {
         mapOf(
           "startBlockNumber" to 10,
           "endBlockNumber" to 20,
-          "blobCompressorVersion" to "V1_2",
+          "blobCompressorVersion" to "V3",
           "tracesApi" to mapOf(
-            "endpoint" to "https://example.com/traces",
+            "endpoint" to "https://example.com/traces/counters",
+            "version" to "v1",
+            "requestLimitPerEndpoint" to 100,
+          ),
+          "tracesConflationApi" to mapOf(
+            "endpoint" to "https://example.com/traces/conflation",
             "version" to "v1",
             "requestLimitPerEndpoint" to 100,
           ),

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -126,10 +126,20 @@ Conflation backtesting allows re-running the conflation and proof-request pipeli
 
 ### How It Works
 
-1. Submit one or more backtesting jobs via `conflation_createProverRequests`, each specifying a block range, blob compressor version, and the traces/state-manager endpoints to use.
-2. Each job spins up an isolated `ConflationBacktestingApp` instance that fetches trace counts from the given Traces API, compresses blobs using the specified compressor version, and writes prover request files to disk — identical in format to the live pipeline.
+1. Submit one or more backtesting jobs via `conflation_createProverRequests`, each specifying a block range, blob compressor version, a **traces** RPC configuration (`tracesApi`, and optionally `tracesConflationApi`), and the Shomei (state manager) endpoint.
+2. Each job spins up an isolated `ConflationBacktestingApp` instance. Trace line counts always use `tracesApi`. If `tracesConflationApi` is **omitted**, the same `tracesApi` client is also used for conflated traces (`linea_generateConflatedTracesToFileV2`). If `tracesConflationApi` is **set** (split-traces deployment), counters stay on `tracesApi` and conflated traces use `tracesConflationApi`; both must declare the **same** `version` string. Blobs use the requested compressor version; prover request files are written under `conflation.backtesting-directory` — same file layout as the live pipeline.
 3. Poll job status via `conflation_getReconflationJobsStatus` until `COMPLETED`.
 
+### Prerequisites and validation
+
+| Rule | Rationale                                                       |
+|------|-----------------------------------------------------------------|
+| `conflation.backtesting-directory` is set in coordinator config | Per-job output needs a parent directory on disk                 |
+| `blobCompressorVersion` is not `V2` | Compressor `V3` or above is required for backtesting            |
+| If `tracesConflationApi` is present, `tracesConflationApi.version` equals `tracesApi.version` | Split clients must target the same traces API protocol version  |
+| No URL overlap between `tracesApi` / `tracesConflationApi` (when set) and the coordinator’s live `[traces]` endpoints (`common`, `counters`, or `conflation`) | Keeps backtesting traffic off the main conflation pipeline URLs |
+
+These checks run when each job is submitted.
 
 ### JSON-RPC API
 
@@ -137,7 +147,7 @@ Conflation backtesting allows re-running the conflation and proof-request pipeli
 
 Submits one or more backtesting jobs. Each element in `params` is an independent job. Returns a list of job IDs (one per submitted job).
 
-**Blob compressor versions:** `V1_2`, `V2`, `V3`
+**Blob compressor versions (backtesting):** `V3` or above.
 
 ```json
 {
@@ -152,7 +162,12 @@ Submits one or more backtesting jobs. Each element in `params` is an independent
       "batchesFixedSize": null,
       "parentBlobShnarf": null,
       "tracesApi": {
-        "endpoint": "http://<traces-node-ip>:8545",
+        "endpoint": "http://<traces-counters-node>:8545",
+        "version": "v2",
+        "requestLimitPerEndpoint": 1
+      },
+      "tracesConflationApi": {
+        "endpoint": "http://<traces-conflation-node>:8545",
         "version": "v2",
         "requestLimitPerEndpoint": 1
       },
@@ -165,6 +180,8 @@ Submits one or more backtesting jobs. Each element in `params` is an independent
   ]
 }
 ```
+
+To use **one** traces base URL for both counters and conflated traces, omit the `tracesConflationApi` object entirely; only `tracesApi` is required in that case.
 
 **curl:**
 
@@ -185,7 +202,12 @@ curl -X POST http://localhost:9546 \
         "batchesFixedSize": null,
         "parentBlobShnarf": null,
         "tracesApi": {
-          "endpoint": "http://<traces-node-ip>:8545",
+          "endpoint": "http://<traces-counters-node>:8545",
+          "version": "beta-v5.0-rc6",
+          "requestLimitPerEndpoint": 1
+        },
+        "tracesConflationApi": {
+          "endpoint": "http://<traces-conflation-node>:8546",
           "version": "beta-v5.0-rc6",
           "requestLimitPerEndpoint": 1
         },
@@ -247,19 +269,23 @@ curl -X POST http://localhost:9546 \
 
 ### Field Reference
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `startBlockNumber` | integer | ✓ | First block of the range to backtest (inclusive) |
-| `endBlockNumber` | integer | ✓ | Last block of the range to backtest (inclusive) |
-| `blobCompressorVersion` | string | ✓ | Compressor version to use: `V1_2`, `V2`, or `V3` |
-| `batchesFixedSize` | integer\|null | | Override batch size; `null` uses calculator-driven batching |
-| `parentBlobShnarf` | string\|null | | Hex-encoded parent shnarf to chain from; `null` starts fresh |
-| `tracesApi.endpoint` | string | ✓ | Traces API URL (typically the backtesting traces node) |
-| `tracesApi.version` | string | ✓ | Traces API version string |
-| `tracesApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to the traces endpoint |
-| `shomeiApi.endpoint` | string | ✓ | State manager (Shomei) URL |
-| `shomeiApi.version` | string | ✓ | Shomei API version string |
-| `shomeiApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to Shomei |
+| Field | Type | Required | Description                                                                                                                                   |
+|-------|------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `startBlockNumber` | integer | ✓ | First block of the range to backtest (inclusive)                                                                                              |
+| `endBlockNumber` | integer | ✓ | Last block of the range to backtest (inclusive)                                                                                               |
+| `blobCompressorVersion` | string | ✓ | Compressor version: `V3` or above for backtesting                                                                            |
+| `batchesFixedSize` | integer\|null | | Override batch size; `null` uses calculator-driven batching                                                                                   |
+| `parentBlobShnarf` | string\|null | | Hex-encoded parent shnarf to chain from; `null` starts fresh                                                                                  |
+| `tracesApi.endpoint` | string | ✓ | Traces API URL for `linea_getBlockTracesCountersV2`                                                                                           |
+| `tracesApi.version` | string | ✓ | Traces API version; when `tracesConflationApi` is set, must match its `version`                                                       |
+| `tracesApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to the counters traces client                                                                                         |
+| `tracesConflationApi` | object\|omitted | | Optional. If omitted, `tracesApi` is also used for `linea_generateConflatedTracesToFileV2`. If present, split-traces mode; nested fields apply. |
+| `tracesConflationApi.endpoint` | string | If split | Traces API URL for `linea_generateConflatedTracesToFileV2` (different base URL than `tracesApi` when using dedicated conflation nodes)        |
+| `tracesConflationApi.version` | string | If split | Must be identical to `tracesApi.version`                                                                                                      |
+| `tracesConflationApi.requestLimitPerEndpoint` | integer | If split | Max concurrent requests to the conflation traces client                                                                                       |
+| `shomeiApi.endpoint` | string | ✓ | State manager (Shomei) URL                                                                                                                    |
+| `shomeiApi.version` | string | ✓ | Shomei API version string                                                                                                                     |
+| `shomeiApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to Shomei                                                                                                             |
 
 ## Test Coverage
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how backtesting builds `traces` client configuration and adds new validation rules, which could reject previously accepted job requests or route traces traffic incorrectly if misconfigured.
> 
> **Overview**
> Backtesting jobs submitted via `conflation_createProverRequests` can now optionally provide a separate `tracesConflationApi` endpoint, allowing counters (`linea_getBlockTracesCountersV2`) and conflated traces generation (`linea_generateConflatedTracesToFileV2`) to be routed to different traces nodes.
> 
> `ConflationBacktestingApp` now (a) validates no overlap between backtesting traces endpoints and the coordinator’s live traces endpoints, and (b) enforces matching `version` strings when `tracesConflationApi` is set; it also updates how the coordinator `traces` config is constructed depending on whether a split endpoint is provided. Defaults for backtesting `requestLimitPerEndpoint` are reduced from `10` to `1`, tests are updated, and docs are expanded to describe the new field and validation rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be76d5d3bd8f14a3fcd0b5f807e11e5d1d48530f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->