### PR TITLE
feat: build risc.bin from arithmetisation

### DIFF
--- a/arithmetization/Makefile
+++ b/arithmetization/Makefile
@@ -14,10 +14,12 @@ GO_CORSET_REPO ?= https://github.com/consensys/go-corset.git
 GO_CORSET_REF_FOR_ZKC ?=
 
 # Used to install go-corset
-GO_CORSET_VERSION ?= v1.2.15
+GO_CORSET_VERSION ?= v1.2.17
 
 ZKC_FILES := $(shell find $(MAKEFILE_DIR)src/main/riscv/* -name "*.zkc")
 ZKC_MAIN := $(MAKEFILE_DIR)src/main/riscv/main.zkc
+ZKC_BINDIR := $(MAKEFILE_DIR)bin
+ZKC_BINARY := riscv.bin
 
 .PHONY: checkout-go-corset install-go-corset install-zkc zkc-compile check
 
@@ -41,7 +43,8 @@ install-zkc: checkout-go-corset
 
 # Compile the main RISC-V ZKC program.
 zkc-compile: $(ZKC_FILES)
-	zkc compile --wir $(ZKC_MAIN) >/dev/null
+	mkdir -p $(ZKC_BINDIR)
+	zkc compile -o $(ZKC_BINDIR)/$(ZKC_BINARY) --wir $(ZKC_MAIN)
 
 zkc-lint:
 	zkc format --check $(ZKC_FILES)


### PR DESCRIPTION
This updates the arithmetisation/Makefile to produce a binary constraint file for the build target "zkc-compile".  The constraint file can be used, for example, to check inputs.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile-only change that adjusts build outputs and bumps a toolchain version; primary risk is CI/build breakage if downstream expects the previous `zkc compile` behavior.
> 
> **Overview**
> `zkc-compile` now creates `arithmetization/bin` and writes a named output artifact (`riscv.bin`) instead of compiling with no output file.
> 
> Also bumps the pinned `go-corset` version from `v1.2.15` to `v1.2.17`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbbff45f171dc0ea60726bcfd0cdd8a98a3b92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->