### PR TITLE
fix(sequencer): enforce EIP-7825 tx gas cap

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/TransactionGasLimitTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/TransactionGasLimitTest.kt
@@ -8,6 +8,7 @@
  */
 package linea.plugin.acc.test
 
+import net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT
 import org.assertj.core.api.Assertions.assertThat
 import org.hyperledger.besu.datatypes.Hash
 import org.hyperledger.besu.tests.acceptance.dsl.account.Accounts
@@ -71,8 +72,7 @@ class TransactionGasLimitTest : LineaPluginPoSTestBase() {
     )
 
     assertThat(txTooBigResp.hasError()).isTrue()
-    assertThat(txTooBigResp.error.message)
-      .isEqualTo("Gas limit of transaction is greater than the allowed max of 9000000")
+    assertThat(txTooBigResp.error.message).isEqualTo(EIP_7825_GAS_LIMIT_ERROR_MESSAGE)
   }
 
   /**
@@ -116,8 +116,7 @@ class TransactionGasLimitTest : LineaPluginPoSTestBase() {
     )
 
     assertThat(txTooBigResp.hasError()).isTrue()
-    assertThat(txTooBigResp.error.message)
-      .isEqualTo("Gas limit of transaction is greater than the allowed max of 9000000")
+    assertThat(txTooBigResp.error.message).isEqualTo(EIP_7825_GAS_LIMIT_ERROR_MESSAGE)
 
     expectedConfirmedTxs
       .map { it.bytes.toHexString() }
@@ -125,8 +124,10 @@ class TransactionGasLimitTest : LineaPluginPoSTestBase() {
   }
 
   companion object {
-    val MAX_TX_GAS_LIMIT = DefaultGasProvider.GAS_LIMIT.toInt()
+    val MAX_TX_GAS_LIMIT = EIP_7825_MAX_TRANSACTION_GAS_LIMIT
     private val GAS_PRICE = DefaultGasProvider.GAS_PRICE
     private val VALUE = BigInteger.ZERO
+    private const val EIP_7825_GAS_LIMIT_ERROR_MESSAGE =
+      "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216"
   }
 }

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/TransactionGasLimitTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/TransactionGasLimitTest.kt
@@ -72,7 +72,7 @@ class TransactionGasLimitTest : LineaPluginPoSTestBase() {
     )
 
     assertThat(txTooBigResp.hasError()).isTrue()
-    assertThat(txTooBigResp.error.message).isEqualTo(EIP_7825_GAS_LIMIT_ERROR_MESSAGE)
+    assertThat(txTooBigResp.error.message).isEqualTo(DIRECT_RPC_GAS_LIMIT_ERROR_MESSAGE)
   }
 
   /**
@@ -116,7 +116,7 @@ class TransactionGasLimitTest : LineaPluginPoSTestBase() {
     )
 
     assertThat(txTooBigResp.hasError()).isTrue()
-    assertThat(txTooBigResp.error.message).isEqualTo(EIP_7825_GAS_LIMIT_ERROR_MESSAGE)
+    assertThat(txTooBigResp.error.message).isEqualTo(DIRECT_RPC_GAS_LIMIT_ERROR_MESSAGE)
 
     expectedConfirmedTxs
       .map { it.bytes.toHexString() }
@@ -127,7 +127,6 @@ class TransactionGasLimitTest : LineaPluginPoSTestBase() {
     val MAX_TX_GAS_LIMIT = EIP_7825_MAX_TRANSACTION_GAS_LIMIT
     private val GAS_PRICE = DefaultGasProvider.GAS_PRICE
     private val VALUE = BigInteger.ZERO
-    private const val EIP_7825_GAS_LIMIT_ERROR_MESSAGE =
-      "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216"
+    private const val DIRECT_RPC_GAS_LIMIT_ERROR_MESSAGE = "Transaction gas limit cap exceeded"
   }
 }

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/EstimateGasTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/EstimateGasTest.kt
@@ -23,6 +23,7 @@ import linea.plugin.acc.test.LineaPluginPoSTestBase
 import linea.plugin.acc.test.TestCommandLineOptionsBuilder
 import net.consensys.linea.bl.TransactionProfitabilityCalculator
 import net.consensys.linea.config.LineaProfitabilityCliOptions
+import net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT
 import net.consensys.linea.rpc.methods.LineaEstimateGas
 import net.consensys.linea.utils.CachingTransactionCompressor
 import org.apache.tuweni.bytes.Bytes
@@ -374,6 +375,29 @@ open class EstimateGasTest : LineaPluginPoSTestBase() {
     )
     val reqLinea = BadLineaEstimateGasRequest(callParams)
     val respLinea = reqLinea.execute(minerNode.nodeRequests())
+    assertThat(respLinea.code).isEqualTo(RpcErrorType.INVALID_PARAMS.code)
+    assertThat(respLinea.message).isEqualTo(RpcErrorType.INVALID_PARAMS.message)
+  }
+
+  @Test
+  fun explicitGasAboveEip7825CapReturnsInvalidParams() {
+    val sender = accounts.secondaryBenefactor
+    val callParams = CallParams(
+      chainId = null,
+      from = sender.address,
+      nonce = null,
+      to = sender.address,
+      value = null,
+      data = Bytes.EMPTY.toHexString(),
+      gas = (EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L).toString(),
+      gasPrice = null,
+      maxFeePerGas = null,
+      maxPriorityFeePerGas = null,
+    )
+
+    val reqLinea = BadLineaEstimateGasRequest(callParams)
+    val respLinea = reqLinea.execute(minerNode.nodeRequests())
+
     assertThat(respLinea.code).isEqualTo(RpcErrorType.INVALID_PARAMS.code)
     assertThat(respLinea.message).isEqualTo(RpcErrorType.INVALID_PARAMS.message)
   }

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/SendBundleEip7825GasLimitTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/SendBundleEip7825GasLimitTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package linea.plugin.acc.test.rpc.linea
+
+import linea.plugin.acc.test.TestCommandLineOptionsBuilder
+import linea.plugin.acc.test.rpc.SendBundleRequest
+import net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigInteger
+
+class SendBundleEip7825GasLimitTest : AbstractSendBundleTest() {
+
+  override fun getTestCliOptions(): List<String> {
+    return TestCommandLineOptionsBuilder()
+      .set("--plugin-linea-max-tx-gas-limit=", "24000000")
+      .set(
+        "--plugin-linea-module-limit-file-path=",
+        getResourcePath("/moduleLimitsLimitless.toml"),
+      )
+      .set("--plugin-linea-limitless-enabled=", "true")
+      .build()
+  }
+
+  @Test
+  fun bundleTxAboveEip7825CapIsRejectedWhenConfiguredLimitIsHigher() {
+    val mulmodExecutor = deployMulmodExecutor()
+    val mulmodTx = mulmodOperation(
+      mulmodExecutor,
+      accounts.primaryBenefactor,
+      1,
+      1_000,
+      BigInteger.valueOf(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L),
+    )
+
+    val sendBundleRequest =
+      SendBundleRequest(BundleParams(arrayOf(mulmodTx.rawTx), Integer.toHexString(2)))
+    val sendBundleResponse = sendBundleRequest.execute(minerNode.nodeRequests())
+
+    assertThat(sendBundleResponse.hasError()).isTrue()
+    assertThat(sendBundleResponse.error.message)
+      .contains("Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216")
+  }
+}

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/SendBundleTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/SendBundleTest.kt
@@ -109,7 +109,8 @@ class SendBundleTest : AbstractSendBundleTest() {
     assertThat(sendBundleResponse.error.message)
       .isEqualTo(
         "Invalid transaction in bundle: hash 0x3f6ff4384305623a7c5cbf05afd9b97c8409be23c4b39c7b16d60001aee4340b," +
-          " reason: Gas limit of transaction is greater than the allowed max of 9000000",
+          " reason: Gas limit 9000001 exceeds configured maximum transaction gas limit of 9000000 " +
+          "(EIP-7825 maximum transaction gas limit is 16777216)",
       )
   }
 

--- a/besu-plugins/linea-sequencer/docs/plugins.md
+++ b/besu-plugins/linea-sequencer/docs/plugins.md
@@ -96,6 +96,10 @@ This includes setting limits such as `TraceLineLimit`, `maxTxGasLimit`, and chec
 of a transaction, and enforcing deny list rules against sender, recipient, and EIP-7702 authorization list entries
 (recovered authority and delegation target address). Per-transaction calldata size validation is optional and only enabled when
 `--plugin-linea-max-tx-calldata-size` is set.
+Since EIP-7825, the effective transaction gas limit is capped at `16_777_216` even when
+`--plugin-linea-max-tx-gas-limit` is configured higher. Values above `16_777_216` are accepted for compatibility with
+existing profiles but do not raise the effective limit above the EIP-7825 cap. Values below `16_777_216` remain stricter
+local limits.
 The validators are in the package `net.consensys.linea.sequencer.txpoolvalidation.validators`.
 
 #### CLI options
@@ -103,7 +107,7 @@ The validators are in the package `net.consensys.linea.sequencer.txpoolvalidatio
 | Command Line Argument                                    | Default Value     |
 |----------------------------------------------------------|-------------------|
 | `--plugin-linea-deny-list-path`                          | lineaDenyList.txt |
-| `--plugin-linea-max-tx-gas-limit`                        | 30_000_000        |
+| `--plugin-linea-max-tx-gas-limit`                        | 16_777_216        |
 | `--plugin-linea-max-tx-calldata-size`                    | not set (disabled)|
 | `--plugin-linea-tx-pool-simulation-check-api-enabled`    | false             |
 | `--plugin-linea-tx-pool-simulation-check-p2p-enabled`    | false             |

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorCliOptions.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaTransactionPoolValidatorCliOptions.java
@@ -9,6 +9,8 @@
 
 package net.consensys.linea.config;
 
+import static net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT;
+
 import com.google.common.base.MoreObjects;
 import jakarta.validation.constraints.Positive;
 import java.io.File;
@@ -33,7 +35,7 @@ public class LineaTransactionPoolValidatorCliOptions implements LineaCliOptions 
       "--plugin-linea-bundle-overriding-deny-list-path";
 
   public static final String MAX_TX_GAS_LIMIT_OPTION = "--plugin-linea-max-tx-gas-limit";
-  public static final int DEFAULT_MAX_TRANSACTION_GAS_LIMIT = 30_000_000;
+  public static final int DEFAULT_MAX_TRANSACTION_GAS_LIMIT = EIP_7825_MAX_TRANSACTION_GAS_LIMIT;
 
   public static final String MAX_TX_CALLDATA_SIZE = "--plugin-linea-max-tx-calldata-size";
 

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/TransactionGasLimitCap.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/TransactionGasLimitCap.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+package net.consensys.linea.config;
+
+public final class TransactionGasLimitCap {
+  public static final int EIP_7825_MAX_TRANSACTION_GAS_LIMIT = 16_777_216;
+
+  private TransactionGasLimitCap() {}
+
+  public static int effectiveMaxTxGasLimit(final int configuredMaxTxGasLimit) {
+    return Math.min(configuredMaxTxGasLimit, EIP_7825_MAX_TRANSACTION_GAS_LIMIT);
+  }
+
+  public static String gasLimitExceededMessage(
+      final long gasLimit, final int configuredMaxTxGasLimit) {
+    final int effectiveLimit = effectiveMaxTxGasLimit(configuredMaxTxGasLimit);
+
+    if (configuredMaxTxGasLimit < EIP_7825_MAX_TRANSACTION_GAS_LIMIT) {
+      return "Gas limit "
+          + gasLimit
+          + " exceeds configured maximum transaction gas limit of "
+          + effectiveLimit
+          + " (EIP-7825 maximum transaction gas limit is "
+          + EIP_7825_MAX_TRANSACTION_GAS_LIMIT
+          + ")";
+    }
+
+    return "Gas limit "
+        + gasLimit
+        + " exceeds EIP-7825 maximum transaction gas limit of "
+        + effectiveLimit;
+  }
+}

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaEstimateGas.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/rpc/methods/LineaEstimateGas.java
@@ -9,6 +9,8 @@
 
 package net.consensys.linea.rpc.methods;
 
+import static net.consensys.linea.config.TransactionGasLimitCap.effectiveMaxTxGasLimit;
+import static net.consensys.linea.config.TransactionGasLimitCap.gasLimitExceededMessage;
 import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.MODULE_NOT_DEFINED;
 import static net.consensys.linea.sequencer.modulelimit.ModuleLineCountValidator.ModuleLineCountResult.TX_MODULE_LINE_COUNT_OVERFLOW;
 import static net.consensys.linea.zktracer.Fork.fromMainnetHardforkIdToTracerFork;
@@ -162,6 +164,7 @@ public class LineaEstimateGas {
 
       log.debug("[{}] Parsed call parameters: {}", logId, callParameters);
       final long gasEstimation = getGasEstimation(callParameters, maybeStateOverrides, logId);
+      validateEstimatedGasLimit(gasEstimation);
       log.atDebug()
           .setMessage("[{}] Gas estimation {}")
           .addArgument(logId)
@@ -339,9 +342,22 @@ public class LineaEstimateGas {
     }
 
     final var gasLimit = callParameters.getGas().orElse(0L);
-    if (gasLimit > txValidatorConf.maxTxGasLimit()) {
+    validateCallerProvidedGasLimit(gasLimit);
+  }
+
+  private void validateCallerProvidedGasLimit(final long gasLimit) {
+    if (gasLimit > effectiveMaxTxGasLimit(txValidatorConf.maxTxGasLimit())) {
       throw new InvalidJsonRpcParameters(
-          "gasLimit above maximum of: " + txValidatorConf.maxTxGasLimit());
+          gasLimitExceededMessage(gasLimit, txValidatorConf.maxTxGasLimit()));
+    }
+  }
+
+  @VisibleForTesting
+  void validateEstimatedGasLimit(final long gasEstimation) {
+    if (gasEstimation > effectiveMaxTxGasLimit(txValidatorConf.maxTxGasLimit())) {
+      throw new PluginRpcEndpointException(
+          new EstimateGasError(
+              gasLimitExceededMessage(gasEstimation, txValidatorConf.maxTxGasLimit())));
     }
   }
 

--- a/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidator.java
@@ -8,8 +8,11 @@
  */
 package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
