### PR TITLE
fix(ci): upgrade claude-code-action to v1.0.101 in ai-analysis job

### DIFF
--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -92,7 +92,7 @@ jobs:
           path: /tmp/docker-logs
 
       - name: Run Claude AI analysis
-        uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 #v1.0.71
+        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the `notify / ai-analysis` job that has been failing with **"Unsupported event type: push"** on every main-branch push that triggers E2E failure notifications.

### Root cause

`anthropics/claude-code-action@v1.0.71` (pinned in `slack-notify-failed-jobs.yml`) checks `github.event_name` and rejects `push` events. When a push to `main` triggers the main workflow and E2E tests fail, the `notify` job calls `slack-notify-failed-jobs.yml`, which runs `claude-code-action` - but the event context is still `push`, causing the action to exit 1.

### Fix

Bumped the pin in `slack-notify-failed-jobs.yml` to `v1.0.101` (`38ec876`), the same version already used in `claude.yml`, which handles this event context correctly.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [ ] I have informed the team of any breaking changes if there are any.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single GitHub Actions workflow pin update for `anthropics/claude-code-action`, affecting only the optional `ai-analysis` notification job.
> 
> **Overview**
> Updates the `slack-notify-failed-jobs` workflow to use `anthropics/claude-code-action@v1.0.101` (from `v1.0.71`) for the `ai-analysis` step, aligning it with other Claude workflows and avoiding failures on `push`-triggered runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea083527d257d8a2351f89117bddca413be2048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->