### PR TITLE
fix(prover): populate CongloVK and VKMerkleRoot in invalidity limitle…

### DIFF
--- a/prover/circuits/invalidity/invalidity.go
+++ b/prover/circuits/invalidity/invalidity.go
@@ -12,6 +12,8 @@ import (
 	emPlonk "github.com/consensys/gnark/std/recursion/plonk"
 	"github.com/consensys/linea-monorepo/prover/circuits"
 	wizardk "github.com/consensys/linea-monorepo/prover/circuits/pi-interconnection/keccak/prover/protocol/wizard"
+	"github.com/consensys/linea-monorepo/prover/maths/field"
+	"github.com/consensys/linea-monorepo/prover/protocol/distributed"
 	wizard "github.com/consensys/linea-monorepo/prover/protocol/wizard"
 	public_input "github.com/consensys/linea-monorepo/prover/public-input"
 	"github.com/ethereum/go-ethereum/common"
@@ -226,17 +228,25 @@ func (b *builder) Compile() (constraint.ConstraintSystem, error) {
 }
 
 type limitlessBuilder struct {
-	congWIOP *wizard.CompiledIOP
+	congWIOP     *wizard.CompiledIOP
+	vkMerkleRoot field.Octuplet
 }
 
-func NewBuilderLimitless(congWIOP *wizard.CompiledIOP) *limitlessBuilder {
-	return &limitlessBuilder{congWIOP: congWIOP}
+func NewBuilderLimitless(congWIOP *wizard.CompiledIOP, vkMerkleRoot field.Octuplet) *limitlessBuilder {
+	return &limitlessBuilder{congWIOP: congWIOP, vkMerkleRoot: vkMerkleRoot}
 }
 
 func (b *limitlessBuilder) Compile() (constraint.ConstraintSystem, error) {
+	vk0 := b.congWIOP.ExtraData[distributed.VerifyingKeyPublicInput].(field.Octuplet)
+	vk1 := b.congWIOP.ExtraData[distributed.VerifyingKey2PublicInput].(field.Octuplet)
+
 	circuit := &CircuitInvalidity{
 		SubCircuit: &BadPrecompileCircuit{
-			ExecutionCtx: ExecutionCtx{LimitlessMode: true},
+			ExecutionCtx: ExecutionCtx{
+				LimitlessMode: true,
+				CongloVK:      [2]field.Octuplet{vk0, vk1},
+				VKMerkleRoot:  b.vkMerkleRoot,
+			},
 		},
 	}
 	circuit.Allocate(Config{ZkEvmComp: b.congWIOP})

--- a/prover/cmd/prover/cmd/setup.go
+++ b/prover/cmd/prover/cmd/setup.go
@@ -372,7 +372,12 @@ func createCircuitBuilder(c circuits.CircuitID, cfg *config.Config, args SetupAr
 			// buf is intentionally not released: zero-copy deserialization means conglo
 			// points into the mmap region, which must stay mapped until Compile() finishes.
 			// For a one-shot setup process this is safe — the OS reclaims it at exit.
-			return invalidity.NewBuilderLimitless(conglo.RecursionCompBLS), extraFlags, nil
+			vkTree, err := zkevm.LoadVerificationKeyMerkleTree(cfg)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to load VK merkle tree for invalidity limitless: %w", err)
+			}
+			vkMerkleRoot := vkTree.GetRoot()
+			return invalidity.NewBuilderLimitless(conglo.RecursionCompBLS, vkMerkleRoot), extraFlags, nil
 		}
 
 		logrus.Info("execution-limitless assets not found; generating them now for invalidity limitless setup")
@@ -383,10 +388,11 @@ func createCircuitBuilder(c circuits.CircuitID, cfg *config.Config, args SetupAr
 			return nil, nil, fmt.Errorf("failed to write limitless invalidity prover assets: %w", err)
 		}
 		compCong := asset.DistWizard.CompiledConglomeration
+		vkMerkleRoot := asset.DistWizard.VerificationKeyMerkleTree.GetRoot()
 		asset = nil
 		runtime.GC()
 
-		return invalidity.NewBuilderLimitless(compCong.RecursionCompBLS), extraFlags, nil
+		return invalidity.NewBuilderLimitless(compCong.RecursionCompBLS, vkMerkleRoot), extraFlags, nil
 	case circuits.InvalidityFilteredAddressCircuitID:
 		keccakComp := invalidity.MakeKeccakCompiledIOP(cfg.Invalidity.MaxRlpByteSize, keccak.WizardCompilationParameters()...)
 		return invalidity.NewBuilder(


### PR DESCRIPTION


The limitless invalidity builder was not extracting verification key data from congWIOP.ExtraData, leaving CongloVK and VKMerkleRoot as zero-valued constants in the compiled constraint system. At prove time, the actual VK values from the conglomeration proof failed the assertIsEqual check against these zero constants.

Extract VK octuplets from ExtraData (matching the execution limitless builder pattern) and pass vkMerkleRoot through from setup.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proof-critical wiring for the limitless invalidity circuit by changing how verifying-key data is injected into the compiled constraint system; a mismatch can break proving/verification but the change is small and localized.
> 
> **Overview**
> Fixes the *limitless invalidity* circuit compilation to embed the correct verifying-key inputs instead of zero-valued constants.
> 
> `invalidity.NewBuilderLimitless` now accepts and threads a `vkMerkleRoot`, and `Compile()` extracts the two conglomeration VK octuplets from `congWIOP.ExtraData` (via `distributed` keys) to populate `ExecutionCtx.CongloVK` and `ExecutionCtx.VKMerkleRoot`. The setup command is updated to load (or derive) the VK Merkle root from execution-limitless assets and pass it into the invalidity limitless builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82765cba99d9a6948d657b0416555db8749a3727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->