### PR TITLE
feat(ci): updated partial prover e2e tests with ftx tests and configs

### DIFF
--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -27,6 +27,11 @@ jobs:
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [ 'local', 'forced-transactions:local' ]
+    name: Run test:partial-prover:${{ matrix.test }} e2e tests
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -104,7 +109,7 @@ jobs:
         id: run_e2e_tests
         timeout-minutes: 30
         run: |
-          LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:local
+          LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:${{ matrix.test }}
 
       - name: Show e2e tests result
         if: always()

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -1,4 +1,4 @@
-name: linea-besu-package-e2e-tests-with-partial-prover
+name: partial-prover-e2e-tests
 
 permissions:
   actions: read
@@ -22,16 +22,12 @@ on:
         type: string
 
 jobs:
-  build-images-and-run-e2e-tests-with-partial-prover:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+  build-and-upload-images:
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     concurrency:
-      group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}-${{ matrix.test }}
+      group: build-images-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        test: [ 'local', 'forced-transactions:local' ]
-    name: Run test:partial-prover:${{ matrix.test }} e2e tests
+    name: Build docker images from source and upload (if needed) for e2e tests
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -55,6 +51,21 @@ jobs:
           sudo apt update
           sudo apt-get install --no-install-recommends --assume-yes tree
           tree .
