### PR TITLE
[ZkTracer] handle ECALL

### DIFF
--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -143,6 +143,7 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
         if funct3 == FUNCT3_ECALL {
             // imm12 is interpreted as funct12 for SYSTEM opcode
             if imm12 == FUNCT12_ECALL {
+                // Note: as we don't fully support CSR, we use ECALL as generic STOP instruction for now
                 new_pc = MAX_UINT_64 // set the stop signal to end the program execution
             } else if imm12 == FUNCT12_EBREAK {
                 printf "[ERROR] EBREAK instruction triggered\n"

--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -141,7 +141,7 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
     else if opcode == SYSTEM {
         // imm12 is interpreted as funct12 for SYSTEM opcode
         if imm12 == FUNCT12_ECALL {
-            pc = MAX_UINT_64 // set the stop signal to end the program execution
+            new_pc = MAX_UINT_64 // set the stop signal to end the program execution
         } else if imm12 == FUNCT12_EBREAK {
             printf "[ERROR] EBREAK instruction triggered\n"
         } else {

--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -141,7 +141,7 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
     else if opcode == SYSTEM {
         // imm12 is interpreted as funct12 for SYSTEM opcode
         if imm12 == FUNCT12_ECALL {
-            //TODO the stuff
+            pc = MAX_UINT_64 // set the stop signal to end the program execution
         } else if imm12 == FUNCT12_EBREAK {
             printf "[ERROR] EBREAK instruction triggered\n"
         } else {

--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -130,15 +130,15 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
         } else if (funct3 == FUNCT3_SRAIW) && (funct7 == FUNCT7_SRAIW) {
             registers[rd] = sgn_extension_u32_u64(_ashr_u32(registers[rs1], uimm5))
         }
-    } 
-    
-    else if opcode == JALR {
+    }
+
+     else if opcode == JALR {
         // only instruction is JALR, no need to switch over funct3
         new_pc = ((registers[rs1] + signext_imm12_64) & MASK_64_ERASE_LAST_BIT) as Address
         registers[rd] = (pc + 4) as DoubleWord
-    } 
-    
-    else if opcode == SYSTEM {
+    }
+
+     else if opcode == SYSTEM {
         // imm12 is interpreted as funct12 for SYSTEM opcode
         if imm12 == FUNCT12_ECALL {
             new_pc = MAX_UINT_64 // set the stop signal to end the program execution

--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -130,13 +130,23 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
         } else if (funct3 == FUNCT3_SRAIW) && (funct7 == FUNCT7_SRAIW) {
             registers[rd] = sgn_extension_u32_u64(_ashr_u32(registers[rs1], uimm5))
         }
-    } else if opcode == JALR {
+    } 
+    
+    else if opcode == JALR {
         // only instruction is JALR, no need to switch over funct3
         new_pc = ((registers[rs1] + signext_imm12_64) & MASK_64_ERASE_LAST_BIT) as Address
         registers[rd] = (pc + 4) as DoubleWord
-    } else if opcode == SYSTEM {
-        // TODO: implement me ...
-        printf "[ERROR] SYSTEM instruction with funct3 %b\n has been triggered, not implemented", funct3
+    } 
+    
+    else if opcode == SYSTEM {
+        // imm12 is interpreted as funct12 for SYSTEM opcode
+        if imm12 == FUNCT12_ECALL {
+            //TODO the stuff
+        } else if imm12 == FUNCT12_EBREAK {
+            printf "[ERROR] EBREAK instruction triggered\n"
+        } else {
+            printf "[ERROR] SYSTEM instruction with funct3 %b\n has been triggered, not implemented", funct3
+        }
     }
 
     // TODO: should never be reached

--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -139,11 +139,14 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
     }
 
      else if opcode == SYSTEM {
-        // imm12 is interpreted as funct12 for SYSTEM opcode
-        if imm12 == FUNCT12_ECALL {
-            new_pc = MAX_UINT_64 // set the stop signal to end the program execution
-        } else if imm12 == FUNCT12_EBREAK {
-            printf "[ERROR] EBREAK instruction triggered\n"
+        // note: same funct3 for ECALL and EBREAK
+        if funct3 == FUNCT3_ECALL {
+            // imm12 is interpreted as funct12 for SYSTEM opcode
+            if imm12 == FUNCT12_ECALL {
+                new_pc = MAX_UINT_64 // set the stop signal to end the program execution
+            } else if imm12 == FUNCT12_EBREAK {
+                printf "[ERROR] EBREAK instruction triggered\n"
+            }
         } else {
             printf "[ERROR] SYSTEM instruction with funct3 %b\n has been triggered, not implemented", funct3
         }

--- a/arithmetization/src/main/riscv/main.zkc
+++ b/arithmetization/src/main/riscv/main.zkc
@@ -17,7 +17,6 @@ fn main<ram, registers>() {
     var pc:Address = ENTRY_POINT
     var opcode:Opcode
     var instruction:Instruction
-    var stop_signal:u1 = 0
     var length:Address = riscV_program_length[0]
 
     // copy public inputs and r5-program into the RAM
@@ -30,7 +29,8 @@ fn main<ram, registers>() {
 
     printf "program length=%d\n", riscV_program_length[0]
 
-    while stop_signal == 0 && pc<length {
+    // We interpret pc == MAX_UINT_64 as the stop signal, which is set by the ecall instruction
+    while pc != MAX_UINT_64 {
         printf "PC=%x\n", pc
         instruction = read_32(pc) as Instruction
         pc = interpreter(instruction, pc)

--- a/arithmetization/src/main/riscv/utils/constants.zkc
+++ b/arithmetization/src/main/riscv/utils/constants.zkc
@@ -255,6 +255,10 @@ const FUNCT3_SRAIW:Funct3 = 0b101, FUNCT7_SRAIW:Funct7 = 0b0100000 // Shift Righ
 // JALR
 const FUNCT3_JALR:Funct3 = 0b000 // JALR
 
+// SYSTEM
+const FUNCT3_ECALL:Funct3 = 0b000, FUNCT12_ECALL:Funct12 = 0b000000000000 // ECALL
+const FUNCT3_EBREAK:Funct3 = 0b000, FUNCT12_EBREAK:Funct12 = 0b000000000001 // EBREAK
+
 // ======================
 // S-type funct3 values
 // ======================

--- a/arithmetization/src/main/riscv/utils/type.zkc
+++ b/arithmetization/src/main/riscv/utils/type.zkc
@@ -9,6 +9,7 @@ type Type = u3
 type Funct3 = u3
 type Funct6 = u6
 type Funct7 = u7
+type Funct12 = u12
 type UImm5 = u5
 type UImm6 = u6
 type Imm12 = u12


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes program termination semantics by treating `ECALL` as a generic stop and updating the main execution loop to rely on a sentinel `pc` value; incorrect decoding could prematurely halt or fail to halt programs.
> 
> **Overview**
> Adds initial handling for RISC-V `SYSTEM` I-type instructions: `ECALL` now sets `new_pc` to `MAX_UINT_64` as a sentinel stop condition, while `EBREAK` emits an error and other `SYSTEM` variants remain unimplemented.
> 
> Updates the RISC-V `main` loop to run until `pc == MAX_UINT_64` (removing the prior `stop_signal`/`pc < length` condition), and introduces a `Funct12` type plus `FUNCT12_*` constants to decode `ECALL`/`EBREAK`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f46ebbf0299e5d1d34f159b919c0a28d9dd826d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->