### PR TITLE
fix(prover): valid-nonce-ftx

### DIFF
--- a/prover/circuits/invalidity/check_native.go
+++ b/prover/circuits/invalidity/check_native.go
@@ -132,8 +132,8 @@ func CheckOnlyNativeNonceBalance(
 
 	switch assi.InvalidityType {
 	case BadNonce:
-		if tx.Nonce() == uint64(accountNonce+1) {
-			return fmt.Errorf("nonce is valid (tx=%d, account+1=%d): not a bad-nonce case", tx.Nonce(), accountNonce+1)
+		if tx.Nonce() == uint64(accountNonce) {
+			return fmt.Errorf("nonce is valid (tx=%d, account=%d): not a bad-nonce case", tx.Nonce(), accountNonce)
 		}
 	case BadBalance:
 		if txCost.Cmp(accountBalance) <= 0 {

--- a/prover/circuits/invalidity/nonce_balance.go
+++ b/prover/circuits/invalidity/nonce_balance.go
@@ -69,11 +69,11 @@ func (circuit *BadNonceBalanceCircuit) Define(api frontend.API) error {
 	// Reconstruct account nonce from limbs (4 x 16-bit, big-endian)
 	accountNonce := combine16BitLimbs(api, toNativeSlice(account.Nonce[:]))
 
-	// Bad nonce: if invalidityType == 0 ----> tx nonce != account nonce + 1
+	// Bad nonce: if invalidityType == 0 ----> tx nonce != account nonce
 	nonceDiff := api.Add(
 		api.Mul(
 			api.Sub(1, circuit.InvalidityType),
-			api.Sub(circuit.TxNonce, api.Add(accountNonce, 1)),
+			api.Sub(circuit.TxNonce, accountNonce),
 		),
 		circuit.InvalidityType)
 	api.AssertIsDifferent(nonceDiff, 0)
@@ -179,7 +179,7 @@ func (cir *BadNonceBalanceCircuit) Assign(assi AssigningInputs) {
 	if assi.InvalidityType != BadNonce && assi.InvalidityType != BadBalance {
 		utils.Panic("expected invalidity type BadNonce or BadBalance but received %v", assi.InvalidityType)
 	}
-	if txNonce == uint64(acNonce+1) && assi.InvalidityType == BadNonce {
+	if txNonce == uint64(acNonce) && assi.InvalidityType == BadNonce {
 		utils.Panic("tried to generate a bad-nonce proof for a possibly valid transaction")
 	}
 	if txCost.Cmp(balance) != 1 && assi.InvalidityType == BadBalance {

--- a/prover/circuits/invalidity/utils_test.go
+++ b/prover/circuits/invalidity/utils_test.go
@@ -615,7 +615,7 @@ var tcases = []TestCases{
 		InvalidityType: 1,
 	},
 	{
-		// EOA
+		// EOA with BadNonce: tx nonce (66) != account nonce (65)
 		Account: Account{
 			Nonce:          65,
 			Balance:        big.NewInt(5690),
@@ -640,7 +640,7 @@ var tcases = []TestCases{
 		},
 		Tx: types.DynamicFeeTx{
 			ChainID:   big.NewInt(59144), // Linea mainnet chain ID
-			Nonce:     65,                // invalid nonce
+			Nonce:     66,                // invalid nonce (account nonce is 65)
 			Value:     big.NewInt(5700),  // invalid value
 			Gas:       1,
 			GasFeeCap: big.NewInt(1), // gas price


### PR DESCRIPTION
(cherry picked from commit 05a0dd7210b323bd3ed53e6acde47471648bb9f3)

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the core `BadNonce` invalidity condition in both native verification and the ZK circuit, which can change which transactions are provable as invalid. Risk is moderate because it affects proof correctness/acceptance for nonce-related invalidity cases.
> 
> **Overview**
> Aligns **BadNonce** invalidity logic to treat a transaction as *not* bad-nonce when `tx.Nonce == account.Nonce` (previously compared against `account.Nonce + 1`) across both native checks (`check_native.go`) and the `BadNonceBalanceCircuit` constraints (`nonce_balance.go`).
> 
> Updates proof generation sanity checks and adjusts the associated test vector in `utils_test.go` to use a mismatching nonce example consistent with the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8823fed461ebeaecdef2bbe219c702bc6ba9a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->