### PR TITLE
fix(sequencer): de-flake BundleSelectionTimeoutTest.multipleBundleSelectionTimeout

### DIFF
--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
@@ -221,6 +221,24 @@ abstract class LineaPluginPoSTestBase : LineaPluginTestBase() {
   }
 
   /**
+   * Build a block giving Besu only [blockBuildingTimeMs] to assemble it. Use a short
+   * value (e.g. 300ms) when the test needs the selector to run a single pass instead
+   * of the default ~10 retries within a 5s window.
+   */
+  protected fun buildNewBlockAndWait(blockBuildingTimeMs: Long) {
+    val initialBlockNumber = getLatestBlockNumber()
+    val latestTimestamp = minerNode.execute(ethTransactions.block()).timestamp
+    buildNewBlock(
+      latestTimestamp.toLong() + blockTimeSeconds!!,
+      blockBuildingTimeMs,
+    ) { false }
+    await()
+      .atMost(3 * blockTimeSeconds!!, TimeUnit.SECONDS)
+      .pollInterval(100, TimeUnit.MILLISECONDS)
+      .untilAsserted { assertThat(getLatestBlockNumber()).isGreaterThan(initialBlockNumber) }
+  }
+
+  /**
    * Creates and sends a blob transaction. This method is designed to be stateless and should not
    * rely on any class properties or instance methods. All required data should be passed as
    * parameters. This makes it easier to test and reuse in different contexts.

--- a/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.kt
+++ b/besu-plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/BundleSelectionTimeoutTest.kt
@@ -124,21 +124,41 @@ class BundleSelectionTimeoutTest : AbstractSendBundleTest() {
   @Test
   fun multipleBundleSelectionTimeout() {
     val mulmodExecutor = deployMulmodExecutor()
+    // Stop background block production so it cannot fire a competing block-2
+    // creation attempt alongside the explicit one below. The background scheduler
+    // uses the default 5s build window, which permits ~10 selection retries — any
+    // one of which can complete the bundle inside the plugin selection budget.
+    buildBlocksInBackground = false
 
-    // singleBundleSelectionTimeout uses 31 txs × 2_000 iterations to reliably trigger the plugin
-    // timeout (1_875 ms for a 5-second Clique block: 5_000 ms × 75% PoA budget × 50% plugin budget).
-    // Here we only have 9 txs, so scale the iterations proportionally
-    // (31 / 9 × 2_000 ≈ 7_000) and gas limit accordingly.
+    // Mirror singleBundleSelectionTimeout's per-tx work (2_000 iter,
+    // MAX_TX_GAS_LIMIT / 10). The plugin selection budget is ~100ms (2% of the 5s
+    // slot, configured in LineaPluginTestBase). The bundle must do enough work to
+    // exceed that budget, and each tx must be small enough that the timeout fires
+    // mid-bundle.
+    //
+    // Total compute time alone doesn't decide whether the timeout fires — total
+    // wall-clock time does. Many small txs is more reliable than a few big ones
+    // for the same total compute, because:
+    //   1. Per-tx selector overhead (signature recovery, module-limit check,
+    //      profitability calc, HUB tracing setup) is paid once per tx and doesn't
+    //      shrink under cache warmup or JIT, so 30 small txs accumulate ~3x more
+    //      fixed overhead than 9 large ones.
+    //   2. The cache/JIT-sensitive compute portion is a smaller fraction of total
+    //      time, so variance from warm caches or a fast runner can't drop the
+    //      bundle below the budget.
+    // The previous shape (9 txs × 7_000 iter, MAX_TX_GAS_LIMIT / 3) made each tx
+    // large enough that on a fast runner the whole bundle could finish inside
+    // the budget — no timeout, calls[1] gets committed, test fails.
     val calls = generateMulmodCalls(
       accounts.primaryBenefactor,
       mulmodExecutor,
       1,
-      10,
-      7_000,
-      MAX_TX_GAS_LIMIT / 3,
+      31,
+      2_000,
+      MAX_TX_GAS_LIMIT / 10,
     )
     val bundle1Calls = calls.copyOfRange(0, 1)
-    val bundle2Calls = calls.copyOfRange(1, 10)
+    val bundle2Calls = calls.copyOfRange(1, 31)
 
     val sendBundleRequestSmall = SendBundleRequest(
       BundleParams(bundle1Calls.map { it.rawTx }.toTypedArray(), Integer.toHexString(2)),
@@ -172,6 +192,14 @@ class BundleSelectionTimeoutTest : AbstractSendBundleTest() {
     sendBundleResponseSmall.assertSuccessResponse()
     sendBundleResponseBig1.assertSuccessResponse()
     followingBundleResponses.forEach { resp -> resp.assertSuccessResponse() }
+
+    // Build block 2 with a short block-building window so Besu's iterative selector
+    // gets only a single selection pass. The default 5s window allows ~10 selection
+    // retries; each retry has its own ~100ms plugin selection budget, so a fast
+    // runner has many independent chances to complete the bundle inside the budget
+    // and include the tx that should have timed out. A short window collapses that
+    // to a single pass.
+    buildNewBlockAndWait(300L)
 
     minerNode.verify(eth.expectSuccessfulTransactionReceipt(transferTxHash.bytes.toHexString()))
     val transferReceipt = ethTransactions.getTransactionReceipt(transferTxHash.bytes.toHexString())


### PR DESCRIPTION
## Summary

`BundleSelectionTimeoutTest.multipleBundleSelectionTimeout` is flaky on CI ([example failure](https://github.com/Consensys/linea-monorepo/actions/runs/25663719114/job/75331020556)). It works locally and on the second CI attempt because the test relies on wall-clock plugin selection timing on hardware-variable infrastructure.

The fix combines three changes — each addresses an independent flake source.

## Root cause

The test asserts that `big bundle 2` (and the following bundles that share its first tx) gets fully excluded from block 2 because it hits the plugin's `PLUGIN_SELECTION_TIMEOUT` (~100 ms — 2% of the 5s slot, configured in `LineaPluginTestBase.kt:169`). On a fast runner the bundle can complete inside that budget; the timeout never fires; `calls[1]` is committed; the assertion fails.

From the failing log:
```
selectedTransactions=0x4bda... (bundle1), 0x66422471... (calls[1]), 0x515001... (transfer)
Selection stats: Detailed[BLOCK_MODULE_LINE_COUNT_FULL=1, INVALID(NONCE_TOO_LOW)=1, SELECTED_ROLLBACK=9]
```
No `PLUGIN_SELECTION_TIMEOUT` in `Detailed[...]` for that selection pass — the runner was fast enough to fit the bundle inside the budget. Other passes in the same run *did* fire the timeout correctly. Pure variance.

Commit `dd99fb0e0 "Fixed BundleSelectionTimeoutTest"` previously removed `override fun getPluginBlockTxsSelectionMaxTime(): Int = 1` (a 1ms budget that made the timeout deterministic). Since then, the test has relied on natural timing.

## The fix — three independent changes

### 1. `buildBlocksInBackground = false`

The base class spawns a 5-second consensus scheduler that retries block 2 every ~500ms. Without this flag, while we explicitly build block 2 with a short window, the background scheduler can fire a *competing* block-2 attempt with the default 5s window — and that one will use the multi-retry path described below to race past us.

### 2. Granular bundle: 30 × 2_000 iter (was 9 × 7_000 iter)

This is the most subtle part. **Total compute time alone doesn't decide whether the timeout fires — total wall-clock time does.** Many small txs is more reliable than a few big ones for the same total compute work.

Each tx in the bundle pays a fixed selector overhead independent of its compute work: signature recovery, gas accounting, `TraceLineLimitTransactionSelector` module-limit check, `ProfitableTransactionSelector` margin calc, HUB tracing setup, profitability cache lookups. Call it ~1.5 ms per tx.

| Shape | Compute | Per-tx overhead | Total |
|---|---|---|---|
| 9 × 7_000 (old) | ~63 ms | 9 × ~1.5 ms = ~14 ms | **~77 ms** (under budget) |
| 30 × 2_000 (new) | ~60 ms | 30 × ~1.5 ms = ~45 ms | **~105 ms** (over budget) |

Equal compute, but granular pays the overhead 3.3× more often. That alone pushes the bundle above the ~100 ms budget while the large-tx version sits just *under* it. Additionally, the cache/JIT-sensitive portion is a smaller fraction of total time with granular txs, so variance from warm caches or a fast runner can't drop the bundle below the budget.

This mirrors `singleBundleSelectionTimeout`, which has been reliable for months on the same `31 × 2_000, MAX_TX_GAS_LIMIT/10` shape.

### 3. Short block-building window: 300 ms (was the default 5s)

This is the change that *requires* a new helper. `engineApiService.buildNewBlock` does `Thread.sleep(blockBuildingTimeMs)` (`EngineAPIService.kt:101`); during that sleep, Besu's iterative selector reruns ~10 selection passes (one every ~500 ms). Each pass has its own ~100 ms plugin selection budget — so even if every pass would individually time out, you only need *one* fast pass to commit the bundle and Besu keeps that selection.

**Why subsequent passes get faster (JIT/cache warmup):**

| State | Rolled back per retry? |
|---|---|
| EVM account/storage state | Yes (bundle atomicity) |
| Selector internal state | Yes |
| **JIT-compiled bytecode** | **No** |
| **HotSpot tier (C1 → C2)** | **No** |
| **JIT'd EVM opcode handlers** | **No** |
| **Storage trie node cache** | **No** |
| **CPU branch predictor / L1+L2 caches** | **No** |

By retry 5-6 the JVM has tier-promoted to C2 with inlining, escape analysis, and loop optimizations. Pure-compute portions can speed up 2-10×. The granular bundle's per-tx overhead is JIT-resistant (mostly bookkeeping, not tight loops), but the compute portion still shrinks — and eventually compute + overhead together fall under 100 ms.

A 300 ms window allows only one selection pass, against cold state, with first-attempt JIT levels. The "best" selection Besu returns is the cold one, which correctly times out the bundle.

The new `buildNewBlockAndWait(blockBuildingTimeMs: Long)` overload in `LineaPluginPoSTestBase.kt` exposes this knob for any test that needs single-pass block creation.

## Empirical validation (local, M-series Mac)

| Combination | Pass rate |
|---|---|
| Original (9 × 7_000, default 5s window) | flaky on CI, fails on my laptop |
| #3 only (short window, large txs) | 2/8 |
| #2 + #3 (granular + short window, background scheduler still on) | 7/8 |
| **#1 + #2 (granular + no background, default 5s window)** | **7/10** — confirms JIT warmup theory |
| **#1 + #2 + #3 (all three)** | **15/15** ✓ |

The #1 + #2 alone result is the clincher for #3: with granular bundles that exceed the budget on the *first* pass, multiple retries in a 5s window still let JIT/cache warmup speed the bundle inside the budget on a later retry.

## Test plan
- [x] `multipleBundleSelectionTimeout` passes 15/15 locally
- [x] `singleBundleSelectionTimeout` still passes
- [x] CI green on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to acceptance-test helpers and test tuning to make wall-clock-time-based timeout assertions deterministic across CI hardware.
> 
> **Overview**
> Makes `BundleSelectionTimeoutTest.multipleBundleSelectionTimeout` deterministic by preventing competing background block builds, reshaping the “timeout” bundle into many smaller txs (31×2_000 iterations with lower gas) to more reliably exceed the plugin selection budget, and explicitly building block 2 with a short build window.
> 
> Adds a `buildNewBlockAndWait(blockBuildingTimeMs)` overload in `LineaPluginPoSTestBase` so tests can force a single selector pass by constraining Besu’s block-building time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e0cd9ffa49baabda3a0aa0aba0a1c471d2cf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->