### PR TITLE
prover (fix): fix the linter errors on main

### DIFF
--- a/prover-ray/wiop/query_local_constraint_test.go
+++ b/prover-ray/wiop/query_local_constraint_test.go
@@ -183,7 +183,7 @@ func TestLocalConstraint_RegistersOnModuleVanishings(t *testing.T) {
 
 	before := len(mod.Vanishings)
 	v := mod.NewLocalConstraint(sys.Context.Childf("lcReg"), col.View(), 0)
-	assert.Equal(t, before+1, len(mod.Vanishings))
+	assert.Len(t, mod.Vanishings, before+1)
 	assert.Same(t, v, mod.Vanishings[before])
 	// "Local" constraints never auto-cancel any rows.
 	assert.Empty(t, v.CancelledPositions)


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that swaps an equality length check for `assert.Len`, with no production code impact.
> 
> **Overview**
> Updates `TestLocalConstraint_RegistersOnModuleVanishings` to use `assert.Len(t, mod.Vanishings, before+1)` instead of comparing `len(mod.Vanishings)` via `assert.Equal`, aligning with lint/style expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037aa965a18e3629eb0d4aec36838ced17786e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->