### PR TITLE
fixup(prover-ray): solve merge conflicts

### DIFF
--- a/prover-ray/wiop/compilers/rangecheck/rangecheck.go
+++ b/prover-ray/wiop/compilers/rangecheck/rangecheck.go
@@ -65,7 +65,7 @@ func createRangeColumn(sys *wiop.System, ctx *wiop.ContextFrame, b int) *wiop.Co
 	}
 
 	cv := &wiop.ConcreteVector{
-		Plain: []field.Vec{field.VecFromBase(elems)},
+		Plain: field.VecFromBase(elems),
 	}
 	return mod.NewPrecomputedColumn(
 		ctx.Childf("range-col-b%d", b),

--- a/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
+++ b/prover-ray/wiop/compilers/rangecheck/rangecheck_test.go
@@ -26,7 +26,7 @@ func makeVec(vals ...uint64) *wiop.ConcreteVector {
 	for i, v := range vals {
 		elems[i].SetUint64(v)
 	}
-	return &wiop.ConcreteVector{Plain: []field.Vec{field.VecFromBase(elems)}}
+	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
 }
 
 // ---- Structural tests ----

--- a/prover-ray/wiop/query_range_check_test.go
+++ b/prover-ray/wiop/query_range_check_test.go
@@ -111,5 +111,5 @@ func makeVecU64(vals ...uint64) *wiop.ConcreteVector {
 	for i, v := range vals {
 		elems[i].SetUint64(v)
 	}
-	return &wiop.ConcreteVector{Plain: []field.Vec{field.VecFromBase(elems)}}
+	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
 }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small type/initialization fix that updates `ConcreteVector{Plain: ...}` construction in rangecheck code and tests; no logic changes beyond data shape.
> 
> **Overview**
> Fixes `rangecheck` precomputed range column and related tests to construct `wiop.ConcreteVector` with `Plain` as a single `field.Vec` (via `field.VecFromBase`) instead of a `[]field.Vec`, matching the current `ConcreteVector` definition and resolving compile/merge-conflict fallout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6e304c3db406b85ec5e491732805c100765d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->