### PR TITLE
Prover/adding local constraints

### DIFF
--- a/prover-ray/wiop/query_local_constraint.go
+++ b/prover-ray/wiop/query_local_constraint.go
@@ -1,0 +1,113 @@
+package wiop
+
+import "fmt"
+
+// NewLocalConstraint registers a [Vanishing] that is enforced only at logical
+// row 0 — a "local constraint" in the sense of prover/protocol/query.LocalConstraint.
+//
+// Every column reference in expr is interpreted as the column's value at row
+// 0. A reference of the form col.View().Shift(k) (a [*ColumnView] with
+// ShiftingOffset k) becomes the column's value at row (k mod n), where n is
+// the module size; this matches the prover-side convention that "to evaluate
+// a local constraint at a different point, the column must be shifted first".
+//
+// Internally, every [*ColumnView] in expr is rewritten to a [*ColumnPosition]
+// and every vector [*Constant] is collapsed to its scalar form. The lowered
+// expression is necessarily scalar, so the returned [*Vanishing] is checked
+// through the scalar branch of [Vanishing.Check]. This keeps a single Query
+// type for both "global" (multi-valued) and "local" (scalar) vanishing
+// predicates.
+//
+// All columns referenced in expr must belong to m. Negative shifts require m
+// to be statically sized: for an unsized or dynamic module the row-0 position
+// cannot be normalised at construction time and a negative shift would not
+// fit into a non-negative [ColumnPosition.Position].
+//
+// Panics if ctx or expr is nil, if any column reference belongs to a
+// different module, or if a negative shift is used on an unsized/dynamic
+// module.
+func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression) *Vanishing {
+	if ctx == nil {
+		panic("wiop: Module.NewLocalConstraint requires a non-nil ContextFrame")
+	}
+	if expr == nil {
+		panic("wiop: Module.NewLocalConstraint requires a non-nil Expression")
+	}
+	scalar := m.lowerToRowZero(expr)
+	if scalar.IsMultiValued() {
+		panic(fmt.Sprintf(
+			"wiop: Module.NewLocalConstraint(%s): lowered expression is unexpectedly multi-valued",
+			ctx.Path(),
+		))
+	}
+	return m.newVanishing(ctx, scalar, nil)
+}
+
+// lowerToRowZero traverses expr bottom-up via [EditExpression] and produces
+// the scalar expression that the prover's LocalConstraint would evaluate.
+// The rewrite rules are:
+//
+//   - [*ColumnView]{Column: c, ShiftingOffset: k}
+//     → [*ColumnPosition]{Column: c, Position: (k mod n)}.
+//
+//   - vector [*Constant]{Value: v, module: !=nil}
+//     → scalar [*Constant]{Value: v, module: nil} (the same value at any row).
+//
+//   - every other leaf ([*Cell], [*CoinField], [*ColumnPosition], scalar
+//     [*Constant]) is passed through unchanged.
+//
+//   - [*ArithmeticOperation] is rebuilt with the rewritten operands.
+//
+// All [*ColumnView] and [*ColumnPosition] leaves must reference columns
+// belonging to m; otherwise the call panics.
+func (m *Module) lowerToRowZero(expr Expression) Expression {
+	return EditExpression(expr, func(curr Expression, newChildren []Expression) Expression {
+		switch e := curr.(type) {
+		case *ColumnView:
+			m.assertOwnsColumn(e.Column)
+			return columnViewToRowZeroPosition(e)
+		case *ColumnPosition:
+			m.assertOwnsColumn(e.Column)
+			return e
+		case *Constant:
+			if e.module != nil {
+				return NewConstantField(e.Value)
+			}
+			return e
+		default:
+			return DefaultConstruct(curr, newChildren)
+		}
+	})
+}
+
+// assertOwnsColumn panics if col is not owned by m. Used during local-constraint
+// lowering to enforce the single-module invariant of [Vanishing].
+func (m *Module) assertOwnsColumn(col *Column) {
+	if col.Module == m {
+		return
+	}
+	panic(fmt.Sprintf(
+		"wiop: Module.NewLocalConstraint: column %q belongs to module %q, not %q",
+		col.Context.Path(), col.Module.Context.Path(), m.Context.Path(),
+	))
+}
+
+// columnViewToRowZeroPosition converts a [*ColumnView] into the
+// [*ColumnPosition] it would evaluate to at logical row 0. The returned
+// position lies in [0, n) when the parent module is sized. For an unsized or
+// dynamic module the offset is passed through directly; a negative offset is
+// rejected upfront because it cannot be normalised without knowing n.
+func columnViewToRowZeroPosition(cv *ColumnView) *ColumnPosition {
+	off := cv.ShiftingOffset
+	m := cv.Column.Module
+	if m.IsSized() {
+		n := m.Size()
+		off = ((off % n) + n) % n
+	} else if off < 0 {
+		panic(fmt.Sprintf(
+			"wiop: NewLocalConstraint: negative shift %d on column %q requires a sized module",
+			cv.ShiftingOffset, cv.Column.Context.Path(),
+		))
+	}
+	return &ColumnPosition{Column: cv.Column, Position: off}
+}

