### PR TITLE
test(contracts): cover Lido funding below target reserve

### DIFF
--- a/contracts/test/hardhat/yield/integration/YieldManager.integration.ts
+++ b/contracts/test/hardhat/yield/integration/YieldManager.integration.ts
@@ -18,7 +18,7 @@ import {
 import { ethers } from "hardhat";
 
 import { encodeSendMessage } from "../../../../common/helpers/encoding";
-import { EMPTY_CALLDATA, ONE_ETHER, ZERO_VALUE, CONNECT_DEPOSIT } from "../../common/constants";
+import { EMPTY_CALLDATA, ONE_ETHER, ZERO_VALUE, CONNECT_DEPOSIT, OperationType } from "../../common/constants";
 import { expectRevertWithCustomError, expectEvent, getAccountsFixture } from "../../common/helpers";
 import {
   decrementBalance,
@@ -155,6 +155,25 @@ describe("Integration tests with LineaRollup, YieldManager and LidoStVaultYieldP
       await expect(claimCall).to.not.be.reverted;
       expect(await getBalance(lineaRollup)).eq(reserveBalanceBefore - transferAmount);
       expect(await getBalance(yieldManager)).eq(yieldManagerBalanceBefore + transferAmount);
+    });
+
+    it("Should block Lido provider funding when withdrawal reserve is above minimum but below target", async () => {
+      // Arrange - Keep the withdrawal reserve healthy but below target after transferring funds to the YieldManager.
+      const fundAmount = ONE_ETHER;
+      await setWithdrawalReserveToMinimum(yieldManager);
+      await incrementBalance(l1MessageServiceAddress, fundAmount);
+      await lineaRollup.connect(nativeYieldOperator).transferFundsForNativeYield(fundAmount);
+      expect(await yieldManager.getTargetReserveDeficit()).to.be.gt(0n);
+
+      // Act
+      const call = yieldManager.connect(nativeYieldOperator).fundYieldProvider(yieldProviderAddress, fundAmount);
+
+      // Assert
+      await expectRevertWithCustomError(yieldProvider, call, "OperationNotSupportedDuringStakingPause", [
+        OperationType.FUND_YIELD_PROVIDER,
+      ]);
+      expect(await getBalance(yieldManager)).eq(fundAmount);
+      expect(await yieldManager.isStakingPaused(yieldProviderAddress)).eq(false);
     });
   });
 


### PR DESCRIPTION
This PR implements issue(s) # N/A

### Summary

Adds integration coverage for the conservative reserve policy in the real Lido provider path. The new test verifies that after ETH is transferred into `YieldManager` while the withdrawal reserve is above minimum but below target, funding the Lido provider is blocked by the staking pause guard and the ETH remains in `YieldManager`.

### Test Plan

- [x] `pnpm -F contracts exec eslint test/hardhat/yield/integration/YieldManager.integration.ts`
- [x] `pnpm -F contracts exec prettier --check test/hardhat/yield/integration/YieldManager.integration.ts`
- [ ] `pnpm -F contracts exec hardhat test contracts/test/hardhat/yield/integration/YieldManager.integration.ts --grep "Should block Lido provider funding when withdrawal reserve is above minimum but below target"` - blocked during Hardhat config loading because `@lidofinance/lsv-cli/dist/utils/fetch-cl.js` is missing locally.

### Checklist

* [x] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Hardhat integration tests and constant imports, with no production contract logic modified.
> 
> **Overview**
> Adds an integration test asserting that when ETH is transferred into `YieldManager` while the withdrawal reserve is **above minimum but still below target**, attempts to `fundYieldProvider` for the Lido provider revert with `OperationNotSupportedDuringStakingPause` (using `OperationType.FUND_YIELD_PROVIDER`) and the ETH remains in `YieldManager`.
> 
> Updates the integration test imports to include `OperationType` for the new revert assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57bc91a7a435b14a53f5748f7afcbdae37d4c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->