### PR TITLE
feat(postman): prefix signer private key with 0x when missing

### DIFF
--- a/postman/src/application/postman/app/config/__tests__/envLoader.test.ts
+++ b/postman/src/application/postman/app/config/__tests__/envLoader.test.ts
@@ -39,6 +39,27 @@ describe("loadPostmanOptionsFromEnv", () => {
     });
   });
 
+  it("should prefix L1/L2 signer private keys with 0x when missing", async () => {
+    await withEnv(
+      {
+        ...TEST_ENV_VARS,
+        L1_SIGNER_PRIVATE_KEY: TEST_L1_SIGNER_PRIVATE_KEY.slice(2),
+        L2_SIGNER_PRIVATE_KEY: TEST_L2_SIGNER_PRIVATE_KEY.slice(2),
+      },
+      () => {
+        const options = loadPostmanOptionsFromEnv();
+        expect(options.l1Options.claiming.signer).toEqual({
+          type: "private-key",
+          privateKey: TEST_L1_SIGNER_PRIVATE_KEY,
+        });
+        expect(options.l2Options.claiming.signer).toEqual({
+          type: "private-key",
+          privateKey: TEST_L2_SIGNER_PRIVATE_KEY,
+        });
+      },
+    );
+  });
+
   it("should build web3signer config when L1_SIGNER_TYPE is web3signer", async () => {
     await withEnv(
       {

--- a/postman/src/application/postman/app/config/envLoader.ts
+++ b/postman/src/application/postman/app/config/envLoader.ts
@@ -1,6 +1,10 @@
 import { PostmanOptions } from "./config";
 import { SignerConfig } from "../../../../infrastructure/blockchain/viem/signers/SignerConfig";
 
+function normalizePrivateKeyHex(raw: string): `0x${string}` {
+  return (raw.startsWith("0x") ? raw : `0x${raw}`) as `0x${string}`;
+}
+
 function buildSignerConfig(prefix: "L1" | "L2"): SignerConfig {
   const signerType = process.env[`${prefix}_SIGNER_TYPE`] ?? "private-key";
 
@@ -33,7 +37,7 @@ function buildSignerConfig(prefix: "L1" | "L2"): SignerConfig {
 
   return {
     type: "private-key",
-    privateKey: (process.env[`${prefix}_SIGNER_PRIVATE_KEY`] ?? "0x") as `0x${string}`,
+    privateKey: normalizePrivateKeyHex(process.env[`${prefix}_SIGNER_PRIVATE_KEY`] ?? "0x"),
   };
 }
 


### PR DESCRIPTION
Made-with: Cursor

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested normalization change limited to env parsing for private-key signers; no protocol or persistence behavior changes.
> 
> **Overview**
> Ensures `L1_SIGNER_PRIVATE_KEY`/`L2_SIGNER_PRIVATE_KEY` env values are accepted even when they omit the `0x` prefix by normalizing them before building the `private-key` signer config.
> 
> Adds a Jest test covering the missing-prefix case to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9a231bd0a92c6ee0aaadf7f0ac8b8804740d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->