### PR TITLE
chore(misc): update shomei docker image on local stack

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -431,7 +431,7 @@ services:
       - l1network
 
   shomei:
-    image: consensys/linea-shomei:${LINEA_SHOMEI_TAG:-3.2.3}
+    image: consensys/linea-shomei:${LINEA_SHOMEI_TAG:-3.2.4}
     hostname: shomei
     container_name: shomei
     profiles: [ "l2", "l2-bc", "external-to-monorepo" ]
@@ -466,7 +466,7 @@ services:
   #      - ../tmp/local/shomei:/data/shomei/:z
 
   shomei-frontend:
-    image: consensys/linea-shomei:${LINEA_SHOMEI_TAG:-3.2.3}
+    image: consensys/linea-shomei:${LINEA_SHOMEI_TAG:-3.2.4}
     hostname: shomei-frontend
     container_name: shomei-frontend
     profiles: [ "l2", "l2-bc", "external-to-monorepo" ]
@@ -658,7 +658,7 @@ services:
       - ../linea-besu/plugins/state-recovery/besu-plugin/build/libs/linea-staterecovery-besu-plugin-SNAPSHOT.jar:/opt/besu/plugins/linea-staterecovery-besu-plugin-SNAPSHOT.jar
 
   shomei-sr:
-    image: consensys/linea-shomei:${LINEA_SHOMEI_TAG:-3.2.3}
+    image: consensys/linea-shomei:${LINEA_SHOMEI_TAG:-3.2.4}
     hostname: shomei-sr
     container_name: shomei-sr
     profiles: [ "staterecovery", "external-to-monorepo" ]


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `consensys/linea-shomei` Docker image tag used by the local docker-compose stack; behavior changes, if any, come solely from the new upstream image version.
> 
> **Overview**
> Updates the local L2 docker-compose stack to use `consensys/linea-shomei` **v3.2.4** (from **v3.2.3**) for the `shomei`, `shomei-frontend`, and `shomei-sr` services.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd785c6b41a6ebb32ec30d5e37bfd15247c43f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->