### PR TITLE
fix(ci): pre-pull images before running coordinator int test with retry

### DIFF
--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -52,6 +52,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Pre-pull images for running integration tests
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          max_attempts: 10
+          retry_on: error
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          command: ./gradlew composePullLocalStackStartedImages
       - name: Run integration tests
         timeout-minutes: 15
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -323,6 +323,22 @@ dockerCompose {
   }
 }
 
+// Pull only the images required by `startedServices` of the `localStack` compose stack.
+// Useful in CI to retry the (sometimes flaky) Docker Hub pull in isolation, without
+// rerunning the integration test.
+tasks.register("composePullLocalStackStartedImages", Exec) {
+  group = 'docker'
+  description = "Pull only the startedServices images for the 'localStack' compose stack."
+  workingDir rootDir
+  doFirst {
+    def settings = dockerCompose.localStack
+    def fileArgs = settings.useComposeFiles.get().collectMany { ['-f', it.toString()] }
+    def additionalArgs = settings.composeAdditionalArgs.get()
+    def services = settings.startedServices.get()
+    commandLine(['docker', 'compose'] + fileArgs + additionalArgs + ['pull'] + services)
+  }
+}
+
 static Boolean hasKotlinPlugin(Project proj) {
   return proj.plugins.hasPlugin("org.jetbrains.kotlin.jvm")
 }


### PR DESCRIPTION
`./gradlew coordinator:app:integrationTestAllNeeded` has been failing quite often recently in CI with
[Example](https://github.com/Consensys/linea-monorepo/actions/runs/25050861249/job/73378342133):
```
  failed to copy: read tcp 10.46.190.26:38878->104.16.97.215:443: read: connection reset by peer                                                                         
  No stopped containers                                                                 
                                                                                        
  > Task :localStackComposeDownForcedOnFailure                                          
  FAILURE: Build failed with an exception.                                              
                                                                                        
  * What went wrong:                                                                    
  Execution failed for task ':localStackComposeUp'.                                     
  > Exit-code 18 when calling docker-compose, stdout: N/A 
```

Root cause: transient network flake pulling Docker images. 104.16.97.215 is Cloudflare (Docker Hub's CDN). Exit code 18 from docker-compose means the pull stream was interrupted mid-transfer. Nothing wrong with the build — just network jitter on the runner.

Solution: create a gradle task to pull the images for localStack, and run it with retry in CI before running the coordinator integration test

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
