### PR TITLE
fix(coordinator): remove traces version from requests

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
@@ -60,19 +60,16 @@ data class ConflationCreateProverRequestJsonDto(
 
 data class TracesApiDto(
   val endpoint: String,
-  val version: String,
   val requestLimitPerEndpoint: Int,
 ) {
   constructor() : this(
     endpoint = "",
-    version = "",
     requestLimitPerEndpoint = 0,
   )
 
   fun toDomainObject(): TracesApiConfig {
     return TracesApiConfig(
       endpoint = this.endpoint.toURL(),
-      version = this.version,
       requestLimitPerEndpoint = this.requestLimitPerEndpoint.toUInt(),
     )
   }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/TracesClientFactory.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/TracesClientFactory.kt
@@ -20,7 +20,6 @@ object TracesClientFactory {
     rpcClientFactory: VertxHttpJsonRpcClientFactory,
     apiConfig: ClientApiConfig,
     ignoreTracesGeneratorErrors: Boolean,
-    expectedTracesApiVersion: String,
     fallBackTracesCounters: TracesCounters,
     logger: Logger,
   ): TracesGeneratorJsonRpcClientV2 {
@@ -36,7 +35,6 @@ object TracesClientFactory {
       ),
       config =
       TracesGeneratorJsonRpcClientV2.Config(
-        expectedTracesApiVersion = expectedTracesApiVersion,
         ignoreTracesGeneratorErrors = ignoreTracesGeneratorErrors,
         fallBackTracesCounters = fallBackTracesCounters,
       ),
@@ -60,7 +58,6 @@ object TracesClientFactory {
             rpcClientFactory,
             configs.common,
             configs.ignoreTracesGeneratorErrors,
-            configs.expectedTracesApiVersion,
             fallBackTracesCounters,
             log ?: LogManager.getLogger("clients.traces"),
           )
@@ -74,7 +71,6 @@ object TracesClientFactory {
             rpcClientFactory,
             configs.counters!!,
             configs.ignoreTracesGeneratorErrors,
-            configs.expectedTracesApiVersion,
             fallBackTracesCounters,
             log ?: LogManager.getLogger("clients.traces.counters"),
           )
@@ -84,7 +80,6 @@ object TracesClientFactory {
             rpcClientFactory,
             configs.conflation!!,
             configs.ignoreTracesGeneratorErrors,
-            configs.expectedTracesApiVersion,
             fallBackTracesCounters,
             log ?: LogManager.getLogger("clients.traces.conflation"),
           )

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -84,12 +84,6 @@ class ConflationBacktestingApp(
     require(mainCoordinatorConfigTracesEndpoints.intersect(backtestingTracesEndpoints).isEmpty()) {
       "Cannot use same traces endpoint for backtesting and main conflation"
     }
-    require(
-      conflationBacktestingAppConfig.tracesConflationApi == null ||
-        conflationBacktestingAppConfig.tracesConflationApi.version == conflationBacktestingAppConfig.tracesApi.version,
-    ) {
-      "When tracesConflationApi is set, its version must match tracesApi.version"
-    }
   }
 
   private val log = LogManager.getLogger("conflation_backtesting_job_${conflationBacktestingAppConfig.jobId()}")
@@ -144,7 +138,6 @@ class ConflationBacktestingApp(
         )
       }
       mainCoordinatorConfig.traces.copy(
-        expectedTracesApiVersion = bt.tracesApi.version,
         common = if (conflationApiClient == null) tracesApiClient else null,
         counters = if (conflationApiClient == null) null else tracesApiClient,
         conflation = conflationApiClient,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingConfig.kt
@@ -20,7 +20,6 @@ data class ConflationBacktestingConfig(
 
 data class TracesApiConfig(
   val endpoint: URL,
-  val version: String,
   val requestLimitPerEndpoint: UInt = 1u,
 )
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/TracesConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/TracesConfig.kt
@@ -6,7 +6,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 data class TracesConfig(
-  val expectedTracesApiVersion: String,
   val common: ClientApiConfig? = null,
   val counters: ClientApiConfig? = null,
   val conflation: ClientApiConfig? = null,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/TracesToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/TracesToml.kt
@@ -6,7 +6,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 data class TracesToml(
-  val expectedTracesApiVersion: String,
   val endpoints: List<URL>? = null,
   val requestLimitPerEndpoint: UInt = UInt.MAX_VALUE,
   val requestTimeout: Duration? = null,
@@ -72,7 +71,6 @@ data class TracesToml(
       }
 
     return TracesConfig(
-      expectedTracesApiVersion = expectedTracesApiVersion,
       common = common,
       counters = if (common == null) reifiedWithCommonDefaults(this.counters) else null,
       conflation = if (common == null) reifiedWithCommonDefaults(this.conflation) else null,

--- a/coordinator/app/src/test/kotlin/linea/coordinator/api/dto/ConflationCreateProverRequestJsonDtoTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/api/dto/ConflationCreateProverRequestJsonDtoTest.kt
@@ -19,12 +19,10 @@ class ConflationCreateProverRequestJsonDtoTest {
         parentBlobShnarf = null,
         tracesApi = TracesApiDto(
           endpoint = "https://example.com/traces/counters",
-          version = "v1",
           requestLimitPerEndpoint = 100,
         ),
         tracesConflationApi = TracesApiDto(
           endpoint = "https://example.com/traces/conflation",
-          version = "v1",
           requestLimitPerEndpoint = 100,
         ),
         shomeiApi = ShomeiApiDto(
@@ -40,7 +38,6 @@ class ConflationCreateProverRequestJsonDtoTest {
         parentBlobShnarf = null,
         tracesApi = TracesApiDto(
           endpoint = "https://example.com/traces",
-          version = "v2",
           requestLimitPerEndpoint = 100,
         ),
         shomeiApi = ShomeiApiDto(
@@ -60,12 +57,10 @@ class ConflationCreateProverRequestJsonDtoTest {
           "blobCompressorVersion" to "V3",
           "tracesApi" to mapOf(
             "endpoint" to "https://example.com/traces/counters",
-            "version" to "v1",
             "requestLimitPerEndpoint" to 100,
           ),
           "tracesConflationApi" to mapOf(
             "endpoint" to "https://example.com/traces/conflation",
-            "version" to "v1",
             "requestLimitPerEndpoint" to 100,
           ),
           "shomeiApi" to mapOf(
@@ -79,7 +74,6 @@ class ConflationCreateProverRequestJsonDtoTest {
           "blobCompressorVersion" to "V2",
           "tracesApi" to mapOf(
             "endpoint" to "https://example.com/traces",
-            "version" to "v2",
             "requestLimitPerEndpoint" to 100,
           ),
           "shomeiApi" to mapOf(
@@ -110,7 +104,6 @@ class ConflationCreateProverRequestJsonDtoTest {
           "unknownTopLevelField" to "ignored",
           "tracesApi" to mapOf(
             "endpoint" to "https://example.com/traces",
-            "version" to "v1",
             "requestLimitPerEndpoint" to 100,
             "unknownTracesField" to "ignored",
           ),
@@ -134,7 +127,6 @@ class ConflationCreateProverRequestJsonDtoTest {
         parentBlobShnarf = null,
         tracesApi = TracesApiDto(
           endpoint = "https://example.com/traces",
-          version = "v1",
           requestLimitPerEndpoint = 100,
         ),
         shomeiApi = ShomeiApiDto(

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/TracesParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/TracesParsingTest.kt
@@ -16,7 +16,6 @@ class TracesParsingTest {
     val toml =
       """
       [traces]
-      expected-traces-api-version = "1.2.0"
       [traces.counters]
       endpoints = ["http://traces-api-1:8080/"]
       request-limit-per-endpoint = 20
@@ -36,7 +35,6 @@ class TracesParsingTest {
 
       [traces.new]
       switch-block-number-inclusive=1_000
-      expected-traces-api-version = "2.0.0"
       [traces.new.counters]
       endpoints = ["http://traces-api-v2-11:8080/", "http://traces-api-v2-12:8080/"]
       request-limit-per-endpoint = 200
@@ -56,7 +54,6 @@ class TracesParsingTest {
 
     val config =
       TracesToml(
-        expectedTracesApiVersion = "1.2.0",
         counters =
         TracesToml.ClientApiConfigToml(
           endpoints = listOf(URI.create("http://traces-api-1:8080/").toURL()),
@@ -82,7 +79,6 @@ class TracesParsingTest {
         ),
         new =
         TracesToml(
-          expectedTracesApiVersion = "2.0.0",
           switchBlockNumberInclusive = 1_000u,
           counters =
           TracesToml.ClientApiConfigToml(
@@ -112,7 +108,6 @@ class TracesParsingTest {
     val tomlMinimal =
       """
       [traces]
-      expected-traces-api-version = "1.2.0"
       [traces.counters]
       endpoints = ["http://traces-api-1:8080/"]
       [traces.conflation]
@@ -121,7 +116,6 @@ class TracesParsingTest {
 
     val configMinimal =
       TracesToml(
-        expectedTracesApiVersion = "1.2.0",
         requestLimitPerEndpoint = UInt.MAX_VALUE,
         requestRetries =
         RequestRetriesToml(
@@ -200,7 +194,6 @@ class TracesParsingTest {
     val tomlWithIgnoreErrors =
       """
       [traces]
-      expected-traces-api-version = "1.2.0"
       ignore-traces-generator-errors = true
       [traces.counters]
       endpoints = ["http://traces-api-1:8080/"]
@@ -219,7 +212,6 @@ class TracesParsingTest {
     val tomlWithIgnoreErrorsDisabled =
       """
       [traces]
-      expected-traces-api-version = "1.2.0"
       ignore-traces-generator-errors = false
       [traces.counters]
       endpoints = ["http://traces-api-1:8080/"]
@@ -238,7 +230,6 @@ class TracesParsingTest {
     val toml =
       """
       [traces]
-      expected-traces-api-version = "1.2.0"
       endpoints = ["http://traces-api-lb:8080/"]
       request-limit-per-endpoint = 2
       request-timeout = "PT60S"
@@ -250,7 +241,6 @@ class TracesParsingTest {
 
     val config =
       TracesConfig(
-        expectedTracesApiVersion = "1.2.0",
         common =
         ClientApiConfig(
           endpoints = listOf("http://traces-api-lb:8080/".toURL()),
@@ -273,7 +263,6 @@ class TracesParsingTest {
     val toml =
       """
       [traces]
-      expected-traces-api-version = "1.2.0"
       endpoints = ["http://traces-api-lb:8080/"]
       request-limit-per-endpoint = 20
       request-timeout = "PT20S"
@@ -300,7 +289,6 @@ class TracesParsingTest {
       )
     val config =
       TracesConfig(
-        expectedTracesApiVersion = "1.2.0",
         common = null,
         counters = commonConfig.copy(endpoints = listOf("http://traces-api-2:8080/".toURL())),
         conflation = commonConfig,

--- a/coordinator/clients/traces-generator-api-client/src/main/kotlin/linea/coordinator/clients/TracesGeneratorJsonRpcClientV2.kt
+++ b/coordinator/clients/traces-generator-api-client/src/main/kotlin/linea/coordinator/clients/TracesGeneratorJsonRpcClientV2.kt
@@ -57,12 +57,11 @@ class TracesGeneratorJsonRpcClientV2(
   )
 
   data class Config(
-    val expectedTracesApiVersion: String,
     val ignoreTracesGeneratorErrors: Boolean = false,
     val fallBackTracesCounters: TracesCounters,
   )
 
-  private var requestBuilder = RequestBuilder(config.expectedTracesApiVersion)
+  private var requestBuilder = RequestBuilder()
 
   override fun getTracesCounters(
     blockNumber: ULong,
@@ -113,7 +112,7 @@ class TracesGeneratorJsonRpcClientV2(
   private fun createFallbackTracesCountersResponse(): GetTracesCountersResponse {
     return GetTracesCountersResponse(
       tracesCounters = config.fallBackTracesCounters,
-      tracesEngineVersion = config.expectedTracesApiVersion,
+      tracesEngineVersion = FALLBACK_TRACES_ENGINE_VERSION,
     )
   }
 
@@ -121,20 +120,20 @@ class TracesGeneratorJsonRpcClientV2(
     startBlockNumber: ULong,
     endBlockNumber: ULong,
   ): GenerateTracesResponse {
-    val defaultFileName = "$startBlockNumber-$endBlockNumber.fake-empty.conflated.${config.expectedTracesApiVersion}.lt"
+    val defaultFileName = "$startBlockNumber-$endBlockNumber.fake-empty.conflated.$FALLBACK_TRACES_ENGINE_VERSION.lt"
     return GenerateTracesResponse(
       tracesFileName = defaultFileName,
-      tracesEngineVersion = config.expectedTracesApiVersion,
+      tracesEngineVersion = FALLBACK_TRACES_ENGINE_VERSION,
     )
   }
 
   private fun createFallbackVirtualBlockConflatedTracesResponse(
     blockNumber: ULong,
   ): GenerateTracesResponse {
-    val defaultFileName = "$blockNumber.fake-empty.conflated.${config.expectedTracesApiVersion}.lt"
+    val defaultFileName = "$blockNumber.fake-empty.conflated.$FALLBACK_TRACES_ENGINE_VERSION.lt"
     return GenerateTracesResponse(
       tracesFileName = defaultFileName,
-      tracesEngineVersion = config.expectedTracesApiVersion,
+      tracesEngineVersion = FALLBACK_TRACES_ENGINE_VERSION,
     )
   }
 
@@ -174,7 +173,6 @@ class TracesGeneratorJsonRpcClientV2(
   }
 
   internal class RequestBuilder(
-    private val expectedTracesEngineVersion: String,
     private val id: AtomicInteger = AtomicInteger(0),
   ) {
     fun buildGetTracesCountersV2Request(blockNumber: ULong): JsonRpcRequest {
@@ -186,8 +184,6 @@ class TracesGeneratorJsonRpcClientV2(
           JsonObject.of(
             "blockNumber",
             blockNumber,
-            "expectedTracesEngineVersion",
-            expectedTracesEngineVersion,
           ),
         ),
       )
@@ -204,8 +200,6 @@ class TracesGeneratorJsonRpcClientV2(
             startBlockNumber,
             "endBlockNumber",
             endBlockNumber,
-            "expectedTracesEngineVersion",
-            expectedTracesEngineVersion,
           ),
         ),
       )
@@ -232,6 +226,8 @@ class TracesGeneratorJsonRpcClientV2(
   }
 
   companion object {
+    private const val FALLBACK_TRACES_ENGINE_VERSION = "fallback"
+
     internal val retryableMethods = setOf(
       "linea_getBlockTracesCountersV2",
       "linea_generateConflatedTracesToFileV2",

--- a/coordinator/clients/traces-generator-api-client/src/test/kotlin/linea/coordinator/clients/TracesApiRequestPriorityComparatorTest.kt
+++ b/coordinator/clients/traces-generator-api-client/src/test/kotlin/linea/coordinator/clients/TracesApiRequestPriorityComparatorTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class TracesApiRequestPriorityComparatorTest {
-  private val reqBuilder = TracesGeneratorJsonRpcClientV2.RequestBuilder("v2")
+  private val reqBuilder = TracesGeneratorJsonRpcClientV2.RequestBuilder()
   private val comparator = TracesGeneratorJsonRpcClientV2.requestPriorityComparator
 
   @Test

--- a/coordinator/clients/traces-generator-api-client/src/test/kotlin/linea/coordinator/clients/TracesGeneratorJsonRpcClientV2Test.kt
+++ b/coordinator/clients/traces-generator-api-client/src/test/kotlin/linea/coordinator/clients/TracesGeneratorJsonRpcClientV2Test.kt
@@ -63,7 +63,6 @@ class TracesGeneratorJsonRpcClientV2Test {
       }
   private lateinit var fakeTracesServerUri: URL
   private lateinit var vertxHttpJsonRpcClient: JsonRpcClient
-  private val expectedTracesApiVersion = "2.3.4"
 
   @BeforeEach
   fun setup(vertx: Vertx) {
@@ -91,7 +90,6 @@ class TracesGeneratorJsonRpcClientV2Test {
       TracesGeneratorJsonRpcClientV2(
         vertxHttpJsonRpcClient,
         TracesGeneratorJsonRpcClientV2.Config(
-          expectedTracesApiVersion = expectedTracesApiVersion,
           fallBackTracesCounters = TracesCountersV2.EMPTY_TRACES_COUNT,
         ),
       )
@@ -173,15 +171,13 @@ class TracesGeneratorJsonRpcClientV2Test {
           JsonObject.of(
             "blockNumber",
             1,
-            "expectedTracesEngineVersion",
-            expectedTracesApiVersion,
           ),
         ),
       )
     wiremock.verify(
       postRequestedFor(urlEqualTo("/"))
         .withHeader("Content-Type", equalTo("application/json"))
-        .withRequestBody(equalToJson(expectedJsonRequest.toString(), false, true)),
+        .withRequestBody(equalToJson(expectedJsonRequest.toString(), false, false)),
     )
   }
 
@@ -313,15 +309,13 @@ class TracesGeneratorJsonRpcClientV2Test {
             queryStartBlockNumber.toLong(),
             "endBlockNumber",
             queryEndBlockNumber.toLong(),
-            "expectedTracesEngineVersion",
-            expectedTracesApiVersion,
           ),
         ),
       )
     wiremock.verify(
       postRequestedFor(urlEqualTo("/"))
         .withHeader("Content-Type", equalTo("application/json"))
-        .withRequestBody(equalToJson(expectedJsonRequest.toString(), false, true)),
+        .withRequestBody(equalToJson(expectedJsonRequest.toString(), false, false)),
     )
   }
 
@@ -442,7 +436,6 @@ class TracesGeneratorJsonRpcClientV2Test {
       TracesGeneratorJsonRpcClientV2(
         vertxHttpJsonRpcClient,
         TracesGeneratorJsonRpcClientV2.Config(
-          expectedTracesApiVersion = expectedTracesApiVersion,
           fallBackTracesCounters = TracesCountersV2.EMPTY_TRACES_COUNT,
         ),
       )
@@ -489,7 +482,6 @@ class TracesGeneratorJsonRpcClientV2Test {
       TracesGeneratorJsonRpcClientV2(
         vertxHttpJsonRpcClient,
         TracesGeneratorJsonRpcClientV2.Config(
-          expectedTracesApiVersion = expectedTracesApiVersion,
           ignoreTracesGeneratorErrors = true,
           fallBackTracesCounters = TracesCountersV2.EMPTY_TRACES_COUNT,
         ),
@@ -502,7 +494,7 @@ class TracesGeneratorJsonRpcClientV2Test {
     assertThat(result).isInstanceOf(Ok::class.java)
     result as Ok
     assertThat(result.value.tracesCounters).isEqualTo(TracesCountersV2.EMPTY_TRACES_COUNT)
-    assertThat(result.value.tracesEngineVersion).isEqualTo(expectedTracesApiVersion)
+    assertThat(result.value.tracesEngineVersion).isEqualTo("fallback")
   }
 
   @Test
@@ -572,7 +564,7 @@ class TracesGeneratorJsonRpcClientV2Test {
     wiremock.verify(
       postRequestedFor(urlEqualTo("/"))
         .withHeader("Content-Type", equalTo("application/json"))
-        .withRequestBody(equalToJson(expectedJsonRequest.toString(), false, true)),
+        .withRequestBody(equalToJson(expectedJsonRequest.toString(), false, false)),
     )
   }
 

--- a/docker/config/coordinator/coordinator-config-v2.toml
+++ b/docker/config/coordinator/coordinator-config-v2.toml
@@ -83,7 +83,6 @@ fs-responses-directory = "/data/prover/v3/aggregation/responses"
 #fs-responses-directory = "/data/prover/v3/aggregation/responses"
 
 [traces]
-expected-traces-api-version = "beta-v5.0-rc3"
 [traces.counters]
 endpoints = ["http://l2-node-besu:8545/"]
 request-limit-per-endpoint = 1

--- a/docs/architecture-description.md
+++ b/docs/architecture-description.md
@@ -424,7 +424,6 @@ The endpoint exposed by the traces-API and used in the flow are:
 ```
 linea_getBlockTracesCountersV2(
   blockNumber                    string
-  expectedTracesEngineVersion    string
 ):
   tracesEngineVersion        string
   tracesCounters             map[string:string]
@@ -436,7 +435,6 @@ linea_getBlockTracesCountersV2(
 linea_generateConflatedTracesToFileV2(
   startBlockNumber              string
   endBlockNumber                string
-  expectedTracesEngineVersion   string
 ):
   tracesEngineVersion        string
   conflatedTracesFileName    string //$first-$last.conflated.v$version.lt

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -127,7 +127,7 @@ Conflation backtesting allows re-running the conflation and proof-request pipeli
 ### How It Works
 
 1. Submit one or more backtesting jobs via `conflation_createProverRequests`, each specifying a block range, blob compressor version, a **traces** RPC configuration (`tracesApi`, and optionally `tracesConflationApi`), and the Shomei (state manager) endpoint.
-2. Each job spins up an isolated `ConflationBacktestingApp` instance. Trace line counts always use `tracesApi`. If `tracesConflationApi` is **omitted**, the same `tracesApi` client is also used for conflated traces (`linea_generateConflatedTracesToFileV2`). If `tracesConflationApi` is **set** (split-traces deployment), counters stay on `tracesApi` and conflated traces use `tracesConflationApi`; both must declare the **same** `version` string. Blobs use the requested compressor version; prover request files are written under `conflation.backtesting-directory` — same file layout as the live pipeline.
+2. Each job spins up an isolated `ConflationBacktestingApp` instance. Trace line counts always use `tracesApi`. If `tracesConflationApi` is **omitted**, the same `tracesApi` client is also used for conflated traces (`linea_generateConflatedTracesToFileV2`). If `tracesConflationApi` is **set** (split-traces deployment), counters stay on `tracesApi` and conflated traces use `tracesConflationApi`. Blobs use the requested compressor version; prover request files are written under `conflation.backtesting-directory` — same file layout as the live pipeline.
 3. Poll job status via `conflation_getReconflationJobsStatus` (one or more job IDs per call) until each job reports `COMPLETED`.
 
 ### Prerequisites and validation
@@ -136,7 +136,6 @@ Conflation backtesting allows re-running the conflation and proof-request pipeli
 |------|-----------------------------------------------------------------|
 | `conflation.backtesting-directory` is set in coordinator config | Per-job output needs a parent directory on disk                 |
 | `blobCompressorVersion` is not `V2` | Compressor `V3` or above is required for backtesting            |
-| If `tracesConflationApi` is present, `tracesConflationApi.version` equals `tracesApi.version` | Split clients must target the same traces API protocol version  |
 | No URL overlap between `tracesApi` / `tracesConflationApi` (when set) and the coordinator’s live `[traces]` endpoints (`common`, `counters`, or `conflation`) | Keeps backtesting traffic off the main conflation pipeline URLs |
 
 These checks run when each job is submitted.
@@ -163,12 +162,10 @@ Submits one or more backtesting jobs. Each element in `params` is an independent
       "parentBlobShnarf": null,
       "tracesApi": {
         "endpoint": "http://<traces-counters-node>:8545",
-        "version": "v2",
         "requestLimitPerEndpoint": 1
       },
       "tracesConflationApi": {
         "endpoint": "http://<traces-conflation-node>:8545",
-        "version": "v2",
         "requestLimitPerEndpoint": 1
       },
       "shomeiApi": {
@@ -202,12 +199,10 @@ curl -X POST http://localhost:9546 \
         "parentBlobShnarf": null,
         "tracesApi": {
           "endpoint": "http://<traces-counters-node>:8545",
-          "version": "beta-v5.0-rc6",
           "requestLimitPerEndpoint": 1
         },
         "tracesConflationApi": {
           "endpoint": "http://<traces-conflation-node>:8546",
-          "version": "beta-v5.0-rc6",
           "requestLimitPerEndpoint": 1
         },
         "shomeiApi": {
@@ -298,11 +293,9 @@ Stops one in-progress backtesting job. `params` must be a JSON array containing 
 | `batchesFixedSize` | integer\|null | | Override batch size; `null` uses calculator-driven batching                                                                                   |
 | `parentBlobShnarf` | string\|null | | Hex-encoded parent shnarf to chain from; `null` starts fresh                                                                                  |
 | `tracesApi.endpoint` | string | ✓ | Traces API URL for `linea_getBlockTracesCountersV2`                                                                                           |
-| `tracesApi.version` | string | ✓ | Traces API version; when `tracesConflationApi` is set, must match its `version`                                                       |
 | `tracesApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to the counters traces client                                                                                         |
 | `tracesConflationApi` | object\|omitted | | Optional. If omitted, `tracesApi` is also used for `linea_generateConflatedTracesToFileV2`. If present, split-traces mode; nested fields apply. |
 | `tracesConflationApi.endpoint` | string | If split | Traces API URL for `linea_generateConflatedTracesToFileV2` (different base URL than `tracesApi` when using dedicated conflation nodes)        |
-| `tracesConflationApi.version` | string | If split | Must be identical to `tracesApi.version`                                                                                                      |
 | `tracesConflationApi.requestLimitPerEndpoint` | integer | If split | Max concurrent requests to the conflation traces client                                                                                       |
 | `shomeiApi.endpoint` | string | ✓ | State manager (Shomei) URL                                                                                                                    |
 | `shomeiApi.requestLimitPerEndpoint` | integer | ✓ | Max concurrent requests to Shomei                                                                                                             |

--- a/docs/features/tracer.md
+++ b/docs/features/tracer.md
@@ -45,8 +45,7 @@ Trace counts per module determine whether a batch can be proven within circuit c
 
 ```
 linea_getBlockTracesCountersV2(
-    blockNumber:                 string,
-    expectedTracesEngineVersion: string
+    blockNumber: string
 ) → {
     tracesEngineVersion: string,
     tracesCounters:      map[string, string]
@@ -55,9 +54,8 @@ linea_getBlockTracesCountersV2(
 
 ```
 linea_generateConflatedTracesToFileV2(
-    startBlockNumber:            string,
-    endBlockNumber:              string,
-    expectedTracesEngineVersion: string
+    startBlockNumber: string,
+    endBlockNumber:   string
 ) → {
     tracesEngineVersion:      string,
     conflatedTracesFileName:  string  // $first-$last.conflated.v$version.lt

--- a/e2e/src/shomei-get-proof.spec.ts
+++ b/e2e/src/shomei-get-proof.spec.ts
@@ -2,7 +2,7 @@ import { serialize } from "@consensys/linea-shared-utils";
 import { describe, it } from "@jest/globals";
 import { BaseError, ContractFunctionExecutionError, toHex } from "viem";
 
-import { awaitUntil, getDockerImageTag } from "./common/utils";
+import { awaitUntil } from "./common/utils";
 import { L2RpcEndpoint } from "./config/clients/l2-client";
 import { LineaGetProofReturnType } from "./config/clients/linea-rpc/linea-get-proof";
 import { createTestContext } from "./config/setup";
@@ -33,9 +33,6 @@ describe("Shomei Linea get proof test suite", () => {
   it.concurrent(
     "Call linea_getProof to Shomei frontend node and get a valid proof",
     async () => {
-      const shomeiImageTag = await getDockerImageTag("shomei-frontend", "consensys/linea-shomei");
-      logger.info(`shomeiImageTag=${shomeiImageTag}`);
-
       let targetL2BlockNumber = await awaitUntil(
         async () => {
           try {


### PR DESCRIPTION
This PR implements issue(s) #2443

### Summary

- Stops sending `expectedTracesEngineVersion` in Coordinator traces-api requests.
- Removes traces API version configuration from Coordinator config and backtesting DTOs, including `TracesToml`.
- Updates tests and docs to reflect the versionless traces-api request payloads.
- Includes the `e2e/src/shomei-get-proof.spec.ts` cleanup requested for this branch.

### Validation

- `./gradlew :coordinator:clients:traces-generator-api-client:test :coordinator:app:test`
- `./gradlew spotlessCheck`
- `git diff --check`

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the JSON-RPC payloads sent to the traces generator and removes related config fields, which can break compatibility if any deployed traces endpoint still expects `expectedTracesEngineVersion` or versioned config inputs.
> 
> **Overview**
> Removes the `expectedTracesEngineVersion` parameter from all coordinator traces JSON-RPC requests (`linea_getBlockTracesCountersV2` / `linea_generateConflatedTracesToFileV2`) and drops traces API version fields from config/DTOs and backtesting validation.
> 
> Updates the traces client to build versionless requests and to use a constant `"fallback"` engine version in fallback responses, then adjusts unit tests, sample `coordinator-config-v2.toml`, and docs to match the new request shapes. Also includes a small E2E cleanup removing unused Shomei docker image tag logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8a2286ab2b6b62e2b00a8a2799ca83ea33812c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->