### PR TITLE
fix(contracts): use the UI signer for ftx

### DIFF
--- a/contracts/.env.template
+++ b/contracts/.env.template
@@ -118,8 +118,10 @@ TARGET_WITHDRAWAL_RESERVE_AMOUNT=
 # Forwards calls to LINEA_ROLLUP_ADDRESS (set above).
 
 # ── AddressFilter (L1) ──────────────────────────────────────────────────
-# Filters addresses for forced transactions. Uses L1_SECURITY_COUNCIL as admin.
-# ADDRESS_FILTER_FILTERED_ADDRESSES=
+# Filters addresses for forced transactions. Deployer holds DEFAULT_ADMIN_ROLE temporarily;
+# filtered addresses are applied in batches, then admin is transferred to L1_SECURITY_COUNCIL.
+# Filtered addresses are loaded from ADDRESS_FILTER_FILE_PATH (defaults to contracts/addresses-filter.txt).
+# ADDRESS_FILTER_FILE_PATH=
 
 # ── ForcedTransactionGateway (L1) ───────────────────────────────────────
 # FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID=

--- a/contracts/.env.template.ci
+++ b/contracts/.env.template.ci
@@ -103,7 +103,8 @@ YIELD_MANAGER_ADDRESS=
 # CallForwardingProxy (L1) — uses LINEA_ROLLUP_ADDRESS
 
 # AddressFilter (L1)
-# ADDRESS_FILTER_FILTERED_ADDRESSES=
+# Filtered addresses are loaded from ADDRESS_FILTER_FILE_PATH (defaults to contracts/addresses-filter.txt).
+# ADDRESS_FILTER_FILE_PATH=
 
 # ForcedTransactionGateway (L1)
 # FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID=

--- a/contracts/.env.template.uat
+++ b/contracts/.env.template.uat
@@ -103,7 +103,8 @@ LINEA_ROLLUP_RATE_LIMIT_AMOUNT="1000000000000000000000" #1000ETH
 # CallForwardingProxy (L1) — uses LINEA_ROLLUP_ADDRESS
 
 # AddressFilter (L1)
-# ADDRESS_FILTER_FILTERED_ADDRESSES=
+# Filtered addresses are loaded from ADDRESS_FILTER_FILE_PATH (defaults to contracts/addresses-filter.txt).
+# ADDRESS_FILTER_FILE_PATH=
 
 # ForcedTransactionGateway (L1)
 # FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID=

