### PR TITLE
fix(ci): workflow security issues

### DIFF
--- a/.github/workflows/github-release-besu-plugin.yml
+++ b/.github/workflows/github-release-besu-plugin.yml
@@ -23,12 +23,16 @@ on:
     inputs:
       pluginName:
         required: true
-        type: string
-        description: 'plugin name used for the tag name, e.g linea-staterecovery'
+        type: choice
+        description: 'plugin name used for the tag name'
+        options:
+          - linea-staterecovery
       workspaceModulePath:
         required: true
-        type: string
-        description: 'Path to plugin to release, e.g state-recovery/besu-plugin'
+        type: choice
+        description: 'Path to plugin to release'
+        options:
+          - state-recovery/besu-plugin
       version:
         required: true
         type: string
@@ -38,6 +42,25 @@ jobs:
   release:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
+      - name: Validate inputs
+        env:
+          INPUT_PLUGIN_NAME: ${{ inputs.pluginName }}
+          INPUT_WORKSPACE_MODULE_PATH: ${{ inputs.workspaceModulePath }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$INPUT_PLUGIN_NAME" =~ ^[a-z][a-z0-9-]+$ ]]; then
+            echo "Error: pluginName must contain only lowercase letters, digits, and hyphens, got: '$INPUT_PLUGIN_NAME'" >&2
+            exit 1
+          fi
+          if ! [[ "$INPUT_WORKSPACE_MODULE_PATH" =~ ^[a-z0-9][a-z0-9/_-]+$ ]]; then
+            echo "Error: workspaceModulePath must contain only lowercase letters, digits, slashes, underscores, and hyphens, got: '$INPUT_WORKSPACE_MODULE_PATH'" >&2
+            exit 1
+          fi
+          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version must be a semantic version (MAJOR.MINOR.PATCH, digits only), got: '$INPUT_VERSION'" >&2
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -52,11 +75,14 @@ jobs:
         run: ./gradlew clean
 
       - name: Build
+        env:
+          WORKSPACE_MODULE_PATH: ${{ inputs.workspaceModulePath }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          GRAGLE_PATH=:$(echo "linea-besu/plugins/${{inputs.workspaceModulePath}}" | sed 's/\//:/g')
-          echo $GRAGLE_PATH
-          ./gradlew $GRAGLE_PATH:shadowJar -Pversion=v${{inputs.version}}
-          ls -lh linea-besu/plugins/${{inputs.workspaceModulePath}}/build/libs
+          GRADLE_PATH=:$(echo "linea-besu/plugins/${WORKSPACE_MODULE_PATH}" | sed 's/\//:/g')
+          echo "${GRADLE_PATH}"
+          ./gradlew "${GRADLE_PATH}:shadowJar" "-Pversion=v${INPUT_VERSION}"
+          ls -lh "linea-besu/plugins/${WORKSPACE_MODULE_PATH}/build/libs"
 
       - name: Release to GitHub
         uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 #v2.5.0

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -44,21 +44,43 @@ jobs:
         with:
           exclude_inputs: network, file
 
+      - name: Validate inputs
+        env:
+          INPUT_FILE: ${{ github.event.inputs.file }}
+          INPUT_PRIVATE_KEY_OVERWRITE: ${{ github.event.inputs.private_key_overwrite }}
+        run: |
+          if ! [[ "$INPUT_FILE" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*\.json$ ]]; then
+            echo "Error: file must be a .json filename using only alphanumeric, dot, hyphen, or underscore characters, got: '$INPUT_FILE'" >&2
+            exit 1
+          fi
+          if [ -n "$INPUT_PRIVATE_KEY_OVERWRITE" ] && ! [[ "$INPUT_PRIVATE_KEY_OVERWRITE" =~ ^(0x)?[0-9a-fA-F]{64}$ ]]; then
+            echo "Error: private_key_overwrite must be a 64-character hex Ethereum private key (optionally 0x-prefixed)" >&2
+            exit 1
+          fi
+
       - name: Determine Private Key
         id: set_private_key
+        env:
+          INPUT_NETWORK: ${{ github.event.inputs.network }}
+          INPUT_PRIVATE_KEY_OVERWRITE: ${{ github.event.inputs.private_key_overwrite }}
+          DEVNET_KEY: ${{ secrets.DEVNET_LOAD_TEST_PRIVATE_KEY }}
+          SEPOLIA_KEY: ${{ secrets.SEPOLIA_LOAD_TEST_PRIVATE_KEY }}
         run: |
-          if [ -n "${{ github.event.inputs.private_key_overwrite }}" ]; then
+          if [ -n "$INPUT_PRIVATE_KEY_OVERWRITE" ]; then
             echo "Using provided private key."
-            echo "PRIVATE_KEY=${{ github.event.inputs.private_key_overwrite }}" >> $GITHUB_ENV
-          elif [ "${{ github.event.inputs.network }}" == "devnet" ]; then
+            echo "PRIVATE_KEY=$INPUT_PRIVATE_KEY_OVERWRITE" >> "$GITHUB_ENV"
+          elif [ "$INPUT_NETWORK" = "devnet" ]; then
             echo "Using devnet private key from secrets."
-            echo "PRIVATE_KEY=${{ secrets.DEVNET_LOAD_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
-          elif [ "${{ github.event.inputs.network }}" == "sepolia" ]; then
+            echo "PRIVATE_KEY=$DEVNET_KEY" >> "$GITHUB_ENV"
+          elif [ "$INPUT_NETWORK" = "sepolia" ]; then
             echo "Using sepolia private key from secrets."
-            echo "PRIVATE_KEY=${{ secrets.SEPOLIA_LOAD_TEST_PRIVATE_KEY }}" >> $GITHUB_ENV
+            echo "PRIVATE_KEY=$SEPOLIA_KEY" >> "$GITHUB_ENV"
           fi
 
       - name: Load Test
+        env:
+          INPUT_NETWORK: ${{ github.event.inputs.network }}
+          INPUT_FILE: ${{ github.event.inputs.file }}
         run: |
-          echo "Network to execute load test on: ${{ github.event.inputs.network }}"
-          ./gradlew :testing-tools:traffic-generator:run --args="-request ${{ github.event.inputs.network }}/${{ github.event.inputs.file }} -pk $PRIVATE_KEY"
+          echo "Network to execute load test on: ${INPUT_NETWORK}"
+          ./gradlew :testing-tools:traffic-generator:run --args="-request ${INPUT_NETWORK}/${INPUT_FILE} -pk ${PRIVATE_KEY}"

--- a/.github/workflows/maven-release-all.yml
+++ b/.github/workflows/maven-release-all.yml
@@ -19,15 +19,19 @@ jobs:
     steps:
       - name: Set version
         id: name
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          TIMESTAMP=`date -u +'%Y%m%d%H%M%S'`
-          INPUT_VERSION=${{ github.event.inputs.version }}
+          TIMESTAMP=$(date -u +'%Y%m%d%H%M%S')
           if [ -z "$INPUT_VERSION" ]; then
-            VERSION="0.0.1-v$TIMESTAMP"
+            VERSION="0.0.1-v${TIMESTAMP}"
+          elif [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION="$INPUT_VERSION"
           else
-            VERSION=$INPUT_VERSION
+            echo "Error: version must be a semantic version (MAJOR.MINOR.PATCH, digits only), got: '$INPUT_VERSION'" >&2
+            exit 1
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Print version
         run: |

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -10,8 +10,14 @@ on:
     inputs:
       libToRelease:
         required: true
-        type: string
-        description: 'Library to release, e.g :jvm-libs:linea:blob-compressor'
+        type: choice
+        description: 'Library to release'
+        options:
+          - ':jvm-libs:linea:blob-compressor'
+          - ':jvm-libs:linea:blob-decompressor'
+          - ':jvm-libs:linea:blob-shnarf-calculator'
+          - ':jvm-libs:linea:linea-contracts:l1-rollup'
+          - ':jvm-libs:linea:linea-contracts:l2-message-service'
       version:
         required: true
         type: string
@@ -21,6 +27,15 @@ jobs:
   release:
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
     steps:
+      - name: Validate inputs
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version must be a semantic version (MAJOR.MINOR.PATCH, digits only), got: '$INPUT_VERSION'" >&2
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,21 +52,24 @@ jobs:
       - name: Build
         # ./gradlew clean is necessary because the build is cached
         # and cause issues with JReleaser
-        run: ./gradlew ${{github.event.inputs.libToRelease}}:build
         env:
+          LIB_TO_RELEASE: ${{ github.event.inputs.libToRelease }}
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
+        run: ./gradlew "${LIB_TO_RELEASE}:build"
 
       - name: Deploy to Local File System
-        run: ./gradlew ${{github.event.inputs.libToRelease}}:publish -Pversion=${{github.event.inputs.version}}
         env:
+          LIB_TO_RELEASE: ${{ github.event.inputs.libToRelease }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
-
+        run: ./gradlew "${LIB_TO_RELEASE}:publish" "-Pversion=${INPUT_VERSION}"
 
       - name: Build and Release to Maven Central
         # ./gradlew clean is necessary because the build is cached
         # and cause issues with JReleaser
-        run: ./gradlew --stacktrace ${{github.event.inputs.libToRelease}}:jreleaserRelease -Pversion=${{github.event.inputs.version}}
         env:
+          LIB_TO_RELEASE: ${{ github.event.inputs.libToRelease }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_GITHUB_USERNAME: ${{ github.actor }}
@@ -61,6 +79,7 @@ jobs:
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+        run: ./gradlew --stacktrace "${LIB_TO_RELEASE}:jreleaserRelease" "-Pversion=${INPUT_VERSION}"
 
       # Persist logs
       - name: JReleaser release output

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -134,6 +134,16 @@ jobs:
     needs: [ build-linux, build-linux-arm64, build-mac-os]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
+      - name: Validate version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if ! [[ "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version must be 'vMAJOR.MINOR.PATCH' (e.g. v1.2.3), got: '$INPUT_VERSION'" >&2
+            exit 1
+          fi
+          echo "VERSION=${INPUT_VERSION}" >> "$GITHUB_ENV"
+
       - name: Load cached binaries
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -143,7 +153,7 @@ jobs:
           ls -la ./
       - name: Zip the release files
         run: |
-          zip -r linea-blob-libs-${{ github.event.inputs.version }}.zip .
+          zip -r "linea-blob-libs-${VERSION}.zip" .
       - name: Get current date
         id: current_date
         run: echo "::set-output name=date::$(date --utc +'%Y-%m-%dT%H:%M:%SZ')"
@@ -154,12 +164,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: blob-libs-${{ github.event.inputs.version }}
-          release_name: Blob libs ${{ github.event.inputs.version }}
+          tag_name: blob-libs-${{ env.VERSION }}
+          release_name: Blob libs ${{ env.VERSION }}
           draft: ${{ github.event.inputs.draft-release }}
           prerelease: ${{ github.event.inputs.pre-release }}
           body: |
-            Go lang blob binaries ${{ github.event.inputs.version }}
+            Go lang blob binaries ${{ env.VERSION }}
             commit: ${{ github.sha }}
             date: ${{ steps.current_date.outputs.date }}
       - name: Upload Release Asset
@@ -168,6 +178,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./linea-blob-libs-${{ github.event.inputs.version }}.zip
-          asset_name: linea-blob-libs-${{ github.event.inputs.version }}.zip
+          asset_path: ./linea-blob-libs-${{ env.VERSION }}.zip
+          asset_name: linea-blob-libs-${{ env.VERSION }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -25,7 +25,21 @@ on:
 
 jobs:
 
+  validate:
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    steps:
+      - name: Validate version
+        id: validate_version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if ! [[ "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: version must be 'vMAJOR.MINOR.PATCH' (e.g. v1.2.3), got: '$INPUT_VERSION'" >&2
+            exit 1
+          fi
+
   build-linux:
+    needs: [validate]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     steps:
       - name: Checkout code
@@ -60,6 +74,7 @@ jobs:
           path: ./prover/target
 
   build-linux-arm64:
+    needs: [validate]
     runs-on: gha-runner-scale-set-ubuntu-24-arm64-med
     steps:
       - name: Checkout code
@@ -94,6 +109,7 @@ jobs:
           path: ./prover/target
 
   build-mac-os:
+    needs: [validate]
     runs-on: macos-latest
     steps:
       - name: Checkout code
@@ -131,19 +147,11 @@ jobs:
 
   release_artefacts:
     name: Release artefacts
-    needs: [ build-linux, build-linux-arm64, build-mac-os]
+    needs: [validate, build-linux, build-linux-arm64, build-mac-os]
     runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    env:
+      VERSION: ${{ github.event.inputs.version }}
     steps:
-      - name: Validate version
-        env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
-        run: |
-          if ! [[ "$INPUT_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: version must be 'vMAJOR.MINOR.PATCH' (e.g. v1.2.3), got: '$INPUT_VERSION'" >&2
-            exit 1
-          fi
-          echo "VERSION=${INPUT_VERSION}" >> "$GITHUB_ENV"
-
       - name: Load cached binaries
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:


### PR DESCRIPTION
This PR fixes the following issues: SR-001 and SR-002

### P1 - High

#### SR-001 - Validate manual Maven release inputs before privileged shell execution

Priority: P1
Severity: High
Component: Cross-Cutting CI and Release Engineering
CWE: CWE-78
Affected files:

- `.github/workflows/maven-release.yml:40`
- `.github/workflows/maven-release.yml:45`
- `.github/workflows/maven-release.yml:53`
- `.github/workflows/maven-release.yml:55-63`

Issue: `workflow_dispatch` inputs `libToRelease` and `version` are interpolated directly into shell commands. The final release step runs the resulting command while Maven Central credentials, GPG signing material, and GitHub release tokens are present in the environment.

Attack path: A user who can dispatch the workflow supplies shell metacharacters in `libToRelease` or `version`. The release job expands that input inside the `run` shell, executes attacker-controlled commands, and exposes or abuses the release credentials available to the same step.

Impact: Compromise of Maven Central release credentials, GPG signing material, GitHub release tokens, or published JVM artifacts.

Remediation: Replace free-form inputs with allowlisted choices or strict regex validation before any shell step. Pass values through environment variables and quote every expansion. Prefer Gradle task allowlists instead of constructing task names from user-controlled strings.

### P2 - Medium

#### SR-002 - Harden remaining manual workflow inputs used in shell and release paths

Priority: P2
Severity: Medium
Component: Cross-Cutting CI and Release Engineering
CWE: CWE-78
Affected files:

- `.github/workflows/maven-release-all.yml:24`
- `.github/workflows/github-release-besu-plugin.yml:56`
- `.github/workflows/github-release-besu-plugin.yml:58-64`
- `.github/workflows/load-test.yml:50-64`
- `.github/workflows/prover-native-lib-blob-compressor-release.yml:146-172`

Issue: Several manual workflows interpolate untrusted inputs into shell commands or release artifact names. Some paths later use GitHub release tokens or load-test private keys.

Attack path: A workflow dispatcher provides crafted input such as command substitution or shell separators. The job can execute unintended commands, poison release artifacts, or expose private keys used by load-test jobs.

Impact: Release artifact tampering, privileged workflow manipulation, or disclosure of non-production but sensitive load-test keys.

Remediation: Validate every manual input with strict allowlists, reject shell metacharacters, quote all variable expansions, and move untrusted values into environment variables. For release workflows, use fixed module maps and semantic-version validators.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple release/load-test GitHub Actions workflows; while changes are mostly input validation/quoting, mistakes could block releases or alter tagging/packaging behavior.
> 
> **Overview**
> Hardens several manually-triggered GitHub Actions workflows to reduce shell-injection risk by **validating/allowlisting inputs** and **quoting all interpolations** before running privileged Gradle/Go/release steps.
> 
> `maven-release.yml` now restricts `libToRelease` to an explicit choice list and validates `version` as `MAJOR.MINOR.PATCH`, passing values via env vars into quoted Gradle commands. Similar semantic-version validation is added to `maven-release-all.yml`, `github-release-besu-plugin.yml` (also converts dispatch inputs to choices), and `prover-native-lib-blob-compressor-release.yml` (adds a dedicated `validate` job and uses env-based versioning for zip/tag/asset names).
> 
> `load-test.yml` adds filename/private-key regex validation and avoids direct input interpolation when selecting secrets and running the load test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d06473771f73f00b9fd0cf74aaf018817511269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->