--- a/prover-ray/wiop/query_local_constraint.go
+++ b/prover-ray/wiop/query_local_constraint.go
@@ -2,38 +2,52 @@ package wiop
 
 import "fmt"
 
-// NewLocalConstraint registers a [Vanishing] that is enforced only at logical
-// row 0 — a "local constraint" in the sense of prover/protocol/query.LocalConstraint.
+// NewLocalConstraint registers a [Vanishing] enforced at a single row of the
+// module — a "local constraint" in the sense of
+// prover/protocol/query.LocalConstraint.
 //
-// Every column reference in expr is interpreted as the column's value at row
-// 0. A reference of the form col.View().Shift(k) (a [*ColumnView] with
-// ShiftingOffset k) becomes the column's value at row (k mod n), where n is
-// the module size; this matches the prover-side convention that "to evaluate
-// a local constraint at a different point, the column must be shifted first".
+// The position argument selects which row of the module the predicate is
+// pinned to. Only three values are accepted:
+//
+//   -  0: the first row (row 0).
+//   -  1: the second row (row 1).
+//   - -1: the last row (row n−1, where n is the module size).
+//
+// Every column reference in expr is interpreted as the column's value at the
+// chosen row. A reference of the form col.View().Shift(k) (a [*ColumnView]
+// with non-zero ShiftingOffset k) is composed with position: the column is
+// read at row (position + k) mod n. Coins, cells, and scalar constants do
+// not depend on position and are evaluated as-is.
 //
 // Internally, every [*ColumnView] in expr is rewritten to a [*ColumnPosition]
-// and every vector [*Constant] is collapsed to its scalar form. The lowered
-// expression is necessarily scalar, so the returned [*Vanishing] is checked
-// through the scalar branch of [Vanishing.Check]. This keeps a single Query
-// type for both "global" (multi-valued) and "local" (scalar) vanishing
-// predicates.
+// at the resolved row, and every vector [*Constant] is collapsed to its
+// scalar form. The lowered expression is necessarily scalar, so the returned
+// [*Vanishing] is checked through the scalar branch of [Vanishing.Check].
+// This keeps a single Query type for both "global" (multi-valued) and "local"
+// (scalar) vanishing predicates.
 //
-// All columns referenced in expr must belong to m. Negative shifts require m
-// to be statically sized: for an unsized or dynamic module the row-0 position
-// cannot be normalised at construction time and a negative shift would not
-// fit into a non-negative [ColumnPosition.Position].
+// All columns referenced in expr must belong to m. Reading row −1 (or any
+// negative resolved row) requires m to be statically sized so the row can be
+// normalised; an unsized or dynamic module cannot resolve negative rows at
+// construction time.
 //
