### PR TITLE
chore(misc): update coordinator image

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -307,7 +307,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-4ddbeba}
+    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-91e155a}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just updates the default `linea-coordinator` container image version; impact is limited to local/dev deployments that use this compose file.
> 
> **Overview**
> Updates `docker/compose-spec-l2-services.yml` to bump the default `consensys/linea-coordinator` image tag from `4ddbeba` to `91e155a`, changing which coordinator build is used when `LINEA_COORDINATOR_TAG` is not explicitly set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474f35fa2ebd22637894a2c688c8b9cc89162c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->