### PR TITLE
feat: [RISCV] machine panic on non zero exit code

### DIFF
--- a/arithmetization/Makefile
+++ b/arithmetization/Makefile
@@ -14,7 +14,7 @@ GO_CORSET_REPO ?= https://github.com/consensys/go-corset.git
 GO_CORSET_REF_FOR_ZKC ?=
 
 # Used to install go-corset
-GO_CORSET_VERSION ?= v1.2.12
+GO_CORSET_VERSION ?= v1.2.14
 
 ZKC_FILES := $(shell find $(MAKEFILE_DIR)src/main/riscv/* -name "*.zkc")
 ZKC_MAIN := $(MAKEFILE_DIR)src/main/riscv/main.zkc

--- a/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/i_type.zkc
@@ -187,9 +187,7 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
             if funct3 == FUNCT3_ECALL {
                 // imm12 is interpreted as funct12 for SYSTEM opcode
                 if imm12 == FUNCT12_ECALL {
-                    printf "ECALL\n"
-                    // Note: as we don't fully support CSR, we use ECALL as generic STOP instruction for now
-                    new_pc = MAX_UINT_64 // set the stop signal to end the program execution
+                    new_pc = process_syscall(pc)
                 } else if imm12 == FUNCT12_EBREAK {
                     printf "[ERROR] EBREAK instruction triggered\n"
                 }
@@ -203,6 +201,25 @@ fn process_I_type_instruction<ram, registers>(opcode:Opcode, instruction_paramet
             printf "\tfunct3 ≡ %x ≡ %b\n", funct3, funct3
             printf "\tfunct7 ≡ %x ≡ %b\n", funct7, funct7
             fail
+        }
+    }
+}
+
+fn process_syscall<registers, ram>(pc:Address) -> (new_pc:Address) {
+    var call_num:DoubleWord = registers[17]
+    //
+    switch call_num {
+        case 93: { // exit 
+            var exit_code:DoubleWord = registers[10]
+            // check for non-zero exit code
+            if exit_code != 0 {
+                fail "exit with code %d", exit_code
+            }
+            // set stop signal to terminate execution
+            new_pc = MAX_UINT_64
+        }
+        default: {
+            fail "unsupported system call (%d)", call_num
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes RISC-V `SYSTEM/ECALL` behavior to terminate execution via a syscall handler and to `fail` on unsupported syscalls or non-zero exit codes, which can affect program termination semantics. Also bumps the `go-corset` toolchain version, which may subtly change compilation/formatting behavior.
> 
> **Overview**
> Adds basic syscall handling for RISC-V `ECALL` by routing it through a new `process_syscall` helper. The only supported syscall is `exit` (93): it now **halts normally only on exit code 0** and triggers `fail` on non-zero exit codes; all other syscall numbers now `fail` as unsupported.
> 
> Updates the arithmetization toolchain dependency by bumping `GO_CORSET_VERSION` from `v1.2.12` to `v1.2.14`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ad564e901077df6799eb3b27c0d08060522d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->