### PR TITLE
fix(prover): update rlp_blocks.bin path in shnarf_calculator tests

### DIFF
--- a/prover/lib/shnarf_calculator/shnarf_calculator_test.go
+++ b/prover/lib/shnarf_calculator/shnarf_calculator_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	blockRlpBin       = "../../../jvm-libs/blob-compressor/src/test/resources/net/consensys/linea/nativecompressor/rlp_blocks.bin"
+	blockRlpBin       = "../../../coordinator/core/src/test/resources/linea/coordination/blob/rlp_blocks.bin"
 	compressorDictBin = "../compressor/compressor_dict.bin"
 )
 


### PR DESCRIPTION
The test data file moved from jvm-libs/blob-compressor/ to coordinator/core/src/test/resources/.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a test fixture file path to match a repository move; no production logic changes.
> 
> **Overview**
> Updates `shnarf_calculator_test.go` to load `rlp_blocks.bin` from its new location under `coordinator/core/src/test/resources/...` instead of the old `jvm-libs/blob-compressor/...` path, keeping the shnarf calculator tests working after the fixture move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3a42f75990c3208651f5ab3f1883c2201faf0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->