### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/docker-build-publish/action.yml
+++ b/.github/actions/docker-build-publish/action.yml
@@ -126,7 +126,7 @@ runs:
 
     - name: Upload Docker image artifact
       if: ${{ inputs.save_artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.artifact_name }}-docker-image.tar.gz

--- a/.github/actions/image-tag-and-push/action.yml
+++ b/.github/actions/image-tag-and-push/action.yml
@@ -67,7 +67,7 @@ runs:
         docker save ${{ inputs.image_name }}:${{ inputs.commit_tag }} | gzip > ${{ steps.split.outputs.image_name_suffix }}-docker-image.tar.gz
     - name: Upload Docker image artifact for later use in e2e test
       if: ${{ github.ref == 'refs/heads/main' && inputs.last_commit_tag_exists == '0' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ steps.split.outputs.image_name_suffix }}
         path: ${{ steps.split.outputs.image_name_suffix }}-docker-image.tar.gz

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -27,10 +27,10 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       name: setup-pnpm
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       name: setup-nodejs
       with:
         node-version-file: .nvmrc

--- a/.github/workflows/all-tools.yml
+++ b/.github/workflows/all-tools.yml
@@ -29,7 +29,7 @@ jobs:
       all-tools: ${{ steps.filter.outputs['all-tools'] }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Filter commit changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: filter
@@ -53,7 +53,7 @@ jobs:
     if: ${{ needs.changes.outputs['all-tools'] == 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check image tags exist
         uses: ./.github/actions/check-image-tags-exist
         with:
@@ -69,7 +69,7 @@ jobs:
       image_tagged: ${{ steps.image_tag_push.outputs.image_tagged }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Tag and push image
         id: image_tag_push
         uses: ./.github/actions/image-tag-and-push
@@ -96,7 +96,7 @@ jobs:
     name: All tools build and push
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/check-lib-versions-changes.yml
+++ b/.github/workflows/check-lib-versions-changes.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -178,14 +178,14 @@ jobs:
 
       - name: Upload review file
         if: ${{ github.event.inputs.save_review_file == 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coordinator-review
           path: /tmp/coordinator-review.md
 
       - name: Upload Claude execution log
         if: ${{ always() && steps.review.outputs.execution_file != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: claude-execution-output
           path: ${{ steps.review.outputs.execution_file }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
@@ -126,7 +126,7 @@ jobs:
           output: sarif-results
 
       - name: Upload CodeQL Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-results-${{ matrix.language }}
           path: sarif-results

--- a/.github/workflows/coordinator-build-and-publish.yml
+++ b/.github/workflows/coordinator-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -32,7 +32,7 @@ jobs:
     name: Coordinator tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
       - name: Setup Java and Gradle
@@ -66,7 +66,7 @@ jobs:
           ./gradlew coordinator:app:integrationTestAllNeeded
       - name: Upload Jacoco execution data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-coordinator-exec
           path: |

--- a/.github/workflows/dockerfile-security-scan.yml
+++ b/.github/workflows/dockerfile-security-scan.yml
@@ -24,7 +24,7 @@ jobs:
     if: false # Disabled — Checkmarx KICS supply chain compromise (2026-04-22)
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run KICS
         uses: checkmarx/kics-github-action@4063ea7186bec9fed1bf055e095a4658693f9998 # v2.1.19
@@ -38,7 +38,7 @@ jobs:
       - name: Upload SARIF to GitHub Security
         if: ${{ !cancelled() && hashFiles('kics-results/results.sarif') != '' }}
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: kics-results/results.sarif
           category: kics-dockerfiles

--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -16,7 +16,7 @@ jobs:
       has_changes_requiring_e2e_testing: ${{ steps.evaluate.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Filter for e2e-relevant paths
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2

--- a/.github/workflows/github-release-besu-plugin.yml
+++ b/.github/workflows/github-release-besu-plugin.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -73,7 +73,7 @@ jobs:
       # Persist logs
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release
           path: |

--- a/.github/workflows/lido-governance-monitor-build-and-publish.yml
+++ b/.github/workflows/lido-governance-monitor-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/lido-governance-monitor-testing.yml
+++ b/.github/workflows/lido-governance-monitor-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -47,7 +47,7 @@ jobs:
           cp operations/native-yield-operations/lido-governance-monitor/coverage/lcov.info ci-lido-coverage/lido-governance-monitor-lcov.info
 
       - name: Upload TS coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lido-ts-coverage-${{ env.COMMIT_TAG }}
           if-no-files-found: error

--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - name: Check besuCommit change
         uses: ./.github/actions/check-lib-version-change

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build docker images from source and upload (if needed) for e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Tracer Environment (for linea-besu-package build)
         if: ${{ inputs.linea_besu_package_image_tag == '' }}

--- a/.github/workflows/linea-sequencer-plugin-testing.yml
+++ b/.github/workflows/linea-sequencer-plugin-testing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Tracer Environment # configures Go, Java, and Gradle
         uses: ./.github/actions/setup-tracer-environment
@@ -33,13 +33,13 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unit-test-report
           path: besu-plugins/linea-sequencer/sequencer/build/reports/tests/test/
       - name: Upload Jacoco execution data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-linea-sequencer-unit-exec
           path: |
@@ -51,7 +51,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Tracer Environment
         uses: ./.github/actions/setup-tracer-environment
@@ -63,13 +63,13 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: acceptance-test-report
           path: besu-plugins/linea-sequencer/acceptance-tests/build/reports/tests/
       - name: Upload Jacoco execution data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-linea-sequencer-acceptance-exec
           path: |

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -34,7 +34,7 @@ jobs:
     name: Run Load Test
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       has-changes-requiring-linea-besu-package-build: ${{ steps.filter.outputs.linea-sequencer-plugin == 'true' || steps.filter.outputs.tracer == 'true' || steps.filter.outputs.tracer-constraints == 'true' ||  steps.filter.outputs.linea-besu == 'true' || steps.filter.outputs.linea-besu-package == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Filter commit changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: filter

--- a/.github/workflows/maven-release-all.yml
+++ b/.github/workflows/maven-release-all.yml
@@ -34,7 +34,7 @@ jobs:
           echo "VERSION: $VERSION"
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -72,7 +72,7 @@ jobs:
       # Persist logs
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release
           path: |

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -65,7 +65,7 @@ jobs:
       # Persist logs
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release
           path: |

--- a/.github/workflows/native-yield-automation-service-build-and-publish.yml
+++ b/.github/workflows/native-yield-automation-service-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/native-yield-automation-service-testing.yml
+++ b/.github/workflows/native-yield-automation-service-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -46,7 +46,7 @@ jobs:
           cp operations/native-yield-operations/automation-service/coverage/lcov.info ci-native-yield-coverage/automation-service-lcov.info
 
       - name: Upload TS coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: native-yield-ts-coverage-${{ env.COMMIT_TAG }}
           if-no-files-found: error

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -39,11 +39,11 @@ jobs:
     name: Run test:partial-prover:${{ matrix.test }} e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download local linea-besu-package docker image
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: linea-besu-package
           path: ${{ github.workspace }}/tmp/artifacts
@@ -57,7 +57,7 @@ jobs:
 
       - name: Download local prover docker image
         if: ${{ inputs.prover_image_tag == '' }}
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: linea-prover
           path: ${{ github.workspace }}/tmp/artifacts
@@ -129,7 +129,7 @@ jobs:
           docker logs l1-el-node --since 1h &>> docker_logs/l1-el-node.txt || true
 
       - name: Archive debug logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: end-2-end-debug-logs-${{ matrix.archive-name }}
@@ -138,7 +138,7 @@ jobs:
             docker_logs/**/*
       
       - name: Archive shared folder
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: end-2-end-shared-folder-${{ matrix.archive-name }}

--- a/.github/workflows/postman-build-and-publish.yml
+++ b/.github/workflows/postman-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/postman-testing.yml
+++ b/.github/workflows/postman-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -48,7 +48,7 @@ jobs:
           cp ts-libs/sdk/sdk-viem/coverage/lcov.info ci-ts-coverage/sdk-viem-lcov.info
 
       - name: Upload TS coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ts-coverage-${{ env.COMMIT_TAG }}
           if-no-files-found: error

--- a/.github/workflows/prover-build-and-publish.yml
+++ b/.github/workflows/prover-build-and-publish.yml
@@ -70,7 +70,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
 

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.22.x
 
@@ -54,7 +54,7 @@ jobs:
           GOARCH="amd64" go build -tags=nocorset -buildmode=c-shared -o ./target/${TARGET_DECOMPRESSOR}_${VERSION}_linux_x86_64.so ${SRC_DECOMPRESSOR}
 
       - name: Cache built binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-artefacts
           path: ./prover/target
@@ -63,9 +63,9 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-arm64-med
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.22.x
           architecture: arm64
@@ -88,7 +88,7 @@ jobs:
           GOARCH="arm64" go build -tags=nocorset -buildmode=c-shared -o ./target/${TARGET_COMPRESSOR}_${VERSION}_linux_arm64.so ${SRC_COMPRESSOR}
           GOARCH="arm64" go build -tags=nocorset -buildmode=c-shared -o ./target/${TARGET_DECOMPRESSOR}_${VERSION}_linux_arm64.so ${SRC_DECOMPRESSOR}
       - name: Cache built binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux-arm64-artefacts
           path: ./prover/target
@@ -97,9 +97,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.22.x
       - name: Build the MacOS artefacts
@@ -124,7 +124,7 @@ jobs:
           GOARCH="arm64" go build -tags=nocorset -buildmode=c-shared -o ./target/${TARGET_DECOMPRESSOR}_${VERSION}_darwin_arm64.dylib ${SRC_DECOMPRESSOR}
 
       - name: Cache built binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: darwin-artefacts
           path: ./prover/target
@@ -135,7 +135,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Load cached binaries
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           merge-multiple: true
       - name: List artifacts
@@ -150,7 +150,7 @@ jobs:
         shell: bash
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -163,7 +163,7 @@ jobs:
             commit: ${{ github.sha }}
             date: ${{ steps.current_date.outputs.date }}
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/prover-ray-testing.yml
+++ b/.github/workflows/prover-ray-testing.yml
@@ -19,16 +19,16 @@ jobs:
     name: Prover static check
     steps:
     - name: checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: 1.25.7
         cache-dependency-path: |
               prover-ray/go.sum
-    - uses: actions/cache@v5.0.4
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/go-build
@@ -65,14 +65,14 @@ jobs:
       - staticcheck
     steps:
     - name: checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: |
               prover-ray/go.sum
-    - uses: actions/cache@v5.0.4
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/go-build

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -19,16 +19,16 @@ jobs:
     name: Prover static check
     steps:
     - name: checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: 1.25.7
         cache-dependency-path: |
               prover/go.sum
-    - uses: actions/cache@v5.0.4
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/go-build
@@ -65,14 +65,14 @@ jobs:
       - staticcheck
     steps:
     - name: checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: |
               prover/go.sum
-    - uses: actions/cache@v5.0.4
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: |
           ~/.cache/go-build

--- a/.github/workflows/reuse-check-images-tags-and-push.yml
+++ b/.github/workflows/reuse-check-images-tags-and-push.yml
@@ -77,7 +77,7 @@ jobs:
       develop_tag: ${{ steps.compute-version-tags.outputs.develop_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Compute version tags
         id: compute-version-tags
@@ -152,7 +152,7 @@ jobs:
       image_tagged_transaction_exclusion_api: ${{ steps.image_tag_push_transaction_exclusion_api.outputs.image_tagged }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1

--- a/.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
+++ b/.github/workflows/reuse-linea-besu-package-run-e2e-tests.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
@@ -74,7 +74,7 @@ jobs:
           mkdir -p tmp/local/traces/v2/conflated
           chmod -R a+rw tmp/local/
       - name: Download local docker image artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: linea-besu-package
           path: ${{ github.workspace }}/tmp/artifacts
@@ -149,7 +149,7 @@ jobs:
             docker logs l2-node-besu-follower --since 1h &>> docker_logs/l2-node-besu-follower.txt || true
           fi
       - name: Archive debug logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() && inputs.e2e-tests-logs-dump }}
         with:
           name: end-2-end-debug-logs

--- a/.github/workflows/reuse-linea-besu-package-run-test.yml
+++ b/.github/workflows/reuse-linea-besu-package-run-test.yml
@@ -14,7 +14,7 @@ jobs:
       profile-files: ${{ steps.list-profiles.outputs.files }}
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Split and list profiles
         id: list-profiles
@@ -38,10 +38,10 @@ jobs:
       DOCKER_IMAGE: ${{ inputs.dockerimage }}
     steps:
       - name: Check repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download local docker image artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: linea-besu-package
           path: ${{ github.workspace }}/tmp/artifacts

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -79,7 +79,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
@@ -108,7 +108,7 @@ jobs:
             make docker-pull-images-external-to-monorepo
 
       - name: Download local docker image artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           pattern: linea-*
@@ -196,7 +196,7 @@ jobs:
           docker logs maru --since 1h &>> docker_logs/maru.txt || true
           docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD:-postgres} postgres pg_dumpall -U ${POSTGRES_USER:-postgres} > docker_logs/db_dump.sql || true
       - name: Archive debug logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() && inputs.e2e-tests-logs-dump }}
         with:
           name: end-2-end-debug-logs

--- a/.github/workflows/reuse-store-image-name-and-tags.yml
+++ b/.github/workflows/reuse-store-image-name-and-tags.yml
@@ -30,7 +30,7 @@ jobs:
       develop_tag: ${{ steps.compute-version-tags.outputs.develop_tag}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Compute version tags
         id: compute-version-tags
         uses: ./.github/actions/compute-version-tags

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -24,16 +24,16 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.23.x
           cache-dependency-path: |
                 prover/go.sum
 
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-build
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Cache Hardhat compiler
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.cache/hardhat-nodejs
           key: ${{ runner.os }}-hardhat-compilers-${{ hashFiles('contracts/hardhat.config.ts', 'contracts/hardhat_overrides.ts') }}
@@ -71,7 +71,7 @@ jobs:
         run: pnpm -F contracts run coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smart-contract-coverage-${{ env.COMMIT_TAG }}.json
           if-no-files-found: error
@@ -95,7 +95,7 @@ jobs:
     name: Solidity format check
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/run-validium-e2e-tests.yml
+++ b/.github/workflows/run-validium-e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -102,7 +102,7 @@ jobs:
           docker logs maru --since 1h &>> docker_logs/maru.txt || true
 
       - name: Archive debug logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() && inputs.e2e-tests-logs-dump }}
         with:
           name: end-2-end-debug-logs

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -41,7 +41,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.release_commit_sha }}
 
@@ -155,7 +155,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.release_commit_sha }}
 

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -30,7 +30,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -84,7 +84,7 @@ jobs:
           cp ts-libs/sdk/sdk-ethers/coverage/lcov.info ci-sdk-coverage/sdk-ethers-lcov.info
 
       - name: Upload TS coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdk-ts-coverage-${{ steps.cov-tag.outputs.TAG }}
           if-no-files-found: error

--- a/.github/workflows/security-report-to-csv.yml
+++ b/.github/workflows/security-report-to-csv.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: CSV export
-        uses: advanced-security/ghas-to-csv@v3
+        uses: advanced-security/ghas-to-csv@8c2ad35efb234e8e1bd12efaced0f0609ad8afbb # v3
       - name: Upload CSV
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ghas-data
           path: ${{ github.workspace }}/*.csv

--- a/.github/workflows/slack-notify-e2e-runtime-report.yml
+++ b/.github/workflows/slack-notify-e2e-runtime-report.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload HTML report
         if: ${{ fromJSON(steps.summary.outputs.json).totalRuns > 0 }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-runtime-report
           path: e2e/e2e-runtime-report.html

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -85,7 +85,7 @@ jobs:
           tail -c 500000 /tmp/failed-job-logs-raw.txt > /tmp/failed-job-logs.txt
 
       - name: Download Docker logs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
           name: ${{ inputs.docker_logs_artifact_name }}
@@ -213,7 +213,7 @@ jobs:
       - name: Upload analysis artifact
         id: upload_artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         continue-on-error: true
         with:
           name: ai-failure-analysis
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload Claude execution log
         if: ${{ always() && steps.claude.outputs.execution_file != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         continue-on-error: true
         with:
           name: ai-execution-log

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           # Issues
           days-before-issue-stale: -1 # Deactivate stale issues

--- a/.github/workflows/staterecovery-testing.yml
+++ b/.github/workflows/staterecovery-testing.yml
@@ -32,7 +32,7 @@ jobs:
     name: Staterecovery tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Staterecovery - Build and Unit tests
@@ -59,7 +59,7 @@ jobs:
           ./gradlew besu-plugins:state-recovery:test-cases:integrationTest
       - name: Upload Jacoco execution data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-staterecovery-exec
           path: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -145,7 +145,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: false
 
@@ -154,31 +154,31 @@ jobs:
 
       - name: Download Jacoco execution data from coordinator
         if: needs.coordinator.result != 'skipped'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: jacoco-coordinator-exec
           path: .
       - name: Download Jacoco execution data from linea-sequencer unit tests
         if: needs.linea-sequencer.result != 'skipped'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: jacoco-linea-sequencer-unit-exec
           path: .
       - name: Download Jacoco execution data from linea-sequencer acceptance tests
         if: needs.linea-sequencer.result != 'skipped'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: jacoco-linea-sequencer-acceptance-exec
           path: .
       - name: Download Jacoco execution data from staterecovery
         if: needs.staterecovery.result != 'skipped'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: jacoco-staterecovery-exec
           path: .
       - name: Download Jacoco execution data from transaction-exclusion-api
         if: needs.transaction-exclusion-api.result != 'skipped'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: jacoco-transaction-exclusion-api-exec
           path: .
@@ -187,7 +187,7 @@ jobs:
         run: |
           ./gradlew jacocoRootReport
       - name: Upload Jacoco test coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacocoRootReport-${{ env.COMMIT_TAG }}.xml
           if-no-files-found: error

--- a/.github/workflows/transaction-exclusion-api-build-and-publish.yml
+++ b/.github/workflows/transaction-exclusion-api-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/transaction-exclusion-api-testing.yml
+++ b/.github/workflows/transaction-exclusion-api-testing.yml
@@ -33,7 +33,7 @@ jobs:
     name: Transaction exclusion api tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Run tests with coverage
@@ -55,7 +55,7 @@ jobs:
           ./gradlew transaction-exclusion-api:app:integrationTestAllNeeded
       - name: Upload Jacoco execution data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-transaction-exclusion-api-exec
           path: |

--- a/.github/workflows/valid-audit-pr-has-tags.yml
+++ b/.github/workflows/valid-audit-pr-has-tags.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Pin every `uses:` ref in `.github/workflows/` (and any composite action
files) to a full 40-character commit SHA, with the original tag
preserved as a `# vX` comment.

## Why

Tags and branches are mutable, so a compromised action can replace what
runs in our pipelines without changing the tag we reference. Pinning to
a SHA closes that supply-chain vector. See GitHub's hardening guide:
<https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>.

## Deadline

**TechOps is enforcing SHA-pinned GitHub Actions across the org by
June 8, 2026.** Merging this PR brings the repo into compliance ahead
of the cut-over; after that date workflows that still reference
mutable tags or branches will be blocked from running.

## How

Generated mechanically with [`pinact run`](https://github.com/suzuki-shunsuke/pinact).
No version bumps were applied (strict pin); follow-up upgrades can come
from Renovate or a separate `pinact run -u` PR.

## Test plan

- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low functional risk (no runtime code changes), but CI could break if any pinned SHAs are incorrect or action outputs/behavior subtly differ from the previously referenced tags.
> 
> **Overview**
> **Pins GitHub Actions dependencies across CI.** Replaces mutable `uses: ...@vX` / `@main` refs in `.github/workflows/*` and composite actions with full commit SHAs, preserving the original version as a comment.
> 
> This includes core actions like `actions/checkout`, `actions/upload-artifact`/`download-artifact`, `actions/setup-node`, `actions/setup-go`, caching actions, and a few workflow-specific actions (e.g., CodeQL SARIF upload, release creation/upload, stale bot), reducing supply-chain risk from tag/branch retargeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54aa54e85cfa367fb8f4f241a3acbd675f9c951f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->