### PR TITLE
Coordinator tidyup pt2

### DIFF
--- a/coordinator/app/src/integrationTest/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofCoordinatorIntTest.kt
+++ b/coordinator/app/src/integrationTest/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobCompressionProofCoordinatorIntTest.kt
@@ -1,7 +1,5 @@
 package net.consensys.zkevm.ethereum.coordination.blob
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
-import build.linea.clients.StateManagerClientV1
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.michaelbull.result.Ok
@@ -9,6 +7,8 @@ import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import io.vertx.junit5.VertxTestContext
 import linea.clients.BlobCompressionProverClientV2
+import linea.clients.GetZkEVMStateMerkleProofResponse
+import linea.clients.StateManagerClientV1
 import linea.domain.Blob
 import linea.domain.BlobCompressionProof
 import linea.domain.BlobCompressionProofRequest

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -1,9 +1,9 @@
 package net.consensys.zkevm.coordinator.app.conflation
 
-import build.linea.clients.StateManagerV1JsonRpcClient
 import io.vertx.core.Vertx
 import linea.LongRunningService
 import linea.clients.ExecutionProverClientV2
+import linea.clients.StateManagerV1JsonRpcClient
 import linea.conflation.ConflationService
 import linea.conflation.FixedLaggingHeadSafeBlockProvider
 import linea.conflation.calculators.CalculatorsFactory

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -1,12 +1,12 @@
 package net.consensys.zkevm.coordinator.app.conflationbacktesting
 
-import build.linea.clients.StateManagerClientV1
-import build.linea.clients.StateManagerV1JsonRpcClient
 import io.vertx.core.Vertx
 import linea.LongRunningService
 import linea.blob.BlobCompressorFactory
 import linea.blob.BlobCompressorVersion
 import linea.clients.ExecutionProverClientV2
+import linea.clients.StateManagerClientV1
+import linea.clients.StateManagerV1JsonRpcClient
 import linea.conflation.AlwaysSafeBlockNumberProvider
 import linea.conflation.ConflationService
 import linea.conflation.FixedLaggingHeadSafeBlockProvider

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobZkStateProviderImpl.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/blob/BlobZkStateProviderImpl.kt
@@ -1,7 +1,7 @@
 package net.consensys.zkevm.ethereum.coordination.blob
 
-import build.linea.clients.GetStateMerkleProofRequest
-import build.linea.clients.StateManagerClientV1
+import linea.clients.GetStateMerkleProofRequest
+import linea.clients.StateManagerClientV1
 import linea.domain.BlockInterval
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitorTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/blockcreation/BlockCreationMonitorTest.kt
@@ -1,6 +1,5 @@
 package net.consensys.zkevm.coordinator.blockcreation
 
-import build.linea.s11n.jackson.ethApiObjectMapper
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.domain.Block
@@ -12,6 +11,7 @@ import linea.kotlin.ByteArrayExt
 import linea.kotlin.toHexString
 import linea.kotlin.toULongFromHex
 import linea.log4j.configureLoggers
+import linea.s11n.jackson.ethApiObjectMapper
 import linea.web3j.ethapi.createEthApiClient
 import net.consensys.linea.async.get
 import net.consensys.zkevm.ethereum.coordination.blockcreation.BlockCreated

--- a/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ExecutionProofRequestDtoMapperTest.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/test/kotlin/net/consensys/zkevm/coordinator/clients/prover/ExecutionProofRequestDtoMapperTest.kt
@@ -1,9 +1,9 @@
 package net.consensys.zkevm.coordinator.clients.prover
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
 import com.fasterxml.jackson.databind.node.ArrayNode
 import linea.clients.BatchExecutionProofRequestV1
 import linea.clients.GenerateTracesResponse
