### PR TITLE
fix(maru): address PR 3126 workflow follow-ups

### DIFF
--- a/.github/workflows/maru-chaos-testing.yml
+++ b/.github/workflows/maru-chaos-testing.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Install helm
-        uses: azure/setup-helm@v4.3.1
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'v3.18.3'
         id: install
@@ -78,7 +78,7 @@ jobs:
       # SSH debugging session - before tests (if explicitly requested)
       - name: Setup upterm session (pre-test)
         if: ${{ inputs.enable_ssh_debug }}
-        uses: lhotari/action-upterm@v1
+        uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
         with:
           ## If no one connects shut down ssh server after timeout.
           wait-timeout-minutes: 20
@@ -148,7 +148,7 @@ jobs:
       # SSH debugging session - on failure (if requested)
       - name: Setup upterm session after failure
         if: ${{ (failure() || steps.chaos-tests.outcome == 'failure') && inputs.ssh_debug_on_failure == true }}
-        uses: lhotari/action-upterm@v1
+        uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
         with:
           ## If no one connects shut down ssh server after timeout.
           wait-timeout-minutes: 20

--- a/.github/workflows/maru-e2e-tests.yml
+++ b/.github/workflows/maru-e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Setup upterm session
         if: ${{ inputs.e2e-tests-with-ssh }}
-        uses: lhotari/action-upterm@v1
+        uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
       - name: Checkout
         uses: actions/checkout@v6
       - name: Login to Docker Hub

--- a/.github/workflows/maru-release.yml
+++ b/.github/workflows/maru-release.yml
@@ -116,7 +116,7 @@ jobs:
           cat maru/CHANGELOG.md >> release-body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
           tag_name: ${{ needs.compute-version.outputs.tag_name }}

--- a/.github/workflows/maru-testing.yml
+++ b/.github/workflows/maru-testing.yml
@@ -42,24 +42,22 @@ jobs:
         uses: ./.github/actions/setup-java-and-gradle
       - name: Build maru and run unit + integration tests
         run: |
-          # force tests to run even if the code is not changed
-          # this is to debug flaky tests
           # :maru:build is an aggregate task defined in maru/build.gradle that
           # depends on each :maru:* subproject's `build`. We avoid `buildNeeded`
           # because :maru:core's testFixtures depend on :maru:serialization
           # which depends on :maru:core's main jar -- linear under `build` but a
           # cycle under `buildNeeded` (which walks testFixtures).
-          ./gradlew -V :maru:build --rerun-tasks
+          ./gradlew -V :maru:build
       - name: Store reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test reports
           path: |
             maru/**/build/reports/tests/
       - name: Upload Jacoco execution data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jacoco-maru-exec
           path: |
@@ -67,6 +65,6 @@ jobs:
           if-no-files-found: ignore
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/maru/app/src/main/kotlin/maru/app/ConsensusMetrics.kt
+++ b/maru/app/src/main/kotlin/maru/app/ConsensusMetrics.kt
@@ -67,11 +67,6 @@ class ConsensusMetrics(
     description = description,
     tags = listOf(Tag("role", role)),
     publishPercentileHistogram = true,
-    // NOTE: zkevm's createHistogram in :jvm-libs:linea:core:metrics does not yet expose
-    // a `percentileBuckets` parameter (was added in newer maru-side metrics versions).
-    // Dropping the customized buckets — the publishPercentileHistogram flag still emits
-    // a percentile histogram with default buckets. Re-add `percentileBuckets` here once
-    // the zkevm metrics interface gains the parameter.
   )
 
   // Total consensus latency: timer-fire to block committed (ms).


### PR DESCRIPTION
#2540 

## Summary

Follow-up cleanup from #3126 for items 1, 3, 7, and 9:

- Pin Maru workflow third-party actions to immutable SHAs.
- Remove `--rerun-tasks` from `maru-testing.yml` and drop the flaky-debug comment.
- Remove the stale `percentileBuckets` comment from `ConsensusMetrics`.
- Pin Socket-reported and adjacent imported Maru workflow actions.

## Validation

- `git diff --check`
- `./gradlew :maru:app:compileKotlin`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to CI workflow hygiene (pinning third-party actions) and minor test job behavior changes (removing `--rerun-tasks`), without impacting runtime or protocol logic.
> 
> **Overview**
> **CI hardening:** Pins several third-party actions in Maru workflows to immutable SHAs (e.g., `azure/setup-helm`, `lhotari/action-upterm`, `softprops/action-gh-release`, `codecov/test-results-action`, and `actions/upload-artifact`) to satisfy supply-chain/security guidance.
> 
> **Workflow behavior tweaks:** Removes `--rerun-tasks` (and the related flaky-test debug comment) from `maru-testing.yml`, and does small YAML hygiene fixes (newline/whitespace).
> 
> **Cleanup:** Deletes a stale comment in `ConsensusMetrics.kt` about unsupported `percentileBuckets` in the histogram API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70b551693f9c1d63212e501e8b141304c2d4cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->