### PR TITLE
chore(ci): small fixes on coordinator review

### DIFF
--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -38,8 +38,8 @@ jobs:
             --json body \
             --jq '.[].body' \
             | grep -oE '[a-zA-Z0-9/_.-]+\.(kt|java|scala|groovy):[0-9]+' \
-            | sort -u > /tmp/previous-findings.txt || true
-          echo "Previously reported locations: $(wc -l < /tmp/previous-findings.txt)"
+            | sort -u > "$GITHUB_WORKSPACE/previous-findings.txt" || true
+          echo "Previously reported locations: $(wc -l < "$GITHUB_WORKSPACE/previous-findings.txt")"
 
       - name: Run Claude Coordinator Review
         id: review
@@ -48,9 +48,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: --model claude-opus-4-7
           prompt: |
-            Before starting your analysis, read the file /tmp/previous-findings.txt.
-            It contains file:line references (e.g. `coordinator/src/.../Foo.kt:42`) already
-            reported in previous reviews. Skip any finding whose primary file:line location
+            Before starting your analysis, read the file `previous-findings.txt` in the
+            repository root. It contains file:line references (e.g. `coordinator/src/.../Foo.kt:42`)
+            already reported in previous reviews. Skip any finding whose primary file:line location
             appears in that file — do not re-report it even if the issue is still present.
 
             You are reviewing the full Kotlin/JVM codebase in the `coordinator/` and
@@ -122,7 +122,7 @@ jobs:
             Example format:
 
             ## Dead Code
-            - [`coordinator/src/.../Foo.kt:42`](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/coordinator/src/.../Foo.kt#L42) — `unusedParam` is never read. Remove the parameter and update all call sites.
+            - [`coordinator/src/.../Foo.kt:42`](../blob/${{ github.sha }}/coordinator/src/.../Foo.kt#L42) — `unusedParam` is never read. Remove the parameter and update all call sites.
               - [ ] ❌ won't fix
               - [ ] ❌ false positive
               - [ ] 🤖 to be fixed
@@ -132,14 +132,14 @@ jobs:
             No issues found.
 
             ## Anti-patterns and Code Smells
-            - [`coordinator/src/.../Bar.kt:17`](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/coordinator/src/.../Bar.kt#L17) — Uses `!!` on a nullable result from `findOrNull` with no justification. Replace with `?: error("...")` or a safe alternative.
+            - [`coordinator/src/.../Bar.kt:17`](../blob/${{ github.sha }}/coordinator/src/.../Bar.kt#L17) — Uses `!!` on a nullable result from `findOrNull` with no justification. Replace with `?: error("...")` or a safe alternative.
               - [ ] ❌ won't fix
               - [ ] ❌ false positive
               - [ ] 🤖 to be fixed
               - [ ] ✅ addressed/fixed
 
             ## Concurrency Issues
-            - [`coordinator/src/.../Baz.kt:88`](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/coordinator/src/.../Baz.kt#L88) — `.get()` called on a `CompletableFuture` on the event-loop thread, which will block it. Use `.thenApply` instead.
+            - [`coordinator/src/.../Baz.kt:88`](../blob/${{ github.sha }}/coordinator/src/.../Baz.kt#L88) — `.get()` called on a `CompletableFuture` on the event-loop thread, which will block it. Use `.thenApply` instead.
               - [ ] ❌ won't fix
               - [ ] ❌ false positive
               - [ ] 🤖 to be fixed


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: updates where the workflow writes/reads the previous-findings file and tweaks markdown link generation; main risk is broken deduping or links in created issues.
> 
> **Overview**
> Improves the `claude-coordinator-review` GitHub Actions workflow by persisting prior review findings to `previous-findings.txt` in the workspace/repo root (instead of `/tmp`) and updating the Claude prompt to read from that location.
> 
> Also adjusts the example finding links in the prompt to use relative `../blob/${{ github.sha }}` URLs instead of constructing absolute links via `${{ github.server_url }}/${{ github.repository }}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e08f875ff024ca48f31025e6fcb411e263b705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->