### PR TITLE
chore(misc): Add maru to allowed scopes

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -28,7 +28,7 @@ ALLOWED_SCOPES=\
 'coordinator prover prover-ray postman tx-exclusion-api '\
 'linea-besu contracts sdk-core sdk-ethers sdk-viem '\
 'tracer sequencer state-recovery jvm-libs blob-libs '\
-'e2e ci docker deps misc'
+'e2e ci docker deps misc maru'
 
 # Match overall structure: <type>(<scope-group>)!?: <subject>
 HEADER_RE="^(${ALLOWED_TYPES})\\(([^)]+)\\)!?: .+"


### PR DESCRIPTION
This PR implements issue(s) #2540 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only relaxes commit-message validation by adding a new allowed scope; no runtime or production code paths change.
> 
> **Overview**
> Extends the Husky `commit-msg` Conventional Commits validator to accept the new scope `maru` in the allowed scope enum, enabling commit messages like `chore(maru): ...` to pass the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b3872fc76c21e264ae903345817203b717bd92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->