+import linea.clients.GetZkEVMStateMerkleProofResponse
 import linea.contract.events.createL2RollingHashUpdatedEthLogV1
 import linea.contract.events.createMessageSentEthLogV1
 import linea.domain.Block

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/FunctionBuildersV8.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/FunctionBuildersV8.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.LineaRollupV8
+import linea.contract.LineaRollupV8
 import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize
 import linea.kotlin.encodeHex

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/LineaRollupEnhancedWrapper.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/LineaRollupEnhancedWrapper.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.LineaRollupV6
+import linea.contract.LineaRollupV6
 import linea.web3j.transactionmanager.AsyncFriendlyTransactionManager
 import net.consensys.linea.contract.Web3JContractAsyncHelper
 import org.web3j.abi.datatypes.Function

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/LineaValidiumEnhancedWrapper.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/LineaValidiumEnhancedWrapper.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.ValidiumV1
+import linea.contract.ValidiumV1
 import linea.web3j.transactionmanager.AsyncFriendlyTransactionManager
 import net.consensys.linea.contract.Web3JContractAsyncHelper
 import org.web3j.abi.datatypes.Function

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupFunctionBuilders.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupFunctionBuilders.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.LineaRollupV6
+import linea.contract.LineaRollupV6
 import linea.contract.l1.LineaRollupContractVersion
 import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.LineaRollupV6
+import linea.contract.LineaRollupV6
 import linea.contract.l1.BlockAndNonce
 import linea.contract.l1.LineaRollupSmartContractClient
 import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaValidiumFunctionBuilders.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaValidiumFunctionBuilders.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.ValidiumV1
+import linea.contract.ValidiumV1
 import linea.contract.l1.LineaValidiumContractVersion
 import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaValidiumSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaValidiumSmartContractClient.kt
@@ -1,6 +1,6 @@
 package net.consensys.linea.contract.l1
 
-import build.linea.contract.ValidiumV1
+import linea.contract.ValidiumV1
 import linea.contract.l1.BlockAndNonce
 import linea.contract.l1.LineaValidiumSmartContractClient
 import linea.contract.l1.Web3JLineaValidiumSmartContractClientReadOnly

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/BatchExecutionProverRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/BatchExecutionProverRequestResponse.kt
@@ -1,6 +1,5 @@
 package linea.clients
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
 import linea.domain.Block
 import linea.domain.BlockInterval
 import linea.domain.EthLog

--- a/coordinator/core-interfaces/src/main/kotlin/linea/clients/InvalidtyProofRequestResponse.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/clients/InvalidtyProofRequestResponse.kt
@@ -1,7 +1,5 @@
 package linea.clients
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
-import build.linea.clients.LineaAccountProof
 import linea.domain.StartBlockTimestampProvider
 import kotlin.time.Instant
 

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/TracesConflationCoordinator.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/TracesConflationCoordinator.kt
@@ -1,7 +1,7 @@
 package net.consensys.zkevm.ethereum.coordination.conflation
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
 import linea.clients.GenerateTracesResponse
