### PR TITLE
prover: add invalidity proofs config to partial prover CI

### DIFF
--- a/docker/config/prover/v3/prover-config-partial.toml
+++ b/docker/config/prover/v3/prover-config-partial.toml
@@ -18,29 +18,32 @@ prover_mode = "dev"
 requests_root_dir = "/data/prover/v3/compression"
 dict_paths = ["/opt/linea/prover/lib/compressor/compressor_dict.bin", "/opt/linea/prover/lib/compressor/dict/25-04-21.bin"]
 
-#[invalidity]
-#prover_mode = "dev"
-#requests_root_dir = "/data/prover/v3/invalidity"
-#max_rlp_byte_size = 4096
+[invalidity]
+prover_mode = "partial"
+requests_root_dir = "/data/prover/v3/invalidity"
+max_rlp_byte_size = 4096
 
 [aggregation]
 prover_mode = "dev"
 requests_root_dir = "/data/prover/v3/aggregation"
 num_proofs = [10]
-# allowed_inputs = [
-#     "execution-dummy",
-#     "data-availability-dummy",
-#     "data-availability-v2",
-# ]
 # Conversion to is_allowed_circuit_id bitmask:
-#   execution-dummy (ID 0, bit 0) = 1 → ALLOWED
-#   data-availability-dummy (ID 1, bit 1) = 1 → ALLOWED
-#   execution (ID 2, bit 2) = 0 → DISALLOWED
-#   execution-large (ID 3, bit 3) = 0 → DISALLOWED
-#   execution-limitless (ID 4, bit 4) = 0 → DISALLOWED
-#   data-availability-v2 (ID 5, bit 5) = 1 → ALLOWED
-# Binary: 0b100011 = 35 (decimal)
-is_allowed_circuit_id = 35
+#   execution-dummy (ID 0, bit 0)                            = 1 → ALLOWED
+#   data-availability-dummy (ID 1, bit 1)                    = 1 → ALLOWED
+#   execution (ID 2, bit 2)                                  = 0 → DISALLOWED
+#   execution-large (ID 3, bit 3)                            = 0 → DISALLOWED
+#   execution-limitless (ID 4, bit 4)                        = 0 → DISALLOWED
+#   data-availability-v2 (ID 5, bit 5)                       = 1 → ALLOWED
+#   invalidity-nonce-balance-dummy (ID 6, bit 6)             = 1 → ALLOWED
+#   invalidity-precompile-logs-dummy (ID 7, bit 7)           = 1 → ALLOWED
+#   invalidity-filtered-address-dummy (ID 8, bit 8)          = 1 → ALLOWED
+#   invalidity-nonce-balance (ID 9, bit 9)                   = 0 → DISALLOWED
+#   invalidity-precompile-logs (ID 10, bit 10)               = 0 → DISALLOWED
+#   invalidity-filtered-address (ID 11, bit 11)              = 0 → DISALLOWED
+#   invalidity-precompile-logs-limitless (ID 12, bit 12)     = 0 → DISALLOWED
+#   invalidity-precompile-logs-large (ID 13, bit 13)         = 0 → DISALLOWED
+# Binary: 0b00000111100011 = 483 (decimal)
+is_allowed_circuit_id = 483
 verifier_id = 0
 
 [layer2]


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it alters which prover circuits run in partial/CI by enabling invalidity proofs and expanding the aggregation allowlist, which can affect CI behavior, runtime, and resource usage.
> 
> **Overview**
> Updates `prover-config-partial.toml` to **enable the `invalidity` prover in `partial` mode** (with its own request directory and `max_rlp_byte_size`).
> 
> Adjusts the aggregation `is_allowed_circuit_id` bitmask (35 → 483) to **include the invalidity dummy circuit IDs** in the allowlist, and refreshes the inline documentation to match the expanded circuit set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659eee1224d286247802283b9d71dc06f9263417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->