### PR TITLE
fix(coordinator): export FTX number metrics

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
@@ -168,6 +168,7 @@ class ConflationApp(
         accountProofClient = zkStateClient,
         tracesClient = tracesClients.tracesConflationClient,
         clock = this.clock,
+        metricsFacade = metricsFacade,
       )
     }
   }

--- a/coordinator/ethereum/forced-transactions/build.gradle
+++ b/coordinator/ethereum/forced-transactions/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
 
   testImplementation project(":jvm-libs:generic:logging")
+  testImplementation project(":jvm-libs:linea:metrics:micrometer")
   testImplementation project(":coordinator:ethereum:test-utils")
   testImplementation testFixtures(project(":coordinator:core"))
   testImplementation testFixtures(project(":jvm-libs:generic:extensions:kotlin"))

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsApp.kt
@@ -28,6 +28,7 @@ import linea.ftx.conflation.ForcedTransactionsSafeBlockNumberManager
 import linea.ftx.conflation.FtxConflationInfo
 import linea.ftx.conflation.InvalidityProofAssembler
 import linea.persistence.ForcedTransactionsDao
+import net.consensys.linea.metrics.MetricsFacade
 import org.apache.logging.log4j.LogManager
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.Queue
@@ -77,6 +78,7 @@ interface ForcedTransactionsApp : LongRunningService {
       accountProofClient: StateManagerAccountProofClient,
       tracesClient: TracesConflationVirtualBlockClientV1,
       clock: Clock,
+      metricsFacade: MetricsFacade,
     ): ForcedTransactionsApp = ForcedTransactionsAppImpl(
       config = config,
       vertx = vertx,
@@ -91,6 +93,7 @@ interface ForcedTransactionsApp : LongRunningService {
       accountProofClient = accountProofClient,
       tracesClient = tracesClient,
       clock = clock,
+      metricsFacade = metricsFacade,
     )
   }
 }
