### PR TITLE
fix(ci): remove re-declaration of sequencer from compose-tracing-v2-c…

### DIFF
--- a/docker/compose-tracing-v2-ci-extension.yml
+++ b/docker/compose-tracing-v2-ci-extension.yml
@@ -21,10 +21,3 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: transaction-exclusion-api
-  
-  sequencer:
-    extends:
-      file: compose-spec-l2-services.yml
-      service: sequencer
-    environment:
-      BESU_PLUGIN_LINEA_LIVENESS_ENABLED: true

--- a/docker/compose-tracing-v2-partialprover-override.yml
+++ b/docker/compose-tracing-v2-partialprover-override.yml
@@ -1,4 +1,11 @@
 services:
+  sequencer:
+    extends:
+      file: compose-spec-l2-services.yml
+      service: sequencer
+    environment:
+      BESU_PLUGIN_LINEA_LIVENESS_ENABLED: false
+
   prover-v3:
     extends:
       file: compose-spec-l2-services.yml

--- a/docker/compose-tracing-v2.yml
+++ b/docker/compose-tracing-v2.yml
@@ -50,8 +50,6 @@ services:
     extends:
       file: compose-spec-l2-services.yml
       service: sequencer
-    environment:
-      BESU_PLUGIN_LINEA_LIVENESS_ENABLED: false
 
   l2-node-besu:
     extends:


### PR DESCRIPTION
…i-extension.yml

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML-only compose changes that mainly remove a duplicate service definition; behavior changes are limited to where `BESU_PLUGIN_LINEA_LIVENESS_ENABLED` is set for the `sequencer` in specific compose variants.
> 
> **Overview**
> Removes the `sequencer` re-declaration from `compose-tracing-v2-ci-extension.yml`, letting it rely on the included `compose-tracing-v2.yml` definition instead.
> 
> Stops setting `BESU_PLUGIN_LINEA_LIVENESS_ENABLED` in the base `compose-tracing-v2.yml`, and adds an explicit `sequencer` override in `compose-tracing-v2-partialprover-override.yml` to set `BESU_PLUGIN_LINEA_LIVENESS_ENABLED: false` for that scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1622cbb8cf446c040dfb89b734f84adc9eb29276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->