### PR TITLE
chores(verifier-ray): run go mod in verifier ray

### DIFF
--- a/verifier-ray/codegen/go.mod
+++ b/verifier-ray/codegen/go.mod
@@ -1,4 +1,3 @@
 module github.com/consensys/linea-monorepo/verifier-ray/codegen
 
 go 1.25.7
-

--- a/verifier-ray/testdata/generate/go.mod
+++ b/verifier-ray/testdata/generate/go.mod
@@ -2,7 +2,7 @@ module github.com/consensys/linea-monorepo/verifier-ray/testdata/generate
 
 go 1.25.7
 
-require github.com/consensys/linea-monorepo/prover-ray v0.0.0
+require github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260518154448-1f6880839cd2
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
@@ -21,5 +21,3 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 )
-
-replace github.com/consensys/linea-monorepo/prover-ray => ../../../prover-ray

--- a/verifier-ray/testdata/generate/go.mod
+++ b/verifier-ray/testdata/generate/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 // indirect
-	github.com/consensys/gnark-crypto v0.20.1 // indirect
+	github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/verifier-ray/testdata/generate/go.sum
+++ b/verifier-ray/testdata/generate/go.sum
@@ -6,6 +6,8 @@ github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
 github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08 h1:EdljQKaHxACX5JMSTXlVM9R8qASU/W1husqDsB2b5tU=
 github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
+github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260518154448-1f6880839cd2 h1:Ggp+FPN2SmxdPC1k77w9YCNef4RUOL9C4algaGIUuWk=
+github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260518154448-1f6880839cd2/go.mod h1:HZncWpppP5LS0qB3moZR1ESi/vIbCEnkG1w65TsAojU=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/verifier-ray/testdata/generate/go.sum
+++ b/verifier-ray/testdata/generate/go.sum
@@ -4,8 +4,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/hcuOBxza6CAA+233tB0eFiunGVEMyv4=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
-github.com/consensys/gnark-crypto v0.20.1 h1:PXDUBvk8AzhvWowHLWBEAfUQcV1/aZgWIqD6eMpXmDg=
-github.com/consensys/gnark-crypto v0.20.1/go.mod h1:RBWrSgy+IDbGR69RRV313th3M/aZU1ubk2om+qHuTSc=
+github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08 h1:EdljQKaHxACX5JMSTXlVM9R8qASU/W1husqDsB2b5tU=
+github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=


### PR DESCRIPTION
Runs go mod on the new verifier-ray folder

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency housekeeping: updates `go.mod`/`go.sum` entries and removes a local `replace`, which could affect builds only if the pinned module versions are incompatible.
> 
> **Overview**
> Normalizes Go module files under `verifier-ray`.
> 
> `verifier-ray/testdata/generate` now pins `prover-ray` to a specific pseudo-version (removing the local `replace`), and bumps `gnark-crypto` to a newer pseudo-version with corresponding `go.sum` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b102dd156184825214fc3cb6d362b408691adff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->