### PR TITLE
chore(besu-plugin): fix JsonRpcManagerTest flackiness

### DIFF
--- a/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
+++ b/besu-plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/jsonrpc/JsonRpcManagerTest.java
@@ -167,10 +167,7 @@ class JsonRpcManagerTest {
     // successful)
     final Path rejTxRpcDir =
         tempDataDir.resolve(JsonRpcManager.JSON_RPC_DIR).resolve(PLUGIN_IDENTIFIER);
-    try (Stream<Path> files = Files.list(rejTxRpcDir)) {
-      long fileCount = files.filter(path -> path.toString().endsWith(".json")).count();
-      assertThat(fileCount).isEqualTo(0);
-    }
+    await().atMost(2, SECONDS).untilAsserted(() -> assertThat(jsonFileCount(rejTxRpcDir)).isZero());
   }
 
   @Test
@@ -282,9 +279,12 @@ class JsonRpcManagerTest {
     // successful)
     final Path rejTxRpcDir =
         tempDataDir.resolve(JsonRpcManager.JSON_RPC_DIR).resolve(PLUGIN_IDENTIFIER);
-    try (Stream<Path> files = Files.list(rejTxRpcDir)) {
-      long fileCount = files.filter(path -> path.toString().endsWith(".json")).count();
-      assertThat(fileCount).isEqualTo(0);
+    await().atMost(2, SECONDS).untilAsserted(() -> assertThat(jsonFileCount(rejTxRpcDir)).isZero());
+  }
+
+  private static long jsonFileCount(final Path directory) throws IOException {
+    try (Stream<Path> files = Files.list(directory)) {
+      return files.filter(path -> path.toString().endsWith(".json")).count();
     }
   }
 }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test assertions, adding Awaitility-based polling to handle asynchronous file cleanup timing.
> 
> **Overview**
> Improves `JsonRpcManagerTest` stability by replacing immediate directory scans with Awaitility polling when asserting that retry-success scenarios delete any persisted `.json` request files.
> 
> Adds a small `jsonFileCount` helper to centralize counting `.json` files in the temp JSON-RPC directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899171cb14a94f8e46070edd852971f1a5f2d8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->