+import linea.clients.GetZkEVMStateMerkleProofResponse
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 data class BlocksTracesConflated(

--- a/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/TracesConflationCoordinatorImpl.kt
+++ b/coordinator/core/src/main/kotlin/net/consensys/zkevm/ethereum/coordination/conflation/TracesConflationCoordinatorImpl.kt
@@ -1,11 +1,11 @@
 package net.consensys.zkevm.ethereum.coordination.conflation
 
-import build.linea.clients.GetStateMerkleProofRequest
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
-import build.linea.clients.StateManagerClientV1
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapBoth
 import linea.clients.GenerateTracesResponse
+import linea.clients.GetStateMerkleProofRequest
+import linea.clients.GetZkEVMStateMerkleProofResponse
+import linea.clients.StateManagerClientV1
 import linea.clients.TracesConflationClientV2
 import linea.clients.TracesServiceErrorType
 import linea.domain.BlockInterval

--- a/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinatorImplTest.kt
+++ b/coordinator/core/src/test/kotlin/net/consensys/zkevm/ethereum/coordination/proofcreation/ZkProofCreationCoordinatorImplTest.kt
@@ -1,10 +1,10 @@
 package net.consensys.zkevm.ethereum.coordination.proofcreation
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
 import com.fasterxml.jackson.databind.node.ArrayNode
 import linea.clients.BatchExecutionProofRequestV1
 import linea.clients.ExecutionProverClientV2
 import linea.clients.GenerateTracesResponse
+import linea.clients.GetZkEVMStateMerkleProofResponse
 import linea.contract.events.createL2RollingHashUpdatedEthLogV1
 import linea.contract.events.createMessageSentEthLogV1
 import linea.domain.BlocksConflation

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -1,11 +1,11 @@
 package linea.ftx
 
-import build.linea.clients.StateManagerAccountProofClient
-import build.linea.clients.StateManagerClientV1
 import io.vertx.core.Vertx
 import linea.DisabledService
 import linea.LongRunningService
 import linea.clients.InvalidityProverClientV1
+import linea.clients.StateManagerAccountProofClient
+import linea.clients.StateManagerClientV1
 import linea.clients.TracesConflationVirtualBlockClientV1
 import linea.conflation.AlwaysSafeBlockNumberProvider
 import linea.conflation.ConflationSafeBlockNumberProvider

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
@@ -1,15 +1,15 @@
 package linea.ftx.conflation
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
-import build.linea.clients.LineaAccountProof
-import build.linea.clients.StateManagerAccountProofClient
-import build.linea.clients.StateManagerClientV1
 import com.github.michaelbull.result.getOrThrow
 import linea.clients.GenerateTracesResponse
+import linea.clients.GetZkEVMStateMerkleProofResponse
 import linea.clients.InvalidityProofRequest
 import linea.clients.InvalidityProofResponse
 import linea.clients.InvalidityProverClientV1
 import linea.clients.InvalidityReason
+import linea.clients.LineaAccountProof
+import linea.clients.StateManagerAccountProofClient
+import linea.clients.StateManagerClientV1
 import linea.clients.TracesConflationVirtualBlockClientV1
 import linea.contract.events.ForcedTransactionAddedEvent
 import linea.domain.BlockInterval

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/FakeStateManagerClient.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/FakeStateManagerClient.kt
@@ -1,11 +1,11 @@
 package linea.ftx
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
-import build.linea.clients.LineaAccountProof
-import build.linea.clients.StateManagerAccountProofClient
-import build.linea.clients.StateManagerClientV1
-import build.linea.clients.StateManagerErrorType
 import com.github.michaelbull.result.Result
+import linea.clients.GetZkEVMStateMerkleProofResponse
+import linea.clients.LineaAccountProof
+import linea.clients.StateManagerAccountProofClient
+import linea.clients.StateManagerClientV1
+import linea.clients.StateManagerErrorType
 import linea.domain.BlockInterval
 import linea.error.ErrorResponse
 import tech.pegasys.teku.infrastructure.async.SafeFuture

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -1,10 +1,10 @@
 package linea.ftx
 
-import build.linea.clients.StateManagerAccountProofClient
-import build.linea.clients.StateManagerClientV1
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.clients.InvalidityProverClientV1
+import linea.clients.StateManagerAccountProofClient
+import linea.clients.StateManagerClientV1
 import linea.clients.TracesConflationVirtualBlockClientV1
 import linea.conflation.FixedLaggingHeadSafeBlockProvider
 import linea.conflation.calculators.CalculatorsFactory

--- a/jvm-libs/generic/extensions/tuweni/src/main/kotlin/linea/tuweni/Bytes32.kt
+++ b/jvm-libs/generic/extensions/tuweni/src/main/kotlin/linea/tuweni/Bytes32.kt
@@ -1,4 +1,4 @@
-package build.linea.tuweni
+package linea.tuweni
 
 import linea.kotlin.toULong
 import org.apache.tuweni.bytes.Bytes32

--- a/jvm-libs/generic/extensions/tuweni/src/test/kotlin/linea/tuweni/Bytes32Test.kt
+++ b/jvm-libs/generic/extensions/tuweni/src/test/kotlin/linea/tuweni/Bytes32Test.kt
@@ -1,4 +1,4 @@
-package build.linea.tuweni
+package linea.tuweni
 
 import linea.kotlin.toBigInteger
 import org.apache.tuweni.bytes.Bytes32

--- a/jvm-libs/generic/json-rpc/src/main/kotlin/net/consensys/linea/jsonrpc/client/ObjectMappers.kt
+++ b/jvm-libs/generic/json-rpc/src/main/kotlin/net/consensys/linea/jsonrpc/client/ObjectMappers.kt
@@ -1,10 +1,10 @@
 package net.consensys.linea.jsonrpc.client
 
-import build.linea.s11n.jackson.ethByteAsHexSerialisersModule
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.vertx.core.json.jackson.VertxModule
+import linea.s11n.jackson.ethByteAsHexSerialisersModule
 
 internal val objectMapper = jacksonObjectMapper()
   .registerModules(VertxModule())

--- a/jvm-libs/generic/json-rpc/src/test/kotlin/net/consensys/linea/jsonrpc/client/JsonRpcV2ClientImplTest.kt
+++ b/jvm-libs/generic/json-rpc/src/test/kotlin/net/consensys/linea/jsonrpc/client/JsonRpcV2ClientImplTest.kt
@@ -1,9 +1,5 @@
 package net.consensys.linea.jsonrpc.client
 
-import build.linea.s11n.jackson.ByteArrayToHexSerializer
-import build.linea.s11n.jackson.ULongToHexSerializer
-import build.linea.s11n.jackson.ethByteAsHexSerialisersModule
-import build.linea.s11n.jackson.ethNumberAsHexSerialisersModule
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
@@ -25,6 +21,10 @@ import io.vertx.core.Vertx
 import io.vertx.core.json.JsonObject
 import io.vertx.junit5.VertxExtension
 import linea.kotlin.decodeHex
+import linea.s11n.jackson.ByteArrayToHexSerializer
+import linea.s11n.jackson.ULongToHexSerializer
+import linea.s11n.jackson.ethByteAsHexSerialisersModule
+import linea.s11n.jackson.ethNumberAsHexSerialisersModule
 import net.consensys.linea.jsonrpc.JsonRpcErrorResponseException
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade

--- a/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/BytesHexSerDe.kt
+++ b/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/BytesHexSerDe.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser

--- a/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/InstantAsHexNumberSerDe.kt
+++ b/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/InstantAsHexNumberSerDe.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser
@@ -8,14 +8,14 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import kotlin.time.Instant
 
-object InstantISO8601Serializer : JsonSerializer<Instant>() {
+object InstantAsHexNumberSerializer : JsonSerializer<Instant>() {
   override fun serialize(value: Instant, gen: JsonGenerator, serializers: SerializerProvider) {
-    gen.writeString(value.toString())
+    gen.writeString("0x${value.epochSeconds.toString(16)}")
   }
 }
 
-object InstantISO8601Deserializer : JsonDeserializer<Instant>() {
+object InstantAsHexNumberDeserializer : JsonDeserializer<Instant>() {
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Instant {
-    return Instant.parse(p.text)
+    return Instant.fromEpochSeconds(p.text.replace("0x", "").toLong(16))
   }
 }

--- a/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/InstantISO8601SerDe.kt
+++ b/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/InstantISO8601SerDe.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser
@@ -8,14 +8,14 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import kotlin.time.Instant
 
-object InstantAsHexNumberSerializer : JsonSerializer<Instant>() {
+object InstantISO8601Serializer : JsonSerializer<Instant>() {
   override fun serialize(value: Instant, gen: JsonGenerator, serializers: SerializerProvider) {
-    gen.writeString("0x${value.epochSeconds.toString(16)}")
+    gen.writeString(value.toString())
   }
 }
 
-object InstantAsHexNumberDeserializer : JsonDeserializer<Instant>() {
+object InstantISO8601Deserializer : JsonDeserializer<Instant>() {
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Instant {
-    return Instant.fromEpochSeconds(p.text.replace("0x", "").toLong(16))
+    return Instant.parse(p.text)
   }
 }

--- a/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/NumbersHexSerDe.kt
+++ b/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/NumbersHexSerDe.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer

--- a/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/ObjectMappers.kt
+++ b/jvm-libs/generic/serialization/jackson/src/main/kotlin/linea/s11n/jackson/ObjectMappers.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule

--- a/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/BytesSerDeTest.kt
+++ b/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/BytesSerDeTest.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/InstantAsHexNumberSerDeTest.kt
+++ b/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/InstantAsHexNumberSerDeTest.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule

--- a/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/InstantISO8601SerDeTest.kt
+++ b/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/InstantISO8601SerDeTest.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson

--- a/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/NumbersSerDeTest.kt
+++ b/jvm-libs/generic/serialization/jackson/src/test/kotlin/linea/s11n/jackson/NumbersSerDeTest.kt
@@ -1,4 +1,4 @@
-package build.linea.s11n.jackson
+package linea.s11n.jackson
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -1,8 +1,8 @@
 package linea.contract.l1
 
-import build.linea.contract.LineaRollupV6
-import build.linea.contract.LineaRollupV8
 import linea.contract.FAKE_READ_ONLY_CREDENTIALS
+import linea.contract.LineaRollupV6
+import linea.contract.LineaRollupV8
 import linea.contract.events.FinalizedStateUpdatedEvent
 import linea.domain.BlockParameter
 import linea.ethapi.EthLogsClient

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaValidiumSmartContractClientReadOnly.kt
@@ -1,7 +1,7 @@
 package linea.contract.l1
 
-import build.linea.contract.ValidiumV1
 import linea.contract.FAKE_READ_ONLY_CREDENTIALS
+import linea.contract.ValidiumV1
 import linea.domain.BlockParameter
 import linea.kotlin.toBigInteger
 import linea.kotlin.toULong

--- a/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/build/linea/clients/StateManagerClientV1.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/build/linea/clients/StateManagerClientV1.kt
@@ -2,6 +2,10 @@ package build.linea.clients
 
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.github.michaelbull.result.Result
+import linea.clients.AsyncClient
+import linea.clients.ClientError
+import linea.clients.ClientRequest
+import linea.clients.unwrapResultMonad
 import linea.domain.BlockInterval
 import linea.error.ErrorResponse
 import linea.kotlin.encodeHex

--- a/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerAccountProofClient.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerAccountProofClient.kt
@@ -1,4 +1,4 @@
-package build.linea.clients
+package linea.clients
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 

--- a/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerClientV1.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerClientV1.kt
@@ -1,11 +1,7 @@
-package build.linea.clients
+package linea.clients
 
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.github.michaelbull.result.Result
-import linea.clients.AsyncClient
-import linea.clients.ClientError
-import linea.clients.ClientRequest
-import linea.clients.unwrapResultMonad
 import linea.domain.BlockInterval
 import linea.error.ErrorResponse
 import linea.kotlin.encodeHex

--- a/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerV1JsonRpcClient.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerV1JsonRpcClient.kt
@@ -1,4 +1,4 @@
-package build.linea.clients
+package linea.clients
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/jvm-libs/linea/clients/linea-state-manager/src/test/kotlin/linea/clients/StateManagerV1JsonRpcClientTest.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/test/kotlin/linea/clients/StateManagerV1JsonRpcClientTest.kt
@@ -1,4 +1,4 @@
-package build.linea.clients
+package linea.clients
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/jvm-libs/linea/core/client-interface/src/main/kotlin/linea/clients/Client.kt
+++ b/jvm-libs/linea/core/client-interface/src/main/kotlin/linea/clients/Client.kt
@@ -1,4 +1,4 @@
-package build.linea.clients
+package linea.clients
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok

--- a/jvm-libs/linea/linea-contracts/l1-rollup/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l1-rollup/build.gradle
@@ -22,7 +22,7 @@ web3jContractWrappers {
   def contractV6Abi = contractsDir.file("LineaRollupV6.0.abi").asFile.absolutePath
   def contractV8Abi = contractsDir.file("LineaRollupV8.0.abi").asFile.absolutePath
 
-  contractsPackage = "build.linea.contract"
+  contractsPackage = "linea.contract"
   contracts = [
     "$contractV6Abi": "LineaRollupV6",
     "$contractV8Abi": "LineaRollupV8"

--- a/jvm-libs/linea/linea-contracts/l1-validium/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l1-validium/build.gradle
@@ -21,7 +21,7 @@ web3jContractWrappers {
   def contractsDir = layout.buildDirectory.dir("${rootProject.projectDir}/contracts/abi").get()
   def validiumV1Abi = contractsDir.file("ValidiumV1.0.abi").asFile.absolutePath
 
-  contractsPackage = "build.linea.contract"
+  contractsPackage = "linea.contract"
   contracts = [
     "$validiumV1Abi": "ValidiumV1"
   ]

--- a/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/domain/Eip4844EthCall.kt
+++ b/jvm-libs/linea/web3j-extensions/src/main/kotlin/linea/web3j/domain/Eip4844EthCall.kt
@@ -1,11 +1,11 @@
 package linea.web3j.domain
 
-import build.linea.s11n.jackson.ByteArrayToHexSerializer
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import linea.s11n.jackson.ByteArrayToHexSerializer
 import org.apache.tuweni.bytes.Bytes
 import org.web3j.crypto.Blob
 import org.web3j.crypto.BlobUtils

--- a/linea-besu/plugins/state-recovery/appcore/logic/src/main/kotlin/linea/staterecovery/BlockImporter.kt
+++ b/linea-besu/plugins/state-recovery/appcore/logic/src/main/kotlin/linea/staterecovery/BlockImporter.kt
@@ -1,7 +1,7 @@
 package linea.staterecovery
 
-import build.linea.clients.StateManagerClientV1
 import io.vertx.core.Vertx
+import linea.clients.StateManagerClientV1
 import linea.domain.BlockInterval
 import net.consensys.linea.async.AsyncRetryer
 import tech.pegasys.teku.infrastructure.async.SafeFuture

--- a/linea-besu/plugins/state-recovery/appcore/logic/src/main/kotlin/linea/staterecovery/StateRecoveryApp.kt
+++ b/linea-besu/plugins/state-recovery/appcore/logic/src/main/kotlin/linea/staterecovery/StateRecoveryApp.kt
@@ -1,9 +1,9 @@
 package linea.staterecovery
 
-import build.linea.clients.StateManagerClientV1
 import io.vertx.core.Vertx
 import linea.EthLogsSearcher
 import linea.LongRunningService
+import linea.clients.StateManagerClientV1
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.domain.BlockParameter
 import linea.domain.BlockParameter.Companion.toBlockParameter

--- a/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/AppConfigurator.kt
+++ b/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/AppConfigurator.kt
@@ -1,10 +1,10 @@
 package linea.staterecovery.plugin
 
-import build.linea.clients.StateManagerClientV1
-import build.linea.clients.StateManagerV1JsonRpcClient
 import io.micrometer.core.instrument.MeterRegistry
 import io.vertx.core.Vertx
 import io.vertx.micrometer.backends.BackendRegistries
+import linea.clients.StateManagerClientV1
+import linea.clients.StateManagerV1JsonRpcClient
 import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
 import linea.domain.RetryConfig
 import linea.ethapi.EthLogsSearcherImpl

--- a/linea-besu/plugins/state-recovery/test-cases/src/e2eTest/kotlin/linea/staterecovery/StateRecoveryE2ETest.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/e2eTest/kotlin/linea/staterecovery/StateRecoveryE2ETest.kt
@@ -1,10 +1,10 @@
 package linea.staterecovery
 
-import build.linea.clients.StateManagerClientV1
-import build.linea.clients.StateManagerV1JsonRpcClient
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
+import linea.clients.StateManagerClientV1
+import linea.clients.StateManagerV1JsonRpcClient
 import linea.contract.events.DataFinalizedV3
 import linea.domain.EthLogEvent
 import linea.ethapi.EthLogsSearcherImpl

--- a/linea-besu/plugins/state-recovery/test-cases/src/integrationTest/kotlin/linea/staterecovery/StateRecoveryWithRealBesuAndStateManagerIntTest.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/integrationTest/kotlin/linea/staterecovery/StateRecoveryWithRealBesuAndStateManagerIntTest.kt
@@ -1,10 +1,10 @@
 package linea.staterecovery
 
-import build.linea.clients.StateManagerClientV1
-import build.linea.clients.StateManagerV1JsonRpcClient
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
+import linea.clients.StateManagerClientV1
+import linea.clients.StateManagerV1JsonRpcClient
 import linea.contract.l1.LineaRollupContractVersion
 import linea.contract.l1.LineaRollupSmartContractClient
 import linea.log4j.configureLoggers

--- a/linea-besu/plugins/state-recovery/test-cases/src/main/kotlin/linea/staterecovery/test/FakeStateManagerClient.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/main/kotlin/linea/staterecovery/test/FakeStateManagerClient.kt
@@ -1,12 +1,12 @@
 package linea.staterecovery.test
 
-import build.linea.clients.GetZkEVMStateMerkleProofResponse
-import build.linea.clients.StateManagerClientV1
-import build.linea.clients.StateManagerErrorType
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import linea.EthLogsSearcher
+import linea.clients.GetZkEVMStateMerkleProofResponse
+import linea.clients.StateManagerClientV1
+import linea.clients.StateManagerErrorType
 import linea.contract.events.DataFinalizedV3
 import linea.domain.BlobRecord
 import linea.domain.BlockInterval

--- a/linea-besu/plugins/state-recovery/test-cases/src/test/kotlin/linea/staterecovery/ManualTestWithFakeExecutionClient.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/test/kotlin/linea/staterecovery/ManualTestWithFakeExecutionClient.kt
@@ -1,7 +1,7 @@
 package linea.staterecovery
 
-import build.linea.clients.StateManagerClientV1
 import io.vertx.core.Vertx
+import linea.clients.StateManagerClientV1
 import linea.domain.BlockNumberAndHash
 import linea.domain.BlockParameter
 import linea.domain.RetryConfig

--- a/linea-besu/plugins/state-recovery/test-cases/src/test/kotlin/linea/staterecovery/test/AssertionsHelper.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/test/kotlin/linea/staterecovery/test/AssertionsHelper.kt
@@ -1,6 +1,6 @@
 package linea.staterecovery.test
 
-import build.linea.clients.StateManagerClientV1
+import linea.clients.StateManagerClientV1
 import linea.domain.BlockInterval
 import linea.ethapi.EthApiBlockClient
 import linea.testing.CommandResult


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a wide-reaching package/namespace rename across coordinator, clients, and shared JVM libs; main risk is missed import/relocation causing compilation or runtime wiring issues rather than behavioral changes.
> 
> **Overview**
> This PR **standardizes package names** by moving multiple shared types from the `build.linea.*` namespace to `linea.*`, updating imports throughout coordinator apps/tests, forced-transactions, and state-recovery.
> 
> It also updates Web3j-generated contract wrapper configuration (`contractsPackage`) to generate into `linea.contract` and adjusts dependent smart-contract client code accordingly, plus renames shared utility/serialization packages (e.g., `linea.s11n.jackson`, `linea.tuweni`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198c1e3ae65487972e4ab4805cc3f419b46a0797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->