### PR TITLE
fix(135): harden pnpm install script policy

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
-          pnpm-install-options: "--frozen-lockfile --prefer-offline"
+          pnpm-install-options: "--frozen-lockfile --prefer-offline --ignore-scripts"
   
       - name: Build sdk-core
         run: pnpm -F @consensys/linea-sdk-core run build
@@ -162,7 +162,7 @@ jobs:
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
-          pnpm-install-options: "--frozen-lockfile --prefer-offline"
+          pnpm-install-options: "--frozen-lockfile --prefer-offline --ignore-scripts"
 
       - name: Verify sdk-core dependency is published on npm
         run: |

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
-          pnpm-install-options: "--frozen-lockfile --prefer-offline"
+          pnpm-install-options: "--frozen-lockfile --prefer-offline --ignore-scripts"
 
       - name: Lint
         env:

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
-          pnpm-install-options: "--frozen-lockfile --prefer-offline"
+          pnpm-install-options: "--frozen-lockfile --prefer-offline --ignore-scripts"
 
       - name: Build sdk-core
         run: pnpm -F @consensys/linea-sdk-core run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,9 @@ After writing or editing code, check LSP diagnostics and fix any type errors or 
 - **Dependabot:** Configured for GitHub Actions dependencies (weekly, Monday 03:00 UTC)
 - **Engine strict:** `engine-strict=true` in `.npmrc`
 
+Additions to `pnpm.onlyBuiltDependencies` require a security review of the package's install script, including its
+network, filesystem, and process execution surface, publisher reputation, and recent npm publish history.
+
 ### Irreversible Operations
 
 These require human approval and follow the release process:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,5 +97,9 @@ ignoredBuiltDependencies:
 
 minimumReleaseAge: 4320
 
+strictDepBuilds: true
+trustPolicy: no-downgrade
+
 onlyBuiltDependencies:
+  # Required by contracts/ blob tests; additions to this allowlist need security review.
   - c-kzg

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,59 @@ packages:
   - ts-libs/**
   - '!contracts/lib/**'
 
+catalog:
+  '@jest/globals': 30.3.0
+  '@typechain/ethers-v6': 0.5.1
+  '@types/jest': 30.0.0
+  '@types/yargs': 17.0.35
+  axios: 1.15.0
+  dotenv: 17.3.1
+  eslint: 9.39.4
+  ethers: 6.16.0
+  express: 5.2.1
+  jest: 30.3.0
+  jest-mock-extended: 4.0.0
+  neverthrow: 8.2.0
+  prettier: 3.8.1
+  prom-client: 15.1.3
+  ts-jest: 29.4.6
+  tsup: 8.5.1
+  tsx: 4.21.0
+  typechain: 8.3.2
+  typescript: 5.9.3
+  viem: 2.47.5
+  winston: 3.19.0
+  yargs: 18.0.0
+  zod: 4.3.6
+
+ignoredBuiltDependencies:
+  - '@arbitrum/nitro-contracts'
+  - '@parcel/watcher'
+  - '@prisma/engines'
+  - better-sqlite3
+  - bigint-buffer
+  - bufferutil
+  - es5-ext
+  - esbuild
+  - keccak
+  - koffi
+  - prisma
+  - secp256k1
+  - sharp
+  - tiny-secp256k1
+  - unrs-resolver
+  - utf-8-validate
+  - web3
+  - web3-bzz
+  - web3-shh
+  - yarn
+
+minimumReleaseAge: 4320
+
+onlyBuiltDependencies:
+  # Required by contracts/ blob tests; additions to this allowlist need security review.
+  - c-kzg
+
 overrides:
   "@hono/node-server@<1.19.10": ">=1.19.10"
   axios@<0.30.0: ">=0.30.0"
@@ -53,53 +106,5 @@ overrides:
   xml2js@<0.5.0: ">=0.5.0"
   zod: "4.3.6"
 
-catalog:
-  '@jest/globals': 30.3.0
-  '@typechain/ethers-v6': 0.5.1
-  '@types/jest': 30.0.0
-  '@types/yargs': 17.0.35
-  axios: 1.15.0
-  dotenv: 17.3.1
-  eslint: 9.39.4
-  ethers: 6.16.0
-  express: 5.2.1
-  jest: 30.3.0
-  jest-mock-extended: 4.0.0
-  neverthrow: 8.2.0
-  prettier: 3.8.1
-  prom-client: 15.1.3
-  ts-jest: 29.4.6
-  tsup: 8.5.1
-  tsx: 4.21.0
-  typechain: 8.3.2
-  typescript: 5.9.3
-  viem: 2.47.5
-  winston: 3.19.0
-  yargs: 18.0.0
-  zod: 4.3.6
-
-ignoredBuiltDependencies:
-  - '@arbitrum/nitro-contracts'
-  - better-sqlite3
-  - bigint-buffer
-  - bufferutil
-  - es5-ext
-  - esbuild
-  - keccak
-  - koffi
-  - secp256k1
-  - utf-8-validate
-  - web3
-  - web3-bzz
-  - web3-shh
-  - yarn
-  - tiny-secp256k1
-
-minimumReleaseAge: 4320
-
 strictDepBuilds: true
 trustPolicy: no-downgrade
-
-onlyBuiltDependencies:
-  # Required by contracts/ blob tests; additions to this allowlist need security review.
-  - c-kzg


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens dependency build/install policies and disables `pnpm` install scripts in SDK CI workflows, which may break builds that implicitly relied on postinstall/prepare hooks or native builds.
> 
> **Overview**
> **Hardens `pnpm` install behavior in CI and workspace policy.** SDK workflows (`sdk-testing`, `sdk-release`, `sdk-publish`) now run `pnpm install` with `--ignore-scripts` to prevent dependency lifecycle scripts from executing during CI/release runs.
> 
> **Strengthens workspace dependency controls.** `pnpm-workspace.yaml` adds `strictDepBuilds: true` and `trustPolicy: no-downgrade`, expands `ignoredBuiltDependencies` (e.g., `prisma`, `sharp`, `@prisma/engines`, `@parcel/watcher`, etc.), and reorganizes `overrides` while keeping the same override set.
> 
> **Documents security expectations.** `AGENTS.md` now explicitly requires a security review for any additions to `pnpm.onlyBuiltDependencies`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9ecb11edd5b504f8db5b736720acd528a7d154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->