### PR TITLE
fix(coordinator): require all three proof flows to reach target before marking conflation backtesting complete

### DIFF
--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/BacktestingProgressTracker.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/BacktestingProgressTracker.kt
@@ -1,0 +1,76 @@
+package net.consensys.zkevm.coordinator.app.conflationbacktesting
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.fetchAndUpdate
+
+/**
+ * Tracks per-flow progress (execution, compression, aggregation) for a conflation backtesting job.
+ *
+ * Each flow submits its proof request asynchronously and independently:
+ *  - Execution proof request creation depends on a remote traces conflation API call with retries.
+ *  - Compression proof request creation depends only on blob creation in the conflation calculator.
+ *  - Aggregation proof request creation depends on compression proof requests being submitted.
+ *
+ * Because these flows run independently, an aggregation request for the target end block can be
+ * created while earlier execution proof requests are still retrying. Backtesting is complete only
+ * when every flow has reached [targetEndBlockNumber].
+ */
+@OptIn(ExperimentalAtomicApi::class)
+class BacktestingProgressTracker(
+  startBlockNumber: ULong,
+  private val targetEndBlockNumber: ULong,
+  private val log: Logger = LogManager.getLogger(BacktestingProgressTracker::class.java),
+) {
+  // Each flow's "no progress yet" state is the block before the backtesting range starts.
+  // BlockCreationMonitor reads this baseline via lastExecutionRequestEndBlock() to gate how
+  // far ahead of the proven head it may fetch; initialising below startBlockNumber - 1 would
+  // keep the gap above blocksFetchLimit and stall block fetching forever.
+  private val initialEndBlock: Long = startBlockNumber.toLong() - 1L
+  private val lastExecutionEndBlock = AtomicLong(initialEndBlock)
+  private val lastCompressionEndBlock = AtomicLong(initialEndBlock)
+  private val lastAggregationEndBlock = AtomicLong(initialEndBlock)
+  private val completionLogged = AtomicBoolean(false)
+
+  fun recordExecutionRequestEndBlock(endBlockNumber: ULong) {
+    record("execution", lastExecutionEndBlock, endBlockNumber)
+  }
+
+  fun recordCompressionRequestEndBlock(endBlockNumber: ULong) {
+    record("compression", lastCompressionEndBlock, endBlockNumber)
+  }
+
+  fun recordAggregationRequestEndBlock(endBlockNumber: ULong) {
+    record("aggregation", lastAggregationEndBlock, endBlockNumber)
+  }
+
+  fun lastExecutionRequestEndBlock(): Long = lastExecutionEndBlock.load()
+
+  fun lastCompressionRequestEndBlock(): Long = lastCompressionEndBlock.load()
+
+  fun lastAggregationRequestEndBlock(): Long = lastAggregationEndBlock.load()
+
+  fun isComplete(): Boolean {
+    val target = targetEndBlockNumber.toLong()
+    return lastExecutionEndBlock.load() >= target &&
+      lastCompressionEndBlock.load() >= target &&
+      lastAggregationEndBlock.load() >= target
+  }
+
+  private fun record(flowName: String, tracker: AtomicLong, endBlockNumber: ULong) {
+    val newValue = endBlockNumber.toLong()
+    tracker.fetchAndUpdate { current -> if (current < newValue) newValue else current }
+    log.info(
+      "Backtesting {} progress: lastEndBlock={} targetEndBlock={}",
+      flowName,
+      tracker.load(),
+      targetEndBlockNumber,
+    )
+    if (isComplete() && completionLogged.compareAndSet(expectedValue = false, newValue = true)) {
+      log.info("Conflation backtesting complete: targetEndBlock={}", targetEndBlockNumber)
+    }
+  }
+}

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -51,15 +51,10 @@ import net.consensys.zkevm.ethereum.coordination.proofcreation.ZkProofCreationCo
 import org.apache.logging.log4j.LogManager
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.nio.file.Path
-import kotlin.concurrent.atomics.AtomicBoolean
-import kotlin.concurrent.atomics.AtomicLong
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.concurrent.atomics.fetchAndUpdate
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
-@OptIn(ExperimentalAtomicApi::class)
 class ConflationBacktestingApp(
   val vertx: Vertx,
   val conflationBacktestingAppConfig: ConflationBacktestingConfig,
@@ -99,24 +94,13 @@ class ConflationBacktestingApp(
 
   private val log = LogManager.getLogger("conflation_backtesting_job_${conflationBacktestingAppConfig.jobId()}")
 
-  private val conflationBacktestingComplete = AtomicBoolean(false)
+  private val progressTracker = BacktestingProgressTracker(
+    startBlockNumber = conflationBacktestingAppConfig.startBlockNumber,
+    targetEndBlockNumber = conflationBacktestingAppConfig.endBlockNumber,
+    log = log,
+  )
 
-  fun isConflationBacktestingComplete(): Boolean = conflationBacktestingComplete.load()
-
-  fun onConflationProgress(
-    blockNumber: ULong,
-  ) {
-    if (blockNumber == conflationBacktestingAppConfig.endBlockNumber) {
-      conflationBacktestingComplete.store(true)
-      log.info("Conflation backtesting complete")
-    } else {
-      log.info(
-        "Conflation backtesting progress: processed till blockNumber={}, targetEndBlock={}",
-        blockNumber,
-        conflationBacktestingAppConfig.endBlockNumber,
-      )
-    }
-  }
+  fun isConflationBacktestingComplete(): Boolean = progressTracker.isComplete()
 
   val backtestingCoordinatorConfig: CoordinatorConfig = mainCoordinatorConfig.copy(
     conflation = mainCoordinatorConfig.conflation.copy(
@@ -244,7 +228,6 @@ class ConflationBacktestingApp(
     logger = log,
   )
 
-  val lastProcessedBatchEndBlockNumber = AtomicLong(conflationBacktestingAppConfig.startBlockNumber.toLong() - 1)
   val proofGeneratingConflationHandlerImpl = run {
     val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient(log = log)
 
@@ -271,15 +254,7 @@ class ConflationBacktestingApp(
           "Backtesting execution proof request produced: batch={}",
           unProvenBatch.intervalString(),
         )
-        // check to prevent out of order proof request from regressing teh last processed batch number.
-        lastProcessedBatchEndBlockNumber.fetchAndUpdate {
-            current ->
-          if (current < proofIndex.endBlockNumber.toLong()) {
-            proofIndex.endBlockNumber.toLong()
-          } else {
-            current
-          }
-        }
+        progressTracker.recordExecutionRequestEndBlock(proofIndex.endBlockNumber)
       },
       vertx = vertx,
       config = ProofGeneratingConflationHandlerImpl.Config(
@@ -338,6 +313,7 @@ class ConflationBacktestingApp(
           blobRecord.intervalString(),
         )
         inMemoryProvenBlobsTracker.acceptProvenBlobRecord(proofIndex, blobRecord)
+        progressTracker.recordCompressionRequestEndBlock(blobRecord.endBlockNumber)
       },
       log = log,
       metricsFacade = metricsFacade,
@@ -379,7 +355,7 @@ class ConflationBacktestingApp(
         "Backtesting aggregation proof request produced: aggregation={}",
         unProvenAggregation.intervalString(),
       )
-      onConflationProgress(proofIndex.endBlockNumber)
+      progressTracker.recordAggregationRequestEndBlock(proofIndex.endBlockNumber)
     },
     invalidityProofProvider = InvalidityProofProviderImpl(DisabledForcedTransactionsDao()),
     aggregationL2StateProvider = AggregationL2StateProviderImpl(
@@ -407,7 +383,7 @@ class ConflationBacktestingApp(
     blockCreationListener = blockToBatchSubmissionCoordinator,
     lastProvenBlockNumberProviderSync = object : LastProvenBlockNumberProviderSync {
       override fun getLastKnownProvenBlockNumber(): Long {
-        return lastProcessedBatchEndBlockNumber.load()
+        return progressTracker.lastExecutionRequestEndBlock()
       }
     },
     config = BlockCreationMonitor.Config(

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/BacktestingProgressTrackerTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/BacktestingProgressTrackerTest.kt
@@ -1,0 +1,129 @@
+package net.consensys.zkevm.coordinator.app.conflationbacktesting
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BacktestingProgressTrackerTest {
+
+  private val startBlock: ULong = 50uL
+  private val targetEndBlock: ULong = 100uL
+  private val initialEndBlock: Long = startBlock.toLong() - 1L
+
+  private fun newTracker(): BacktestingProgressTracker = BacktestingProgressTracker(
+    startBlockNumber = startBlock,
+    targetEndBlockNumber = targetEndBlock,
+  )
+
+  @Test
+  fun `initial last-end-block values are startBlockNumber minus one for all flows`() {
+    val tracker = newTracker()
+    assertThat(tracker.isComplete()).isFalse()
+    assertThat(tracker.lastExecutionRequestEndBlock()).isEqualTo(initialEndBlock)
+    assertThat(tracker.lastCompressionRequestEndBlock()).isEqualTo(initialEndBlock)
+    assertThat(tracker.lastAggregationRequestEndBlock()).isEqualTo(initialEndBlock)
+  }
+
+  @Test
+  fun `is not complete when only execution flow reaches target`() {
+    val tracker = newTracker()
+    tracker.recordExecutionRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isFalse()
+  }
+
+  @Test
+  fun `is not complete when only execution and compression flows reach target`() {
+    val tracker = newTracker()
+    tracker.recordExecutionRequestEndBlock(targetEndBlock)
+    tracker.recordCompressionRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isFalse()
+  }
+
+  @Test
+  fun `is not complete when only aggregation flow reaches target`() {
+    // Reproduces the bug: aggregation can finish while execution still lags due to retrying
+    // traces conflation, so completion must require all three flows.
+    val tracker = newTracker()
+    tracker.recordAggregationRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isFalse()
+  }
+
+  @Test
+  fun `is not complete when only compression and aggregation flows reach target`() {
+    val tracker = newTracker()
+    tracker.recordCompressionRequestEndBlock(targetEndBlock)
+    tracker.recordAggregationRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isFalse()
+  }
+
+  @Test
+  fun `is complete only when all three flows reach target`() {
+    val tracker = newTracker()
+    tracker.recordExecutionRequestEndBlock(targetEndBlock)
+    tracker.recordCompressionRequestEndBlock(targetEndBlock)
+    tracker.recordAggregationRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isTrue()
+  }
+
+  @Test
+  fun `is complete when flows surpass target`() {
+    val tracker = newTracker()
+    tracker.recordExecutionRequestEndBlock(targetEndBlock + 5uL)
+    tracker.recordCompressionRequestEndBlock(targetEndBlock + 3uL)
+    tracker.recordAggregationRequestEndBlock(targetEndBlock + 1uL)
+    assertThat(tracker.isComplete()).isTrue()
+  }
+
+  @Test
+  fun `out of order execution callbacks do not regress progress`() {
+    val tracker = newTracker()
+    tracker.recordExecutionRequestEndBlock(80uL)
+    tracker.recordExecutionRequestEndBlock(60uL)
+    assertThat(tracker.lastExecutionRequestEndBlock()).isEqualTo(80L)
+  }
+
+  @Test
+  fun `out of order compression callbacks do not regress progress`() {
+    val tracker = newTracker()
+    tracker.recordCompressionRequestEndBlock(75uL)
+    tracker.recordCompressionRequestEndBlock(60uL)
+    assertThat(tracker.lastCompressionRequestEndBlock()).isEqualTo(75L)
+  }
+
+  @Test
+  fun `out of order aggregation callbacks do not regress progress`() {
+    val tracker = newTracker()
+    tracker.recordAggregationRequestEndBlock(70uL)
+    tracker.recordAggregationRequestEndBlock(60uL)
+    assertThat(tracker.lastAggregationRequestEndBlock()).isEqualTo(70L)
+  }
+
+  @Test
+  fun `lastExecutionRequestEndBlock returns highest recorded value`() {
+    val tracker = newTracker()
+    tracker.recordExecutionRequestEndBlock(60uL)
+    tracker.recordExecutionRequestEndBlock(90uL)
+    tracker.recordExecutionRequestEndBlock(70uL)
+    assertThat(tracker.lastExecutionRequestEndBlock()).isEqualTo(90L)
+  }
+
+  @Test
+  fun `is complete is independent of order in which flows reach target`() {
+    val tracker = newTracker()
+    tracker.recordAggregationRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isFalse()
+    tracker.recordCompressionRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isFalse()
+    tracker.recordExecutionRequestEndBlock(targetEndBlock)
+    assertThat(tracker.isComplete()).isTrue()
+  }
+
+  @Test
+  fun `lastExecutionRequestEndBlock baseline keeps BlockCreationMonitor fetch gap small at startup`() {
+    // Regression guard: BlockCreationMonitor refuses to fetch when
+    // (nextBlockToFetch - lastKnownProvenBlock) > blocksFetchLimit. With startBlockNumber=50,
+    // initial nextBlockToFetch=startBlockNumber=50, so the initial gap must be 1.
+    val tracker = newTracker()
+    val initialGap = startBlock.toLong() - tracker.lastExecutionRequestEndBlock()
+    assertThat(initialGap).isEqualTo(1L)
+  }
+}


### PR DESCRIPTION
fix: track per-flow progress to determine conflation backtesting completion

Previously ConflationBacktestingApp.onConflationProgress was wired only to the
aggregation request handler and decided completion solely from aggregation's
end block. Because the execution, compression, and aggregation flows submit
proof requests asynchronously and independently (in particular, execution
proof request creation can lag arbitrarily on traces conflation API retries
while compression and aggregation proceed off the in-memory blob store), this
could mark backtesting complete while execution proof requests for the final
batches were still pending.

Replace the single completion flag with BacktestingProgressTracker, which
records the highest end block reached by each flow with atomic max-updates
and reports complete only when all three reach the configured target. The
tracker also serves as the LastProvenBlockNumberProviderSync for
BlockCreationMonitor, so its baseline is initialised to startBlockNumber - 1
to preserve the previous fetch-gap behaviour at startup.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backtesting job completion and block-fetch gating to rely on new per-flow progress tracking; incorrect tracking could cause premature job shutdown or stalled block fetching.
> 
> **Overview**
> Fixes conflation backtesting completion logic by introducing `BacktestingProgressTracker`, which atomically tracks the highest end-block reached by **execution**, **compression**, and **aggregation** proof-request flows and reports completion only when *all three* reach the configured target.
> 
> `ConflationBacktestingApp` is rewired to record progress from each flow’s proof-request handler and to use the tracker’s execution baseline as `BlockCreationMonitor`’s last-proven provider, preserving startup fetch-gap behavior. Adds unit tests covering completion conditions, out-of-order callbacks, and the startup baseline regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7d5cb44e513be147e541b8f813d1032f99f664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->