### PR TITLE
fix(contracts): remove token from url and value from logs

### DIFF
--- a/contracts/common/helpers/environment.ts
+++ b/contracts/common/helpers/environment.ts
@@ -3,7 +3,8 @@ export function getRequiredEnvVar(name: string): string {
   if (!envValue) {
     throw new Error(`Required environment variable "${name}" is missing or empty.`);
   }
-  console.log(`Using environment variable ${name}=${envValue}`);
+  // Do not log the value of the environment variable for safety reasons
+  console.log(`Using environment variable ${name}`);
   return envValue;
 }
 

--- a/contracts/scripts/hardhat/signer-ui-bridge.ts
+++ b/contracts/scripts/hardhat/signer-ui-bridge.ts
@@ -768,12 +768,18 @@ async function getTransactionWithRetry(
   intervalMs: number,
 ): Promise<TransactionResponse | null> {
   const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    const tx = await getTransactionWithTimeout(provider, hash, Math.min(TX_LOOKUP_RPC_ATTEMPT_TIMEOUT_MS, timeoutMs));
+  let remainingMs = timeoutMs;
+  while (remainingMs > 0) {
+    const tx = await getTransactionWithTimeout(provider, hash, Math.min(TX_LOOKUP_RPC_ATTEMPT_TIMEOUT_MS, remainingMs));
     if (tx) {
       return tx;
     }
-    await new Promise((resolveSleep) => setTimeout(resolveSleep, intervalMs));
+    remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      break;
+    }
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, Math.min(intervalMs, remainingMs)));
+    remainingMs = timeoutMs - (Date.now() - startedAt);
   }
   return null;
 }

--- a/contracts/scripts/hardhat/signer-ui-bridge.ts
+++ b/contracts/scripts/hardhat/signer-ui-bridge.ts
@@ -1775,6 +1775,7 @@ class SignerUiSession {
       writeJson(response, 400, { error: "No matching pending transaction request was found." });
       return;
     }
