### PR TITLE
fix(sequencer): bypass bg scheduler collision in buildNewBlockAndWait(Long)

### DIFF
--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
@@ -224,12 +224,18 @@ abstract class LineaPluginPoSTestBase : LineaPluginTestBase() {
    * Build a block giving Besu only [blockBuildingTimeMs] to assemble it. Use a short
    * value (e.g. 300ms) when the test needs the selector to run a single pass instead
    * of the default ~10 retries within a 5s window.
+   *
+   * The timestamp is bumped by 1s past the natural slot timestamp so our fcu's
+   * payloadId differs from anything the background consensus scheduler may have
+   * already started building. Without this offset, an in-progress background build
+   * (with stale txpool state) absorbs our fcu and getPayload returns its cached
+   * selection, missing any txs the test sent after the background tick fired.
    */
   protected fun buildNewBlockAndWait(blockBuildingTimeMs: Long) {
     val initialBlockNumber = getLatestBlockNumber()
     val latestTimestamp = minerNode.execute(ethTransactions.block()).timestamp
     buildNewBlock(
-      latestTimestamp.toLong() + blockTimeSeconds!!,
+      latestTimestamp.toLong() + blockTimeSeconds!! + 1L,
       blockBuildingTimeMs,
     ) { false }
     await()


### PR DESCRIPTION
## Summary

Follow-up to #3051. The 300ms short-build-window fix exposed a second race against the background consensus scheduler that only triggers on slower CI runners (e.g. https://github.com/Consensys/linea-monorepo/actions/runs/25735214622/job/75570471965 on PR #3063).

## Root cause

Test ↔ background-scheduler race timeline from the failing CI run:

```
12:49:16.097   bg scheduler T+5 tick → fcu starts block 2 build (5s window)
12:49:16.601   selector starts first selection pass (cold pool)
12:49:16.638   first pass finishes → only bundle1 small in pool, 1 tx selected
12:49:16.640+  test's 7 linea_sendBundle RPCs start landing
12:49:16.659   transfer lands
12:49:16.673   test's fcu — same timestamp (1778590156) → same payloadId
                "Block proposal for the same payload id 0x7ddb59aa84550033
                 already present, nothing to do"
12:49:16.978   test's getPayload cancels and returns cached 1-tx selection
                                                                ↑
                                            transfer never selected, test fails
```

Two factors combined:

1. **`buildBlocksInBackground = false` cannot prevent the T+5 tick on CI.** Web3j's `PollingTransactionReceiptProcessor` polls every 1s, so `deployMulmodExecutor` doesn't return until ~1s after block 1 commits — and the scheduler's T+5 tick fires at exactly T+5s. The test thread can't reach the flag-set in time.
2. **Same-timestamp fcu joins the in-progress build.** Both the background scheduler (`Instant.now().epochSecond`) and our explicit `buildNewBlock(latestTimestamp + blockTimeSeconds, ...)` resolve to the same second value, producing identical payloadIds. Besu's engine doesn't start a fresh build — it just sees "already building this".

## Fix

Bump the explicit timestamp by 1s past the natural slot timestamp in `buildNewBlockAndWait(Long)`:

```kotlin
buildNewBlock(
  latestTimestamp.toLong() + blockTimeSeconds!! + 1L,  // +1 to avoid colliding
  blockBuildingTimeMs,
) { false }
```

This forces a different `payloadId` → Besu cancels the in-progress build and starts a fresh one, with all currently-pending txs in pool when the first selection pass runs. Clique allows the +1 timestamp (>= minimum slot interval) and no test logic depends on the exact slot timing.

## Why this didn't reproduce locally

Same race exists, just doesn't close. Local RPC roundtrips for the 7 bundles + transfer complete in <50ms — fast enough that everything lands in the pool *before* the first selection pass runs. CI's containerized JSON-RPC stack takes ~540ms for the same sequence, opening the window for the cached-selection failure.

## Test plan

- [x] `multipleBundleSelectionTimeout` passes 10/10 locally with this fix
- [ ] CI green on this PR
- [ ] Will run the sequencer acceptance-tests CI job 5 times via re-run to verify reliability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only adjusts acceptance-test block-building timestamps, but it may subtly change timing-dependent test expectations around Clique slot timestamps.
> 
> **Overview**
> Updates `LineaPluginPoSTestBase.buildNewBlockAndWait(Long)` to add a **+1s timestamp offset** when triggering a short-window block build, ensuring the resulting `payloadId` does not collide with any in-progress background scheduler build.
> 
> Adds inline documentation explaining the race (background build absorbing the test FCU and `getPayload` returning a cached selection), improving CI reliability for bundle-selection timing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7634a8943b9bcda86d029499d1f7d9f1e9ac11e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->