### PR TITLE
chore(e2e): remove unused shomei tag variable

### DIFF
--- a/e2e/src/shomei-get-proof.spec.ts
+++ b/e2e/src/shomei-get-proof.spec.ts
@@ -2,7 +2,7 @@ import { serialize } from "@consensys/linea-shared-utils";
 import { describe, it } from "@jest/globals";
 import { BaseError, ContractFunctionExecutionError, toHex } from "viem";
 
-import { awaitUntil, getDockerImageTag } from "./common/utils";
+import { awaitUntil } from "./common/utils";
 import { L2RpcEndpoint } from "./config/clients/l2-client";
 import { LineaGetProofReturnType } from "./config/clients/linea-rpc/linea-get-proof";
 import { createTestContext } from "./config/setup";
@@ -33,9 +33,6 @@ describe("Shomei Linea get proof test suite", () => {
   it.concurrent(
     "Call linea_getProof to Shomei frontend node and get a valid proof",
     async () => {
-      const shomeiImageTag = await getDockerImageTag("shomei-frontend", "consensys/linea-shomei");
-      logger.info(`shomeiImageTag=${shomeiImageTag}`);
-
       let targetL2BlockNumber = await awaitUntil(
         async () => {
           try {


### PR DESCRIPTION
This PR implements issue(s) #2811 

Follow up to #3099 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a debug-only Docker image tag lookup/log from an E2E test without changing test behavior or runtime logic.
> 
> **Overview**
> Removes the unused `getDockerImageTag` import and the associated `shomeiImageTag` lookup/logging from `shomei-get-proof.spec.ts`, leaving the `linea_getProof` test flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1da1f27520d2743f7ed124c04248150ea74c9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->