+    const pendingRequest = this.pendingRequest;
 
     this.setTransactionProgress(
       payload.requestId,
@@ -1789,6 +1790,11 @@ class SignerUiSession {
       TX_LOOKUP_INTERVAL_MS,
     );
 
+    if (!this.pendingRequest || this.pendingRequest !== pendingRequest) {
+      writeJson(response, 409, { error: "Pending transaction request was cancelled before validation completed." });
+      return;
+    }
+
     if (!onChain) {
       const message =
         `Transaction ${payload.hash} was returned by the browser wallet, but Hardhat could not find it on ` +
@@ -1796,7 +1802,7 @@ class SignerUiSession {
         "Check the wallet activity against this exact RPC/chain, or increase HARDHAT_SIGNER_UI_TX_LOOKUP_TIMEOUT_MS.";
       this.setTransactionProgress(payload.requestId, "failed", message);
       console.warn(`HARDHAT_SIGNER_UI: ${message}`);
-      const rejectOutcome = this.pendingRequest.reject;
+      const rejectOutcome = pendingRequest.reject;
       this.pendingRequest = undefined;
       writeJson(response, 400, { error: message }, () => {
         queueMicrotask(() => rejectOutcome(new Error(message)));
@@ -1812,7 +1818,7 @@ class SignerUiSession {
 
     const mismatch = getOnChainTransactionPromptMismatch(
       onChain,
-      this.pendingRequest.prompt.request,
+      pendingRequest.prompt.request,
       this.walletState.address,
     );
     if (mismatch) {
@@ -1820,7 +1826,7 @@ class SignerUiSession {
         txHash: payload.hash,
         mismatch,
         tx: onChain,
-        promptRequest: this.pendingRequest.prompt.request,
+        promptRequest: pendingRequest.prompt.request,
       });
       this.setTransactionProgress(
         payload.requestId,
@@ -1840,7 +1846,7 @@ class SignerUiSession {
       chainId: payload.chainId,
     };
 
-    const { resolve: resolveOutcome } = this.pendingRequest;
+    const { resolve: resolveOutcome } = pendingRequest;
     this.pendingRequest = undefined;
     this.setTransactionProgress(
       payload.requestId,

--- a/contracts/scripts/hardhat/signer-ui-bridge.ts
+++ b/contracts/scripts/hardhat/signer-ui-bridge.ts
@@ -208,6 +208,7 @@ const HARDHAT_SIGNER_UI_SESSION_TOKEN_HEADER = "x-hardhat-signer-ui-session-toke
 const MAX_JSON_BODY_BYTES = 256 * 1024;
 const TX_LOOKUP_TIMEOUT_MS_DEFAULT = 12_000;
 const TX_LOOKUP_INTERVAL_MS = 200;
+const TX_LOOKUP_RPC_ATTEMPT_TIMEOUT_MS = 5_000;
 
 /**
  * Some RPC / wallet paths (e.g. private submission) return txs slowly; override with
@@ -224,6 +225,7 @@ function getSignerUiTxLookupTimeoutMs(): number {
   }
   return Math.min(Math.max(n, 1000), 300_000);
 }
+
 /** Time to allow the browser to poll terminal `sessionOutcome` before the bridge closes (deploy batch only). */
 const DEFAULT_SHUTDOWN_DRAIN_MS = 1500;
 /** After the bridge port closes, wait before SIGTERM on Next so the UI can observe connection loss first. */
@@ -767,13 +769,31 @@ async function getTransactionWithRetry(
 ): Promise<TransactionResponse | null> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    const tx = await provider.getTransaction(hash);
+    const tx = await getTransactionWithTimeout(provider, hash, Math.min(TX_LOOKUP_RPC_ATTEMPT_TIMEOUT_MS, timeoutMs));
     if (tx) {
       return tx;
     }
     await new Promise((resolveSleep) => setTimeout(resolveSleep, intervalMs));
   }
   return null;
+}
+
+async function getTransactionWithTimeout(
+  provider: Provider,
+  hash: string,
+  timeoutMs: number,
+): Promise<TransactionResponse | null> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      provider.getTransaction(hash),
+      new Promise<null>((resolveTimeout) => {
+        timeoutHandle = setTimeout(() => resolveTimeout(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
 }
 
 function formatMismatchValue(value: string | bigint | null | undefined): string {
@@ -955,15 +975,22 @@ function writeJson(response: ServerResponse, statusCode: number, payload: unknow
   response.end(JSON.stringify(payload));
 }
 
+function buildSignerUiUrl(uiPort: number, apiBaseUrl: string): string {
+  return `http://${LOCALHOST}:${uiPort}?apiBaseUrl=${encodeURIComponent(apiBaseUrl)}`;
+}
+
+function isAllowedSignerUiOrigin(request: IncomingMessage, uiPort: number): boolean {
+  return request.headers.origin === `http://${LOCALHOST}:${uiPort}`;
+}
+
 /**
  * Only allow the local Next dev origin. Reflecting arbitrary Origin would let any website trigger
  * credentialess cross-origin requests to the bridge from the user's browser (mitigated by Private
  * Network Access in some browsers, but we still avoid wildcard / reflection).
  */
 function applySignerUiCors(request: IncomingMessage, response: ServerResponse, uiPort: number): void {
-  const allowedOrigin = `http://${LOCALHOST}:${uiPort}`;
   const origin = request.headers.origin;
-  if (origin === allowedOrigin) {
+  if (isAllowedSignerUiOrigin(request, uiPort) && typeof origin === "string") {
     response.setHeader("Access-Control-Allow-Origin", origin);
     response.setHeader("Vary", "Origin");
   }
@@ -1179,6 +1206,7 @@ class SignerUiSession {
   private signer?: SignerUiSigner;
   private sessionOutcome: "complete" | "error" | null = null;
   private sessionOutcomeMessage: string | null = null;
+  private sessionAuthenticated = false;
 
   public constructor(context: SignerUiContext) {
     this.context = context;
@@ -1570,7 +1598,7 @@ class SignerUiSession {
     }
 
     while (Date.now() - startedAt < SESSION_TIMEOUT_MS) {
-      const transaction = await provider.getTransaction(hash);
+      const transaction = await getTransactionWithTimeout(provider, hash, TX_LOOKUP_RPC_ATTEMPT_TIMEOUT_MS);
       if (transaction) {
         return transaction;
       }
@@ -1606,12 +1634,19 @@ class SignerUiSession {
       return;
     }
 
+    const url = new URL(request.url ?? "/", `http://${LOCALHOST}`);
+
+    if (request.method === "POST" && url.pathname === "/api/bootstrap") {
+      this.handleBootstrapRoute(request, response);
+      return;
+    }
+
     if (!isValidSignerUiSessionToken(this.sessionSecret, request)) {
       writeJson(response, 401, { error: "Missing or invalid signer UI session token." });
       return;
     }
 
-    const url = new URL(request.url ?? "/", `http://${LOCALHOST}`);
+    this.sessionAuthenticated = true;
 
     if (request.method === "GET" && url.pathname === "/health") {
       writeJson(response, 200, { ok: true, sessionId: this.sessionId });
@@ -1644,6 +1679,22 @@ class SignerUiSession {
     }
 
     writeJson(response, 404, { error: "Not found" });
+  }
+
+  private handleBootstrapRoute(request: IncomingMessage, response: ServerResponse): void {
+    if (this.uiPort === undefined || !isAllowedSignerUiOrigin(request, this.uiPort)) {
+      writeJson(response, 403, { error: "Signer UI bootstrap must originate from the local signer UI." });
+      return;
+    }
+
+    if (this.sessionAuthenticated) {
+      writeJson(response, 409, {
+        error: "Signer UI session has already been bootstrapped. Reopen the original tab for this Hardhat run.",
+      });
+      return;
+    }
+
+    writeJson(response, 200, { sessionToken: this.sessionSecret });
   }
 
   private async handleWalletRoute(request: IncomingMessage, response: ServerResponse): Promise<void> {
@@ -1739,14 +1790,16 @@ class SignerUiSession {
     );
 
     if (!onChain) {
-      this.setTransactionProgress(
-        payload.requestId,
-        "failed",
-        "Transaction not found on the RPC yet. Wait for the wallet to broadcast, then try again from the UI if needed.",
-      );
-      writeJson(response, 400, {
-        error:
-          "Transaction not found on the RPC yet. Wait for the wallet to broadcast, then try again from the UI if needed.",
+      const message =
+        `Transaction ${payload.hash} was returned by the browser wallet, but Hardhat could not find it on ` +
+        `${this.context.networkName} after ${getSignerUiTxLookupTimeoutMs()}ms. ` +
+        "Check the wallet activity against this exact RPC/chain, or increase HARDHAT_SIGNER_UI_TX_LOOKUP_TIMEOUT_MS.";
+      this.setTransactionProgress(payload.requestId, "failed", message);
+      console.warn(`HARDHAT_SIGNER_UI: ${message}`);
+      const rejectOutcome = this.pendingRequest.reject;
+      this.pendingRequest = undefined;
+      writeJson(response, 400, { error: message }, () => {
+        queueMicrotask(() => rejectOutcome(new Error(message)));
       });
       return;
     }
@@ -1849,11 +1902,18 @@ class SignerUiSession {
   }
 
   private getUiUrl(): string {
-    const base = `http://${LOCALHOST}:${this.uiPort}?apiBaseUrl=${encodeURIComponent(this.getApiBaseUrl())}`;
-    return `${base}&sessionToken=${encodeURIComponent(this.sessionSecret)}`;
+    if (this.uiPort === undefined) {
+      throw new Error("Signer UI port has not been allocated.");
+    }
+
+    return buildSignerUiUrl(this.uiPort, this.getApiBaseUrl());
   }
 
   private getApiBaseUrl(): string {
+    if (this.serverPort === undefined) {
+      throw new Error("Signer UI bridge port has not been allocated.");
+    }
+
     return `http://${LOCALHOST}:${this.serverPort}`;
   }
 
@@ -2200,6 +2260,7 @@ export async function signerUiHardhatDeployRunSubtaskAction(
 }
 
 export const __testOnlySignerUiBridge = {
+  buildSignerUiUrl,
   buildSerializedTransactionRequest,
   calldataMatchesPromptForSignerUiValidation,
   normalizeGasFeeFieldsForWallet,

--- a/contracts/signer-ui/README.md
+++ b/contracts/signer-ui/README.md
@@ -4,7 +4,7 @@ When `HARDHAT_SIGNER_UI=true`, Hardhat deploy scripts can route transactions thr
 
 `HARDHAT_SIGNER_UI=true` and `DEPLOYER_PRIVATE_KEY` are mutually exclusive. If both are set, Hardhat fails immediately rather than guessing between browser signing and private-key signing.
 
-The Hardhat side (`contracts/scripts/hardhat/signer-ui-bridge.ts`) starts a **local HTTP bridge** (session API + CORS), launches **`pnpm --dir contracts/signer-ui exec next dev`** on a free port, prints/opens the UI URL, and blocks until each transaction is **verified on-chain** against the pending request.
+The Hardhat side (`contracts/scripts/hardhat/signer-ui-bridge.ts`) starts a **local HTTP bridge** (session API + CORS), launches **`pnpm --dir contracts/signer-ui exec next dev`** on a free port, prints/opens the UI URL, bootstraps the browser session over loopback, and blocks until each transaction is **verified on-chain** against the pending request.
 
 This app is local operator tooling for the contracts package. It is not intended to be published, imported, or consumed as a standalone package.
 
@@ -61,7 +61,7 @@ pnpm exec hardhat deploy --network zkevm_dev --tags TestERC20
 ```
 
 1. Open the printed URL (or rely on auto-open unless `HARDHAT_SIGNER_UI_OPEN_BROWSER=false`).
-2. Use the full URL including `sessionToken` — it authenticates the browser to the bridge.
+2. Use the printed URL from the current Hardhat run. The browser bootstraps its bridge token over loopback; the token is not included in the URL.
 3. Connect the wallet and switch chain if prompted.
 4. Approve the transaction; the CLI continues when the tx matches the pending request on the RPC.
 

--- a/contracts/signer-ui/app/bridgeApiClient.ts
+++ b/contracts/signer-ui/app/bridgeApiClient.ts
@@ -26,6 +26,25 @@ function parseErrorMessageFromBody(text: string): string | undefined {
   return trimmed;
 }
 
+export async function bootstrapSession(apiBaseUrl: string, fetchImpl: typeof fetch = fetch): Promise<string> {
+  const response = await fetchImpl(`${apiBaseUrl}/api/bootstrap`, {
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    const bodyText = await response.text();
+    const errorMessage = parseErrorMessageFromBody(bodyText);
+    throw new Error(errorMessage ?? `Session bootstrap failed with ${response.status}`);
+  }
+
+  const parsed = (await response.json()) as { sessionToken?: unknown };
+  if (typeof parsed.sessionToken !== "string" || parsed.sessionToken.length === 0) {
+    throw new Error("Session bootstrap response did not include a token.");
+  }
+
+  return parsed.sessionToken;
+}
+
 export async function postJson(
   url: string,
   payload: unknown,

--- a/contracts/signer-ui/app/page.tsx
+++ b/contracts/signer-ui/app/page.tsx
@@ -18,7 +18,6 @@ import {
   signerTxFragmentId,
   signerUiHistoryStorageKey,
   signerUiLastSessionIdStorageKey,
-  signerUiSessionSecretStorageKey,
   transactionExplorerUrl,
   transactionKindBadgeLabels,
   type TransactionDetails,
@@ -310,11 +309,6 @@ function ContractsDeployUiPage() {
 
     if (sessionSecretFromUrl) {
       setSessionSecret(sessionSecretFromUrl);
-      try {
-        sessionStorage.setItem(signerUiSessionSecretStorageKey(apiBaseUrl), sessionSecretFromUrl);
-      } catch {
-        /* storage full or disabled */
-      }
       const nextUrl = new URL(window.location.href);
       nextUrl.searchParams.delete("sessionToken");
       window.history.replaceState({}, "", `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
@@ -324,26 +318,11 @@ function ContractsDeployUiPage() {
       };
     }
 
-    const storageKey = signerUiSessionSecretStorageKey(apiBaseUrl);
     const loadSessionSecret = async () => {
-      const cachedSessionSecret = sessionStorage.getItem(storageKey);
-      if (cachedSessionSecret) {
-        if (!cancelled) {
-          setSessionSecret(cachedSessionSecret);
-          setSessionAuthReady(true);
-        }
-        return;
-      }
-
       try {
         const bootstrappedSessionSecret = await bootstrapSession(apiBaseUrl);
         if (cancelled) {
           return;
-        }
-        try {
-          sessionStorage.setItem(storageKey, bootstrappedSessionSecret);
-        } catch {
-          /* storage full or disabled */
         }
         setSessionSecret(bootstrappedSessionSecret);
         setSessionAuthReady(true);

--- a/contracts/signer-ui/app/page.tsx
+++ b/contracts/signer-ui/app/page.tsx
@@ -5,7 +5,7 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { flushSync } from "react-dom";
 
-import { HARDHAT_SIGNER_UI_SESSION_TOKEN_HEADER, postJson } from "./bridgeApiClient";
+import { HARDHAT_SIGNER_UI_SESSION_TOKEN_HEADER, bootstrapSession, postJson } from "./bridgeApiClient";
 import { LineaWordmark } from "./components/LineaWordmark";
 import {
   canEnableSignButton,
@@ -305,20 +305,61 @@ function ContractsDeployUiPage() {
       return;
     }
 
+    let cancelled = false;
+    setSessionAuthReady(false);
+
     if (sessionSecretFromUrl) {
       setSessionSecret(sessionSecretFromUrl);
+      try {
+        sessionStorage.setItem(signerUiSessionSecretStorageKey(apiBaseUrl), sessionSecretFromUrl);
+      } catch {
+        /* storage full or disabled */
+      }
       const nextUrl = new URL(window.location.href);
       nextUrl.searchParams.delete("sessionToken");
       window.history.replaceState({}, "", `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
       setSessionAuthReady(true);
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     const storageKey = signerUiSessionSecretStorageKey(apiBaseUrl);
-    setSessionSecret((previousSessionSecret) => {
-      return previousSessionSecret ?? sessionStorage.getItem(storageKey);
-    });
-    setSessionAuthReady(true);
+    const loadSessionSecret = async () => {
+      const cachedSessionSecret = sessionStorage.getItem(storageKey);
+      if (cachedSessionSecret) {
+        if (!cancelled) {
+          setSessionSecret(cachedSessionSecret);
+          setSessionAuthReady(true);
+        }
+        return;
+      }
+
+      try {
+        const bootstrappedSessionSecret = await bootstrapSession(apiBaseUrl);
+        if (cancelled) {
+          return;
+        }
+        try {
+          sessionStorage.setItem(storageKey, bootstrappedSessionSecret);
+        } catch {
+          /* storage full or disabled */
+        }
+        setSessionSecret(bootstrappedSessionSecret);
+        setSessionAuthReady(true);
+      } catch (error) {
+        if (!cancelled) {
+          setSessionSecret(null);
+          setActionError((error as Error).message ?? "Failed to bootstrap the signer session.");
+          setSessionAuthReady(true);
+        }
+      }
+    };
+
+    void loadSessionSecret();
+    return () => {
+      cancelled = true;
+    };
   }, [apiBaseUrl, sessionSecretFromUrl]);
 
   const sessionUrl = useMemo(() => {
@@ -370,9 +411,7 @@ function ContractsDeployUiPage() {
     }
 
     if (!sessionSecret) {
-      setActionError(
-        "Missing session token. Open this UI using the full URL from Hardhat (HARDHAT_SIGNER_UI), not a bookmark without sessionToken.",
-      );
+      setActionError("Missing session token. Open this UI from the current Hardhat signer run, not an old bookmark.");
       return;
     }
 

--- a/contracts/signer-ui/app/pageHelpers.ts
+++ b/contracts/signer-ui/app/pageHelpers.ts
@@ -86,10 +86,6 @@ export function signerUiLastSessionIdStorageKey(apiBaseUrl: string): string {
   return `signerUiLastSessionId:${apiBaseUrl}`;
 }
 
-export function signerUiSessionSecretStorageKey(apiBaseUrl: string): string {
-  return `signerUiSessionSecret:${apiBaseUrl}`;
-}
-
 export function transactionExplorerUrl(blockExplorerUrls: string[], txHash: string): string | null {
   const base = blockExplorerUrls.find((u) => typeof u === "string" && u.length > 0);
   if (!base) {

--- a/contracts/signer-ui/test/bridgeApiClient.test.ts
+++ b/contracts/signer-ui/test/bridgeApiClient.test.ts
@@ -1,7 +1,44 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { HARDHAT_SIGNER_UI_SESSION_TOKEN_HEADER, __testOnly, postJson } from "../app/bridgeApiClient.ts";
+import {
+  HARDHAT_SIGNER_UI_SESSION_TOKEN_HEADER,
+  __testOnly,
+  bootstrapSession,
+  postJson,
+} from "../app/bridgeApiClient.ts";
+
+test("bootstrapSession requests local bootstrap without a bearer header", async () => {
+  let capturedUrl: string | undefined;
+  let capturedInit: RequestInit | undefined;
+
+  const fetchMock: typeof fetch = async (input, init) => {
+    capturedUrl = String(input);
+    capturedInit = init;
+    return new Response(JSON.stringify({ sessionToken: "session-secret" }), { status: 200 });
+  };
+
+  const token = await bootstrapSession("http://127.0.0.1:15555", fetchMock);
+
+  assert.equal(token, "session-secret");
+  assert.equal(capturedUrl, "http://127.0.0.1:15555/api/bootstrap");
+  assert.equal(capturedInit?.method, "POST");
+  assert.equal(capturedInit?.headers, undefined);
+});
+
+test("bootstrapSession rejects malformed responses", async () => {
+  const fetchMock: typeof fetch = async () => {
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+
+  await assert.rejects(
+    () => bootstrapSession("http://127.0.0.1:15555", fetchMock),
+    (error: unknown) => {
+      assert.equal((error as Error).message, "Session bootstrap response did not include a token.");
+      return true;
+    },
+  );
+});
 
 test("postJson sends JSON payload and signer-ui session header", async () => {
   let capturedUrl: string | undefined;

--- a/contracts/signer-ui/test/pageHelpers.test.ts
+++ b/contracts/signer-ui/test/pageHelpers.test.ts
@@ -9,7 +9,6 @@ import {
   progressTone,
   scrollToHistoryFragment,
   signerAddressMismatch,
-  signerUiSessionSecretStorageKey,
   signerTxFragmentId,
   signerUiHistoryStorageKey,
   signerUiLastSessionIdStorageKey,
@@ -43,10 +42,6 @@ test("storage key helpers are deterministic", () => {
   assert.equal(
     signerUiLastSessionIdStorageKey("http://127.0.0.1:15555"),
     "signerUiLastSessionId:http://127.0.0.1:15555",
-  );
-  assert.equal(
-    signerUiSessionSecretStorageKey("http://127.0.0.1:15555"),
-    "signerUiSessionSecret:http://127.0.0.1:15555",
   );
 });
 

--- a/contracts/test/hardhat/scripts/signerUiBridgePayloadParsers.ts
+++ b/contracts/test/hardhat/scripts/signerUiBridgePayloadParsers.ts
@@ -3,6 +3,13 @@ import { expect } from "chai";
 import { __testOnlySignerUiBridge } from "../../../scripts/hardhat/signer-ui-bridge";
 
 describe("signer-ui bridge payload parsing and request shaping", () => {
+  it("builds the signer UI URL without a bearer session token", () => {
+    const url = __testOnlySignerUiBridge.buildSignerUiUrl(3001, "http://127.0.0.1:15555");
+
+    expect(url).to.equal("http://127.0.0.1:3001?apiBaseUrl=http%3A%2F%2F127.0.0.1%3A15555");
+    expect(url).not.to.contain("sessionToken");
+  });
+
   it("parses wallet payload with valid address and integer chain id", () => {
     const parsed = __testOnlySignerUiBridge.parseWalletPayload({
       address: "0x000000000000000000000000000000000000dEaD",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the local Hardhat signer UI authenticates to the loopback bridge (new bootstrap route and state tracking) and tweaks RPC transaction polling, so failures could break deploy signing flows even though scope is limited to local tooling.
> 
> **Overview**
> **Removes secret leakage from logs and URLs.** `getRequiredEnvVar` no longer prints environment variable values, and the Hardhat signer UI URL no longer includes the bearer `sessionToken` query param.
> 
> **Adds loopback session bootstrapping for the signer UI.** The bridge now exposes `POST /api/bootstrap` (origin-restricted) to return the session token once per session, and the Next.js UI calls `bootstrapSession()` to fetch/store it instead of relying on URL/sessionStorage secrets.
> 
> **Hardens bridge transaction lookup and error handling.** RPC `getTransaction` polling is wrapped with per-attempt timeouts, sleep intervals respect remaining time, and `/api/respond` now detects cancelled pending requests and produces clearer failure messaging when a tx never appears on the configured RPC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea1d4016cbc5765a5de85359ea094cccf82d33f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->