### PR TITLE
feat(prover): add chainID sanity check for invalidity prover

### DIFF
--- a/prover/backend/invalidity/limitless/prove.go
+++ b/prover/backend/invalidity/limitless/prove.go
@@ -44,6 +44,8 @@ func Prove(cfg *config.Config, req *backendInvalidity.Request) (*backendInvalidi
 		return nil, fmt.Errorf("could not decode the RlpEncodedTx: %w", err)
 	}
 
+	backendInvalidity.SanityCheckInvalidityChainConfig(cfg, tx)
+
 	funcInput := backendInvalidity.FuncInput(req, cfg)
 
 	// Build the zkEVM witness for the simulated execution

--- a/prover/backend/invalidity/prove.go
+++ b/prover/backend/invalidity/prove.go
@@ -3,6 +3,7 @@ package invalidity
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"os"
 	"path"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	linTypes "github.com/consensys/linea-monorepo/prover/utils/types"
 	"github.com/consensys/linea-monorepo/prover/zkevm"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -81,6 +83,8 @@ func Prove(cfg *config.Config, req *Request, large bool) (*Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not decode the RlpEncodedTx: %w", err)
 	}
+
+	SanityCheckInvalidityChainConfig(cfg, tx)
 
 	funcInput := FuncInput(req, cfg)
 
@@ -280,4 +284,29 @@ func Prove(cfg *config.Config, req *Request, large bool) (*Response, error) {
 		ProverMode:                       cfg.Invalidity.ProverMode,
 	}
 	return rsp, nil
+}
+
+// SanityCheckInvalidityChainConfig checks that the transaction's chainID matches
+// the config. For non-legacy txs the chainID is embedded in the transaction;
+// for legacy txs this check is skipped (chainID derived from V is unreliable).
+func SanityCheckInvalidityChainConfig(cfg *config.Config, tx *ethtypes.Transaction) {
+	if tx.Type() == ethtypes.LegacyTxType {
+		return
+	}
+	cfgChainID := new(big.Int).SetUint64(uint64(cfg.Layer2.ChainID))
+	txChainID := tx.ChainId()
+	if txChainID == nil || txChainID.Sign() == 0 {
+		return
+	}
+	if txChainID.Cmp(cfgChainID) != 0 {
+		utils.Panic(
+			"chain config mismatch — transaction chainID does not match config!\n\n"+
+				"  config chainID: %d\n"+
+				"  tx chainID:     %s\n\n"+
+				"  Check your config file's [layer2] chain_id setting.\n",
+			cfg.Layer2.ChainID, txChainID.String(),
+		)
+	}
+	logrus.Infof("Invalidity chain config check passed: tx chainID=%s matches config chainID=%d",
+		txChainID.String(), cfg.Layer2.ChainID)
 }


### PR DESCRIPTION
Verify that the transaction's chainID matches the prover config before generating invalidity proofs. This catches config mismatches early rather than producing an invalid proof.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new runtime guard that panics when the tx `chainID` disagrees with `cfg.Layer2.ChainID`, which can newly fail invalidity proof generation in misconfigured environments.
> 
> **Overview**
> Adds a **chainID/config sanity check** to invalidity proving (both standard and limitless pipelines) by validating non-legacy transactions’ `tx.ChainId()` against `cfg.Layer2.ChainID` before building inputs/witnesses.
> 
> On mismatch, the prover now `utils.Panic`s with a targeted config hint; legacy or missing/zero chain IDs are skipped, and successful checks emit an info log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae89a72214cc37a5341701773b244007721403c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->