### PR TITLE
Remove state manager version from Shomei proof requests

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/StateManagerConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/StateManagerConfig.kt
@@ -6,7 +6,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 data class StateManagerConfig(
-  val version: String,
   val endpoints: List<URL>,
   val requestLimitPerEndpoint: UInt = UInt.MAX_VALUE,
   val requestTimeout: Duration? = null,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/StateManagerToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/StateManagerToml.kt
@@ -6,7 +6,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 data class StateManagerToml(
-  val version: String,
   val endpoints: List<URL>,
   val requestLimitPerEndpoint: UInt = UInt.MAX_VALUE,
   val requestTimeout: Duration? = null,
@@ -18,7 +17,6 @@ data class StateManagerToml(
 ) {
   fun reified(): StateManagerConfig {
     return StateManagerConfig(
-      version = this.version,
       endpoints = this.endpoints,
       requestLimitPerEndpoint = this.requestLimitPerEndpoint,
       requestTimeout = this.requestTimeout,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
@@ -1,5 +1,6 @@
 package net.consensys.zkevm.coordinator.api.dto
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import linea.blob.BlobCompressorVersion
 import linea.kotlin.toURL
@@ -44,8 +45,10 @@ data class ConflationCreateProverRequestJsonDto(
   companion object {
     fun parseFrom(request: JsonRpcRequest): List<ConflationCreateProverRequestJsonDto> {
       try {
-        return jacksonObjectMapper().readValue(
-          jacksonObjectMapper().writeValueAsString(request.params),
+        val objectMapper = jacksonObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        return objectMapper.readValue(
+          objectMapper.writeValueAsString(request.params),
           Array<ConflationCreateProverRequestJsonDto>::class.java,
         ).toList()
       } catch (e: Exception) {
@@ -77,18 +80,15 @@ data class TracesApiDto(
 
 data class ShomeiApiDto(
   val endpoint: String,
-  val version: String,
   val requestLimitPerEndpoint: Int,
 ) {
   constructor() : this(
     endpoint = "",
-    version = "",
     requestLimitPerEndpoint = 0,
   )
   fun toDomainObject(): ShomeiApiConfig {
     return ShomeiApiConfig(
       endpoint = this.endpoint.toURL(),
-      version = this.version,
       requestLimitPerEndpoint = this.requestLimitPerEndpoint.toUInt(),
     )
   }

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflation/ConflationApp.kt
@@ -97,7 +97,6 @@ class ConflationApp(
     maxInflightRequestsPerClient = configs.stateManager.requestLimitPerEndpoint,
     requestRetry = configs.stateManager.requestRetries.toJsonRpcRetry(),
     requestTimeout = configs.stateManager.requestTimeout?.inWholeMilliseconds,
-    zkStateManagerVersion = configs.stateManager.version,
     logger = LogManager.getLogger("clients.StateManagerShomeiClient"),
   )
   val tracesClients =

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -153,7 +153,6 @@ class ConflationBacktestingApp(
     stateManager = mainCoordinatorConfig.stateManager.copy(
       endpoints = listOf(conflationBacktestingAppConfig.shomeiApi.endpoint),
       requestLimitPerEndpoint = conflationBacktestingAppConfig.shomeiApi.requestLimitPerEndpoint,
-      version = conflationBacktestingAppConfig.shomeiApi.version,
     ),
   ).also {
     log.info("Conflation backtesting coordinatorConfig={}", it)
@@ -223,7 +222,6 @@ class ConflationBacktestingApp(
   private val zkStateClient: StateManagerClientV1 = StateManagerV1JsonRpcClient.create(
     rpcClientFactory = httpJsonRpcClientFactory,
     endpoints = backtestingCoordinatorConfig.stateManager.endpoints.map { it.toURI() },
-    zkStateManagerVersion = backtestingCoordinatorConfig.stateManager.version,
     maxInflightRequestsPerClient = backtestingCoordinatorConfig.stateManager.requestLimitPerEndpoint,
     requestRetry = backtestingCoordinatorConfig.stateManager.requestRetries.toJsonRpcRetry(),
     requestTimeout = backtestingCoordinatorConfig.stateManager.requestTimeout?.inWholeMilliseconds,

--- a/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingConfig.kt
+++ b/coordinator/app/src/main/kotlin/net/consensys/zkevm/coordinator/app/conflationbacktesting/ConflationBacktestingConfig.kt
@@ -26,6 +26,5 @@ data class TracesApiConfig(
 
 data class ShomeiApiConfig(
   val endpoint: URL,
-  val version: String,
   val requestLimitPerEndpoint: UInt = 1u,
 )

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/StateManagerParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/StateManagerParsingTest.kt
@@ -13,7 +13,6 @@ class StateManagerParsingTest {
     val toml =
       """
       [state-manager]
-      version = "2.2.0"
       endpoints = ["http://shomei:8888/"]
       request-limit-per-endpoint = 3
       request-timeout = "PT30S"
@@ -25,7 +24,6 @@ class StateManagerParsingTest {
 
     val config =
       StateManagerToml(
-        version = "2.2.0",
         endpoints = listOf("http://shomei:8888/".toURL()),
         requestLimitPerEndpoint = 3u,
         requestTimeout = 30.seconds,
@@ -40,13 +38,11 @@ class StateManagerParsingTest {
     val tomlMinimal =
       """
       [state-manager]
-      version = "2.2.0"
       endpoints = ["http://shomei:8888/"]
       """.trimIndent()
 
     val configMinimal =
       StateManagerToml(
-        version = "2.2.0",
         endpoints = listOf("http://shomei:8888/".toURL()),
         requestLimitPerEndpoint = UInt.MAX_VALUE,
         requestTimeout = null,

--- a/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDtoTest.kt
+++ b/coordinator/app/src/test/kotlin/net/consensys/zkevm/coordinator/api/dto/ConflationCreateProverRequestJsonDtoTest.kt
@@ -29,7 +29,6 @@ class ConflationCreateProverRequestJsonDtoTest {
         ),
         shomeiApi = ShomeiApiDto(
           endpoint = "https://example.com/shomei",
-          version = "v1",
           requestLimitPerEndpoint = 50,
         ),
       ),
@@ -46,7 +45,6 @@ class ConflationCreateProverRequestJsonDtoTest {
         ),
         shomeiApi = ShomeiApiDto(
           endpoint = "https://example.com/shomei",
-          version = "v2",
           requestLimitPerEndpoint = 50,
         ),
       ),
@@ -72,7 +70,6 @@ class ConflationCreateProverRequestJsonDtoTest {
           ),
           "shomeiApi" to mapOf(
             "endpoint" to "https://example.com/shomei",
-            "version" to "v1",
             "requestLimitPerEndpoint" to 50,
           ),
         ),
@@ -87,7 +84,6 @@ class ConflationCreateProverRequestJsonDtoTest {
           ),
           "shomeiApi" to mapOf(
             "endpoint" to "https://example.com/shomei",
-            "version" to "v2",
             "requestLimitPerEndpoint" to 50,
           ),
         ),
@@ -98,6 +94,55 @@ class ConflationCreateProverRequestJsonDtoTest {
 
     assertEquals(2, dtoList.size)
     assertThat(dtoList).isEqualTo(expectedDtoList)
+  }
+
+  @Test
+  fun `parseFrom should ignore unknown JSON RPC request params`() {
+    val jsonRpcRequest = JsonRpcRequestListParams(
+      jsonrpc = "2.0",
+      id = 1,
+      method = "conflation_createProverRequests",
+      params = listOf(
+        mapOf(
+          "startBlockNumber" to 10,
+          "endBlockNumber" to 20,
+          "blobCompressorVersion" to "V3",
+          "unknownTopLevelField" to "ignored",
+          "tracesApi" to mapOf(
+            "endpoint" to "https://example.com/traces",
+            "version" to "v1",
+            "requestLimitPerEndpoint" to 100,
+            "unknownTracesField" to "ignored",
+          ),
+          "shomeiApi" to mapOf(
+            "endpoint" to "https://example.com/shomei",
+            "version" to "legacy-version-field",
+            "requestLimitPerEndpoint" to 50,
+          ),
+        ),
+      ),
+    )
+
+    val dtoList = ConflationCreateProverRequestJsonDto.parseFrom(jsonRpcRequest)
+
+    assertThat(dtoList).containsExactly(
+      ConflationCreateProverRequestJsonDto(
+        startBlockNumber = 10,
+        endBlockNumber = 20,
+        blobCompressorVersion = "V3",
+        batchesFixedSize = null,
+        parentBlobShnarf = null,
+        tracesApi = TracesApiDto(
+          endpoint = "https://example.com/traces",
+          version = "v1",
+          requestLimitPerEndpoint = 100,
+        ),
+        shomeiApi = ShomeiApiDto(
+          endpoint = "https://example.com/shomei",
+          requestLimitPerEndpoint = 50,
+        ),
+      ),
+    )
   }
 
   @Test

--- a/docker/compose-tracing-v2-partialprover-override.yml
+++ b/docker/compose-tracing-v2-partialprover-override.yml
@@ -30,4 +30,3 @@ services:
       config__override__conflation__conflation_deadline: PT30M
       config__override__conflation__blob_compression__batches_limit: 1
       config__override__conflation__proof_aggregation__deadline: PT30M
-      CONFIG_OVERRIDE_OPTS: ${LINEA_SHOMEI_TAG:+-Dconfig.override.state-manager.version=$LINEA_SHOMEI_TAG}

--- a/docker/config/coordinator/coordinator-config-v2.toml
+++ b/docker/config/coordinator/coordinator-config-v2.toml
@@ -100,7 +100,6 @@ backoff-delay = "PT1S"
 failures-warning-threshold = 10
 
 [state-manager]
-version = "3.2.3"
 endpoints = ["http://shomei:8888/"]
 request-limit-per-endpoint = 3
 [state-manager.request-retries]

--- a/docs/architecture-description.md
+++ b/docs/architecture-description.md
@@ -187,7 +187,6 @@ End point exposed by the state manager and used in the flow are:
 rollup_getZkEVMStateMerkleProofV0(
   startBlockNumber      int
   endBlockNumber        int
-  zkStateManagerVersion string
 ):
   zkParentStateRootHash  string
   zkStateMerkleProof     StateMerkleProof[^1]

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -173,7 +173,6 @@ Submits one or more backtesting jobs. Each element in `params` is an independent
       },
       "shomeiApi": {
         "endpoint": "http://shomei:8888",
-        "version": "v0.0.4",
         "requestLimitPerEndpoint": 1
       }
     }
@@ -213,7 +212,6 @@ curl -X POST http://localhost:9546 \
         },
         "shomeiApi": {
           "endpoint": "http://shomei:8888",
-          "version": "3.0.0",
           "requestLimitPerEndpoint": 1
         }
       }
@@ -307,7 +305,6 @@ Stops one in-progress backtesting job. `params` must be a JSON array containing 
 | `tracesConflationApi.version` | string | If split | Must be identical to `tracesApi.version`                                                                                                      |
 | `tracesConflationApi.requestLimitPerEndpoint` | integer | If split | Max concurrent requests to the conflation traces client                                                                                       |
 | `shomeiApi.endpoint` | string | ✓ | State manager (Shomei) URL                                                                                                                    |
-| `shomeiApi.version` | string | ✓ | Shomei API version string                                                                                                                     |
 | `shomeiApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to Shomei                                                                                                             |
 
 ## Test Coverage

--- a/e2e/src/config/clients/linea-rpc/rollup-get-zkevm-state-merkle-proof-v0.ts
+++ b/e2e/src/config/clients/linea-rpc/rollup-get-zkevm-state-merkle-proof-v0.ts
@@ -3,7 +3,6 @@ import type { Client, Hash, Transport, Chain, Account } from "viem";
 export type RollupGetZkEVMStateMerkleProofV0Parameters = {
   startBlockNumber: number;
   endBlockNumber: number;
-  zkStateManagerVersion: string;
 };
 
 export type RollupGetZkEVMStateMerkleProofV0ReturnType = {

--- a/e2e/src/shomei-get-proof.spec.ts
+++ b/e2e/src/shomei-get-proof.spec.ts
@@ -124,7 +124,6 @@ describe("Shomei Linea get proof test suite", () => {
       const { zkEndStateRootHash } = await lineaShomeiClient.rollupGetZkEVMStateMerkleProofV0({
         startBlockNumber: Number(targetL2BlockNumber),
         endBlockNumber: Number(targetL2BlockNumber),
-        zkStateManagerVersion: shomeiImageTag,
       });
 
       logger.info(`zkEndStateRootHash=${zkEndStateRootHash}`);

--- a/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerV1JsonRpcClient.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/main/kotlin/linea/clients/StateManagerV1JsonRpcClient.kt
@@ -24,7 +24,6 @@ import java.net.URI
 
 class StateManagerV1JsonRpcClient(
   private val rpcClient: JsonRpcV2Client,
-  private val zkStateManagerVersion: String,
   private val log: Logger = LogManager.getLogger(StateManagerV1JsonRpcClient::class.java),
 ) : StateManagerClientV1, StateManagerAccountProofClient {
 
@@ -37,7 +36,6 @@ class StateManagerV1JsonRpcClient(
       maxInflightRequestsPerClient: UInt,
       requestRetry: RequestRetryConfig,
       requestTimeout: Long? = null,
-      zkStateManagerVersion: String,
       logger: Logger = LogManager.getLogger(StateManagerV1JsonRpcClient::class.java),
     ): StateManagerV1JsonRpcClient {
       return StateManagerV1JsonRpcClient(
@@ -49,7 +47,6 @@ class StateManagerV1JsonRpcClient(
           log = logger,
           shallRetryRequestsClientBasePredicate = { it is Err },
         ),
-        zkStateManagerVersion = zkStateManagerVersion,
       )
     }
   }
@@ -70,8 +67,6 @@ class StateManagerV1JsonRpcClient(
         blockInterval.startBlockNumber.toLong(),
         "endBlockNumber",
         blockInterval.endBlockNumber.toLong(),
-        "zkStateManagerVersion",
-        zkStateManagerVersion,
       ),
     )
 

--- a/jvm-libs/linea/clients/linea-state-manager/src/test/kotlin/linea/clients/StateManagerV1JsonRpcClientTest.kt
+++ b/jvm-libs/linea/clients/linea-state-manager/src/test/kotlin/linea/clients/StateManagerV1JsonRpcClientTest.kt
@@ -70,7 +70,6 @@ class StateManagerV1JsonRpcClientTest {
         10.milliseconds,
         1u,
       ),
-      zkStateManagerVersion = "0.1.2",
     )
   }
 

--- a/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/AppConfigurator.kt
+++ b/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/AppConfigurator.kt
@@ -96,7 +96,6 @@ fun createAppClients(
   stateManagerClientEndpoint: URI,
   blobscanRequestRateLimitBackoffDelay: Duration? = null,
   stateManagerRequestRetry: RetryConfig = RetryConfig(backoffDelay = 1.seconds),
-  zkStateManagerVersion: String = "2.3.0",
 ): AppClients {
   val ethLogsSearcher =
     run {
@@ -143,7 +142,6 @@ fun createAppClients(
       endpoints = listOf(stateManagerClientEndpoint),
       maxInflightRequestsPerClient = 10u,
       requestRetry = stateManagerRequestRetry.toRequestRetryConfig(),
-      zkStateManagerVersion = zkStateManagerVersion,
       logger = LogManager.getLogger("linea.plugin.staterecovery.clients.state-manager"),
     )
   val transactionDetailsClient: TransactionDetailsClient =

--- a/linea-besu/plugins/state-recovery/test-cases/src/e2eTest/kotlin/linea/staterecovery/StateRecoveryE2ETest.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/e2eTest/kotlin/linea/staterecovery/StateRecoveryE2ETest.kt
@@ -64,7 +64,6 @@ class StateRecoveryE2ETest {
         backoffDelay = 10.milliseconds,
         timeout = 2.seconds,
       ),
-      zkStateManagerVersion = "2.3.0",
       logger = LogManager.getLogger("test.clients.l1.state-manager"),
     )
 

--- a/linea-besu/plugins/state-recovery/test-cases/src/integrationTest/kotlin/linea/staterecovery/StateRecoveryWithRealBesuAndStateManagerIntTest.kt
+++ b/linea-besu/plugins/state-recovery/test-cases/src/integrationTest/kotlin/linea/staterecovery/StateRecoveryWithRealBesuAndStateManagerIntTest.kt
@@ -65,7 +65,6 @@ class StateRecoveryWithRealBesuAndStateManagerIntTest {
         backoffDelay = 1.seconds,
         timeout = 4.seconds,
       ),
-      zkStateManagerVersion = "2.3.0",
       logger = LogManager.getLogger("test.clients.l1.state-manager"),
     )
 

--- a/prover/cmd/dev-tools/state-manager-inspector/Readme.md
+++ b/prover/cmd/dev-tools/state-manager-inspector/Readme.md
@@ -29,7 +29,6 @@ Flags:
   -h, --help                    help for state-manager-inspector
       --max-rps duration        minimal time to wait between each request (default 20ms)
       --num-threads int         number of threads to use for verification (default 10)
-      --shomei-version string   version string to send to shomei via rpc (default "0.0.1")
       --start int               starting block of the range (must be the beginning of a conflated batch)
       --stop int                end of the range to fetch
       --url string              host:port of the shomei state-manager to query (default "https://127.0.0.1:443")
@@ -38,6 +37,5 @@ Flags:
 ## Example
 
 ```bash
-bin/state-manager-inspector --url https://127.0.0.1:443 --start 0 --stop 1000 --shomei-version 0.0.1-dev-18823579 --max-rps 20ms --num-threads 3 --block-range 10
+bin/state-manager-inspector --url https://127.0.0.1:443 --start 0 --stop 1000 --max-rps 20ms --num-threads 3 --block-range 10
 ```
-

--- a/prover/cmd/dev-tools/state-manager-inspector/cmd/cmd.go
+++ b/prover/cmd/dev-tools/state-manager-inspector/cmd/cmd.go
@@ -16,13 +16,12 @@ var rootCmd = &cobra.Command{
 
 // global variables holding the programs arguments
 var (
-	startArg      int
-	stopArg       int
-	shomeiVersion string
-	url           string
-	maxRps        time.Duration
-	numThreads    int
-	blockRange    int
+	startArg   int
+	stopArg    int
+	url        string
+	maxRps     time.Duration
+	numThreads int
+	blockRange int
 )
 
 // initializes the programs flags
@@ -30,7 +29,6 @@ func init() {
 	rootCmd.Flags().IntVar(&startArg, "start", 0, "starting block of the range (must be the beginning of a conflated batch)")
 	rootCmd.Flags().IntVar(&stopArg, "stop", 0, "end of the range to fetch")
 	rootCmd.Flags().StringVar(&url, "url", "https://127.0.0.1:443", "host:port of the shomei state-manager to query")
-	rootCmd.Flags().StringVar(&shomeiVersion, "shomei-version", "0.0.1", "version string to send to shomei via rpc")
 	rootCmd.Flags().DurationVar(&maxRps, "max-rps", 20*time.Millisecond, "minimal time to wait between each request")
 	rootCmd.Flags().IntVar(&numThreads, "num-threads", runtime.NumCPU(), "number of threads to use for verification")
 	rootCmd.Flags().IntVar(&blockRange, "block-range", 10, "size of the range to fetch from shomei for each request")

--- a/prover/cmd/dev-tools/state-manager-inspector/cmd/run.go
+++ b/prover/cmd/dev-tools/state-manager-inspector/cmd/run.go
@@ -95,7 +95,6 @@ func fetchAndInspect(cmd *cobra.Command, args []string) error {
 			&zkEVMStateMerkleProofV0Req{
 				StartBlockNumber: start,
 				EndBlockNumber:   stop,
-				ShomeiVersion:    shomeiVersion,
 			},
 		)
 

--- a/prover/cmd/dev-tools/state-manager-inspector/cmd/shomei.go
+++ b/prover/cmd/dev-tools/state-manager-inspector/cmd/shomei.go
@@ -22,8 +22,7 @@ const (
 	"params": [
 		{
 			"startBlockNumber": "{{.StartBlockNumberHex}}",
-			"endBlockNumber": "{{.EndBlockNumberHex}}",
-			"zkStateManagerVersion": "{{.ShomeiVersion}}"
+			"endBlockNumber": "{{.EndBlockNumberHex}}"
 		}
 	],
 	"id": 1
@@ -58,7 +57,6 @@ type zkEVMStateMerkleProofV0Req struct {
 	EndBlockNumber      int
 	StartBlockNumberHex string
 	EndBlockNumberHex   string
-	ShomeiVersion       string
 }
 
 // Sends a request to collect the zk state proofs for a conflated sequence of

--- a/prover/cmd/dev-tools/state-manager-inspector/cmd/shomei_test.go
+++ b/prover/cmd/dev-tools/state-manager-inspector/cmd/shomei_test.go
@@ -45,7 +45,6 @@ func TestShomeiReceptor(t *testing.T) {
 		&zkEVMStateMerkleProofV0Req{
 			StartBlockNumber: 0,
 			EndBlockNumber:   1,
-			ShomeiVersion:    "0.0.1-dev-18823579",
 		},
 	)
 


### PR DESCRIPTION
## Summary

- Remove request-side state manager/Shomei version from `rollup_getZkEVMStateMerkleProofV0` callers across coordinator, E2E, state recovery, and prover tooling.
- Remove coordinator/backtesting config plumbing for Shomei version overrides while keeping response-side `zkStateManagerVersion` parsing and prover propagation.
- Allow backtesting DTO parsing to ignore unknown parameters, including legacy `shomeiApi.version`.
- Update docs and local stack partial prover override references.

#2811

## Testing

- `./gradlew :jvm-libs:linea:clients:linea-state-manager:test --tests linea.clients.StateManagerV1JsonRpcClientTest`
- `./gradlew :coordinator:app:test --tests linea.coordinator.config.v2.StateManagerParsingTest --tests net.consensys.zkevm.coordinator.api.dto.ConflationCreateProverRequestJsonDtoTest`
- `./gradlew :linea-besu:plugins:state-recovery:besu-plugin:compileKotlin :linea-besu:plugins:state-recovery:test-cases:compileKotlin :linea-besu:plugins:state-recovery:test-cases:compileTestKotlin`
- `pnpm -F e2e run lint`
- `go test ./cmd/dev-tools/state-manager-inspector/...`
- `./gradlew spotlessCheck`
- `./gradlew :coordinator:app:spotlessCheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JSON-RPC request shape for `rollup_getZkEVMStateMerkleProofV0` across multiple callers and removes config/CLI flags, which could break compatibility with older State Manager deployments expecting the version parameter.
> 
> **Overview**
> Removes the request-side Shomei/state-manager *version* plumbing end-to-end: coordinator `state-manager` config and TOML no longer carry a `version`, and all JVM/TS/Go callers stop sending `zkStateManagerVersion` in `rollup_getZkEVMStateMerkleProofV0` request params.
> 
> Backtesting request DTOs drop `shomeiApi.version` and now parse JSON-RPC params with `FAIL_ON_UNKNOWN_PROPERTIES=false` to tolerate legacy/extra fields; tests, example configs, docker overrides, and docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e772590c467549515b93a1429da61efa0a4611a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->