+      
+      - name: Save linea-besu-package docker image as artifact
+        if: ${{ inputs.linea_besu_package_image_tag == '' }}
+        run: |
+          docker images
+          docker save consensys/linea-besu-package:local | gzip > linea-besu-package-image.tar.gz
+        shell: bash
+
+      - name: Upload linea-besu-package docker image artifact
+        if: ${{ inputs.linea_besu_package_image_tag == '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+        with:
+          name: linea-besu-package
+          path: linea-besu-package-image.tar.gz
+          retention-days: 1
 
       - name: Install Go (for prover build)
         if: ${{ inputs.linea_besu_package_image_tag != '' &&  inputs.prover_image_tag == '' }}
@@ -70,78 +81,25 @@ jobs:
         env:
           JAVA_OPTS: -Xmx2g -Dorg.gradle.daemon=false
 
-      - name: Setup nodejs environment (for e2e tests)
-        uses: ./.github/actions/setup-nodejs
+      - name: Save prover docker image as artifact
+        if: ${{ inputs.prover_image_tag == '' }}
+        run: |
+          docker images
+          docker save consensys/linea-prover:local | gzip > linea-prover-image.tar.gz
+        shell: bash
+
+      - name: Upload prover docker image artifact
+        if: ${{ inputs.prover_image_tag == '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         with:
-          pnpm-install-options: '-F contracts -F "e2e..." --frozen-lockfile --prefer-offline'
-          commands: |
-            pnpm run -F "e2e^..." build
+          name: linea-prover
+          path: linea-prover-image.tar.gz
+          retention-days: 1
+  
+  run-e2e-tests-with-partial-prover:
+    uses: ./.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+    with:
+      linea_besu_package_image_tag: ${{ inputs.linea_besu_package_image_tag }}
+      prover_image_tag: ${{ inputs.prover_image_tag }}
+      shomei_image_tag: ${{ inputs.shomei_image_tag }}
 
-      - name: Create directory for conflated traces
-        run: |
-          mkdir -p tmp/local/traces/v2/conflated
-          chmod -R a+rw tmp/local/
-
-      - name: Spin up fresh environment with besu tracing with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
-        with:
-          max_attempts: 10
-          retry_on: error
-          retry_wait_seconds: 30
-          timeout_minutes: 10
-          # TODO: hardcoded image tags for testing, should be removed 
-          command: |
-            LINEA_BESU_PACKAGE_TAG=${{ inputs.linea_besu_package_image_tag || 'local' }} \
-            LINEA_PROVER_TAG=${{ inputs.prover_image_tag || 'local' }} \
-            LINEA_SHOMEI_TAG=${{ inputs.shomei_image_tag }} \
-            make start-env-with-tracing-v2-partialprover CLEAN_PREVIOUS_ENV=false
-          on_retry_command: |
-            make clean-environment
-
-      - name: List docker containers/images
-        if: always()
-        continue-on-error: true
-        run: |
-          docker ps -la && docker images
-          docker container ls -a
-
-      - name: Run e2e tests with partial prover
-        id: run_e2e_tests
-        timeout-minutes: 30
-        run: |
-          LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:${{ matrix.test }}
-
-      - name: Show e2e tests result
-        if: always()
-        run: |
-          echo "E2E_TESTS_RESULT: ${{ steps.run_e2e_tests.outcome }}"
-
-      - name: Dump logs
-        if: failure()
-        run: |
-          mkdir -p docker_logs
-          find tmp/local/ >> docker_logs/files_in_shared_dir.txt || true
-          docker ps -a >> docker_logs/docker_ps.txt || true
-          docker logs coordinator --since 1h &>> docker_logs/coordinator.txt || true
-          docker logs prover-v3 --since 1h &>> docker_logs/prover-v3.txt || true
-          docker logs shomei --since 1h &>> docker_logs/shomei.txt || true
-          docker logs l2-node-besu --since 1h &>> docker_logs/l2-node-besu.txt || true
-          docker logs sequencer --since 1h &>> docker_logs/sequencer.txt || true
-          docker logs l1-el-node --since 1h &>> docker_logs/l1-el-node.txt || true
-
-      - name: Archive debug logs
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: end-2-end-debug-logs
-          if-no-files-found: error
-          path: |
-            docker_logs/**/*
-      
-      - name: Archive shared folder
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: end-2-end-shared-folder
-          path: |
-            tmp/local/**/*

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -25,7 +25,7 @@ jobs:
   build-images-and-run-e2e-tests-with-partial-prover:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
     concurrency:
-      group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}
+      group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}-${{ matrix.test }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -97,6 +97,7 @@ jobs:
           retention-days: 1
   
   run-e2e-tests-with-partial-prover:
+    needs: [build-and-upload-images]
     uses: ./.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
     with:
       linea_besu_package_image_tag: ${{ inputs.linea_besu_package_image_tag }}

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -30,7 +30,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [ 'local', 'forced-transactions:local' ]
+        include:
+          - test: local
+            archive-name: local
+          - test: forced-transactions:local
+            archive-name: forced-transactions-local
+
     name: Run test:partial-prover:${{ matrix.test }} e2e tests
     steps:
       - name: Checkout
@@ -127,7 +132,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: end-2-end-debug-logs-${{ matrix.test }}
+          name: end-2-end-debug-logs-${{ matrix.archive-name }}
           if-no-files-found: error
           path: |
             docker_logs/**/*
@@ -136,6 +141,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: end-2-end-shared-folder-${{ matrix.test }}
+          name: end-2-end-shared-folder-${{ matrix.archive-name }}
           path: |
             tmp/local/**/*

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: end-2-end-debug-logs
+          name: end-2-end-debug-logs-${{ matrix.test }}
           if-no-files-found: error
           path: |
             docker_logs/**/*
@@ -136,6 +136,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: end-2-end-shared-folder
+          name: end-2-end-shared-folder-${{ matrix.test }}
           path: |
             tmp/local/**/*

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Run e2e tests with partial prover
         id: run_e2e_tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:${{ matrix.test }}
 

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -1,0 +1,141 @@
+name: partial-prover-run-e2e-tests-in-parallel
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+
+on:
+  workflow_call:
+    inputs:
+      linea_besu_package_image_tag:
+        description: 'Target linea-besu-package image tag (i.e. [prefix]-[YYYYMMDDHHMMSS]-[commit]), if not given, would build the linea-besu-package image from source'
+        required: false
+        type: string
+      prover_image_tag:
+        description: 'Target prover image tag, if not given, would build the prover image from source'
+        required: false
+        type: string
+      shomei_image_tag:
+        description: 'Target shomei image tag, if not given, would use the version declared in docker/compose-spec-l2-services.yml'
+        required: false
+        type: string
+
+jobs:
+  download-images-and-run-e2e-tests-with-partial-prover:
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    concurrency:
+      group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}-${{ matrix.test }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [ 'local', 'forced-transactions:local' ]
+    name: Run test:partial-prover:${{ matrix.test }} e2e tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download local linea-besu-package docker image
+        if: ${{ inputs.linea_besu_package_image_tag == '' }}
+        uses: actions/download-artifact@v7
+        with:
+          pattern: linea-besu-package
+          path: ${{ github.workspace }}/tmp/artifacts
+
+      - name: Load local linea-besu-package docker image
+        if: ${{ inputs.linea_besu_package_image_tag == '' }}
+        run: |
+          pwd && ls -la && echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" &&
+          gunzip -c $GITHUB_WORKSPACE/tmp/artifacts/linea-besu-package-image.tar.gz | docker load
+        shell: bash
+
+      - name: Download local prover docker image
+        if: ${{ inputs.prover_image_tag == '' }}
+        uses: actions/download-artifact@v7
+        with:
+          pattern: linea-prover
+          path: ${{ github.workspace }}/tmp/artifacts
+
+      - name: Load local prover docker image
+        if: ${{ inputs.prover_image_tag == '' }}
+        run: |
+          pwd && ls -la && echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" &&
+          gunzip -c $GITHUB_WORKSPACE/tmp/artifacts/linea-prover-image.tar.gz | docker load
+        shell: bash
+
+      - name: Setup nodejs environment (for e2e tests)
+        uses: ./.github/actions/setup-nodejs
+        with:
+          pnpm-install-options: '-F contracts -F "e2e..." --frozen-lockfile --prefer-offline'
+          commands: |
+            pnpm run -F "e2e^..." build
+
+      - name: Create directory for conflated traces
+        run: |
+          mkdir -p tmp/local/traces/v2/conflated
+          chmod -R a+rw tmp/local/
+
+      - name: Spin up fresh environment with besu tracing with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          max_attempts: 10
+          retry_on: error
+          retry_wait_seconds: 30
+          timeout_minutes: 10
+          # TODO: hardcoded image tags for testing, should be removed 
+          command: |
+            LINEA_BESU_PACKAGE_TAG=${{ inputs.linea_besu_package_image_tag || 'local' }} \
+            LINEA_PROVER_TAG=${{ inputs.prover_image_tag || 'local' }} \
+            LINEA_SHOMEI_TAG=${{ inputs.shomei_image_tag }} \
+            make start-env-with-tracing-v2-partialprover CLEAN_PREVIOUS_ENV=false
+          on_retry_command: |
+            make clean-environment
+
+      - name: List docker containers/images
+        if: always()
+        continue-on-error: true
+        run: |
+          docker ps -la && docker images
+          docker container ls -a
+
+      - name: Run e2e tests with partial prover
+        id: run_e2e_tests
+        timeout-minutes: 30
+        run: |
+          LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:${{ matrix.test }}
+
+      - name: Show e2e tests result
+        if: always()
+        run: |
+          echo "E2E_TESTS_RESULT: ${{ steps.run_e2e_tests.outcome }}"
+
+      - name: Dump logs
+        if: failure()
+        run: |
+          mkdir -p docker_logs
+          find tmp/local/ >> docker_logs/files_in_shared_dir.txt || true
+          docker ps -a >> docker_logs/docker_ps.txt || true
+          docker logs coordinator --since 1h &>> docker_logs/coordinator.txt || true
+          docker logs prover-v3 --since 1h &>> docker_logs/prover-v3.txt || true
+          docker logs shomei --since 1h &>> docker_logs/shomei.txt || true
+          docker logs l2-node-besu --since 1h &>> docker_logs/l2-node-besu.txt || true
+          docker logs sequencer --since 1h &>> docker_logs/sequencer.txt || true
+          docker logs l1-el-node --since 1h &>> docker_logs/l1-el-node.txt || true
+
+      - name: Archive debug logs
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: end-2-end-debug-logs
+          if-no-files-found: error
+          path: |
+            docker_logs/**/*
+      
+      - name: Archive shared folder
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: end-2-end-shared-folder
+          path: |
+            tmp/local/**/*

--- a/docker/compose-tracing-v2-ci-extension.yml
+++ b/docker/compose-tracing-v2-ci-extension.yml
@@ -21,3 +21,10 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: transaction-exclusion-api
+  
+  sequencer:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: sequencer
+    environment:
+      BESU_PLUGIN_LINEA_LIVENESS_ENABLED: true

--- a/docker/compose-tracing-v2-partialprover-override.yml
+++ b/docker/compose-tracing-v2-partialprover-override.yml
@@ -21,6 +21,6 @@ services:
     environment:
       config__override__conflation__blocks_limit: 20
       config__override__conflation__conflation_deadline: PT30M
-      config__override__conflation__blob_compression__batches_limit: 2
+      config__override__conflation__blob_compression__batches_limit: 1
       config__override__conflation__proof_aggregation__deadline: PT30M
       CONFIG_OVERRIDE_OPTS: ${LINEA_SHOMEI_TAG:+-Dconfig.override.state-manager.version=$LINEA_SHOMEI_TAG}

--- a/docker/compose-tracing-v2.yml
+++ b/docker/compose-tracing-v2.yml
@@ -50,6 +50,8 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: sequencer
+    environment:
+      BESU_PLUGIN_LINEA_LIVENESS_ENABLED: false
 
   l2-node-besu:
     extends:

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,7 +16,7 @@
     "test:sendbundle:local": "TEST_ENV=local jest send-bundle.spec.ts",
     "test:partial-prover:messaging:local": "TEST_ENV=local PARTIAL_PROVER=true jest messaging.spec.ts -t 'L1/L2 message txs for partial prover e2e testing'",
     "test:partial-prover:finalization:local": "TEST_ENV=local PARTIAL_PROVER=true jest submission-finalization.spec.ts -t 'Check latest L2 block number has been finalized on L1'",
-    "test:partial-prover:forced-transactions:local": "TEST_ENV=local PARTIAL_PROVER=true jest e2e/src/forced-transactions.spec.ts",
+    "test:partial-prover:forced-transactions:local": "TEST_ENV=local PARTIAL_PROVER=true jest forced-transactions.spec.ts",
     "test:partial-prover:local": "TEST_ENV=local jest opcodes.spec.ts l2.spec.ts eip7702.spec.ts && pnpm run test:partial-prover:messaging:local && pnpm run test:partial-prover:finalization:local",
     "test:dev": "TEST_ENV=dev jest --config ./jest.testnet.config.ts --bail --runInBand --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts --testPathIgnorePatterns=restart.spec.ts",
     "test:sepolia": "TEST_ENV=sepolia jest --config ./jest.testnet.config.ts --bail --runInBand --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts --testPathIgnorePatterns=restart.spec.ts",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,6 +16,7 @@
     "test:sendbundle:local": "TEST_ENV=local jest send-bundle.spec.ts",
     "test:partial-prover:messaging:local": "TEST_ENV=local PARTIAL_PROVER=true jest messaging.spec.ts -t 'L1/L2 message txs for partial prover e2e testing'",
     "test:partial-prover:finalization:local": "TEST_ENV=local PARTIAL_PROVER=true jest submission-finalization.spec.ts -t 'Check latest L2 block number has been finalized on L1'",
+    "test:partial-prover:forced-transactions:local": "TEST_ENV=local PARTIAL_PROVER=true jest e2e/src/forced-transactions.spec.ts",
     "test:partial-prover:local": "TEST_ENV=local jest opcodes.spec.ts l2.spec.ts eip7702.spec.ts && pnpm run test:partial-prover:messaging:local && pnpm run test:partial-prover:finalization:local",
     "test:dev": "TEST_ENV=dev jest --config ./jest.testnet.config.ts --bail --runInBand --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts --testPathIgnorePatterns=restart.spec.ts",
     "test:sepolia": "TEST_ENV=sepolia jest --config ./jest.testnet.config.ts --bail --runInBand --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts --testPathIgnorePatterns=restart.spec.ts",

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -26,6 +26,8 @@ import {
 const context = createTestContext();
 const l1AccountManager = context.getL1AccountManager();
 const l2AccountManager = context.getL2AccountManager();
+const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 1200_000;
+const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 1800_000;
 
 async function expectReceiptNotFound(
   client: { getTransactionReceipt: (args: { hash: Hash }) => Promise<unknown> },
@@ -147,7 +149,7 @@ describe("Forced transaction test suite", () => {
         toBlock: "latest",
         pollingIntervalMs: 2_000,
         strict: true,
-        timeoutMs: 200_000,
+        timeoutMs: l1EventTimeOutMs,
         criteria: async (events) =>
           events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
       });
@@ -156,7 +158,7 @@ describe("Forced transaction test suite", () => {
         `Finalization includes forced transaction. blockNumber=${finalizedEvent.args.blockNumber} forcedTransactionNumber=${finalizedEvent.args.forcedTransactionNumber}`,
       );
     },
-    200_000,
+    timeOutMs,
   );
 
   it.concurrent(
@@ -258,7 +260,7 @@ describe("Forced transaction test suite", () => {
         fromBlock: receipt.blockNumber,
         toBlock: "latest",
         pollingIntervalMs: 2_000,
-        timeoutMs: 200_000,
+        timeoutMs: l1EventTimeOutMs,
         strict: true,
         criteria: async (events) =>
           events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
@@ -273,7 +275,7 @@ describe("Forced transaction test suite", () => {
       await expectReceiptNotFound(l2PublicClient, l2TxHash);
       logger.debug("Checked for forced transaction receipt on L2; confirmed that receipt was not found as expected.");
     },
-    200_000,
+    timeOutMs,
   );
 
   it.concurrent(
@@ -409,7 +411,7 @@ describe("Forced transaction test suite", () => {
         fromBlock: receipt.blockNumber,
         toBlock: "latest",
         pollingIntervalMs: 2_000,
-        timeoutMs: 200_000,
+        timeoutMs: l1EventTimeOutMs,
         strict: true,
         criteria: async (events) =>
           events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
@@ -424,7 +426,7 @@ describe("Forced transaction test suite", () => {
       await expectReceiptNotFound(l2PublicClient, l2TxHash);
       logger.debug("BadPrecompile forced transaction confirmed: receipt not found on L2 as expected.");
     },
-    300_000,
+    timeOutMs,
   );
 
   it.concurrent(
@@ -570,7 +572,7 @@ describe("Forced transaction test suite", () => {
         fromBlock: receipt.blockNumber,
         toBlock: "latest",
         pollingIntervalMs: 2_000,
-        timeoutMs: 200_000,
+        timeoutMs: l1EventTimeOutMs,
         strict: true,
         criteria: async (events) =>
           events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
@@ -585,7 +587,7 @@ describe("Forced transaction test suite", () => {
       await expectReceiptNotFound(l2PublicClient, l2TxHash);
       logger.debug("TooManyLogs forced transaction confirmed: receipt not found on L2 as expected.");
     },
-    300_000,
+    timeOutMs,
   );
 
   it.concurrent(
@@ -705,7 +707,7 @@ describe("Forced transaction test suite", () => {
               fromBlock: receipt.blockNumber,
               toBlock: "latest",
               pollingIntervalMs: 2_000,
-              timeoutMs: 200_000,
+              timeoutMs: l1EventTimeOutMs,
               strict: true,
               criteria: async (events) =>
                 events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
@@ -725,7 +727,7 @@ describe("Forced transaction test suite", () => {
         );
       });
     },
-    300_000,
+    timeOutMs,
   );
 
   it.concurrent(
@@ -845,7 +847,7 @@ describe("Forced transaction test suite", () => {
               fromBlock: receipt.blockNumber,
               toBlock: "latest",
               pollingIntervalMs: 2_000,
-              timeoutMs: 200_000,
+              timeoutMs: l1EventTimeOutMs,
               strict: true,
               criteria: async (events) =>
                 events.filter((e) => e.args.forcedTransactionNumber >= submittedForcedTransactionNumber),
@@ -865,6 +867,6 @@ describe("Forced transaction test suite", () => {
         );
       });
     },
-    300_000,
+    timeOutMs,
   );
 });

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -432,7 +432,7 @@ describe("Forced transaction test suite", () => {
   it.concurrent(
     "Should reject a forced transaction that exceeds the L2-L1 log limit (TooManyLogs)",
     async () => {
-      if (process.env.PARTIAL_PROVER != "true") {
+      if (process.env.PARTIAL_PROVER == "true") {
         logger.warn('Skipped the forced transaction "TooManyLogs" test with partial prover');
         return;
       }

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -598,6 +598,14 @@ describe("Forced transaction test suite", () => {
   it.concurrent(
     "Should reject a forced transaction from a denylisted sender (FilteredAddressFrom)",
     async () => {
+      // For partial prover test, if we run both denylisted tests, one of them would have
+      // the FTX event simulated at a high number block number compared to those in other
+      // FTX tests, so here we disabled one of them
+      if (process.env.PARTIAL_PROVER == "true") {
+        logger.warn('Skipped the forced transaction "FilteredAddressFrom" test with partial prover');
+        return;
+      }
+
       const [l1Account, l2DeniedSender, l2Recipient] = await Promise.all([
         l1AccountManager.generateAccount(),
         l2AccountManager.generateAccount(),

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -598,6 +598,11 @@ describe("Forced transaction test suite", () => {
   it.concurrent(
     "Should reject a forced transaction from a denylisted sender (FilteredAddressFrom)",
     async () => {
+      if (process.env.PARTIAL_PROVER == "true") {
+        logger.warn('Skipped the forced transaction "FilteredAddressFrom" test with partial prover');
+        return;
+      }
+
       const [l1Account, l2DeniedSender, l2Recipient] = await Promise.all([
         l1AccountManager.generateAccount(),
         l2AccountManager.generateAccount(),

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -26,8 +26,8 @@ import {
 const context = createTestContext();
 const l1AccountManager = context.getL1AccountManager();
 const l2AccountManager = context.getL2AccountManager();
-const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 1600_000;
-const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 2400_000;
+const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 2400_000;
+const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 3000_000;
 
 async function expectReceiptNotFound(
   client: { getTransactionReceipt: (args: { hash: Hash }) => Promise<unknown> },

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -598,11 +598,6 @@ describe("Forced transaction test suite", () => {
   it.concurrent(
     "Should reject a forced transaction from a denylisted sender (FilteredAddressFrom)",
     async () => {
-      if (process.env.PARTIAL_PROVER == "true") {
-        logger.warn('Skipped the forced transaction "FilteredAddressFrom" test with partial prover');
-        return;
-      }
-
       const [l1Account, l2DeniedSender, l2Recipient] = await Promise.all([
         l1AccountManager.generateAccount(),
         l2AccountManager.generateAccount(),

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -432,6 +432,11 @@ describe("Forced transaction test suite", () => {
   it.concurrent(
     "Should reject a forced transaction that exceeds the L2-L1 log limit (TooManyLogs)",
     async () => {
+      if (process.env.PARTIAL_PROVER != "true") {
+        logger.warn('Skipped the forced transaction "TooManyLogs" test with partial prover');
+        return;
+      }
+
       const [l1Account, l2Deployer, l2ForcedAccount] = await Promise.all([
         l1AccountManager.generateAccount(),
         l2AccountManager.generateAccount(),

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -26,8 +26,8 @@ import {
 const context = createTestContext();
 const l1AccountManager = context.getL1AccountManager();
 const l2AccountManager = context.getL2AccountManager();
-const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 1200_000;
-const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 1800_000;
+const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 1600_000;
+const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 2400_000;
 
 async function expectReceiptNotFound(
   client: { getTransactionReceipt: (args: { hash: Hash }) => Promise<unknown> },

--- a/e2e/src/messaging.spec.ts
+++ b/e2e/src/messaging.spec.ts
@@ -257,6 +257,7 @@ describe("Messaging test suite", () => {
       const l1Account = await l1AccountManager.generateAccount();
       const l2Account = await l2AccountManager.generateAccount();
       const l2PublicClient = context.l2PublicClient();
+      const l2MessageService = context.l2Contracts.l2MessageService(l2PublicClient);
       const l2BlockBeforeSend = await l2PublicClient.getBlockNumber();
 
       // L1->L2 message with calldata
@@ -285,8 +286,8 @@ describe("Messaging test suite", () => {
 
       logger.debug(`Waiting for L1L2MessageHashesAddedToInbox event on L2. messageHash=${messageHash1}`);
       const [messageHash1AddedEvent] = await waitForEvents(l2PublicClient, {
-        abi: L2MessageServiceV1Abi,
-        address: context.l2Contracts.l2MessageService(l2PublicClient).address,
+        abi: l2MessageService.abi,
+        address: l2MessageService.address,
         eventName: "L1L2MessageHashesAddedToInbox",
         fromBlock: l2BlockBeforeSend,
         toBlock: "latest",
@@ -301,8 +302,8 @@ describe("Messaging test suite", () => {
 
       logger.debug(`Waiting for L1L2MessageHashesAddedToInbox event on L2. messageHash=${messageHash2}`);
       const [messageHash2AddedEvent] = await waitForEvents(l2PublicClient, {
-        abi: L2MessageServiceV1Abi,
-        address: context.l2Contracts.l2MessageService(l2PublicClient).address,
+        abi: l2MessageService.abi,
+        address: l2MessageService.address,
         eventName: "L1L2MessageHashesAddedToInbox",
         fromBlock: l2BlockBeforeSend,
         toBlock: "latest",


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to CI workflow refactor (new reusable workflow, artifact-based image handoff, and parallel matrix runs) that could affect test reliability/runtime. Runtime behavior of partial-prover test environments also changes via docker-compose config tweaks and conditional test skips/timeouts.
> 
> **Overview**
> **Refactors partial-prover CI** by splitting the workflow into a `build-and-upload-images` job that saves locally-built `linea-besu-package`/`linea-prover` images as short-lived artifacts, and a reusable `partial-prover-run-e2e-tests-in-parallel` workflow that downloads/loads those images and runs e2e tests via a matrix (now including `forced-transactions:local`).
> 
> **Updates runtime configs and tests** by toggling `BESU_PLUGIN_LINEA_LIVENESS_ENABLED` per compose file, tightening partial-prover coordinator blob compression batches (`2` → `1`), adding a new `pnpm` script for partial-prover forced-transactions, and making forced-transactions tests partial-prover-aware (larger timeouts plus skipping a couple of cases), with a small fix in messaging tests to reuse the resolved L2 message service ABI/address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01319ac5c029f983d1fb656b674b425207b7187d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->