### PR TITLE
chore(ci): harden codecov-external-pr.yml

### DIFF
--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -20,12 +20,6 @@ jobs:
       commit-tag: ${{ steps.compute-commit-tag.outputs.COMMIT_TAG }}
       sdk-commit-tag: ${{ steps.compute-commit-tag.outputs.SDK_COMMIT_TAG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref:        ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
       - name: Compute commit tag
         shell: bash
         id: compute-commit-tag
@@ -35,12 +29,13 @@ jobs:
           WORKFLOW_RUN_PR_HEAD_SHA: ${{ github.event.workflow_run.pull_requests[0].head.sha || '' }}
         # COMMIT_TAG is derived from workflow_run.head_sha and used by workflows that upload artifacts using the shared commit_tag.
         # SDK_COMMIT_TAG is derived from the PR head SHA for sdk-testing PR runs to match sdk-testing.yml's cov-tag step.
+        # We use bash substring (${VAR:0:7}) instead of `git rev-parse --short=7` to avoid checking out fork code in this privileged workflow_run context.
         run: |
-          COMMIT_TAG="$(git rev-parse --short=7 "$WORKFLOW_RUN_HEAD_SHA")"
+          COMMIT_TAG="${WORKFLOW_RUN_HEAD_SHA:0:7}"
           SDK_COMMIT_TAG="$COMMIT_TAG"
 
           if [[ "$TRIGGERING_WORKFLOW" == "sdk-testing" ]] && [[ -n "$WORKFLOW_RUN_PR_HEAD_SHA" ]]; then
-            SDK_COMMIT_TAG="$(git rev-parse --short=7 "$WORKFLOW_RUN_PR_HEAD_SHA")"
+            SDK_COMMIT_TAG="${WORKFLOW_RUN_PR_HEAD_SHA:0:7}"
           fi
 
           echo "COMMIT_TAG=$COMMIT_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -41,9 +41,12 @@ jobs:
           echo "COMMIT_TAG=$COMMIT_TAG" >> "$GITHUB_OUTPUT"
           echo "SDK_COMMIT_TAG=$SDK_COMMIT_TAG" >> "$GITHUB_OUTPUT"
       - name: Show commit tag
+        env:
+          COMMIT_TAG: ${{ steps.compute-commit-tag.outputs.COMMIT_TAG }}
+          SDK_COMMIT_TAG: ${{ steps.compute-commit-tag.outputs.SDK_COMMIT_TAG }}
         run: |
-          echo "COMMIT_TAG: ${{ steps.compute-commit-tag.outputs.COMMIT_TAG }}"
-          echo "SDK_COMMIT_TAG: ${{ steps.compute-commit-tag.outputs.SDK_COMMIT_TAG }}"
+          echo "COMMIT_TAG: $COMMIT_TAG"
+          echo "SDK_COMMIT_TAG: $SDK_COMMIT_TAG"
 
   # Ideally we would use dorny/paths-filter@v3 to conditionally trigger an upload job based on file changes
   # However there is a limitation in Github Actions where workflows triggered by a `workflow_run` event have no access to metadata on external fork PRs - https://github.com/orgs/community/discussions/25220

--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -58,8 +58,6 @@ jobs:
     permissions:
       actions: read    # download artifacts from another workflow run
       contents: read   # codecov commit correlation
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Download Jacoco test coverage report (from coordinator-testing.yml)
         continue-on-error: true
@@ -91,8 +89,6 @@ jobs:
     permissions:
       actions: read    # download artifacts from another workflow run
       contents: read   # codecov commit correlation
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Download smart contract coverage report (from run-smc.tests.yml)
         id: smc-report-download
@@ -124,8 +120,6 @@ jobs:
     permissions:
       actions: read    # download artifacts from another workflow run
       contents: read   # codecov commit correlation
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Download TS test coverage reports (from postman-testing.yml)
         continue-on-error: true
@@ -175,8 +169,6 @@ jobs:
     permissions:
       actions: read    # download artifacts from another workflow run
       contents: read   # codecov commit correlation
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Download TS coverage (from native-yield-automation-service-testing.yml)
         continue-on-error: true
@@ -216,8 +208,6 @@ jobs:
     permissions:
       actions: read    # download artifacts from another workflow run
       contents: read   # codecov commit correlation
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Download TS coverage (from lido-governance-monitor-testing.yml)
         continue-on-error: true
@@ -257,8 +247,6 @@ jobs:
     permissions:
       actions: read    # download artifacts from another workflow run
       contents: read   # codecov commit correlation
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Download TS coverage (from sdk-testing.yml)
         continue-on-error: true

--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -6,16 +6,16 @@ on:
     types:
       - completed
 
-permissions:
-  # Required to read uploaded artifact from another workflow run
-  actions: read
-  contents: read
+# Workflow-level permissions are denied by default; each job below declares
+# the minimum scopes it needs (least privilege).
+permissions: {}
 
 jobs:
   get-commit-tag:
     if: github.event.workflow_run.head_repository.fork == true
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: get-commit-tag
+    permissions: {}
     outputs:
       commit-tag: ${{ steps.compute-commit-tag.outputs.COMMIT_TAG }}
       sdk-commit-tag: ${{ steps.compute-commit-tag.outputs.SDK_COMMIT_TAG }}
@@ -55,6 +55,9 @@ jobs:
     needs: [ get-commit-tag ]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-coordinator
+    permissions:
+      actions: read    # download artifacts from another workflow run
+      contents: read   # codecov commit correlation
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -85,6 +88,9 @@ jobs:
     needs: [ get-commit-tag ]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-smart-contracts
+    permissions:
+      actions: read    # download artifacts from another workflow run
+      contents: read   # codecov commit correlation
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -115,6 +121,9 @@ jobs:
     needs: [ get-commit-tag ]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-ts
+    permissions:
+      actions: read    # download artifacts from another workflow run
+      contents: read   # codecov commit correlation
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -163,6 +172,9 @@ jobs:
     needs: [ get-commit-tag ]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-native-yield-ts
+    permissions:
+      actions: read    # download artifacts from another workflow run
+      contents: read   # codecov commit correlation
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -201,6 +213,9 @@ jobs:
     needs: [ get-commit-tag ]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-lido-ts
+    permissions:
+      actions: read    # download artifacts from another workflow run
+      contents: read   # codecov commit correlation
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -239,6 +254,9 @@ jobs:
     needs: [ get-commit-tag ]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: upload-codecov-sdk-ts
+    permissions:
+      actions: read    # download artifacts from another workflow run
+      contents: read   # codecov commit correlation
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:

--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Download Jacoco test coverage report (from coordinator-testing.yml)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: coordinator-report-download
         with:
           name: jacocoRootReport-${{ needs.get-commit-tag.outputs.commit-tag }}.xml
@@ -93,7 +93,7 @@ jobs:
       - name: Download smart contract coverage report (from run-smc.tests.yml)
         id: smc-report-download
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smart-contract-coverage-${{ needs.get-commit-tag.outputs.commit-tag }}.json
           path: |
@@ -123,7 +123,7 @@ jobs:
     steps:
       - name: Download TS test coverage reports (from postman-testing.yml)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: ts-coverage-download
         with:
           name: ts-coverage-${{ needs.get-commit-tag.outputs.commit-tag }}
@@ -172,7 +172,7 @@ jobs:
     steps:
       - name: Download TS coverage (from native-yield-automation-service-testing.yml)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: native-yield-coverage-download
         with:
           name: native-yield-ts-coverage-${{ needs.get-commit-tag.outputs.commit-tag }}
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Download TS coverage (from lido-governance-monitor-testing.yml)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: lido-coverage-download
         with:
           name: lido-ts-coverage-${{ needs.get-commit-tag.outputs.commit-tag }}
@@ -250,7 +250,7 @@ jobs:
     steps:
       - name: Download TS coverage (from sdk-testing.yml)
         continue-on-error: true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         id: sdk-coverage-download
         with:
           name: sdk-ts-coverage-${{ needs.get-commit-tag.outputs.sdk-commit-tag }}


### PR DESCRIPTION
Defense-in-depth hardening of `.github/workflows/codecov-external-pr.yml`, the workflow that uploads coverage reports for PRs from external forks. The `workflow_run` privilege-separation architecture is already correct; these changes eliminate unnecessary attack surface and align with current GitHub Actions security best practices.

### Changes (5 separate commits for ease of review)

1. **Remove fork checkout from privileged `workflow_run` context** - the `get-commit-tag` job was checking out fork code solely to run `git rev-parse --short=7`. The full SHA is in the event payload; `${SHA:0:7}` is the equivalent operation without checkout.
2. **Scope permissions per-job (least privilege)** - workflow-level `permissions: {}` (deny by default); each job declares only what it needs. Compute job (pure bash) gets `{}`; upload jobs get `actions: read` + `contents: read`.
3. **Remove redundant job-level `CODECOV_TOKEN` env** - the `with: token: ${{ secrets.CODECOV_TOKEN }}` on each codecov step is the sole required access point. The job-level env was leaking the token into the `actions/download-artifact` step that processes untrusted fork artifacts.
4. **SHA-pin `actions/download-artifact`** - all 6 occurrences pinned from mutable `@v7` to `@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`. Dependabot (already configured for github-actions, weekly) will bump it forward.
5. **Use `env:` pattern in Show commit tag step** - removes the last `${{ ... }}` interpolation inside a `run:` block. Values were already sanitized; this enforces the uniform "no expression interpolation in `run` blocks" rule.

### Why this is low risk

The `workflow_run` trigger already provides effective privilege separation. No secret exfiltration is possible without a separate supply-chain compromise of a GitHub Action. These changes are behavior-preserving for the green path; failure modes are loud (action errors, permission denied, codecov "didn't upload" tile).

### Local verification

- `actionlint` clean (with the pre-existing self-hosted runner-label noise filtered)
- No `actions/checkout` step
- No `git rev-parse` runtime invocation
- No `${{ ... }}` interpolation inside any `run:` block
- No job-level `CODECOV_TOKEN` env (sole access via per-step `with: token:`)
- All 18 third-party `uses:` SHA-pinned with version comment (6x `download-artifact` v8.0.1, 12x `codecov-action` v6.0.0)
- Top-level `permissions: {}` with per-job scopes (7 explicit blocks)

### Post-merge

Codecov upload behavior for external fork PRs will be verified by monitoring the next fork PR's `workflow_run`. Failure modes are visible in CI logs.

### Note on `${SHA:0:7}` vs `git rev-parse --short=7`

`${SHA:0:7}` is strictly the first 7 chars; `git rev-parse --short=7` is "minimum 7, extend if ambiguous in repo." For Linea's commit count, 7-char prefix collisions are vanishingly rare. Matches `sdk-testing.yml`'s existing fork-PR artifact tag derivation (line 74).

### Checklist

* [x] I wrote new tests for my new core changes. - N/A (CI workflow only)
* [x] I have successfully ran tests, style checker and build against my new changes locally. - `actionlint` clean
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR. - N/A (CI workflow only)
* [x] I have informed the team of any breaking changes if there are any. - no breaking changes
