### PR TITLE
chore: update gnark

### DIFF
--- a/prover/go.mod
+++ b/prover/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/consensys/compress v0.3.0
-	github.com/consensys/gnark v0.14.1-0.20260505192735-3460cedcac43
+	github.com/consensys/gnark v0.14.1-0.20260511210335-f4e549a26ef3
 	github.com/consensys/gnark-crypto v0.20.2-0.20260402204920-39238e584b99
 	github.com/consensys/go-corset v1.2.10
 	github.com/crate-crypto/go-kzg-4844 v1.1.0

--- a/prover/go.sum
+++ b/prover/go.sum
@@ -75,10 +75,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/consensys/compress v0.3.0 h1:HRIcHvWkW9C9req0ZWg7mhYHzBarohXhcszIwHONVkM=
 github.com/consensys/compress v0.3.0/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/hcuOBxza6CAA+233tB0eFiunGVEMyv4=
-github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
-github.com/consensys/gnark v0.14.1-0.20260505192735-3460cedcac43 h1:RpbSPTqYtqLGas8Z65mw12uJBWL3BO2s6amtRmvx2SM=
-github.com/consensys/gnark v0.14.1-0.20260505192735-3460cedcac43/go.mod h1:RIWXG9Gl+Ls2enSayeA/NdcM/FI3OOf6AqNdI2Jv8QU=
+github.com/consensys/gnark v0.14.1-0.20260511210335-f4e549a26ef3 h1:z9iMO0WPlstMefH1wI1w+9sMc6AFqvOiLuukk/UgSQg=
+github.com/consensys/gnark v0.14.1-0.20260511210335-f4e549a26ef3/go.mod h1:RIWXG9Gl+Ls2enSayeA/NdcM/FI3OOf6AqNdI2Jv8QU=
 github.com/consensys/gnark-crypto v0.20.2-0.20260402204920-39238e584b99 h1:FREtFb4IoZWOj6MexddSuReVU7ViMChjuspD7SO8dGY=
 github.com/consensys/gnark-crypto v0.20.2-0.20260402204920-39238e584b99/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
 github.com/consensys/go-corset v1.2.10 h1:uKUICiHmERuMWzDRiRJr285fV2WncNGiCENSdNcQodY=


### PR DESCRIPTION
Update gnark dependency for pulling in circuit changes for the precompile circuits.

NB! Changes circuits, so a breaking change.

@gusiri - should the base branch be main or `post-sf`?

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because updating `gnark` can change circuit definitions and proof generation/verification behavior, potentially breaking compatibility with existing proofs or on-chain precompile expectations.
> 
> **Overview**
> Updates the `prover` module to use a newer `github.com/consensys/gnark` pseudo-version, with corresponding `go.sum` checksum churn to match.
> 
> No application code changes are included, but this dependency bump is expected to pull in *circuit changes* (breaking behavior for generated/proved circuits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91fcba098d7a10f466390ff59f46d08a3676fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->