### PR TITLE
chore: update to latest gnark and gnark-crypto

### DIFF
--- a/prover/go.mod
+++ b/prover/go.mod
@@ -5,8 +5,8 @@ go 1.25.7
 require (
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/consensys/compress v0.3.0
-	github.com/consensys/gnark v0.14.1-0.20260511210335-f4e549a26ef3
-	github.com/consensys/gnark-crypto v0.20.2-0.20260402204920-39238e584b99
+	github.com/consensys/gnark v0.15.1-0.20260515142004-ae23035f9957
+	github.com/consensys/gnark-crypto v0.20.2-0.20260518142632-dffbd6f30adb
 	github.com/consensys/go-corset v1.2.10
 	github.com/crate-crypto/go-kzg-4844 v1.1.0
 	github.com/dlclark/regexp2 v1.11.2

--- a/prover/go.sum
+++ b/prover/go.sum
@@ -75,10 +75,10 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/consensys/compress v0.3.0 h1:HRIcHvWkW9C9req0ZWg7mhYHzBarohXhcszIwHONVkM=
 github.com/consensys/compress v0.3.0/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark v0.14.1-0.20260511210335-f4e549a26ef3 h1:z9iMO0WPlstMefH1wI1w+9sMc6AFqvOiLuukk/UgSQg=
-github.com/consensys/gnark v0.14.1-0.20260511210335-f4e549a26ef3/go.mod h1:RIWXG9Gl+Ls2enSayeA/NdcM/FI3OOf6AqNdI2Jv8QU=
-github.com/consensys/gnark-crypto v0.20.2-0.20260402204920-39238e584b99 h1:FREtFb4IoZWOj6MexddSuReVU7ViMChjuspD7SO8dGY=
-github.com/consensys/gnark-crypto v0.20.2-0.20260402204920-39238e584b99/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
+github.com/consensys/gnark v0.15.1-0.20260515142004-ae23035f9957 h1:4/+bXhNAly5nBf/kfCp2OXWnin/qh3rOrbCjIFiMjYE=
+github.com/consensys/gnark v0.15.1-0.20260515142004-ae23035f9957/go.mod h1:RIWXG9Gl+Ls2enSayeA/NdcM/FI3OOf6AqNdI2Jv8QU=
+github.com/consensys/gnark-crypto v0.20.2-0.20260518142632-dffbd6f30adb h1:62p/9G5DyYLN5gF1QnyGFV4p2md/zTTthyN01jgMSQo=
+github.com/consensys/gnark-crypto v0.20.2-0.20260518142632-dffbd6f30adb/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
 github.com/consensys/go-corset v1.2.10 h1:uKUICiHmERuMWzDRiRJr285fV2WncNGiCENSdNcQodY=
 github.com/consensys/go-corset v1.2.10/go.mod h1:QKFoNJZHdCrDslg9XFjk+GoFMgrhKSVdBNnx4hq7WJA=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=


### PR DESCRIPTION
Updates gnark and gnark-crypto. Fixes https://github.com/Consensys/linea-monorepo/pull/3130 . 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core ZK proving dependencies (`gnark`/`gnark-crypto`), which can affect circuit compilation/proving behavior and performance even though no application code changes are included.
> 
> **Overview**
> Updates the prover module’s cryptography stack by bumping `github.com/consensys/gnark` to `v0.15.1-...` and `github.com/consensys/gnark-crypto` to `v0.20.2-...`, with corresponding `go.sum` hash updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa365c549f82f57da021b5afe453593c439f5cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->