--- a/contracts/deploy/03_deploy_LineaRollupV8WithReinitialization.ts
+++ b/contracts/deploy/03_deploy_LineaRollupV8WithReinitialization.ts
@@ -1,9 +1,3 @@
-import {
-  PAUSE_STATE_DATA_SUBMISSION_ROLE,
-  UNPAUSE_STATE_DATA_SUBMISSION_ROLE,
-  STATE_DATA_SUBMISSION_PAUSE_TYPE,
-  SECURITY_COUNCIL_ROLE,
-} from "contracts/common/constants";
 import { LineaRollup__factory } from "contracts/typechain-types";
 import { ethers, upgrades } from "hardhat";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -13,78 +7,50 @@ import { tryVerifyContract, getRequiredEnvVar } from "../common/helpers";
 import { getUiSigner, withSignerUiSession } from "../scripts/hardhat/signer-ui-bridge";
 
 const func: DeployFunction = withSignerUiSession(
-  "03_deploy_LineaRollupWithReinitialization.ts",
+  "03_deploy_LineaRollupV8WithReinitialization.ts",
   async function (hre: HardhatRuntimeEnvironment) {
     const signer = await getUiSigner(hre);
-    let upgradePauseTypeRoles = [];
-    let upgradeUnpauseTypeRoles = [];
-    let upgradeRoleAddresses = [];
 
-    const securityCouncilAddress = getRequiredEnvVar("L1_SECURITY_COUNCIL");
     const proxyAddress = getRequiredEnvVar("LINEA_ROLLUP_ADDRESS");
-
-    upgradeRoleAddresses = [
-      {
-        addressWithRole: securityCouncilAddress,
-        role: SECURITY_COUNCIL_ROLE,
-      },
-      {
-        addressWithRole: securityCouncilAddress,
-        role: PAUSE_STATE_DATA_SUBMISSION_ROLE,
-      },
-      {
-        addressWithRole: securityCouncilAddress,
-        role: UNPAUSE_STATE_DATA_SUBMISSION_ROLE,
-      },
-    ];
-
-    upgradePauseTypeRoles = [{ pauseType: STATE_DATA_SUBMISSION_PAUSE_TYPE, role: PAUSE_STATE_DATA_SUBMISSION_ROLE }];
-    upgradeUnpauseTypeRoles = [
-      { pauseType: STATE_DATA_SUBMISSION_PAUSE_TYPE, role: UNPAUSE_STATE_DATA_SUBMISSION_ROLE },
-    ];
+    const forcedTransactionFeeInWei = getRequiredEnvVar("LINEA_ROLLUP_FORCED_TRANSACTION_FEE_IN_WEI");
+    const addressFilter = getRequiredEnvVar("LINEA_ROLLUP_ADDRESS_FILTER");
 
     const contractName = "LineaRollup";
 
     const factory = await ethers.getContractFactory(contractName, signer);
 
-    console.log("Deploying Contract...");
-    const newContract = await upgrades.deployImplementation(factory, {
+    console.log("Deploying new LineaRollup implementation...");
+    const newImplementation = await upgrades.deployImplementation(factory, {
       kind: "transparent",
     });
 
-    const contract = newContract.toString();
+    const implementationAddress = newImplementation.toString();
+    console.log(`Implementation deployed at ${implementationAddress}`);
 
-    console.log(`Contract deployed at ${contract}`);
-
-    // The encoding should be used through the safe.
-    // THIS IS JUST A SAMPLE AND WILL BE ADJUSTED WHEN NEEDED FOR GENERATING THE CALLDATA FOR THE UPGRADE CALL
-    // https://www.4byte.directory/signatures/?bytes4_signature=0x9623609d
-    const upgradeCallWithReinitializationUsingSecurityCouncil = ethers.concat([
+    // Encoded calldata for upgradeAndCall via ProxyAdmin (selector 0x9623609d).
+    // Submit this through the Security Council Safe using upgradeAndCall on the ProxyAdmin.
+    // See: https://www.4byte.directory/signatures/?bytes4_signature=0x9623609d
+    const upgradeCallWithReinitialization = ethers.concat([
       "0x9623609d",
       ethers.AbiCoder.defaultAbiCoder().encode(
         ["address", "address", "bytes"],
         [
           proxyAddress,
-          newContract,
-          LineaRollup__factory.createInterface().encodeFunctionData("reinitializeV8", [
-            upgradeRoleAddresses,
-            upgradePauseTypeRoles,
-            upgradeUnpauseTypeRoles,
+          newImplementation,
+          LineaRollup__factory.createInterface().encodeFunctionData("reinitializeLineaRollupV9", [
+            forcedTransactionFeeInWei,
+            addressFilter,
           ]),
         ],
       ),
     ]);
 
-    console.log(
-      "Encoded Tx Upgrade with Reinitialization from Security Council:",
-      "\n",
-      upgradeCallWithReinitializationUsingSecurityCouncil,
-    );
-    console.log("\n");
+    console.log("Encoded upgradeAndCall calldata for reinitializeLineaRollupV9:");
+    console.log("\n", upgradeCallWithReinitialization, "\n");
 
-    await tryVerifyContract(contract);
+    await tryVerifyContract(implementationAddress);
   },
 );
 
 export default func;
-func.tags = ["LineaRollupWithReinitialization"];
+func.tags = ["LineaRollupV8WithReinitialization"];

--- a/contracts/deploy/21_deploy_AddressFilter.ts
+++ b/contracts/deploy/21_deploy_AddressFilter.ts
@@ -1,30 +1,100 @@
 import { PRECOMPILES_ADDRESSES } from "contracts/common/constants";
 import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-import { LogContractDeployment, getRequiredEnvVar, tryVerifyContractWithConstructorArgs } from "../common/helpers";
+import {
+  LogContractDeployment,
+  getOptionalEnvVar,
+  getRequiredEnvVar,
+  tryVerifyContractWithConstructorArgs,
+} from "../common/helpers";
+import { getUiSigner, withSignerUiSession } from "../scripts/hardhat/signer-ui-bridge";
 
-const func: DeployFunction = async function () {
-  const contractName = "AddressFilter";
+const DEFAULT_FILTERED_ADDRESS_PATH = join(__dirname, "..", "addresses-filter.txt");
 
-  const lineaRollupSecurityCouncil = getRequiredEnvVar("L1_SECURITY_COUNCIL");
-  const filteredAddresses = getRequiredEnvVar("ADDRESS_FILTER_FILTERED_ADDRESSES").split(",");
+/** Keeps each `setFilteredStatus` tx under Osaka-era gas limits (cold mapping writes per address). */
+const SET_FILTERED_STATUS_BATCH_SIZE = 300;
 
-  const defaultFilterAddresses = [...PRECOMPILES_ADDRESSES, ...filteredAddresses];
+/**
+ * Filtered addresses loaded from the file at `ADDRESS_FILTER_FILE_PATH` (env) or
+ * `contracts/addresses-filter.txt` (default). YAML-style list entries; excludes
+ * precompiles already covered by {@link PRECOMPILES_ADDRESSES}.
+ */
+function loadAddressFilterFilteredAddressesFromFile(): string[] {
+  const filePath = getOptionalEnvVar("ADDRESS_FILTER_FILE_PATH") ?? DEFAULT_FILTERED_ADDRESS_PATH;
+  const precompileSet = new Set(PRECOMPILES_ADDRESSES.map((a) => a.toLowerCase()));
+  const text = readFileSync(filePath, "utf8");
+  console.log(`AddressFilter: loading filtered addresses from ${filePath}`);
+  const entryRe = /-\s*"(0x[a-fA-F0-9]{40})"/g;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(text)) !== null) {
+    const addr = `0x${m[1].slice(2).toLowerCase()}`;
+    const key = addr.toLowerCase();
+    if (precompileSet.has(key) || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(addr);
+  }
+  return out;
+}
 
-  const factory = await ethers.getContractFactory(contractName);
-  const contract = await factory.deploy(lineaRollupSecurityCouncil, defaultFilterAddresses);
+export const ADDRESS_FILTER_FILTERED_ADDRESSES: string[] = loadAddressFilterFilteredAddressesFromFile();
 
-  await LogContractDeployment(contractName, contract);
-  const contractAddress = await contract.getAddress();
+const func: DeployFunction = withSignerUiSession(
+  "21_deploy_AddressFilter.ts",
+  async function (hre: HardhatRuntimeEnvironment) {
+    const contractName = "AddressFilter";
+    const signer = await getUiSigner(hre);
 
-  const args = [lineaRollupSecurityCouncil, defaultFilterAddresses];
-  await tryVerifyContractWithConstructorArgs(
-    contractAddress,
-    "src/rollup/forcedTransactions/AddressFilter.sol:AddressFilter",
-    args,
-  );
-};
+    const councilAddress = ethers.getAddress(getRequiredEnvVar("L1_SECURITY_COUNCIL"));
+    const deployerAddress = ethers.getAddress(await signer.getAddress());
+    const filteredAddresses = ADDRESS_FILTER_FILTERED_ADDRESSES;
+
+    // Constructor initcode must stay under EIP-3860 (49152 bytes). Deployer is temporary DEFAULT_ADMIN.
+    const constructorInitialList = [...PRECOMPILES_ADDRESSES];
+
+    const factory = await ethers.getContractFactory(contractName, signer);
+    const contract = await factory.deploy(deployerAddress, constructorInitialList);
+
+    await LogContractDeployment(contractName, contract);
+    const contractAddress = await contract.getAddress();
+
+    if (filteredAddresses.length > 0) {
+      const batchTotal = Math.ceil(filteredAddresses.length / SET_FILTERED_STATUS_BATCH_SIZE);
+      for (let i = 0; i < filteredAddresses.length; i += SET_FILTERED_STATUS_BATCH_SIZE) {
+        const chunk = filteredAddresses.slice(i, i + SET_FILTERED_STATUS_BATCH_SIZE);
+        const batchIndex = Math.floor(i / SET_FILTERED_STATUS_BATCH_SIZE) + 1;
+        console.log(`AddressFilter: setFilteredStatus batch ${batchIndex}/${batchTotal} (${chunk.length} addresses)…`);
+        const tx = await contract.setFilteredStatus(chunk, true);
+        await tx.wait();
+      }
+    }
+
+    const defaultAdminRole = await contract.DEFAULT_ADMIN_ROLE();
+
+    if (deployerAddress !== councilAddress) {
+      console.log(`AddressFilter: granting DEFAULT_ADMIN_ROLE to L1_SECURITY_COUNCIL ${councilAddress}…`);
+      await (await contract.grantRole(defaultAdminRole, councilAddress)).wait();
+      console.log("AddressFilter: deployer renouncing DEFAULT_ADMIN_ROLE…");
+      await (await contract.renounceRole(defaultAdminRole, deployerAddress)).wait();
+    } else {
+      console.log("AddressFilter: deployer equals L1_SECURITY_COUNCIL — skipping grant/renounce (admin unchanged).");
+    }
+
+    const args = [deployerAddress, constructorInitialList];
+    await tryVerifyContractWithConstructorArgs(
+      contractAddress,
+      "src/rollup/forcedTransactions/AddressFilter.sol:AddressFilter",
+      args,
+    );
+  },
+);
 
 export default func;
 func.tags = ["AddressFilter"];

--- a/contracts/deploy/21_deploy_AddressFilter.ts
+++ b/contracts/deploy/21_deploy_AddressFilter.ts
@@ -19,11 +19,14 @@ const DEFAULT_FILTERED_ADDRESS_PATH = join(__dirname, "..", "addresses-filter.tx
 const SET_FILTERED_STATUS_BATCH_SIZE = 300;
 
 /**
- * Filtered addresses loaded from the file at `ADDRESS_FILTER_FILE_PATH` (env) or
+ * Reads filtered addresses from the file at `ADDRESS_FILTER_FILE_PATH` (env) or
  * `contracts/addresses-filter.txt` (default). YAML-style list entries; excludes
  * precompiles already covered by {@link PRECOMPILES_ADDRESSES}.
+ *
+ * Called lazily inside the deploy function so a missing file does not crash unrelated
+ * Hardhat deploy runs that load this module for other `--tags`.
  */
-function loadAddressFilterFilteredAddressesFromFile(): string[] {
+export function loadAddressFilterFilteredAddressesFromFile(): string[] {
   const filePath = getOptionalEnvVar("ADDRESS_FILTER_FILE_PATH") ?? DEFAULT_FILTERED_ADDRESS_PATH;
   const precompileSet = new Set(PRECOMPILES_ADDRESSES.map((a) => a.toLowerCase()));
   const text = readFileSync(filePath, "utf8");
@@ -44,8 +47,6 @@ function loadAddressFilterFilteredAddressesFromFile(): string[] {
   return out;
 }
 
-export const ADDRESS_FILTER_FILTERED_ADDRESSES: string[] = loadAddressFilterFilteredAddressesFromFile();
-
 const func: DeployFunction = withSignerUiSession(
   "21_deploy_AddressFilter.ts",
   async function (hre: HardhatRuntimeEnvironment) {
@@ -54,7 +55,7 @@ const func: DeployFunction = withSignerUiSession(
 
     const councilAddress = ethers.getAddress(getRequiredEnvVar("L1_SECURITY_COUNCIL"));
     const deployerAddress = ethers.getAddress(await signer.getAddress());
-    const filteredAddresses = ADDRESS_FILTER_FILTERED_ADDRESSES;
+    const filteredAddresses = loadAddressFilterFilteredAddressesFromFile();
 
     // Constructor initcode must stay under EIP-3860 (49152 bytes). Deployer is temporary DEFAULT_ADMIN.
     const constructorInitialList = [...PRECOMPILES_ADDRESSES];

--- a/contracts/deploy/22_deploy_ForcedTransactionGateway.ts
+++ b/contracts/deploy/22_deploy_ForcedTransactionGateway.ts
@@ -1,58 +1,67 @@
 import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 
 import { LogContractDeployment, getRequiredEnvVar, tryVerifyContractWithConstructorArgs } from "../common/helpers";
+import { getUiSigner, withSignerUiSession } from "../scripts/hardhat/signer-ui-bridge";
 
-const func: DeployFunction = async function () {
-  const contractName = "ForcedTransactionGateway";
+const func: DeployFunction = withSignerUiSession(
+  "22_deploy_ForcedTransactionGateway.ts",
+  async function (hre: HardhatRuntimeEnvironment) {
+    const contractName = "ForcedTransactionGateway";
+    const signer = await getUiSigner(hre);
 
-  const lineaRollupAddress = getRequiredEnvVar("LINEA_ROLLUP_ADDRESS");
-  const destinationChainId = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID");
-  const l2BlockBuffer = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_L2_BLOCK_BUFFER");
-  const maxGasLimit = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_MAX_GAS_LIMIT");
-  const maxInputLengthBuffer = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_MAX_INPUT_LENGTH_BUFFER");
-  const defaultAdmin = getRequiredEnvVar("L1_SECURITY_COUNCIL");
-  const addressFilter = getRequiredEnvVar("FORCED_TRANSACTION_ADDRESS_FILTER");
-  const mimcLibraryAddress = getRequiredEnvVar("MIMC_LIBRARY_ADDRESS");
+    const lineaRollupAddress = getRequiredEnvVar("LINEA_ROLLUP_ADDRESS");
+    const destinationChainId = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID");
+    const l2BlockBuffer = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_L2_BLOCK_BUFFER");
+    const maxGasLimit = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_MAX_GAS_LIMIT");
+    const maxInputLengthBuffer = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_MAX_INPUT_LENGTH_BUFFER");
+    const defaultAdmin = getRequiredEnvVar("L1_SECURITY_COUNCIL");
+    const addressFilter = getRequiredEnvVar("FORCED_TRANSACTION_ADDRESS_FILTER");
+    const mimcLibraryAddress = getRequiredEnvVar("MIMC_LIBRARY_ADDRESS");
 
-  const factory = await ethers.getContractFactory("ForcedTransactionGateway", {
-    libraries: { Mimc: mimcLibraryAddress },
-  });
-  const l2BlockDurationSeconds = getRequiredEnvVar("FORCED_TRANSACTION_L2_BLOCK_DURATION_SECONDS");
-  const blockNumberDeadlineBuffer = getRequiredEnvVar("FORCED_TRANSACTION_BLOCK_NUMBER_DEADLINE_BUFFER");
+    const factory = await ethers.getContractFactory(contractName, {
+      libraries: { Mimc: mimcLibraryAddress },
+    });
+    const l2BlockDurationSeconds = getRequiredEnvVar("FORCED_TRANSACTION_L2_BLOCK_DURATION_SECONDS");
+    const blockNumberDeadlineBuffer = getRequiredEnvVar("FORCED_TRANSACTION_BLOCK_NUMBER_DEADLINE_BUFFER");
 
-  const contract = await factory.deploy(
-    lineaRollupAddress,
-    destinationChainId,
-    l2BlockBuffer,
-    maxGasLimit,
-    maxInputLengthBuffer,
-    defaultAdmin,
-    addressFilter,
-    l2BlockDurationSeconds,
-    blockNumberDeadlineBuffer,
-  );
+    const contract = await factory
+      .connect(signer)
+      .deploy(
+        lineaRollupAddress,
+        destinationChainId,
+        l2BlockBuffer,
+        maxGasLimit,
+        maxInputLengthBuffer,
+        defaultAdmin,
+        addressFilter,
+        l2BlockDurationSeconds,
+        blockNumberDeadlineBuffer,
+      );
 
-  await LogContractDeployment(contractName, contract);
-  const contractAddress = await contract.getAddress();
+    await LogContractDeployment(contractName, contract);
+    const contractAddress = await contract.getAddress();
 
-  const args = [
-    lineaRollupAddress,
-    destinationChainId,
-    l2BlockBuffer,
-    maxGasLimit,
-    maxInputLengthBuffer,
-    defaultAdmin,
-    addressFilter,
-    l2BlockDurationSeconds,
-    blockNumberDeadlineBuffer,
-  ];
-  await tryVerifyContractWithConstructorArgs(
-    contractAddress,
-    "src/rollup/forcedTransactions/ForcedTransactionGateway.sol:ForcedTransactionGateway",
-    args,
-  );
-};
+    const args = [
+      lineaRollupAddress,
+      destinationChainId,
+      l2BlockBuffer,
+      maxGasLimit,
+      maxInputLengthBuffer,
+      defaultAdmin,
+      addressFilter,
+      l2BlockDurationSeconds,
+      blockNumberDeadlineBuffer,
+    ];
+    await tryVerifyContractWithConstructorArgs(
+      contractAddress,
+      "src/rollup/forcedTransactions/ForcedTransactionGateway.sol:ForcedTransactionGateway",
+      args,
+      { Mimc: mimcLibraryAddress },
+    );
+  },
+);
 
 export default func;
 func.tags = ["ForcedTransactionGateway"];

--- a/contracts/docs/deployment/l1/address-filter.md
+++ b/contracts/docs/deployment/l1/address-filter.md
@@ -4,7 +4,7 @@
 
 <br />
 
-Deploys the AddressFilter contract used to filter addresses for forced transactions. The contract is initialized with the L1 Security Council as admin and a set of filtered addresses (in addition to default precompile addresses).
+Deploys the AddressFilter contract used to filter addresses for forced transactions. The contract is initialized with the deployer as temporary `DEFAULT_ADMIN_ROLE`, precompiles set in the constructor, and the remaining filtered addresses applied via batched `setFilteredStatus` calls. Admin is then transferred to the Security Council. Filtered addresses (beyond precompiles) are read from the file at `ADDRESS_FILTER_FILE_PATH` (default: `contracts/addresses-filter.txt`).
 
 Parameters that should be filled either in .env or passed as CLI arguments:
 
@@ -14,8 +14,8 @@ Parameters that should be filled either in .env or passed as CLI arguments:
 | \**DEPLOYER_PRIVATE_KEY* | true     | key | Network-specific private key used when deploying the contract |
 | \**BLOCK_EXPLORER_API_KEY*  | false     | key | Network-specific Block Explorer API Key used for verifying deployed contracts. |
 | INFURA_API_KEY     | true     | key | Infura API Key. |
-| L1_SECURITY_COUNCIL | true | address | L1 Security Council address (contract admin) |
-| ADDRESS_FILTER_FILTERED_ADDRESSES | true | address | Comma-separated list of addresses to filter (added on top of default precompiles) |
+| L1_SECURITY_COUNCIL | true | address | L1 Security Council address (receives `DEFAULT_ADMIN_ROLE` after filtered addresses are applied) |
+| ADDRESS_FILTER_FILE_PATH | false | path | Absolute or relative path to the filtered addresses file. Defaults to `contracts/addresses-filter.txt` |
 
 <br />
 
@@ -26,7 +26,7 @@ npx hardhat deploy --network sepolia --tags AddressFilter
 
 Base command with cli arguments:
 ```shell
-DEPLOYER_PRIVATE_KEY=<key> ETHERSCAN_API_KEY=<key> INFURA_API_KEY=<key> L1_SECURITY_COUNCIL=<address> ADDRESS_FILTER_FILTERED_ADDRESSES=<address1>,<address2> npx hardhat deploy --network sepolia --tags AddressFilter
+DEPLOYER_PRIVATE_KEY=<key> ETHERSCAN_API_KEY=<key> INFURA_API_KEY=<key> L1_SECURITY_COUNCIL=<address> npx hardhat deploy --network sepolia --tags AddressFilter
 ```
 
 (make sure to replace `<key>` `<address>` with actual values)

--- a/contracts/docs/deployment/l1/linea-rollup.md
+++ b/contracts/docs/deployment/l1/linea-rollup.md
@@ -61,13 +61,13 @@ pnpm exec hardhat deploy --network sepolia --tags LineaRollupWithReinitializatio
 
 ### LineaRollupV8WithReinitialization
 
-Deploys a new LineaRollup implementation and generates encoded upgrade calldata with `reinitializeLineaRollupV9`.
+Deploys a new LineaRollup implementation and generates encoded `upgradeAndCall` calldata for `reinitializeLineaRollupV9`. Submit the printed calldata through the Security Council Safe targeting the ProxyAdmin.
 
 | Parameter name | Required | Input value | Description |
 |---|---|---|---|
 | \**DEPLOYER_PRIVATE_KEY* | true | key | Network-specific private key |
 | LINEA_ROLLUP_ADDRESS | true | address | Existing LineaRollup proxy address |
-| LINEA_ROLLUP_FORCED_TRANSACTION_FEE_IN_WEI | true | uint256 | Forced transaction fee in wei |
+| LINEA_ROLLUP_FORCED_TRANSACTION_FEE_IN_WEI | true | uint256 | Forced transaction fee in wei (must be > 0) |
 | LINEA_ROLLUP_ADDRESS_FILTER | true | address | AddressFilter contract address |
 
 ```shell


### PR DESCRIPTION
This adjusts the address filter deploy to batch many addresses and to allow for the usage of the Signer UI if desired

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L1 deployment/upgrade scripts for `AddressFilter`, `ForcedTransactionGateway`, and LineaRollup upgrade calldata generation; incorrect env/file inputs or role transfer could misconfigure production deployments.
> 
> **Overview**
> **Deployment scripts now support the Signer UI flow for forced-transactions components.** `AddressFilter` and `ForcedTransactionGateway` deploys are wrapped with `withSignerUiSession`/`getUiSigner`, and `ForcedTransactionGateway` verification now includes linked library info.
> 
> **`AddressFilter` deployment is reworked to handle large filtered lists safely.** Filtered addresses are loaded from a new `ADDRESS_FILTER_FILE_PATH` (default `contracts/addresses-filter.txt`), only precompiles are set in the constructor to stay under initcode limits, remaining addresses are applied in batches via `setFilteredStatus`, and `DEFAULT_ADMIN_ROLE` is transferred from the deployer to `L1_SECURITY_COUNCIL`.
> 
> **LineaRollup upgrade script output is updated.** `03_deploy_LineaRollupV8WithReinitialization` now deploys a new implementation and prints encoded ProxyAdmin `upgradeAndCall` calldata for `reinitializeLineaRollupV9` using `LINEA_ROLLUP_FORCED_TRANSACTION_FEE_IN_WEI` and `LINEA_ROLLUP_ADDRESS_FILTER`, with updated tags/docs/env templates accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ecf3e4090c09a2d0482346c899a4dd1402cb75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->