### PR TITLE
fix(contracts): exclude yield storage layout from docgen

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -181,6 +181,7 @@ const config: HardhatUserConfig = {
       "security/reentrancy/TransientStorageReentrancyGuardUpgradeable.sol",
       "tokens",
       "verifiers",
+      "yield/YieldManagerStorageLayout.sol",
     ],
     pages: "files",
     outputDir: "docs/api/",


### PR DESCRIPTION
This PR implements issue(s) # N/A

### Summary

Excludes `YieldManagerStorageLayout.sol` from Solidity docgen output so docgen no longer evaluates the audited storage helper NatSpec that uses `$` / `$$` return variable names. This keeps audited Solidity untouched and fixes the `solidity-docgen` parser crash.

### Verification

- `cd contracts && pnpm exec hardhat docgen`
- `pnpm -F contracts run solidity:docgen`
- `pnpm -F contracts run lint:ts`

### Checklist

* [ ] I wrote new tests for my new core changes. N/A - tooling configuration only.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR. N/A - not deployed.
* [ ] I have informed the team of any breaking changes if there are any. N/A - no breaking changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk tooling/config change that only affects generated Solidity documentation output. No contract logic or deployment behavior is modified.
> 
> **Overview**
> Updates `contracts/hardhat.config.ts` to exclude `yield/YieldManagerStorageLayout.sol` from `solidity-docgen` generation, avoiding docgen processing/parsing of that audited storage-layout helper and preventing docgen crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75729f812db98a462bf0e06a6448e4dbab25e2e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->