### PR TITLE
fix(ci): unblock subsequent workflow when merge PR into main and upda…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,6 @@ jobs:
     secrets: inherit
 
   filter-commit-changes:
-    needs: [lint-latest-commit-messages]
-    if: always()
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Filter commit changes
     outputs:

--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -307,7 +307,7 @@ services:
   coordinator:
     hostname: coordinator
     container_name: coordinator
-    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-91e155a}
+    image: consensys/linea-coordinator:${LINEA_COORDINATOR_TAG:-189076b}
     profiles: [ "l2", "debug" ]
     depends_on:
       l2-genesis-initialization:
@@ -357,7 +357,7 @@ services:
             config/coordinator-config.toml
         fi
     volumes:
-      - ./config/l2-genesis-initialization/coordinator-config-v2-hardforks.toml:/opt/consensys/linea/coordinator/config/coordinator-config.toml:ro
+      - ./config/coordinator/coordinator-config-v2.toml:/opt/consensys/linea/coordinator/config/coordinator-config.toml:ro
       - ./config/common/traces-limits-v5.toml:/opt/consensys/linea/coordinator/config/traces-limits-v5.toml:ro
       - ./config/common/smart-contract-errors.toml:/opt/consensys/linea/coordinator/config/smart-contract-errors.toml:ro
       - ./config/common/gas-price-cap-time-of-day-multipliers.toml:/opt/consensys/linea/coordinator/config/gas-price-cap-time-of-day-multipliers.toml:ro

--- a/docker/config/l2-genesis-initialization/init.sh
+++ b/docker/config/l2-genesis-initialization/init.sh
@@ -4,7 +4,6 @@ date
 cd initialization || exit
 cp -T "genesis-maru.json.template" "genesis-maru.json"
 cp -T "genesis-besu.json.template" "genesis-besu.json"
-cp -T "/coordinator/coordinator-config-v2.toml" "coordinator-config-v2-hardforks.toml"
 
 fork_timestamp=$(($(date +%s) + 60))
 echo "Fork Timestamp: $fork_timestamp"
@@ -13,4 +12,5 @@ sed -i "s/%FORK_TIME%/$fork_timestamp/g" genesis-besu.json
 
 echo $fork_timestamp > /initialization/fork-timestamp.txt
 # Right now only Osaka is supported by the tracer, so no need to override forks
+#cp -T "/coordinator/coordinator-config-v2.toml" "coordinator-config-v2-hardforks.toml"
 #sed -i'' "s/^\(timestamp-based-hard-forks[ ]*=[ ]*\).*/\1[${fork_timestamp}]/" coordinator-config-v2-hardforks.toml


### PR DESCRIPTION
…te coordinator tag and remove the use of coordinator hardforks.toml config

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts GitHub Actions job dependencies and coordinator runtime configuration, which could change when downstream jobs run and how local L2 dev deployments boot.
> 
> **Overview**
> **CI:** Updates `.github/workflows/main.yml` so `filter-commit-changes` no longer depends on `lint-latest-commit-messages`, preventing later jobs from being blocked by that step.
> 
> **Local dev/docker:** Bumps the `linea-coordinator` image tag in `docker/compose-spec-l2-services.yml` and switches the coordinator to mount the standard `coordinator-config-v2.toml` instead of the generated `coordinator-config-v2-hardforks.toml`. The genesis init script stops generating the hardforks config (copy/override lines are now commented out).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5ec21f2b83900495919446f52aad3323688e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->