### PR TITLE
chore(deps): migrate lsv-cli to 1.8

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -28,7 +28,7 @@
     "@chainsafe/persistent-merkle-tree": "1.2.5",
     "@consensys/eslint-config": "workspace:*",
     "@ethereumjs/util": "10.1.1",
-    "@lidofinance/lsv-cli": "1.4.0",
+    "@lidofinance/lsv-cli": "1.8.0",
     "@lodestar/types": "1.42.0",
     "@nomicfoundation/hardhat-ethers": "3.1.3",
     "@nomicfoundation/hardhat-foundry": "1.2.1",

--- a/contracts/scripts/operational/yieldBoost/testing/unstakePermissionless.ts
+++ b/contracts/scripts/operational/yieldBoost/testing/unstakePermissionless.ts
@@ -2,7 +2,7 @@ import {
   fetchBeaconHeader,
   fetchBeaconState,
   fetchBeaconHeaderByParentRoot,
-} from "@lidofinance/lsv-cli/dist/utils/fetchCL";
+} from "@lidofinance/lsv-cli/dist/utils/fetch-cl.js";
 import { createBeaconHeaderProof, createStateProof } from "@lidofinance/lsv-cli/dist/utils/proof/proofs.js";
 import { hexlify, AbiCoder } from "ethers";
 import * as fs from "fs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ importers:
         specifier: 10.1.1
         version: 10.1.1
       '@lidofinance/lsv-cli':
-        specifier: 1.4.0
-        version: 1.4.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(bufferutil@4.1.0)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.1)
+        specifier: 1.8.0
+        version: 1.8.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(bufferutil@4.1.0)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.1)
       '@lodestar/types':
         specifier: 1.42.0
         version: 1.42.0
@@ -13510,7 +13510,7 @@ snapshots:
       multiformats: 13.4.2
       weald: 1.1.1
 
-  '@lidofinance/lsv-cli@1.4.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(bufferutil@4.1.0)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.1)':
+  '@lidofinance/lsv-cli@1.8.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.74.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(bufferutil@4.1.0)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.6)))(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.4.1)':
     dependencies:
       '@chainsafe/blst': 2.2.0
       '@chainsafe/persistent-merkle-tree': 1.2.5


### PR DESCRIPTION
## Summary
- Bump the contracts workspace `@lidofinance/lsv-cli` dependency from 1.4.0 to 1.8.0.
- Update the yield boost operational script import to the 1.8 `fetch-cl.js` utility path.

## Contract impact
- No Solidity files changed.
- No deployed-bytecode inputs or generated contract artifacts are included.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm -F contracts run build`

Closes #3062

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to the `contracts` workspace plus a small import-path update in an operational script; main risk is build/runtime breakage if the new `lsv-cli` package layout or behavior differs.
> 
> **Overview**
> Updates the `contracts` workspace to use `@lidofinance/lsv-cli` `1.8.0` (from `1.4.0`) and refreshes `pnpm-lock.yaml` accordingly.
> 
> Adjusts the yield-boost operational script `unstakePermissionless.ts` to import CL fetch helpers from the new `lsv-cli` path (`dist/utils/fetch-cl.js`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e14cde1c0e47e34312e146c998ac359a0d1977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->