### PR TITLE
fix(prover): remove global overwrite in FullZKEVMWithSuite 

### DIFF
--- a/prover/zkevm/full.go
+++ b/prover/zkevm/full.go
@@ -414,6 +414,5 @@ func FullZKEVMWithSuite(
 	}
 
 	// Initialize the Full zkEVM arithmetization
-	fullZkEvm = NewZkEVM(settings)
-	return fullZkEvm
+	return NewZkEVM(settings)
 }

--- a/prover/zkevm/zkevm_test.go
+++ b/prover/zkevm/zkevm_test.go
@@ -18,3 +18,23 @@ func TestCanGenerateFullZkEVM(t *testing.T) {
 
 	_ = FullZkEvm(&cfg.TracesLimits, cfg)
 }
+
+// FullZKEVMWithSuite must not overwrite memoized globals.
+func TestFullZKEVMWithSuiteNoGlobalOverwrite(t *testing.T) {
+	cfg, err := config.NewConfigFromFileUnchecked("../config/config-mainnet-limitless.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sentinel := &ZkEvm{}
+	original := fullZkEvm
+	fullZkEvm = sentinel
+
+	_ = FullZKEVMWithSuite(&cfg.TracesLimits, cfg, dummyCompilationSuite, nil)
+
+	if fullZkEvm != sentinel {
+		t.Fatal("FullZKEVMWithSuite overwrote the fullZkEvm global")
+	}
+
+	fullZkEvm = original
+}


### PR DESCRIPTION
# Problem

FullZKEVMWithSuite() is a utility function that creates a new *ZkEvm with a given compilation suite. However, it assigns its result to the package-level global fullZkEvm before returning (fullZkEvm = NewZkEVM(settings)). This silently overwrites the cached instance that FullZkEvm() guards with sync.Once.

During make setup (all circuits), execution-limitless calls NewLimitlessZkEVM() → FullZKEVMWithSuite(..., nil), which creates a ZkEvm with RecursionCompiledIOP = nil (because PostRecursionCompilationSuite is nil) and overwrites the global. When invalidity-precompile-logs runs next, FullZkEvm() returns the corrupted instance (the sync.Once already fired), and BadPrecompileCircuit.Allocate() panics on config.ZkEvmComp.NumRounds().

# Error
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x19fbc1c]

goroutine 1 [running]:
github.com/consensys/linea-monorepo/prover/protocol/wizard.(*CompiledIOP).NumRounds(...)
        prover/protocol/wizard/compiled.go:142
github.com/consensys/linea-monorepo/prover/circuits/invalidity.(*BadPrecompileCircuit).Allocate(...)
        prover/circuits/invalidity/bad_precompile.go:68
```

# Fix

Changed FullZKEVMWithSuite() to return a local value (return NewZkEVM(settings)) instead of writing to the global. Only the sync.Once closures in FullZkEvm(), FullZkEvmLarge(), and FullZkEVMCheckOnly() should write to their respective globals.

# Why this wasn't caught before

The bug existed since FullZKEVMWithSuite was extracted into its own function — the global assignment came along as a copy-paste artifact. It was hidden because nothing reused FullZkEvm() during setup until the invalidity circuits were added. The invalidity-precompile circuits are the first to call FullZkEvm() after the corrupted write, which exposed the nil pointer.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches zkEVM construction/memoization logic used across prover setups; a mistake here could change which compiled instance is reused and lead to hard-to-debug runtime panics. Change is small and covered by a targeted regression test.
> 
> **Overview**
> Stops `FullZKEVMWithSuite` from overwriting the package-level `fullZkEvm` cache by returning `NewZkEVM(settings)` directly instead of assigning to the global.
> 
> Adds a regression test (`TestFullZKEVMWithSuiteNoGlobalOverwrite`) to ensure calling `FullZKEVMWithSuite` does not mutate the memoized `fullZkEvm` instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783eb17e587f5af913a6cd3ad08676656fd11db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->