+import static net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT;
+import static net.consensys.linea.config.TransactionGasLimitCap.effectiveMaxTxGasLimit;
+import static net.consensys.linea.config.TransactionGasLimitCap.gasLimitExceededMessage;
+
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolValidator;
@@ -19,16 +22,30 @@ import org.hyperledger.besu.plugin.services.txvalidator.PluginTransactionPoolVal
  * gas limit of a transaction could be less than the block gas limit.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class GasLimitValidator implements PluginTransactionPoolValidator {
-  final int maxTxGasLimit;
+  final int configuredMaxTxGasLimit;
+  final int effectiveMaxTxGasLimit;
+
+  public GasLimitValidator(final int maxTxGasLimit) {
+    this.configuredMaxTxGasLimit = maxTxGasLimit;
+    this.effectiveMaxTxGasLimit = effectiveMaxTxGasLimit(maxTxGasLimit);
+
+    if (maxTxGasLimit > EIP_7825_MAX_TRANSACTION_GAS_LIMIT) {
+      log.warn(
+          "Configured maximum transaction gas limit {} exceeds EIP-7825 maximum transaction gas "
+              + "limit {}; using effective maximum transaction gas limit {}",
+          maxTxGasLimit,
+          EIP_7825_MAX_TRANSACTION_GAS_LIMIT,
+          effectiveMaxTxGasLimit);
+    }
+  }
 
   @Override
   public Optional<String> validateTransaction(
       final Transaction transaction, final boolean isLocal, final boolean hasPriority) {
-    if (transaction.getGasLimit() > maxTxGasLimit) {
+    if (transaction.getGasLimit() > effectiveMaxTxGasLimit) {
       final String errMsg =
-          "Gas limit of transaction is greater than the allowed max of " + maxTxGasLimit;
+          gasLimitExceededMessage(transaction.getGasLimit(), configuredMaxTxGasLimit);
       log.debug(errMsg);
       return Optional.of(errMsg);
     }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/TransactionGasLimitCapTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/TransactionGasLimitCapTest.java
@@ -45,8 +45,7 @@ class TransactionGasLimitCapTest {
         TransactionGasLimitCap.gasLimitExceededMessage(gasLimit, configuredMaxTxGasLimit);
 
     assertThat(message)
-        .isEqualTo(
-            "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
+        .isEqualTo("Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
   }
 
   @Test

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/TransactionGasLimitCapTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/config/TransactionGasLimitCapTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+package net.consensys.linea.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TransactionGasLimitCapTest {
+
+  @Test
+  void effectiveMaxTxGasLimitUsesConfiguredLimitWhenLowerThanEip7825Cap() {
+    final int configuredMaxTxGasLimit = 9_000_000;
+
+    final int effectiveMaxTxGasLimit =
+        TransactionGasLimitCap.effectiveMaxTxGasLimit(configuredMaxTxGasLimit);
+
+    assertThat(effectiveMaxTxGasLimit).isEqualTo(configuredMaxTxGasLimit);
+  }
+
+  @Test
+  void effectiveMaxTxGasLimitUsesEip7825CapWhenConfiguredLimitIsHigher() {
+    final int configuredMaxTxGasLimit = 24_000_000;
+
+    final int effectiveMaxTxGasLimit =
+        TransactionGasLimitCap.effectiveMaxTxGasLimit(configuredMaxTxGasLimit);
+
+    assertThat(effectiveMaxTxGasLimit)
+        .isEqualTo(TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT);
+  }
+
+  @Test
+  void gasLimitExceededMessageUsesEip7825CapMessageWhenConfiguredLimitIsHigher() {
+    final long gasLimit = 16_777_217L;
+    final int configuredMaxTxGasLimit = 24_000_000;
+
+    final String message =
+        TransactionGasLimitCap.gasLimitExceededMessage(gasLimit, configuredMaxTxGasLimit);
+
+    assertThat(message)
+        .isEqualTo(
+            "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
+  }
+
+  @Test
+  void gasLimitExceededMessageUsesConfiguredLimitMessageWhenConfiguredLimitIsLower() {
+    final long gasLimit = 9_000_001L;
+    final int configuredMaxTxGasLimit = 9_000_000;
+
+    final String message =
+        TransactionGasLimitCap.gasLimitExceededMessage(gasLimit, configuredMaxTxGasLimit);
+
+    assertThat(message)
+        .isEqualTo(
+            "Gas limit 9000001 exceeds configured maximum transaction gas limit of 9000000 "
+                + "(EIP-7825 maximum transaction gas limit is 16777216)");
+  }
+}

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaEstimateGasTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaEstimateGasTest.java
@@ -13,9 +13,19 @@ import static net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import net.consensys.linea.bl.TransactionProfitabilityCalculator;
 import net.consensys.linea.config.LineaProfitabilityConfiguration;
@@ -23,12 +33,22 @@ import net.consensys.linea.config.LineaRpcConfiguration;
 import net.consensys.linea.config.LineaTracerConfiguration;
 import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
 import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import org.hyperledger.besu.datatypes.StateOverrideMap;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.transaction.ImmutableCallParameter;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
 import org.hyperledger.besu.plugin.services.TransactionSimulationService;
+import org.hyperledger.besu.plugin.services.TransactionSimulationService.SimulationParameters;
 import org.hyperledger.besu.plugin.services.WorldStateService;
 import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
+import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
+import org.hyperledger.besu.plugin.services.rpc.PluginRpcResponse;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 import org.junit.jupiter.api.Test;
 
 class LineaEstimateGasTest {
@@ -40,17 +60,21 @@ class LineaEstimateGasTest {
 
   @Test
   void acceptsEstimateAtEip7825MaxWhenConfiguredLimitIsHigher() {
-    final LineaEstimateGas method = createLineaEstimateGas(24_000_000);
+    final TestContext context = createLineaEstimateGas(24_000_000);
 
-    assertDoesNotThrow(() -> method.validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT));
+    assertDoesNotThrow(
+        () -> context.method().validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT));
   }
 
   @Test
   void rejectsEstimateAboveEip7825MaxWhenConfiguredLimitIsHigher() {
-    final LineaEstimateGas method = createLineaEstimateGas(24_000_000);
+    final TestContext context = createLineaEstimateGas(24_000_000);
 
     assertThatThrownBy(
-            () -> method.validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L))
+            () ->
+                context
+                    .method()
+                    .validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L))
         .isInstanceOf(PluginRpcEndpointException.class)
         .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
         .satisfies(
@@ -60,9 +84,9 @@ class LineaEstimateGasTest {
 
   @Test
   void rejectsEstimateAboveConfiguredMaxWhenConfiguredLimitIsLower() {
-    final LineaEstimateGas method = createLineaEstimateGas(9_000_000);
+    final TestContext context = createLineaEstimateGas(9_000_000);
 
-    assertThatThrownBy(() -> method.validateEstimatedGasLimit(9_000_001L))
+    assertThatThrownBy(() -> context.method().validateEstimatedGasLimit(9_000_001L))
         .isInstanceOf(PluginRpcEndpointException.class)
         .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
         .satisfies(
@@ -70,13 +94,64 @@ class LineaEstimateGasTest {
                 assertThat(error.getMessage()).isEqualTo(CONFIGURED_LIMIT_EXCEEDED_MESSAGE));
   }
 
-  private static LineaEstimateGas createLineaEstimateGas(final int maxTxGasLimit) {
+  @Test
+  void executeRejectsEstimateAboveEip7825MaxBeforeSimulationAndProfitabilityCalculation() {
+    final TestContext context = createLineaEstimateGas(24_000_000);
+    final PluginRpcRequest request = request(callParameter());
+    when(context.besuConfiguration().getMinGasPrice()).thenReturn(Wei.ZERO);
+    when(context.blockchainService().getNextBlockBaseFee()).thenReturn(Optional.of(Wei.ZERO));
+    when(context.rpcEndpointService().call(eq("eth_estimateGas"), any(Object[].class)))
+        .thenReturn(successResponse("0x1000001"));
+
+    assertThatThrownBy(() -> context.method().execute(request))
+        .isInstanceOf(PluginRpcEndpointException.class)
+        .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
+        .satisfies(
+            error ->
+                assertThat(error.getMessage()).isEqualTo(EIP_7825_LIMIT_EXCEEDED_MESSAGE));
+    verify(context.transactionSimulationService(), never())
+        .simulate(
+            any(org.hyperledger.besu.datatypes.CallParameter.class),
+            anyStateOverrideMap(),
+            any(ProcessableBlockHeader.class),
+            any(OperationTracer.class),
+            anySimulationParameters());
+    verify(context.transactionProfitabilityCalculator(), never()).getCompressedTxSize(any());
+    verify(context.transactionProfitabilityCalculator(), never())
+        .profitablePriorityFeePerGas(any(), anyDouble(), anyLong(), any(), anyInt());
+  }
+
+  @Test
+  void executeRejectsCallerProvidedGasAboveEip7825MaxWhenConfiguredLimitIsHigher() {
+    final TestContext context = createLineaEstimateGas(24_000_000);
+    final PluginRpcRequest request = request(callParameter(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L));
+
+    assertThatThrownBy(() -> context.method().execute(request))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessage(EIP_7825_LIMIT_EXCEEDED_MESSAGE);
+  }
+
+  @Test
+  void executeRejectsCallerProvidedGasAboveConfiguredMaxWhenConfiguredLimitIsLower() {
+    final TestContext context = createLineaEstimateGas(9_000_000);
+    final PluginRpcRequest request = request(callParameter(9_000_001L));
+
+    assertThatThrownBy(() -> context.method().execute(request))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessage(CONFIGURED_LIMIT_EXCEEDED_MESSAGE);
+  }
+
+  private static TestContext createLineaEstimateGas(final int maxTxGasLimit) {
+    final BesuConfiguration besuConfiguration = mock(BesuConfiguration.class);
+    final TransactionSimulationService transactionSimulationService =
+        mock(TransactionSimulationService.class);
+    final BlockchainService blockchainService = mock(BlockchainService.class);
+    final RpcEndpointService rpcEndpointService = mock(RpcEndpointService.class);
+    final TransactionProfitabilityCalculator transactionProfitabilityCalculator =
+        mock(TransactionProfitabilityCalculator.class);
     final LineaEstimateGas method =
         new LineaEstimateGas(
-            mock(BesuConfiguration.class),
-            mock(TransactionSimulationService.class),
-            mock(BlockchainService.class),
-            mock(RpcEndpointService.class));
+            besuConfiguration, transactionSimulationService, blockchainService, rpcEndpointService);
 
     method.init(
         mock(LineaRpcConfiguration.class),
@@ -97,8 +172,58 @@ class LineaEstimateGasTest {
             .isLimitless(true)
             .build(),
         mock(WorldStateService.class),
-        mock(TransactionProfitabilityCalculator.class));
+        transactionProfitabilityCalculator);
 
-    return method;
+    return new TestContext(
+        method,
+        besuConfiguration,
+        transactionSimulationService,
+        blockchainService,
+        rpcEndpointService,
+        transactionProfitabilityCalculator);
   }
+
+  private static PluginRpcRequest request(final Object... params) {
+    final PluginRpcRequest request = mock(PluginRpcRequest.class);
+    when(request.getParams()).thenReturn(params);
+    return request;
+  }
+
+  private static ImmutableCallParameter callParameter() {
+    return ImmutableCallParameter.builder().build();
+  }
+
+  private static ImmutableCallParameter callParameter(final long gasLimit) {
+    return ImmutableCallParameter.builder().gas(gasLimit).build();
+  }
+
+  private static Optional<StateOverrideMap> anyStateOverrideMap() {
+    return any();
+  }
+
+  private static EnumSet<SimulationParameters> anySimulationParameters() {
+    return any();
+  }
+
+  private static PluginRpcResponse successResponse(final Object result) {
+    return new PluginRpcResponse() {
+      @Override
+      public Object getResult() {
+        return result;
+      }
+
+      @Override
+      public RpcResponseType getType() {
+        return RpcResponseType.SUCCESS;
+      }
+    };
+  }
+
+  private record TestContext(
+      LineaEstimateGas method,
+      BesuConfiguration besuConfiguration,
+      TransactionSimulationService transactionSimulationService,
+      BlockchainService blockchainService,
+      RpcEndpointService rpcEndpointService,
+      TransactionProfitabilityCalculator transactionProfitabilityCalculator) {}
 }

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaEstimateGasTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaEstimateGasTest.java
@@ -72,14 +72,11 @@ class LineaEstimateGasTest {
 
     assertThatThrownBy(
             () ->
-                context
-                    .method()
-                    .validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L))
+                context.method().validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L))
         .isInstanceOf(PluginRpcEndpointException.class)
         .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
         .satisfies(
-            error ->
-                assertThat(error.getMessage()).isEqualTo(EIP_7825_LIMIT_EXCEEDED_MESSAGE));
+            error -> assertThat(error.getMessage()).isEqualTo(EIP_7825_LIMIT_EXCEEDED_MESSAGE));
   }
 
   @Test
@@ -90,8 +87,7 @@ class LineaEstimateGasTest {
         .isInstanceOf(PluginRpcEndpointException.class)
         .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
         .satisfies(
-            error ->
-                assertThat(error.getMessage()).isEqualTo(CONFIGURED_LIMIT_EXCEEDED_MESSAGE));
+            error -> assertThat(error.getMessage()).isEqualTo(CONFIGURED_LIMIT_EXCEEDED_MESSAGE));
   }
 
   @Test
@@ -107,8 +103,7 @@ class LineaEstimateGasTest {
         .isInstanceOf(PluginRpcEndpointException.class)
         .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
         .satisfies(
-            error ->
-                assertThat(error.getMessage()).isEqualTo(EIP_7825_LIMIT_EXCEEDED_MESSAGE));
+            error -> assertThat(error.getMessage()).isEqualTo(EIP_7825_LIMIT_EXCEEDED_MESSAGE));
     verify(context.transactionSimulationService(), never())
         .simulate(
             any(org.hyperledger.besu.datatypes.CallParameter.class),
@@ -124,7 +119,8 @@ class LineaEstimateGasTest {
   @Test
   void executeRejectsCallerProvidedGasAboveEip7825MaxWhenConfiguredLimitIsHigher() {
     final TestContext context = createLineaEstimateGas(24_000_000);
-    final PluginRpcRequest request = request(callParameter(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L));
+    final PluginRpcRequest request =
+        request(callParameter(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L));
 
     assertThatThrownBy(() -> context.method().execute(request))
         .isInstanceOf(InvalidJsonRpcParameters.class)

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaEstimateGasTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaEstimateGasTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+package net.consensys.linea.rpc.methods;
+
+import static net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import java.util.Set;
+import net.consensys.linea.bl.TransactionProfitabilityCalculator;
+import net.consensys.linea.config.LineaProfitabilityConfiguration;
+import net.consensys.linea.config.LineaRpcConfiguration;
+import net.consensys.linea.config.LineaTracerConfiguration;
+import net.consensys.linea.config.LineaTransactionPoolValidatorConfiguration;
+import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.BlockchainService;
+import org.hyperledger.besu.plugin.services.RpcEndpointService;
+import org.hyperledger.besu.plugin.services.TransactionSimulationService;
+import org.hyperledger.besu.plugin.services.WorldStateService;
+import org.hyperledger.besu.plugin.services.exception.PluginRpcEndpointException;
+import org.junit.jupiter.api.Test;
+
+class LineaEstimateGasTest {
+  private static final String EIP_7825_LIMIT_EXCEEDED_MESSAGE =
+      "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216";
+  private static final String CONFIGURED_LIMIT_EXCEEDED_MESSAGE =
+      "Gas limit 9000001 exceeds configured maximum transaction gas limit of 9000000 "
+          + "(EIP-7825 maximum transaction gas limit is 16777216)";
+
+  @Test
+  void acceptsEstimateAtEip7825MaxWhenConfiguredLimitIsHigher() {
+    final LineaEstimateGas method = createLineaEstimateGas(24_000_000);
+
+    assertDoesNotThrow(() -> method.validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT));
+  }
+
+  @Test
+  void rejectsEstimateAboveEip7825MaxWhenConfiguredLimitIsHigher() {
+    final LineaEstimateGas method = createLineaEstimateGas(24_000_000);
+
+    assertThatThrownBy(
+            () -> method.validateEstimatedGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L))
+        .isInstanceOf(PluginRpcEndpointException.class)
+        .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
+        .satisfies(
+            error ->
+                assertThat(error.getMessage()).isEqualTo(EIP_7825_LIMIT_EXCEEDED_MESSAGE));
+  }
+
+  @Test
+  void rejectsEstimateAboveConfiguredMaxWhenConfiguredLimitIsLower() {
+    final LineaEstimateGas method = createLineaEstimateGas(9_000_000);
+
+    assertThatThrownBy(() -> method.validateEstimatedGasLimit(9_000_001L))
+        .isInstanceOf(PluginRpcEndpointException.class)
+        .extracting(exception -> ((PluginRpcEndpointException) exception).getRpcMethodError())
+        .satisfies(
+            error ->
+                assertThat(error.getMessage()).isEqualTo(CONFIGURED_LIMIT_EXCEEDED_MESSAGE));
+  }
+
+  private static LineaEstimateGas createLineaEstimateGas(final int maxTxGasLimit) {
+    final LineaEstimateGas method =
+        new LineaEstimateGas(
+            mock(BesuConfiguration.class),
+            mock(TransactionSimulationService.class),
+            mock(BlockchainService.class),
+            mock(RpcEndpointService.class));
+
+    method.init(
+        mock(LineaRpcConfiguration.class),
+        LineaTransactionPoolValidatorConfiguration.builder()
+            .denyListPath("")
+            .deniedAddresses(Set.of())
+            .bundleOverridingDenyListPath("")
+            .bundleDeniedAddresses(Set.of())
+            .maxTxGasLimit(maxTxGasLimit)
+            .txPoolSimulationCheckApiEnabled(false)
+            .txPoolSimulationCheckP2pEnabled(false)
+            .build(),
+        mock(LineaProfitabilityConfiguration.class),
+        mock(LineaL1L2BridgeSharedConfiguration.class),
+        LineaTracerConfiguration.builder()
+            .moduleLimitsFilePath("")
+            .moduleLimitsMap(Map.of())
+            .isLimitless(true)
+            .build(),
+        mock(WorldStateService.class),
+        mock(TransactionProfitabilityCalculator.class));
+
+    return method;
+  }
+}

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
@@ -33,25 +33,25 @@ public class GasLimitValidatorTest {
   @Test
   public void rejectsTransactionAboveEip7825MaxWhenConfiguredAtEip7825Max() {
     final GasLimitValidator validator = new GasLimitValidator(EIP_7825_MAX_TRANSACTION_GAS_LIMIT);
-    final Transaction transaction = transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L);
+    final Transaction transaction =
+        transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L);
 
     final Optional<String> result = validator.validateTransaction(transaction, false, false);
 
     assertThat(result)
-        .contains(
-            "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
+        .contains("Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
   }
 
   @Test
   public void rejectsTransactionAboveEip7825MaxWhenConfiguredAboveEip7825Max() {
     final GasLimitValidator validator = new GasLimitValidator(24_000_000);
-    final Transaction transaction = transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L);
+    final Transaction transaction =
+        transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L);
 
     final Optional<String> result = validator.validateTransaction(transaction, false, false);
 
     assertThat(result)
-        .contains(
-            "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
+        .contains("Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
   }
 
   @Test

--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/txpoolvalidation/validators/GasLimitValidatorTest.java
@@ -9,44 +9,69 @@
 
 package net.consensys.linea.sequencer.txpoolvalidation.validators;
 
+import static net.consensys.linea.config.TransactionGasLimitCap.EIP_7825_MAX_TRANSACTION_GAS_LIMIT;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.datatypes.Wei;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@Slf4j
-@RequiredArgsConstructor
 public class GasLimitValidatorTest {
-  public static final int MAX_TX_GAS_LIMIT = 9_000_000;
-  private GasLimitValidator gasLimitValidator;
 
-  @BeforeEach
-  public void initialize() {
-    gasLimitValidator = new GasLimitValidator(MAX_TX_GAS_LIMIT);
+  @Test
+  public void acceptsTransactionAtEip7825MaxTransactionGasLimit() {
+    final GasLimitValidator validator = new GasLimitValidator(EIP_7825_MAX_TRANSACTION_GAS_LIMIT);
+    final Transaction transaction = transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT);
+
+    final Optional<String> result = validator.validateTransaction(transaction, false, false);
+
+    assertThat(result).isEmpty();
   }
 
   @Test
-  public void validatedWithValidGasLimit() {
-    final org.hyperledger.besu.ethereum.core.Transaction.Builder builder =
-        org.hyperledger.besu.ethereum.core.Transaction.builder();
-    final org.hyperledger.besu.ethereum.core.Transaction transaction =
-        builder.gasLimit(MAX_TX_GAS_LIMIT).gasPrice(Wei.ZERO).payload(Bytes.EMPTY).build();
-    Assertions.assertEquals(
-        gasLimitValidator.validateTransaction(transaction, false, false), Optional.empty());
+  public void rejectsTransactionAboveEip7825MaxWhenConfiguredAtEip7825Max() {
+    final GasLimitValidator validator = new GasLimitValidator(EIP_7825_MAX_TRANSACTION_GAS_LIMIT);
+    final Transaction transaction = transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L);
+
+    final Optional<String> result = validator.validateTransaction(transaction, false, false);
+
+    assertThat(result)
+        .contains(
+            "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
   }
 
   @Test
-  public void rejectedWithMaxGasLimitPlusOne() {
-    final org.hyperledger.besu.ethereum.core.Transaction.Builder builder =
-        org.hyperledger.besu.ethereum.core.Transaction.builder();
-    final org.hyperledger.besu.ethereum.core.Transaction transaction =
-        builder.gasLimit(MAX_TX_GAS_LIMIT + 1).gasPrice(Wei.ZERO).payload(Bytes.EMPTY).build();
-    Assertions.assertEquals(
-        gasLimitValidator.validateTransaction(transaction, false, false).orElseThrow(),
-        "Gas limit of transaction is greater than the allowed max of " + MAX_TX_GAS_LIMIT);
+  public void rejectsTransactionAboveEip7825MaxWhenConfiguredAboveEip7825Max() {
+    final GasLimitValidator validator = new GasLimitValidator(24_000_000);
+    final Transaction transaction = transactionWithGasLimit(EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1L);
+
+    final Optional<String> result = validator.validateTransaction(transaction, false, false);
+
+    assertThat(result)
+        .contains(
+            "Gas limit 16777217 exceeds EIP-7825 maximum transaction gas limit of 16777216");
+  }
+
+  @Test
+  public void rejectsTransactionAboveConfiguredMaxWhenConfiguredBelowEip7825Max() {
+    final GasLimitValidator validator = new GasLimitValidator(9_000_000);
+    final Transaction transaction = transactionWithGasLimit(9_000_001L);
+
+    final Optional<String> result = validator.validateTransaction(transaction, false, false);
+
+    assertThat(result)
+        .contains(
+            "Gas limit 9000001 exceeds configured maximum transaction gas limit of 9000000 "
+                + "(EIP-7825 maximum transaction gas limit is 16777216)");
+  }
+
+  private static Transaction transactionWithGasLimit(final long gasLimit) {
+    return org.hyperledger.besu.ethereum.core.Transaction.builder()
+        .gasLimit(gasLimit)
+        .gasPrice(Wei.ZERO)
+        .payload(Bytes.EMPTY)
+        .build();
   }
 }

--- a/docs/superpowers/specs/2026-04-27-eip-7825-tx-gas-limit-design.md
+++ b/docs/superpowers/specs/2026-04-27-eip-7825-tx-gas-limit-design.md
@@ -1,0 +1,171 @@
+# EIP-7825 Transaction Gas Limit Design
+
+## Context
+
+Issue 1798 asks the Linea sequencer TxGasLimit plugin to align with EIP-7825, which caps each
+transaction at `16_777_216` gas.
+
+Current behavior:
+
+- `LineaTransactionPoolValidatorCliOptions.DEFAULT_MAX_TRANSACTION_GAS_LIMIT` is `30_000_000`.
+- `GasLimitValidator` rejects only when `transaction.getGasLimit() > maxTxGasLimit`.
+- `GasLimitValidator` is used for txpool admission through `LineaTransactionPoolValidatorFactory`
+  and for bundle validation through `LineaBundleEndpointsPlugin`.
+- `LineaEstimateGas` rejects a caller-provided `gas` value above the configured
+  `txValidatorConf.maxTxGasLimit()`.
+- `LineaEstimateGas` does not check the decoded `eth_estimateGas` result against the configured
+  transaction gas limit before returning it.
+- `linea-besu-package/linea-besu/profiles/advanced-mainnet.toml` and
+  `linea-besu-package/linea-besu/profiles/advanced-sepolia.toml` currently configure
+  `plugin-linea-max-tx-gas-limit=24000000`.
+
+## Decisions
+
+- Enforce EIP-7825 unconditionally in the Linea plugin layer. Do not add fork-aware branching.
+- Preserve existing packaged profile files. Do not edit `linea-besu-package/linea-besu/profiles/*.toml`.
+- Keep `--plugin-linea-max-tx-gas-limit` as an operator-configured local maximum, but cap the
+  runtime effective limit at the EIP-7825 value.
+- Do not add a new Linea block-import validator. Block-level protocol validation remains outside
+  this change.
+- Document rejection metrics and alerts as a follow-up. Do not implement new metrics in this change.
+
+## Effective Limit
+
+Define one authoritative EIP-7825 cap for the sequencer plugin:
+
+```text
+EIP_7825_MAX_TRANSACTION_GAS_LIMIT = 16_777_216
+```
+
+All runtime validation uses:
+
+```text
+effectiveMaxTxGasLimit = min(configuredMaxTxGasLimit, EIP_7825_MAX_TRANSACTION_GAS_LIMIT)
+```
+
+This preserves startup compatibility with existing production profiles that configure
+`24_000_000`, while ensuring those profiles cannot raise the effective runtime limit above
+`16_777_216`.
+
+Operators may still configure a lower value. For example, `9_000_000` remains a stricter local cap.
+
+## Components
+
+Add a small shared constant/helper in the sequencer code near the existing transaction pool
+validator configuration or validator package.
+
+The helper should provide:
+
+- The EIP-7825 max transaction gas limit constant.
+- A function that computes the effective limit from the configured limit.
+- A shared rejection message formatter.
+
+Update `LineaTransactionPoolValidatorCliOptions` so the default max transaction gas limit is
+`16_777_216`.
+
+Update `GasLimitValidator` so it stores and enforces the effective limit. Keep the inclusive
+boundary:
+
+```text
+accept gasLimit <= effectiveMaxTxGasLimit
+reject gasLimit > effectiveMaxTxGasLimit
+```
+
+`LineaTransactionPoolValidatorFactory` and `LineaBundleEndpointsPlugin` should continue passing
+`transactionPoolValidatorConfiguration().maxTxGasLimit()` into `GasLimitValidator`. The validator
+itself should apply the EIP-7825 cap.
+
+Update `LineaEstimateGas` so it uses the same effective limit for both:
+
+- Caller-provided `gas` in request parameters.
+- The decoded `eth_estimateGas` result before line-count simulation and before fee-estimation
+  transaction construction.
+
+## Error Handling
+
+Use clear EIP-7825 wording in gas-limit rejections. The message should include the effective limit.
+
+`GasLimitValidator` and bundle validation should return the same style of string rejection used
+today, but with EIP-7825 wording and the effective cap.
+
+`LineaEstimateGas` should preserve existing JSON-RPC error categories:
+
+- Caller-provided `gas` above the cap returns an invalid-params error.
+- Computed estimate above the cap returns an estimate error.
+
+If configured max transaction gas is above `16_777_216`, do not fail startup. A one-time warning is
+acceptable if it is attached to configuration or validator construction. Do not log a warning for
+each rejected transaction.
+
+## Documentation
+
+Update sequencer plugin docs to say:
+
+- The default `--plugin-linea-max-tx-gas-limit` is `16_777_216`.
+- Since EIP-7825, the effective max transaction gas limit is capped at `16_777_216`.
+- A configured value above `16_777_216` is tolerated for compatibility with existing profiles, but
+  does not raise the effective limit.
+- A configured value below `16_777_216` is enforced as a stricter local cap.
+
+Documentation files to review:
+
+- `besu-plugins/linea-sequencer/docs/plugins.md`
+- `docs/tech/components/besu-plugins.md`
+- `tracer/PLUGINS.md`
+- `tracer/docs/plugins.md`
+
+Do not update `linea-besu-package/linea-besu/profiles/*.toml`.
+
+## Testing
+
+Unit tests:
+
+- `GasLimitValidatorTest` accepts a transaction at exactly `16_777_216`.
+- `GasLimitValidatorTest` rejects a transaction at `16_777_217`.
+- `GasLimitValidatorTest` verifies configured values above `16_777_216` are clamped.
+- `GasLimitValidatorTest` verifies configured values below `16_777_216` remain stricter local caps.
+- Add focused tests for the helper if it contains branching beyond the effective-limit calculation
+  and message formatting.
+
+Acceptance tests:
+
+- `TransactionGasLimitTest` should use an explicit EIP-7825 cap constant rather than
+  `DefaultGasProvider.GAS_LIMIT`.
+- Bundle validation should assert the same cap behavior through `linea_sendBundle`.
+- `EstimateGasTest` should cover explicit request `gas > 16_777_216`.
+- Cover computed `eth_estimateGas` results above the cap with a unit test or a stable acceptance
+  test. Prefer a unit test if an acceptance scenario would require heavy or fragile execution.
+
+Avoid changing unrelated tests that use `DefaultGasProvider.GAS_LIMIT` for normal contract calls
+unless those tests actually depend on the maximum transaction gas limit.
+
+Verification commands:
+
+```bash
+./gradlew :besu-plugins:linea-sequencer:test
+./gradlew :besu-plugins:linea-sequencer:acceptance-tests:acceptanceTests --tests '*TransactionGasLimitTest'
+./gradlew :besu-plugins:linea-sequencer:acceptance-tests:acceptanceTests --tests '*SendBundleTest'
+./gradlew :besu-plugins:linea-sequencer:acceptance-tests:acceptanceTests --tests '*EstimateGasTest'
+```
+
+Run the full sequencer acceptance suite if the environment and time allow:
+
+```bash
+./gradlew :besu-plugins:linea-sequencer:acceptance-tests:acceptanceTests
+```
+
+## Non-Goals
+
+- No edits to `linea-besu-package/linea-besu/profiles/*.toml`.
+- No new Linea block-import validator.
+- No metrics or alert implementation.
+- No fork-aware behavior.
+- No broad refactor of transaction validation or estimate-gas flow.
+
+## Follow-Up
+
+Create a follow-up task for operational visibility:
+
+- Track txpool/API rejection count by reason.
+- Alert on post-upgrade spikes in EIP-7825 gas-limit rejections.
+- Monitor transaction gas-limit distribution around `16_777_216`.

--- a/docs/tech/components/besu-plugins.md
+++ b/docs/tech/components/besu-plugins.md
@@ -394,12 +394,15 @@ abstract class AbstractLineaSharedPrivateOptionsPlugin : BesuPlugin {
 ### Sequencer Plugin Options
 
 ```bash
---plugin-linea-max-tx-gas-limit=30000000
+--plugin-linea-max-tx-gas-limit=16777216
 --plugin-linea-max-call-data-size=30720
 --plugin-linea-denied-addresses=0x...
 --plugin-linea-profitability-min-margin=0.01
 --plugin-linea-trace-limits-file=/config/traces-limits-v2.toml
 ```
+
+Linea caps the effective transaction gas limit at `16_777_216`. Higher configured values are tolerated for compatibility
+with existing profiles, but they do not increase the enforced limit.
 
 ### State Recovery Plugin Options
 

--- a/tracer/PLUGINS.md
+++ b/tracer/PLUGINS.md
@@ -64,7 +64,7 @@ that are not allowed to add transactions to the pool.
 | Option Name             | Default Value     | Command Line Argument                 |
 |-------------------------|-------------------|---------------------------------------|
 | DENY_LIST_PATH          | lineaDenyList.txt | `--plugin-linea-deny-list-path`       |
-| MAX_TX_GAS_LIMIT_OPTION | 30_000_000        | `--plugin-linea-max-tx-gas-limit`     |
+| MAX_TX_GAS_LIMIT_OPTION | 16_777_216        | `--plugin-linea-max-tx-gas-limit`     |
 | MAX_TX_CALLDATA_SIZE    | 60_000            | `--plugin-linea-max-tx-calldata-size` |
 
 ## RPC

--- a/tracer/docs/plugins.md
+++ b/tracer/docs/plugins.md
@@ -65,7 +65,7 @@ that are not allowed to add transactions to the pool.
 | Option Name             | Default Value     | Command Line Argument                 |
 |-------------------------|-------------------|---------------------------------------|
 | DENY_LIST_PATH          | lineaDenyList.txt | `--plugin-linea-deny-list-path`       |
-| MAX_TX_GAS_LIMIT_OPTION | 30_000_000        | `--plugin-linea-max-tx-gas-limit`     |
+| MAX_TX_GAS_LIMIT_OPTION | 16_777_216        | `--plugin-linea-max-tx-gas-limit`     |
 | MAX_TX_CALLDATA_SIZE    | 60_000            | `--plugin-linea-max-tx-calldata-size` |
 
 ## RPC


### PR DESCRIPTION
This PR implements issue(s) #1798

### Summary

- Adds a shared EIP-7825 transaction gas cap helper with effective cap `min(configured, 16_777_216)`.
- Enforces the effective cap in txpool/bundle validation and `linea_estimateGas`.
- Keeps existing profile values above the cap startup-compatible while clamping runtime behavior.
- Adds unit and acceptance coverage for high configured limits, lower local limits, bundle validation, direct tx behavior, and `linea_estimateGas`.
- Updates sequencer/tracer docs to document the new default and effective cap.

### Test Plan

- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home PATH="/Users/jeffersontang/go/bin:$PATH" rtk proxy ./gradlew --no-daemon --configure-on-demand :besu-plugins:linea-sequencer:sequencer:test`
- [x] Targeted acceptance tests: `*TransactionGasLimitTest`, `*EstimateGasTest`, `*SendBundleTest`, `*SendBundleEip7825GasLimitTest`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home PATH="/Users/jeffersontang/go/bin:$PATH" rtk proxy ./gradlew --no-daemon --configure-on-demand :besu-plugins:linea-sequencer:sequencer:checkSpdxHeader`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home PATH="/Users/jeffersontang/go/bin:$PATH" rtk proxy ./gradlew --no-daemon --configure-on-demand spotlessCheck`
- [x] `git diff -- linea-besu-package/linea-besu/profiles` returned no output
- [ ] Full acceptance suite had one timing-sensitive failure in `BundleSelectionTimeoutTest.multipleBundleSelectionTimeout`; the exact test passed when rerun in isolation.

### Notes

- No `linea-besu-package/linea-besu/profiles/*.toml` files were changed.
- `checkLicense` is not available for the sequencer project; `checkSpdxHeader` was run instead.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR. (N/A - no deployment config changed; acceptance coverage included)
* [x] I have informed the team of any breaking changes if there are any. (N/A - no breaking changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction admission and `linea_estimateGas` behavior by clamping configured max gas to the EIP-7825 cap and updating error handling, which can affect which transactions/bundles are accepted and how clients react to errors.
> 
> **Overview**
> Enforces the EIP-7825 per-transaction gas cap (`16_777_216`) across the Linea sequencer plugin by introducing `TransactionGasLimitCap` (effective limit = `min(configured, EIP-7825)`) and using it in `GasLimitValidator` (txpool + bundle validation) and `LineaEstimateGas`.
> 
> Updates defaults and operator-facing behavior: `--plugin-linea-max-tx-gas-limit` default is now `16_777_216`, higher configured values are tolerated but *clamped*, and rejection messages are standardized to include whether the configured limit or EIP-7825 cap was exceeded.
> 
> Adds/updates unit + acceptance tests to cover caller-provided and computed `linea_estimateGas` limits, bundle rejection when configured limits exceed EIP-7825, and revised error messages; documentation is updated to reflect the new default and effective cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1504a054e941a1a7cc85bed79b6a931ec2efdec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->