### PR TITLE
fix(linea-besu): pin package release actions

### DIFF
--- a/.github/actions/linea-besu-package/assemble/action.yml
+++ b/.github/actions/linea-besu-package/assemble/action.yml
@@ -46,14 +46,14 @@ runs:
     - name: generate token to fetch artifacts from private besu-fleet-plugin
       id: generate_token
       if: ${{ inputs.fetch_besu_fleet_plugin == 'true' }}
-      uses: getsentry/action-github-app-token@v3
+      uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc #v3
       with:
         private_key: ${{ inputs.fleet_github_app_private_key }}
         app_id: ${{ inputs.fleet_github_app_id }}
 
     - name: get plugins from private besu-fleet-plugin
       if: ${{ inputs.fetch_besu_fleet_plugin == 'true' }}
-      uses: dsaltares/fetch-gh-release-asset@master
+      uses: dsaltares/fetch-gh-release-asset@aa2ab1243d6e0d5b405b973c89fa4d06a2d0fff7 #1.1.2
       with:
         repo: 'Consensys/besu-fleet-plugin'
         version: 'tags/${{ inputs.besu_fleet_plugin_version }}'

--- a/.github/workflows/linea-besu-package-build-and-upload.yml
+++ b/.github/workflows/linea-besu-package-build-and-upload.yml
@@ -40,7 +40,7 @@ jobs:
       dockerimage: ${{ steps.build-plugins-and-assemble.outputs.dockerimage }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
 
       - name: Build plugins and assemble
         id: build-plugins-and-assemble
@@ -101,7 +101,7 @@ jobs:
         shell: bash
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         with:
           name: linea-besu-package
           path: linea-besu-package-images.tar.gz

--- a/.github/workflows/reuse-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reuse-linea-besu-package-build-test-push.yml
@@ -88,7 +88,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
 
       - name: Build plugins and assemble
         id: build-plugins-and-assemble


### PR DESCRIPTION
## Summary
- Pin Linea Besu package release workflow actions to full commit SHAs.
- Keep the original action tags in comments for maintainability.

## Validation
- Parsed the affected YAML files successfully.
- Ran actionlint on the affected workflows with repository-specific runner labels ignored.
- Verified no external mutable action refs remain in the affected release workflow files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins GitHub Action references to immutable commit SHAs, without changing build logic or outputs.
> 
> **Overview**
> **Pins external GitHub Actions used by the Linea Besu package build/release pipelines to full commit SHAs** (keeping the original version tags in comments) to eliminate mutable refs.
> 
> This updates the composite `assemble` action (`getsentry/action-github-app-token`, `dsaltares/fetch-gh-release-asset`) and the workflows that build/upload/push images (`actions/checkout`, `actions/upload-artifact`) to use commit-pinned `uses:` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffb600981fcb73e36897f1b7a441c5c00050abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->