### PR TITLE
fix: exclude pnpm trust downgrades

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,3 +108,13 @@ overrides:
 
 strictDepBuilds: true
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  # Required by eslint-plugin-import and other legacy tooling pulled during Docker deploy.
+  # These semver releases predate npm provenance, so pnpm flags them as trust downgrades.
+  - semver@6.3.1 || 5.7.2
+  # Required by eslint-plugin-import's TypeScript resolver in the operations Docker deploy path.
+  # The package version has no provenance evidence, but is pinned by the existing lockfile.
+  - eslint-import-resolver-typescript@3.10.1
+  # Pulled via ethers -> @types/node@22.7.5 during legacy deploy resolution.
+  # Excluded to keep deploy working while trustPolicy remains enabled for all other packages.
+  - undici-types@6.19.8


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts pnpm's supply-chain trust enforcement by exempting specific transitive dependencies, which could weaken provenance guarantees during installs if misused.
> 
> **Overview**
> Unblocks installs/deploys with `trustPolicy: no-downgrade` by adding a new `trustPolicyExclude` allowlist in `pnpm-workspace.yaml`.
> 
> The exclude list explicitly exempts `semver`, `eslint-import-resolver-typescript`, and `undici-types` versions that currently lack provenance evidence but are required by legacy tooling and the existing lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ee2a7380b20a58794ecd3e106c8592979cde9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->