### PR TITLE
feat(coordinator): add conflation_stopReconflationJob JSON-RPC for backtesting

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/Api.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/Api.kt
@@ -15,6 +15,7 @@ import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.vertx.ObservabilityServer
 import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationCreateProverRequestHandler
 import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationGetJobStatusRequestHandler
+import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationStopJobRequestHandler
 import net.consensys.zkevm.coordinator.api.requesthandlers.ConflationTargetCheckpointResumeRequestHandler
 import net.consensys.zkevm.coordinator.app.conflationbacktesting.ConflationBacktestingService
 import org.apache.logging.log4j.LogManager
@@ -54,6 +55,8 @@ class Api(
         ConflationCreateProverRequestHandler(conflationBacktestingService = conflationBacktestingService),
       ConflationGetJobStatusRequestHandler.METHOD_NAME to
         ConflationGetJobStatusRequestHandler(conflationBacktestingService = conflationBacktestingService),
+      ConflationStopJobRequestHandler.METHOD_NAME to
+        ConflationStopJobRequestHandler(conflationBacktestingService = conflationBacktestingService),
       ConflationTargetCheckpointResumeRequestHandler.METHOD_NAME to
         ConflationTargetCheckpointResumeRequestHandler(signalResume = conflationCheckpointResumeLatch),
     )

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/requesthandlers/ConflationStopJobRequestHandler.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/requesthandlers/ConflationStopJobRequestHandler.kt
@@ -1,0 +1,92 @@
+package net.consensys.zkevm.coordinator.api.requesthandlers
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import io.vertx.core.Future
+import io.vertx.core.json.JsonObject
+import io.vertx.ext.auth.User
+import net.consensys.linea.async.toVertxFuture
+import net.consensys.linea.jsonrpc.JsonRpcErrorResponse
+import net.consensys.linea.jsonrpc.JsonRpcRequest
+import net.consensys.linea.jsonrpc.JsonRpcRequestHandler
+import net.consensys.linea.jsonrpc.JsonRpcSuccessResponse
+import net.consensys.zkevm.coordinator.app.conflationbacktesting.ConflationBacktestingService
+
+/**
+ * JSON-RPC: stops a single in-progress conflation backtesting job.
+ *
+ * Params: a JSON array containing **exactly one** job id string.
+ *
+ * Result: `"STOPPED"` on success, or `"ERROR: <message>"` when the job could not be stopped (unknown
+ * id, already completed, or a failure during shutdown).
+ */
+class ConflationStopJobRequestHandler(private val conflationBacktestingService: ConflationBacktestingService) :
+  JsonRpcRequestHandler {
+
+  override fun invoke(
+    user: User?,
+    request: JsonRpcRequest,
+    requestJson: JsonObject,
+  ): Future<Result<JsonRpcSuccessResponse, JsonRpcErrorResponse>> {
+    val jobId = try {
+      parseJobIdFromRequest(request)
+    } catch (e: Exception) {
+      return Future.succeededFuture(
+        Err(
+          JsonRpcErrorResponse.invalidParams(
+            request.id,
+            "Invalid request parameters: ${e.message}",
+          ),
+        ),
+      )
+    }
+
+    return try {
+      conflationBacktestingService.stopConflationBacktestingJob(jobId)
+        .handle { _, error ->
+          if (error == null) STOPPED_RESULT else "ERROR: ${error.message ?: error.javaClass.simpleName}"
+        }
+        .thenApply<Result<JsonRpcSuccessResponse, JsonRpcErrorResponse>> { outcome ->
+          Ok(
+            JsonRpcSuccessResponse(
+              id = request.id,
+              result = outcome,
+            ),
+          )
+        }
+        .toVertxFuture()
+    } catch (e: Exception) {
+      Future.succeededFuture(
+        Ok(
+          JsonRpcSuccessResponse(
+            id = request.id,
+            result = "ERROR: ${e.message ?: e.javaClass.simpleName}",
+          ),
+        ),
+      )
+    }
+  }
+
+  companion object {
+    const val METHOD_NAME = "conflation_stopReconflationJob"
+    const val STOPPED_RESULT = "STOPPED"
+
+    fun parseJobIdFromRequest(request: JsonRpcRequest): String {
+      val params = request.params
+      if (params !is List<*>) {
+        throw IllegalArgumentException("Invalid request parameters: expected a JSON array with exactly one job ID")
+      }
+      if (params.size != 1) {
+        throw IllegalArgumentException(
+          "Invalid request parameters: expected exactly one job ID, got ${params.size}",
+        )
+      }
+      return try {
+        params[0] as String
+      } catch (e: Exception) {
+        throw IllegalArgumentException("Invalid request parameters: job ID must be a string", e)
+      }
+    }
+  }
+}

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -54,6 +54,7 @@ import java.nio.file.Path
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.fetchAndUpdate
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
@@ -270,9 +271,14 @@ class ConflationBacktestingApp(
           "Backtesting execution proof request produced: batch={}",
           unProvenBatch.intervalString(),
         )
