### PR TITLE
chore(misc): update besu commit hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,6 @@ contracts/.claude/settings.local.json
 .worktrees/
 e2e/e2e-runtime-report.html
 e2e/e2e-runtime-report-summary.json
-/linea-besu/.besu-resolved
 .zig-cache/
 
 # Runtime sequencer deny-list, seeded empty by Makefile/gradle before each env start

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ undercouchDownload = "5.6.0"
 # This is the single source of truth for the Besu version.
 # During task execution, linea-besu/build.gradle resolves this commit,
 # writes linea-besu/.besu-resolved, and read by dependent modules.
-besuCommit = "41cad9916393d73c1d050340b586b6f796405d57"
+besuCommit = "36cda4fd1f5cfe0d55044885fde3530d71b7d57a"
 blobCompressor = "4.0.1"
 commonsIo = "2.21.0"
 blobShnarfCalculator = "3.0.1"

--- a/linea-besu/.besu-resolved
+++ b/linea-besu/.besu-resolved
@@ -2,5 +2,5 @@
 # Written by Gradle (:linea-besu:resolveBesuVersion) and refreshed by CI
 # (.github/workflows/linea-besu-build-and-publish.yml) on besuCommit bumps.
 # Do NOT edit by hand and do NOT commit local changes — this file is gitignored.
-besuCommit=41cad9916393d73c1d050340b586b6f796405d57
-besuVersion=26.4.0-RC2-41cad99
+besuCommit=36cda4fd1f5cfe0d55044885fde3530d71b7d57a
+besuVersion=26.5.0-36cda4f

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/types/TransactionProcessingMetadata.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/types/TransactionProcessingMetadata.java
@@ -230,8 +230,7 @@ public class TransactionProcessingMetadata {
     floorCost =
         // the value below will not work in the Cancun TXN_DATA module (where it spits out 0,
         // but we still carry out the computation with the Prague value).
-        hub.gasCalculator.transactionFloorCost(
-            getBesuTransaction().getPayload(), numberOfZeroBytesInPayload);
+        hub.gasCalculator.transactionFloorCost(getBesuTransaction());
     floorCostPrague = GAS_CONST_G_TRANSACTION + this.weightedByteCount() * FLOOR_TOKEN_COST;
     initiallyAvailableGas = getInitiallyAvailableGas();
 

--- a/tracer/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
+++ b/tracer/reference-tests/src/test/java/net/consensys/linea/BlockchainReferenceTestTools.java
@@ -49,7 +49,6 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.mainnet.BlockAccessListValidator;
 import org.hyperledger.besu.ethereum.mainnet.BlockImportResult;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
@@ -60,6 +59,7 @@ import org.hyperledger.besu.ethereum.referencetests.BlockchainReferenceTestCaseS
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestProtocolSchedules;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.hyperledger.besu.testutil.JsonTestParameters;
 import org.junit.jupiter.api.Assumptions;
 

--- a/tracer/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
+++ b/tracer/reference-tests/src/test/java/net/consensys/linea/CorsetBlockProcessor.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.*;
@@ -44,6 +43,7 @@ import org.hyperledger.besu.ethereum.vm.BlockchainBasedBlockHashLookup;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 
 @Slf4j
 public class CorsetBlockProcessor extends MainnetBlockProcessor {

--- a/tracer/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
+++ b/tracer/testing/src/main/java/net/consensys/linea/testing/ReplayExecutionEnvironment.java
@@ -62,6 +62,7 @@ import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.junit.jupiter.api.TestInfo;
 
 /** Responsible for executing EVM transactions in replay tests. */

--- a/tracer/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
+++ b/tracer/testing/src/main/java/net/consensys/linea/testing/ToyExecutionTools.java
@@ -49,6 +49,7 @@ import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.fluent.SimpleBlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.worldstate.MutableWorldState;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.TestInfo;
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the pinned Besu commit/version and adapts tracer/test code to upstream API changes; runtime behavior (gas floor cost calculation and world state types) could shift subtly with the new Besu release.
> 
> **Overview**
> Bumps the pinned Besu dependency (`besuCommit`) and updates the resolved mapping in `linea-besu/.besu-resolved` to `26.5.0`.
> 
> Updates tracer code to match new Besu APIs: `TransactionProcessingMetadata` now computes `floorCost` via `gasCalculator.transactionFloorCost(Transaction)` instead of passing payload/zero-byte count, and several test/replay utilities switch `MutableWorldState` imports to `org.hyperledger.besu.plugin.services.worldstate.MutableWorldState`.
> 
> Removes the `.gitignore` entry for `linea-besu/.besu-resolved`, making the resolved-version cache file eligible to be committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49135f99115d5524a246bef189cd79d171673bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->