### PR TITLE
fix(ci): provide correct path to rlp_blocks.bin

### DIFF
--- a/prover/lib/compressor/blob/internal/rlpblocks/rlpblocks.go
+++ b/prover/lib/compressor/blob/internal/rlpblocks/rlpblocks.go
@@ -22,7 +22,7 @@ var Get = sync.OnceValue(func() [][]byte {
 		panic(err)
 	}
 
-	rlpBlocksBinPath := filepath.Join(rootPath, "coordinator/core/src/test/resources/net/consensys/zkevm/coordination/blob/rlp_blocks.bin")
+	rlpBlocksBinPath := filepath.Join(rootPath, "coordinator/core/src/test/resources/linea/coordination/blob/rlp_blocks.bin")
 
 	// Try to read execution response data and generate blocks
 	var blocks [][]byte


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line path correction for a test resource file, affecting only where `rlp_blocks.bin` is read/written for JVM tests.
> 
> **Overview**
> Updates `rlpblocks.Get` to look for/write `rlp_blocks.bin` under the `coordinator` test resources at `.../src/test/resources/linea/coordination/blob/` instead of the old `net/consensys/zkevm/...` path, fixing CI/test failures due to an incorrect resource location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6b3e8bf295e5d889083abd6a974c358982ae773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->