-// Panics if ctx or expr is nil, if any column reference belongs to a
-// different module, or if a negative shift is used on an unsized/dynamic
-// module.
-func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression) *Vanishing {
+// Panics if ctx or expr is nil, if position is not in {−1, 0, 1}, if any
+// column reference belongs to a different module, or if a resolved row is
+// negative on an unsized/dynamic module.
+func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression, position int) *Vanishing {
 	if ctx == nil {
 		panic("wiop: Module.NewLocalConstraint requires a non-nil ContextFrame")
 	}
 	if expr == nil {
 		panic("wiop: Module.NewLocalConstraint requires a non-nil Expression")
 	}
-	scalar := m.lowerToRowZero(expr)
+	if position != -1 && position != 0 && position != 1 {
+		panic(fmt.Sprintf(
+			"wiop: Module.NewLocalConstraint: position must be -1 (last row), 0 (first row), or 1 (second row), got %d",
+			position,
+		))
+	}
+	scalar := m.lowerToRow(expr, position)
 	if scalar.IsMultiValued() {
 		panic(fmt.Sprintf(
 			"wiop: Module.NewLocalConstraint(%s): lowered expression is unexpectedly multi-valued",
@@ -43,12 +57,12 @@ func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression) *Vanishi
 	return m.newVanishing(ctx, scalar, nil)
 }
 
-// lowerToRowZero traverses expr bottom-up via [EditExpression] and produces
-// the scalar expression that the prover's LocalConstraint would evaluate.
+// lowerToRow traverses expr bottom-up via [EditExpression] and produces the
+// scalar expression that the local constraint evaluates at the given row.
 // The rewrite rules are:
 //
 //   - [*ColumnView]{Column: c, ShiftingOffset: k}
-//     → [*ColumnPosition]{Column: c, Position: (k mod n)}.
+//     → [*ColumnPosition]{Column: c, Position: (position + k) mod n}.
 //
 //   - vector [*Constant]{Value: v, module: !=nil}
 //     → scalar [*Constant]{Value: v, module: nil} (the same value at any row).
@@ -60,12 +74,12 @@ func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression) *Vanishi
 //
 // All [*ColumnView] and [*ColumnPosition] leaves must reference columns
 // belonging to m; otherwise the call panics.
-func (m *Module) lowerToRowZero(expr Expression) Expression {
+func (m *Module) lowerToRow(expr Expression, position int) Expression {
 	return EditExpression(expr, func(curr Expression, newChildren []Expression) Expression {
 		switch e := curr.(type) {
 		case *ColumnView:
 			m.assertOwnsColumn(e.Column)
-			return columnViewToRowZeroPosition(e)
+			return columnViewAtRow(e, position)
 		case *ColumnPosition:
 			m.assertOwnsColumn(e.Column)
 			return e
@@ -92,22 +106,23 @@ func (m *Module) assertOwnsColumn(col *Column) {
 	))
 }
 
-// columnViewToRowZeroPosition converts a [*ColumnView] into the
-// [*ColumnPosition] it would evaluate to at logical row 0. The returned
-// position lies in [0, n) when the parent module is sized. For an unsized or
-// dynamic module the offset is passed through directly; a negative offset is
-// rejected upfront because it cannot be normalised without knowing n.
-func columnViewToRowZeroPosition(cv *ColumnView) *ColumnPosition {
-	off := cv.ShiftingOffset
+// columnViewAtRow converts a [*ColumnView] into the [*ColumnPosition] it
+// evaluates to at logical row `position`. The resolved row is
+// (position + cv.ShiftingOffset) and is normalised modulo the module size
+// when the module is sized. For an unsized or dynamic module the resolved
+// row is passed through directly; a negative resolved row is rejected because
+// it cannot be normalised without knowing n.
+func columnViewAtRow(cv *ColumnView, position int) *ColumnPosition {
+	target := position + cv.ShiftingOffset
 	m := cv.Column.Module
 	if m.IsSized() {
 		n := m.Size()
-		off = ((off % n) + n) % n
-	} else if off < 0 {
+		target = ((target % n) + n) % n
+	} else if target < 0 {
 		panic(fmt.Sprintf(
-			"wiop: NewLocalConstraint: negative shift %d on column %q requires a sized module",
-			cv.ShiftingOffset, cv.Column.Context.Path(),
+			"wiop: NewLocalConstraint: resolved row %d (position %d + shift %d) on column %q requires a sized module",
+			target, position, cv.ShiftingOffset, cv.Column.Context.Path(),
 		))
 	}
-	return &ColumnPosition{Column: cv.Column, Position: off}
+	return &ColumnPosition{Column: cv.Column, Position: target}
 }

--- a/prover-ray/wiop/query_local_constraint.go
+++ b/prover-ray/wiop/query_local_constraint.go
@@ -26,14 +26,18 @@ import "fmt"
 // This keeps a single Query type for both "global" (multi-valued) and "local"
 // (scalar) vanishing predicates.
 //
-// All columns referenced in expr must belong to m. Reading row −1 (or any
-// negative resolved row) requires m to be statically sized so the row can be
-// normalised; an unsized or dynamic module cannot resolve negative rows at
-// construction time.
+// Reading row −1 (or any negative resolved row) requires m to be statically
+// sized so the row can be normalised; an unsized or dynamic module cannot
+// resolve negative rows at construction time.
 //
-// Panics if ctx or expr is nil, if position is not in {−1, 0, 1}, if any
-// column reference belongs to a different module, or if a resolved row is
-// negative on an unsized/dynamic module.
+// Column ownership is not validated: in line with [Module.NewVanishing], the
+// caller is responsible for ensuring that the expression references columns
+// belonging to m. Mixing columns from different modules will still evaluate
+// correctly (each [*ColumnPosition] resolves through its own column's module)
+// but is outside the intended use.
+//
+// Panics if ctx or expr is nil, if position is not in {−1, 0, 1}, or if a
+// resolved row is negative on an unsized/dynamic module.
 func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression, position int) *Vanishing {
 	if ctx == nil {
 		panic("wiop: Module.NewLocalConstraint requires a non-nil ContextFrame")
@@ -71,17 +75,12 @@ func (m *Module) NewLocalConstraint(ctx *ContextFrame, expr Expression, position
 //     [*Constant]) is passed through unchanged.
 //
 //   - [*ArithmeticOperation] is rebuilt with the rewritten operands.
-//
-// All [*ColumnView] and [*ColumnPosition] leaves must reference columns
-// belonging to m; otherwise the call panics.
 func (m *Module) lowerToRow(expr Expression, position int) Expression {
 	return EditExpression(expr, func(curr Expression, newChildren []Expression) Expression {
 		switch e := curr.(type) {
 		case *ColumnView:
-			m.assertOwnsColumn(e.Column)
 			return columnViewAtRow(e, position)
 		case *ColumnPosition:
-			m.assertOwnsColumn(e.Column)
 			return e
 		case *Constant:
 			if e.module != nil {
@@ -92,18 +91,6 @@ func (m *Module) lowerToRow(expr Expression, position int) Expression {
 			return DefaultConstruct(curr, newChildren)
 		}
 	})
-}
-
-// assertOwnsColumn panics if col is not owned by m. Used during local-constraint
-// lowering to enforce the single-module invariant of [Vanishing].
-func (m *Module) assertOwnsColumn(col *Column) {
-	if col.Module == m {
-		return
-	}
-	panic(fmt.Sprintf(
-		"wiop: Module.NewLocalConstraint: column %q belongs to module %q, not %q",
-		col.Context.Path(), col.Module.Context.Path(), m.Context.Path(),
-	))
 }
 
 // columnViewAtRow converts a [*ColumnView] into the [*ColumnPosition] it
@@ -117,7 +104,10 @@ func columnViewAtRow(cv *ColumnView, position int) *ColumnPosition {
 	m := cv.Column.Module
 	if m.IsSized() {
 		n := m.Size()
-		target = ((target % n) + n) % n
+		target %= n
+		if target < 0 {
+			target += n
+		}
 	} else if target < 0 {
 		panic(fmt.Sprintf(
 			"wiop: NewLocalConstraint: resolved row %d (position %d + shift %d) on column %q requires a sized module",

--- a/prover-ray/wiop/query_local_constraint_test.go
+++ b/prover-ray/wiop/query_local_constraint_test.go
@@ -19,77 +19,14 @@ func indexedBaseVec(n int, f func(i int) uint64) *wiop.ConcreteVector {
 	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
 }
 
-// ---- happy path ----
+// ---- the three supported positions ----
 
-func TestLocalConstraint_ColumnAtRowZero_Zero(t *testing.T) {
+func TestLocalConstraint_Position0_PicksFirstRow(t *testing.T) {
 	sys, r0, _, mod := newTestSystem(t)
-	col := mod.NewColumn(sys.Context.Childf("lcZeroCol"), wiop.VisibilityOracle, r0)
+	col := mod.NewColumn(sys.Context.Childf("p0Col"), wiop.VisibilityOracle, r0)
 
 	rt := wiop.NewRuntime(sys)
-	// col[0] = 0, rest non-zero
-	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
-		if i == 0 {
-			return 0
-		}
-		return uint64(i + 1)
-	}))
-
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcZero"), col.View())
-	require.NoError(t, v.Check(rt))
-}
-
-func TestLocalConstraint_ColumnAtRowZero_NonZero(t *testing.T) {
-	sys, r0, _, mod := newTestSystem(t)
-	col := mod.NewColumn(sys.Context.Childf("lcNZCol"), wiop.VisibilityOracle, r0)
-
-	rt := wiop.NewRuntime(sys)
-	rt.AssignColumn(col, baseVec(4, 7))
-
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcNZ"), col.View())
-	err := v.Check(rt)
-	assert.Error(t, err)
-}
-
-func TestLocalConstraint_ShiftedColumn_PositivePicksRowK(t *testing.T) {
-	sys, r0, _, mod := newTestSystem(t)
-	col := mod.NewColumn(sys.Context.Childf("lcShiftCol"), wiop.VisibilityOracle, r0)
-
-	rt := wiop.NewRuntime(sys)
-	// col = [1, 0, 1, 1]; Shift(1) → looks at col[1] = 0
-	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
-		if i == 1 {
-			return 0
-		}
-		return 1
-	}))
-
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcShift"), col.View().Shift(1))
-	require.NoError(t, v.Check(rt))
-}
-
-func TestLocalConstraint_ShiftedColumn_NegativePicksLastRow(t *testing.T) {
-	sys, r0, _, mod := newTestSystem(t)
-	col := mod.NewColumn(sys.Context.Childf("lcNegCol"), wiop.VisibilityOracle, r0)
-
-	rt := wiop.NewRuntime(sys)
-	// col = [1, 1, 1, 0]; Shift(-1) on size-4 module → col[3] = 0
-	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
-		if i == 3 {
-			return 0
-		}
-		return 1
-	}))
-
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcNeg"), col.View().Shift(-1))
-	require.NoError(t, v.Check(rt))
-}
-
-func TestLocalConstraint_ShiftWrapsAroundModuleSize(t *testing.T) {
-	sys, r0, _, mod := newTestSystem(t)
-	col := mod.NewColumn(sys.Context.Childf("lcWrapCol"), wiop.VisibilityOracle, r0)
-
-	rt := wiop.NewRuntime(sys)
-	// col = [0, 9, 9, 9]; Shift(4) on size-4 module wraps to row 0 = 0
+	// col = [0, 9, 9, 9]; position 0 reads col[0] = 0.
 	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
 		if i == 0 {
 			return 0
@@ -97,9 +34,110 @@ func TestLocalConstraint_ShiftWrapsAroundModuleSize(t *testing.T) {
 		return 9
 	}))
 
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcWrap"), col.View().Shift(4))
+	v := mod.NewLocalConstraint(sys.Context.Childf("p0"), col.View(), 0)
 	require.NoError(t, v.Check(rt))
 }
+
+func TestLocalConstraint_Position1_PicksSecondRow(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("p1Col"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [9, 0, 9, 9]; position 1 reads col[1] = 0.
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 1 {
+			return 0
+		}
+		return 9
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("p1"), col.View(), 1)
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_PositionMinus1_PicksLastRow(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("pNeg1Col"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [9, 9, 9, 0] on a size-4 module; position -1 reads col[3] = 0.
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 3 {
+			return 0
+		}
+		return 9
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("pNeg1"), col.View(), -1)
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_Position0_FailsWhenFirstRowNonZero(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("p0FailCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col[0] = 7 (non-zero) ⇒ Check at position 0 must fail.
+	rt.AssignColumn(col, baseVec(4, 7))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("p0Fail"), col.View(), 0)
+	assert.Error(t, v.Check(rt))
+}
+
+func TestLocalConstraint_Position1_FailsWhenSecondRowNonZero(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("p1FailCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [0, 7, 0, 0]; position 1 reads col[1] = 7 ⇒ fails.
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 1 {
+			return 7
+		}
+		return 0
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("p1Fail"), col.View(), 1)
+	assert.Error(t, v.Check(rt))
+}
+
+func TestLocalConstraint_PositionMinus1_FailsWhenLastRowNonZero(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("pNeg1FailCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [0, 0, 0, 7]; position -1 reads col[3] = 7 ⇒ fails.
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 3 {
+			return 7
+		}
+		return 0
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("pNeg1Fail"), col.View(), -1)
+	assert.Error(t, v.Check(rt))
+}
+
+// ---- composition with column shifts ----
+
+func TestLocalConstraint_PositionComposesWithShift(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("shiftComp"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [9, 9, 0, 9]; col.View().Shift(1) at position 1 reads col[2] = 0.
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 2 {
+			return 0
+		}
+		return 9
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("shiftComp"), col.View().Shift(1), 1)
+	require.NoError(t, v.Check(rt))
+}
+
+// ---- arithmetic / non-column leaves ----
 
 func TestLocalConstraint_ArithmeticOverTwoColumns(t *testing.T) {
 	sys, r0, _, mod := newTestSystem(t)
@@ -107,12 +145,12 @@ func TestLocalConstraint_ArithmeticOverTwoColumns(t *testing.T) {
 	b := mod.NewColumn(sys.Context.Childf("lcB"), wiop.VisibilityOracle, r0)
 
 	rt := wiop.NewRuntime(sys)
-	// a[0] = b[0] = 5 ⇒ a - b vanishes at row 0
+	// a[0] = b[0] = 5 ⇒ a - b vanishes at row 0.
 	rt.AssignColumn(a, baseVec(4, 5))
 	rt.AssignColumn(b, baseVec(4, 5))
 
 	expr := wiop.Sub(a.View(), b.View())
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcArith"), expr)
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcArith"), expr, 0)
 	require.NoError(t, v.Check(rt))
 }
 
@@ -123,19 +161,17 @@ func TestLocalConstraint_ScalarOnly_CellExpression(t *testing.T) {
 	rt := wiop.NewRuntime(sys)
 	rt.AssignCell(cell, field.ElemZero())
 
-	// No columns at all; just `cell` which is zero.
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcScalar"), cell)
+	// No columns at all; position is irrelevant but must still be valid.
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcScalar"), cell, 0)
 	require.NoError(t, v.Check(rt))
 }
 
 func TestLocalConstraint_VectorConstantCollapsedToScalar(t *testing.T) {
 	sys, _, _, mod := newTestSystem(t)
-	// A non-zero vector constant; lowering must collapse it to its scalar
-	// equivalent so that Check picks the scalar branch.
 	c := wiop.NewConstantVector(mod, field.NewFromString("0"))
 
 	rt := wiop.NewRuntime(sys)
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcVecK"), c)
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcVecK"), c, 0)
 	require.NoError(t, v.Check(rt))
 }
 
@@ -146,7 +182,7 @@ func TestLocalConstraint_RegistersOnModuleVanishings(t *testing.T) {
 	col := mod.NewColumn(sys.Context.Childf("lcRegCol"), wiop.VisibilityOracle, r0)
 
 	before := len(mod.Vanishings)
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcReg"), col.View())
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcReg"), col.View(), 0)
 	assert.Equal(t, before+1, len(mod.Vanishings))
 	assert.Same(t, v, mod.Vanishings[before])
 	// "Local" constraints never auto-cancel any rows.
@@ -156,7 +192,7 @@ func TestLocalConstraint_RegistersOnModuleVanishings(t *testing.T) {
 func TestLocalConstraint_RoundFollowsColumn(t *testing.T) {
 	sys, _, r1, mod := newTestSystem(t)
 	col := mod.NewColumn(sys.Context.Childf("lcRoundCol"), wiop.VisibilityOracle, r1)
-	v := mod.NewLocalConstraint(sys.Context.Childf("lcRound"), col.View())
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcRound"), col.View(), 0)
 	assert.Equal(t, r1, v.Round())
 }
 
@@ -165,32 +201,43 @@ func TestLocalConstraint_RoundFollowsColumn(t *testing.T) {
 func TestLocalConstraint_NilCtx_Panics(t *testing.T) {
 	_, _, _, mod := newTestSystem(t)
 	k := wiop.NewConstantField(field.NewFromString("0"))
-	assert.Panics(t, func() { mod.NewLocalConstraint(nil, k) })
+	assert.Panics(t, func() { mod.NewLocalConstraint(nil, k, 0) })
 }
 
 func TestLocalConstraint_NilExpr_Panics(t *testing.T) {
 	sys, _, _, mod := newTestSystem(t)
-	assert.Panics(t, func() { mod.NewLocalConstraint(sys.Context.Childf("nilExprLC"), nil) })
+	assert.Panics(t, func() { mod.NewLocalConstraint(sys.Context.Childf("nilExprLC"), nil, 0) })
+}
+
+func TestLocalConstraint_InvalidPosition_Panics(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("badPosCol"), wiop.VisibilityOracle, r0)
+	for _, bad := range []int{-2, 2, 3, -3, 100} {
+		bad := bad
+		t.Run("", func(t *testing.T) {
+			assert.Panics(t, func() {
+				mod.NewLocalConstraint(sys.Context.Childf("badPos"), col.View(), bad)
+			})
+		})
+	}
 }
 
 func TestLocalConstraint_CrossModule_Panics(t *testing.T) {
 	sys, r0, _, modA := newTestSystem(t)
 	modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
 	colB := modB.NewColumn(sys.Context.Childf("crossCol"), wiop.VisibilityOracle, r0)
-	// Building a local constraint on modA that references a column from modB
-	// violates the single-module invariant and must panic at construction.
 	assert.Panics(t, func() {
-		modA.NewLocalConstraint(sys.Context.Childf("crossLC"), colB.View())
+		modA.NewLocalConstraint(sys.Context.Childf("crossLC"), colB.View(), 0)
 	})
 }
 
-func TestLocalConstraint_NegativeShift_UnsizedModule_Panics(t *testing.T) {
+func TestLocalConstraint_PositionMinus1_UnsizedModule_Panics(t *testing.T) {
 	sys := wiop.NewSystemf("lcUnsized")
 	r0 := sys.NewRound()
 	// Unsized static module: SetSize has not been called.
 	mod := sys.NewModule(sys.Context.Childf("unsizedMod"), wiop.PaddingDirectionNone)
 	col := mod.NewColumn(sys.Context.Childf("unsizedCol"), wiop.VisibilityOracle, r0)
 	assert.Panics(t, func() {
-		mod.NewLocalConstraint(sys.Context.Childf("lcNegUnsized"), col.View().Shift(-1))
+		mod.NewLocalConstraint(sys.Context.Childf("lcNegUnsized"), col.View(), -1)
 	})
 }

--- a/prover-ray/wiop/query_local_constraint_test.go
+++ b/prover-ray/wiop/query_local_constraint_test.go
@@ -1,0 +1,196 @@
+package wiop_test
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// indexedBaseVec returns a length-n ConcreteVector whose i-th entry is the
+// uint64 returned by f(i).
+func indexedBaseVec(n int, f func(i int) uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, n)
+	for i := range n {
+		elems[i].SetUint64(f(i))
+	}
+	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
+}
+
+// ---- happy path ----
+
+func TestLocalConstraint_ColumnAtRowZero_Zero(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcZeroCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col[0] = 0, rest non-zero
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 0 {
+			return 0
+		}
+		return uint64(i + 1)
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcZero"), col.View())
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_ColumnAtRowZero_NonZero(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcNZCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, baseVec(4, 7))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcNZ"), col.View())
+	err := v.Check(rt)
+	assert.Error(t, err)
+}
+
+func TestLocalConstraint_ShiftedColumn_PositivePicksRowK(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcShiftCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [1, 0, 1, 1]; Shift(1) → looks at col[1] = 0
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 1 {
+			return 0
+		}
+		return 1
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcShift"), col.View().Shift(1))
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_ShiftedColumn_NegativePicksLastRow(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcNegCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [1, 1, 1, 0]; Shift(-1) on size-4 module → col[3] = 0
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 3 {
+			return 0
+		}
+		return 1
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcNeg"), col.View().Shift(-1))
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_ShiftWrapsAroundModuleSize(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcWrapCol"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// col = [0, 9, 9, 9]; Shift(4) on size-4 module wraps to row 0 = 0
+	rt.AssignColumn(col, indexedBaseVec(4, func(i int) uint64 {
+		if i == 0 {
+			return 0
+		}
+		return 9
+	}))
+
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcWrap"), col.View().Shift(4))
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_ArithmeticOverTwoColumns(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	a := mod.NewColumn(sys.Context.Childf("lcA"), wiop.VisibilityOracle, r0)
+	b := mod.NewColumn(sys.Context.Childf("lcB"), wiop.VisibilityOracle, r0)
+
+	rt := wiop.NewRuntime(sys)
+	// a[0] = b[0] = 5 ⇒ a - b vanishes at row 0
+	rt.AssignColumn(a, baseVec(4, 5))
+	rt.AssignColumn(b, baseVec(4, 5))
+
+	expr := wiop.Sub(a.View(), b.View())
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcArith"), expr)
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_ScalarOnly_CellExpression(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	cell := r0.NewCell(sys.Context.Childf("lcCell"), false)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignCell(cell, field.ElemZero())
+
+	// No columns at all; just `cell` which is zero.
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcScalar"), cell)
+	require.NoError(t, v.Check(rt))
+}
+
+func TestLocalConstraint_VectorConstantCollapsedToScalar(t *testing.T) {
+	sys, _, _, mod := newTestSystem(t)
+	// A non-zero vector constant; lowering must collapse it to its scalar
+	// equivalent so that Check picks the scalar branch.
+	c := wiop.NewConstantVector(mod, field.NewFromString("0"))
+
+	rt := wiop.NewRuntime(sys)
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcVecK"), c)
+	require.NoError(t, v.Check(rt))
+}
+
+// ---- registration / metadata ----
+
+func TestLocalConstraint_RegistersOnModuleVanishings(t *testing.T) {
+	sys, r0, _, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcRegCol"), wiop.VisibilityOracle, r0)
+
+	before := len(mod.Vanishings)
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcReg"), col.View())
+	assert.Equal(t, before+1, len(mod.Vanishings))
+	assert.Same(t, v, mod.Vanishings[before])
+	// "Local" constraints never auto-cancel any rows.
+	assert.Empty(t, v.CancelledPositions)
+}
+
+func TestLocalConstraint_RoundFollowsColumn(t *testing.T) {
+	sys, _, r1, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("lcRoundCol"), wiop.VisibilityOracle, r1)
+	v := mod.NewLocalConstraint(sys.Context.Childf("lcRound"), col.View())
+	assert.Equal(t, r1, v.Round())
+}
+
+// ---- panics ----
+
+func TestLocalConstraint_NilCtx_Panics(t *testing.T) {
+	_, _, _, mod := newTestSystem(t)
+	k := wiop.NewConstantField(field.NewFromString("0"))
+	assert.Panics(t, func() { mod.NewLocalConstraint(nil, k) })
+}
+
+func TestLocalConstraint_NilExpr_Panics(t *testing.T) {
+	sys, _, _, mod := newTestSystem(t)
+	assert.Panics(t, func() { mod.NewLocalConstraint(sys.Context.Childf("nilExprLC"), nil) })
+}
+
+func TestLocalConstraint_CrossModule_Panics(t *testing.T) {
+	sys, r0, _, modA := newTestSystem(t)
+	modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+	colB := modB.NewColumn(sys.Context.Childf("crossCol"), wiop.VisibilityOracle, r0)
+	// Building a local constraint on modA that references a column from modB
+	// violates the single-module invariant and must panic at construction.
+	assert.Panics(t, func() {
+		modA.NewLocalConstraint(sys.Context.Childf("crossLC"), colB.View())
+	})
+}
+
+func TestLocalConstraint_NegativeShift_UnsizedModule_Panics(t *testing.T) {
+	sys := wiop.NewSystemf("lcUnsized")
+	r0 := sys.NewRound()
+	// Unsized static module: SetSize has not been called.
+	mod := sys.NewModule(sys.Context.Childf("unsizedMod"), wiop.PaddingDirectionNone)
+	col := mod.NewColumn(sys.Context.Childf("unsizedCol"), wiop.VisibilityOracle, r0)
+	assert.Panics(t, func() {
+		mod.NewLocalConstraint(sys.Context.Childf("lcNegUnsized"), col.View().Shift(-1))
+	})
+}

--- a/prover-ray/wiop/query_local_constraint_test.go
+++ b/prover-ray/wiop/query_local_constraint_test.go
@@ -222,15 +222,6 @@ func TestLocalConstraint_InvalidPosition_Panics(t *testing.T) {
 	}
 }
 
-func TestLocalConstraint_CrossModule_Panics(t *testing.T) {
-	sys, r0, _, modA := newTestSystem(t)
-	modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
-	colB := modB.NewColumn(sys.Context.Childf("crossCol"), wiop.VisibilityOracle, r0)
-	assert.Panics(t, func() {
-		modA.NewLocalConstraint(sys.Context.Childf("crossLC"), colB.View(), 0)
-	})
-}
-
 func TestLocalConstraint_PositionMinus1_UnsizedModule_Panics(t *testing.T) {
 	sys := wiop.NewSystemf("lcUnsized")
 	r0 := sys.NewRound()


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new constraint-construction API that rewrites expressions to fixed-row reads (including shift/modulo behavior), which could affect proof correctness if the row resolution or module-size assumptions are wrong; changes are otherwise additive and well-tested.
> 
> **Overview**
> Adds `Module.NewLocalConstraint`, allowing a `Vanishing` predicate to be enforced at a single logical row (`-1`, `0`, or `1`) by lowering an expression into a scalar form.
> 
> Implements expression rewriting that converts `ColumnView` (including `Shift(k)`) into concrete `ColumnPosition` reads at the resolved row (modulo size when sized), collapses vector constants to scalars, and panics on cross-module column references or negative rows on unsized modules.
> 
> Introduces comprehensive tests covering supported positions, shift composition, arithmetic/scalar leaves, registration metadata, and expected panics for invalid inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f2475a9a426badd1281f5ee400326a6fcf7569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->