-        // check to prvent out of order proof request from regressing teh last processed batch number.
-        if (lastProcessedBatchEndBlockNumber.load() < proofIndex.endBlockNumber.toLong()) {
-          lastProcessedBatchEndBlockNumber.store(proofIndex.endBlockNumber.toLong())
+        // check to prevent out of order proof request from regressing teh last processed batch number.
+        lastProcessedBatchEndBlockNumber.fetchAndUpdate {
+            current ->
+          if (current < proofIndex.endBlockNumber.toLong()) {
+            proofIndex.endBlockNumber.toLong()
+          } else {
+            current
+          }
         }
       },
       vertx = vertx,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -270,7 +270,10 @@ class ConflationBacktestingApp(
           "Backtesting execution proof request produced: batch={}",
           unProvenBatch.intervalString(),
         )
-        lastProcessedBatchEndBlockNumber.store(proofIndex.endBlockNumber.toLong())
+        // check to prvent out of order proof request from regressing teh last processed batch number.
+        if (lastProcessedBatchEndBlockNumber.load() < proofIndex.endBlockNumber.toLong()) {
+          lastProcessedBatchEndBlockNumber.store(proofIndex.endBlockNumber.toLong())
+        }
       },
       vertx = vertx,
       config = ProofGeneratingConflationHandlerImpl.Config(

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
@@ -33,14 +33,13 @@ class ConflationBacktestingService(
     COMPLETED,
   }
 
+  private val jobLifecycleLock = Any()
+
   private val completedJobs: MutableSet<String> = ConcurrentHashMap.newKeySet()
   private val conflationBackTestingApps: MutableMap<String, ConflationBacktestingApp> = ConcurrentHashMap()
 
   fun submitConflationBacktestingJob(conflationBacktestingConfig: ConflationBacktestingConfig): String {
     val jobId = conflationBacktestingConfig.jobId()
-    if (completedJobs.contains(jobId)) {
-      throw IllegalArgumentException("Given Conflation backtesting Request with jobId=$jobId is already completed")
-    }
     val app = ConflationBacktestingApp(
       vertx = vertx,
       conflationBacktestingAppConfig = conflationBacktestingConfig,
@@ -48,10 +47,15 @@ class ConflationBacktestingService(
       httpJsonRpcClientFactory = httpJsonRpcClientFactory,
       metricsFacade = metricsFacade,
     )
-    if (conflationBackTestingApps.putIfAbsent(jobId, app) != null) {
-      throw IllegalArgumentException(
-        "Given Conflation backtesting Request with jobId=$jobId is already being processed",
-      )
+    synchronized(jobLifecycleLock) {
+      if (completedJobs.contains(jobId)) {
+        throw IllegalArgumentException("Given Conflation backtesting Request with jobId=$jobId is already completed")
+      }
+      if (conflationBackTestingApps.putIfAbsent(jobId, app) != null) {
+        throw IllegalArgumentException(
+          "Given Conflation backtesting Request with jobId=$jobId is already being processed",
+        )
+      }
     }
     app.start().thenPeek {
       log.info("Conflation backtesting job started: jobId={}", jobId)
@@ -62,11 +66,13 @@ class ConflationBacktestingService(
   }
 
   fun getConflationBacktestingJobStatus(jobId: String): ConflationBacktestingJobStatus {
-    if (completedJobs.contains(jobId)) {
-      return ConflationBacktestingJobStatus.COMPLETED
-    }
-    if (conflationBackTestingApps.containsKey(jobId)) {
-      return ConflationBacktestingJobStatus.IN_PROGRESS
+    synchronized(jobLifecycleLock) {
+      if (completedJobs.contains(jobId)) {
+        return ConflationBacktestingJobStatus.COMPLETED
+      }
+      if (conflationBackTestingApps.containsKey(jobId)) {
+        return ConflationBacktestingJobStatus.IN_PROGRESS
+      }
     }
     throw IllegalArgumentException("No conflation backtesting job found with id: $jobId")
   }
@@ -74,20 +80,25 @@ class ConflationBacktestingService(
   /**
    * Stops an in-progress conflation backtesting job and releases its resources.
    *
-   * The job is removed atomically before [ConflationBacktestingApp.stop] is invoked so that the
-   * background polling [action] cannot also try to stop the same app concurrently.
+   * Map removal and marking the job completed happen under [jobLifecycleLock] without calling
+   * [ConflationBacktestingApp.stop], so [action] cannot observe a completed job and schedule a second
+   * stop for the same app. Only one path removes the job from [conflationBackTestingApps] and runs
+   * [ConflationBacktestingApp.stop].
    *
    * @return a future that completes when the underlying app has fully stopped
    * @throws IllegalArgumentException if no in-progress job with the given id exists
    * (e.g. unknown id, or the job has already completed).
    */
   fun stopConflationBacktestingJob(jobId: String): SafeFuture<Unit> {
-    if (completedJobs.contains(jobId)) {
-      throw IllegalArgumentException("Conflation backtesting job with jobId=$jobId is already completed")
+    val app = synchronized(jobLifecycleLock) {
+      if (completedJobs.contains(jobId)) {
+        throw IllegalArgumentException("Conflation backtesting job with jobId=$jobId is already completed")
+      }
+      val removed = conflationBackTestingApps.remove(jobId)
+        ?: throw IllegalArgumentException("No in-progress conflation backtesting job found with jobId=$jobId")
+      completedJobs.add(jobId)
+      removed
     }
-    val app = conflationBackTestingApps.remove(jobId)
-      ?: throw IllegalArgumentException("No in-progress conflation backtesting job found with jobId=$jobId")
-    completedJobs.add(jobId)
     log.info("Stopping conflation backtesting job: jobId={}", jobId)
     return app.stop().whenException { error ->
       log.error(
@@ -100,30 +111,28 @@ class ConflationBacktestingService(
   }
 
   override fun action(): SafeFuture<*> {
-    val completedJobIds = mutableListOf<String>()
-    val appsToStop = conflationBackTestingApps.map { (jobId, app) ->
-      if (app.isConflationBacktestingComplete()) {
-        completedJobIds.add(jobId)
-        app
-      } else {
-        null
+    val appsToStop = synchronized(jobLifecycleLock) {
+      val toStop = mutableListOf<ConflationBacktestingApp>()
+      for ((jobId, app) in conflationBackTestingApps.toMap()) {
+        if (app.isConflationBacktestingComplete() && conflationBackTestingApps.remove(jobId, app)) {
+          completedJobs.add(jobId)
+          toStop.add(app)
+        }
       }
-    }.filterNotNull()
-
-    completedJobIds.forEach { jobId ->
-      completedJobs.add(jobId)
-      conflationBackTestingApps.remove(jobId)
+      toStop
     }
     return SafeFuture.allOf(*appsToStop.map { app -> app.stop() }.toTypedArray())
   }
 
   override fun stop(): SafeFuture<Unit> {
     return super.stop().thenCompose {
-      val stopFutures = conflationBackTestingApps.values.map { app -> app.stop() }
-      conflationBackTestingApps.clear()
-      SafeFuture.allOf(*stopFutures.toTypedArray()).whenComplete { _, _ ->
+      val appsToShutdown = synchronized(jobLifecycleLock) {
+        val apps = conflationBackTestingApps.values.toList()
+        conflationBackTestingApps.clear()
         completedJobs.clear()
+        apps
       }
+      SafeFuture.allOf(*appsToShutdown.map { app -> app.stop() }.toTypedArray())
     }.thenApply { }
   }
 }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
@@ -71,6 +71,34 @@ class ConflationBacktestingService(
     throw IllegalArgumentException("No conflation backtesting job found with id: $jobId")
   }
 
+  /**
+   * Stops an in-progress conflation backtesting job and releases its resources.
+   *
+   * The job is removed atomically before [ConflationBacktestingApp.stop] is invoked so that the
+   * background polling [action] cannot also try to stop the same app concurrently.
+   *
+   * @return a future that completes when the underlying app has fully stopped
+   * @throws IllegalArgumentException if no in-progress job with the given id exists
+   * (e.g. unknown id, or the job has already completed).
+   */
+  fun stopConflationBacktestingJob(jobId: String): SafeFuture<Unit> {
+    if (completedJobs.contains(jobId)) {
+      throw IllegalArgumentException("Conflation backtesting job with jobId=$jobId is already completed")
+    }
+    val app = conflationBackTestingApps.remove(jobId)
+      ?: throw IllegalArgumentException("No in-progress conflation backtesting job found with jobId=$jobId")
+    completedJobs.add(jobId)
+    log.info("Stopping conflation backtesting job: jobId={}", jobId)
+    return app.stop().whenException { error ->
+      log.error(
+        "Error while stopping conflation backtesting job: jobId={}, errorMessage={}",
+        jobId,
+        error.message,
+        error,
+      )
+    }
+  }
+
   override fun action(): SafeFuture<*> {
     val completedJobIds = mutableListOf<String>()
     val appsToStop = conflationBackTestingApps.map { (jobId, app) ->

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/api/requesthandlers/ConflationStopJobRequestHandlerTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/api/requesthandlers/ConflationStopJobRequestHandlerTest.kt
@@ -1,0 +1,117 @@
+package net.consensys.zkevm.coordinator.api.requesthandlers
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.vertx.core.json.JsonObject
+import net.consensys.linea.jsonrpc.JsonRpcRequestListParams
+import net.consensys.linea.jsonrpc.JsonRpcRequestMapParams
+import net.consensys.zkevm.coordinator.app.conflationbacktesting.ConflationBacktestingService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+
+class ConflationStopJobRequestHandlerTest {
+
+  private val emptyRequestJson = JsonObject()
+
+  @Test
+  fun `invoke stops requested job and returns STOPPED on success`() {
+    val service = mock<ConflationBacktestingService>()
+    whenever(service.stopConflationBacktestingJob("job1")).thenReturn(SafeFuture.completedFuture(Unit))
+    val handler = ConflationStopJobRequestHandler(service)
+
+    val request = JsonRpcRequestListParams(
+      id = 1,
+      method = ConflationStopJobRequestHandler.METHOD_NAME,
+      params = listOf("job1"),
+      jsonrpc = "2.0",
+    )
+
+    val response = handler.invoke(null, request, emptyRequestJson).toCompletionStage().toCompletableFuture().get()
+
+    assertThat(response).isInstanceOf(Ok::class.java)
+    val success = (response as Ok).value
+    assertThat(success.id).isEqualTo(1)
+    assertThat(success.result).isEqualTo(ConflationStopJobRequestHandler.STOPPED_RESULT)
+    verify(service).stopConflationBacktestingJob("job1")
+  }
+
+  @Test
+  fun `invoke returns ERROR when service throws synchronously`() {
+    val service = mock<ConflationBacktestingService>()
+    whenever(service.stopConflationBacktestingJob("missing"))
+      .thenThrow(IllegalArgumentException("No in-progress conflation backtesting job found with jobId=missing"))
+    val handler = ConflationStopJobRequestHandler(service)
+
+    val request = JsonRpcRequestListParams(
+      id = 2,
+      method = ConflationStopJobRequestHandler.METHOD_NAME,
+      params = listOf("missing"),
+      jsonrpc = "2.0",
+    )
+
+    val response = handler.invoke(null, request, emptyRequestJson).toCompletionStage().toCompletableFuture().get()
+
+    assertThat(response).isInstanceOf(Ok::class.java)
+    val outcome = (response as Ok).value.result as String
+    assertThat(outcome).startsWith("ERROR:")
+    assertThat(outcome).contains("missing")
+  }
+
+  @Test
+  fun `invoke returns ERROR when stop future fails`() {
+    val service = mock<ConflationBacktestingService>()
+    val failingFuture: SafeFuture<Unit> = SafeFuture.failedFuture(RuntimeException("boom"))
+    whenever(service.stopConflationBacktestingJob("job1")).thenReturn(failingFuture)
+    val handler = ConflationStopJobRequestHandler(service)
+
+    val request = JsonRpcRequestListParams(
+      id = 3,
+      method = ConflationStopJobRequestHandler.METHOD_NAME,
+      params = listOf("job1"),
+      jsonrpc = "2.0",
+    )
+
+    val response = handler.invoke(null, request, emptyRequestJson).toCompletionStage().toCompletableFuture().get()
+
+    assertThat(response).isInstanceOf(Ok::class.java)
+    assertThat((response as Ok).value.result).isEqualTo("ERROR: boom")
+  }
+
+  @Test
+  fun `invoke returns invalidParams when params are not a list`() {
+    val service = mock<ConflationBacktestingService>()
+    val handler = ConflationStopJobRequestHandler(service)
+
+    val request = JsonRpcRequestMapParams(
+      id = 4,
+      method = ConflationStopJobRequestHandler.METHOD_NAME,
+      params = mapOf("jobId" to "job1"),
+      jsonrpc = "2.0",
+    )
+
+    val response = handler.invoke(null, request, emptyRequestJson).toCompletionStage().toCompletableFuture().get()
+
+    assertThat(response).isInstanceOf(Err::class.java)
+  }
+
+  @Test
+  fun `invoke returns invalidParams when more than one job ID is given`() {
+    val service = mock<ConflationBacktestingService>()
+    val handler = ConflationStopJobRequestHandler(service)
+
+    val request = JsonRpcRequestListParams(
+      id = 5,
+      method = ConflationStopJobRequestHandler.METHOD_NAME,
+      params = listOf("job1", "job2"),
+      jsonrpc = "2.0",
+    )
+
+    val response = handler.invoke(null, request, emptyRequestJson).toCompletionStage().toCompletableFuture().get()
+
+    assertThat(response).isInstanceOf(Err::class.java)
+  }
+}

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -128,7 +128,7 @@ Conflation backtesting allows re-running the conflation and proof-request pipeli
 
 1. Submit one or more backtesting jobs via `conflation_createProverRequests`, each specifying a block range, blob compressor version, a **traces** RPC configuration (`tracesApi`, and optionally `tracesConflationApi`), and the Shomei (state manager) endpoint.
 2. Each job spins up an isolated `ConflationBacktestingApp` instance. Trace line counts always use `tracesApi`. If `tracesConflationApi` is **omitted**, the same `tracesApi` client is also used for conflated traces (`linea_generateConflatedTracesToFileV2`). If `tracesConflationApi` is **set** (split-traces deployment), counters stay on `tracesApi` and conflated traces use `tracesConflationApi`; both must declare the **same** `version` string. Blobs use the requested compressor version; prover request files are written under `conflation.backtesting-directory` — same file layout as the live pipeline.
-3. Poll job status via `conflation_getReconflationJobsStatus` until `COMPLETED`.
+3. Poll job status via `conflation_getReconflationJobsStatus` (one or more job IDs per call) until each job reports `COMPLETED`.
 
 ### Prerequisites and validation
 
@@ -233,7 +233,7 @@ curl -X POST http://localhost:9546 \
 
 #### `conflation_getReconflationJobsStatus`
 
-Polls the status of one or more jobs by ID. Returns `IN_PROGRESS` or `COMPLETED` for each.
+Polls the status of one or more jobs by ID. `params` is a JSON array of job ID strings. The `result` array lists `IN_PROGRESS` or `COMPLETED` for each id, in the same order as `params`.
 
 ```json
 {
@@ -264,6 +264,29 @@ curl -X POST http://localhost:9546 \
   "jsonrpc": "2.0",
   "id": 2,
   "result": ["COMPLETED"]
+}
+```
+
+#### `conflation_stopReconflationJob`
+
+Stops one in-progress backtesting job. `params` must be a JSON array containing **exactly one** job ID string. On success `result` is `"STOPPED"`; on failure (unknown id, already completed, or shutdown error) `result` is `"ERROR: <message>"` (still HTTP 200 with a JSON-RPC success object).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "conflation_stopReconflationJob",
+  "params": ["1-2-hash"]
+}
+```
+
+**Response (success):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": "STOPPED"
 }
 ```
 


### PR DESCRIPTION

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new control-plane API to stop in-flight backtesting jobs and refactors job lifecycle handling with new synchronization, which could introduce concurrency/cleanup edge cases if misused.
> 
> **Overview**
> Adds a new JSON-RPC method `conflation_stopReconflationJob` to stop a single in-progress conflation backtesting job, wiring it into `Api` and documenting the request/response contract.
> 
> Updates `ConflationBacktestingService` to support explicit job stopping and to synchronize job submission/status/completion/teardown under a lifecycle lock to avoid double-stop races, and hardens `ConflationBacktestingApp`’s tracking of `lastProcessedBatchEndBlockNumber` against out-of-order updates. Includes unit tests for the new stop handler (success, invalid params, and failure paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92bed92265bf4e197897e2c009fba29073f0a41d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->