@@ -119,6 +122,7 @@ internal class ForcedTransactionsAppImpl(
   private val accountProofClient: StateManagerAccountProofClient,
   private val tracesClient: TracesConflationVirtualBlockClientV1,
   private val clock: Clock,
+  private val metricsFacade: MetricsFacade,
   safeBlockNumberProvider: ForcedTransactionConflationSafeBlockNumberProvider =
     ForcedTransactionConflationSafeBlockNumberProvider(),
 ) : ForcedTransactionsApp {
@@ -184,6 +188,11 @@ internal class ForcedTransactionsAppImpl(
       }
       .thenCompose { ftxResumePointProvider.getLastProcessedForcedTransaction() }
       .thenCompose { (lastProcessedForcedTransactionNumber, ftxRecord) ->
+        val metrics = ForcedTransactionsMetricsRecorder(
+          metricsFacade = metricsFacade,
+          initialLatestForcedTransactionNumber = lastProcessedForcedTransactionNumber,
+        )
+
         // check the database for the highest simulatedExecutionBlockNumber of in-flight forced transactions (if any)
         // otherwise, lock safe block number to 0 until we fetch all events from L1 and determine the correct safe block number to conflate to
         if (ftxRecord != null) {
@@ -227,6 +236,7 @@ internal class ForcedTransactionsAppImpl(
           l1EarliestBlock = BlockParameter.Tag.EARLIEST,
           l1HighestBlock = config.l1HighestBlockTag,
           ftxQueue = ftxQueue,
+          metrics = metrics,
         )
 
         rehydrateConflationQueueFromDao().thenCompose {

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsL1EventsFetcher.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsL1EventsFetcher.kt
@@ -33,6 +33,7 @@ internal class ForcedTransactionsL1EventsFetcher(
   private val l1EarliestBlock: BlockParameter = BlockParameter.Tag.EARLIEST,
   private val l1HighestBlock: BlockParameter = BlockParameter.Tag.FINALIZED,
   private val ftxQueue: Queue<ForcedTransactionWithTimestamp>,
+  private val metrics: ForcedTransactionsMetrics = NoOpForcedTransactionsMetrics,
   private val log: Logger = LogManager.getLogger(ForcedTransactionsL1EventsFetcher::class.java),
 ) : LongRunningService {
   private lateinit var eventsSubscription: EthLogsFilterSubscriptionManager
@@ -150,6 +151,7 @@ internal class ForcedTransactionsL1EventsFetcher(
           l1BlockTimestamp = l1BlockTimestamp,
         )
         ftxQueue.add(ftxWithTimestamp)
+        metrics.recordAcceptedEvent(event.event.forcedTransactionNumber)
       }
         .onFailure {
           log.warn("failed to add event to queue, it will retry on next tick: errorMessage={}", it.message)

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsMetrics.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsMetrics.kt
@@ -1,0 +1,40 @@
+package linea.ftx
+
+import linea.metrics.LineaMetricsCategory
+import net.consensys.linea.metrics.Counter
+import net.consensys.linea.metrics.MetricsFacade
+import java.util.concurrent.atomic.AtomicLong
+
+internal interface ForcedTransactionsMetrics {
+  fun recordAcceptedEvent(forcedTransactionNumber: ULong)
+}
+
+internal class ForcedTransactionsMetricsRecorder(
+  metricsFacade: MetricsFacade,
+  initialLatestForcedTransactionNumber: ULong,
+) : ForcedTransactionsMetrics {
+  private val latestForcedTransactionNumber = AtomicLong(initialLatestForcedTransactionNumber.toLong())
+  private val acceptedEventsCounter: Counter = metricsFacade.createCounter(
+    category = LineaMetricsCategory.FORCED_TRANSACTION,
+    name = "events.accepted",
+    description = "Number of ForcedTransactionAdded L1 events accepted by the coordinator",
+  )
+
+  init {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.FORCED_TRANSACTION,
+      name = "latest.number",
+      description = "Latest ForcedTransactionAdded forced transaction number observed by the coordinator",
+      measurementSupplier = { latestForcedTransactionNumber.get() },
+    )
+  }
+
+  override fun recordAcceptedEvent(forcedTransactionNumber: ULong) {
+    latestForcedTransactionNumber.set(forcedTransactionNumber.toLong())
+    acceptedEventsCounter.increment()
+  }
+}
+
+internal object NoOpForcedTransactionsMetrics : ForcedTransactionsMetrics {
+  override fun recordAcceptedEvent(forcedTransactionNumber: ULong) {}
+}

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsMetrics.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsMetrics.kt
@@ -16,14 +16,14 @@ internal class ForcedTransactionsMetricsRecorder(
   private val latestForcedTransactionNumber = AtomicLong(initialLatestForcedTransactionNumber.toLong())
   private val acceptedEventsCounter: Counter = metricsFacade.createCounter(
     category = LineaMetricsCategory.FORCED_TRANSACTION,
-    name = "events.accepted",
-    description = "Number of ForcedTransactionAdded L1 events accepted by the coordinator",
+    name = "events.consumed",
+    description = "Number of ForcedTransactionAdded L1 events consumed by the coordinator",
   )
 
   init {
     metricsFacade.createGauge(
       category = LineaMetricsCategory.FORCED_TRANSACTION,
-      name = "latest.number",
+      name = "events.highest",
       description = "Latest ForcedTransactionAdded forced transaction number observed by the coordinator",
       measurementSupplier = { latestForcedTransactionNumber.get() },
     )

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -310,8 +310,8 @@ class ForcedTransactionsAppTest {
     await()
       .atMost(5.seconds.toJavaDuration())
       .untilAsserted {
-        assertThat(meterRegistry.find("forced.transaction.events.accepted").counter()?.count()).isEqualTo(2.0)
-        assertThat(meterRegistry.find("forced.transaction.latest.number").gauge()?.value()).isEqualTo(12.0)
+        assertThat(meterRegistry.find("forced.transaction.events.consumed").counter()?.count()).isEqualTo(2.0)
+        assertThat(meterRegistry.find("forced.transaction.events.highest").gauge()?.value()).isEqualTo(12.0)
       }
     app.stop().get()
   }

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -1,5 +1,6 @@
 package linea.ftx
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.vertx.core.Vertx
 import io.vertx.junit5.VertxExtension
 import linea.clients.InvalidityProverClientV1
@@ -37,6 +38,7 @@ import linea.persistence.ftx.FakeForcedTransactionsDao
 import linea.timer.VertxTimerFactory
 import net.consensys.FakeFixedClock
 import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
 import net.consensys.linea.traces.TracesCountersV5
 import net.consensys.linea.traces.TracingModuleV5
 import org.apache.logging.log4j.Level
@@ -119,6 +121,7 @@ class ForcedTransactionsAppTest {
     ftxProcessingDelay: Duration = Duration.ZERO,
     fakeForcedTransactionsClientErrorRatio: Double = 0.5,
     safeBlockTracker: SafeBlockTracker? = null,
+    metricsFacade: MetricsFacade = MicrometerMetricsFacade(registry = SimpleMeterRegistry()),
   ): ForcedTransactionsAppImpl {
     val config = ForcedTransactionsApp.Config(
       l1PollingInterval = l1PollingInterval,
@@ -144,6 +147,7 @@ class ForcedTransactionsAppTest {
       accountProofClient = this.accountProofClient,
       tracesClient = this.tracesClient,
       clock = fakeClock,
+      metricsFacade = metricsFacade,
       safeBlockNumberProvider = ForcedTransactionConflationSafeBlockNumberProvider(listener = safeBlockTracker),
     )
   }
@@ -257,6 +261,57 @@ class ForcedTransactionsAppTest {
       .atMost(5.seconds.toJavaDuration())
       .untilAsserted {
         assertThat(app.conflationSafeBlockNumberProvider.getHighestSafeBlockNumber()).isNull()
+      }
+    app.stop().get()
+  }
+
+  @Test
+  fun `should export accepted forced transaction event metrics`() {
+    val meterRegistry = SimpleMeterRegistry()
+    val metricsFacade: MetricsFacade = MicrometerMetricsFacade(registry = meterRegistry)
+    val ftxAddedEvents = listOf(
+      createFtxAddedEvent(
+        l1BlockNumber = 990UL,
+        ftxNumber = 10UL,
+        l2DeadLine = 100UL,
+      ),
+      createFtxAddedEvent(
+        l1BlockNumber = 1_100UL,
+        ftxNumber = 11UL,
+        l2DeadLine = 200UL,
+      ),
+      createFtxAddedEvent(
+        l1BlockNumber = 1_200UL,
+        ftxNumber = 12UL,
+        l2DeadLine = 220UL,
+      ),
+    )
+    this.l1Client.setLogs(ftxAddedEvents)
+    this.fakeContractClient.finalizedStateProvider.l1FinalizedState = LineaRollupFinalizedState(
+      blockNumber = 100UL,
+      blockTimestamp = Clock.System.now(),
+      messageNumber = 0UL,
+      forcedTransactionNumber = 10UL,
+    )
+
+    val app = createApp(
+      l1PollingInterval = 10.milliseconds,
+      l1EventSearchBlockChunk = 100u,
+      fakeForcedTransactionsClientErrorRatio = 0.0,
+      metricsFacade = metricsFacade,
+    )
+    this.l1Client.setFinalizedBlockTag(5_000UL)
+    this.l1Client.setLatestBlockTag(10_000UL)
+    this.l2Client.setLatestBlockTag(2_000UL)
+    this.fakeClock.setTimeTo(this.l1Client.blockTimestamp(BlockParameter.Tag.LATEST) + 12.seconds)
+
+    app.start().get()
+
+    await()
+      .atMost(5.seconds.toJavaDuration())
+      .untilAsserted {
+        assertThat(meterRegistry.find("forced.transaction.events.accepted").counter()?.count()).isEqualTo(2.0)
+        assertThat(meterRegistry.find("forced.transaction.latest.number").gauge()?.value()).isEqualTo(12.0)
       }
     app.stop().get()
   }


### PR DESCRIPTION
## Summary
- Add forced transaction metrics for accepted `ForcedTransactionAdded` L1 events
- Export the latest observed forced transaction number as a gauge
- Wire Coordinator metrics into the forced-transactions app and cover the metric behavior in tests

#3118

## Validation
- `./gradlew :coordinator:app:compileKotlin :coordinator:ethereum:forced-transactions:test spotlessCheck`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds metrics plumbing and a small side-effect on event acceptance, without changing forced-transaction processing logic.
> 
> **Overview**
> Exports new forced-transaction metrics: a counter for consumed `ForcedTransactionAdded` L1 events and a gauge for the highest observed forced-transaction number.
> 
> Wires `MetricsFacade` into `ForcedTransactionsApp` (via `ConflationApp`) and records metrics when the L1 events fetcher accepts an in-order event. Adds Micrometer-based test coverage validating the emitted metric names/values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86817b922176e2b8b5037aec6f7ff3dc065ade67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->