### PR TITLE
refactor(verifier-ray): rename randomField, sumElement

### DIFF
--- a/verifier-ray/.gitignore
+++ b/verifier-ray/.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
 zig-out/
+testdata/generate/generate
 

--- a/verifier-ray/src/crypto/fiat_shamir.zig
+++ b/verifier-ray/src/crypto/fiat_shamir.zig
@@ -23,14 +23,14 @@ pub const Transcript = struct {
         }
     }
 
-    pub fn randomField(self: *Transcript) poseidon2.Digest {
-        const challenge = self.hasher.sumElement();
+    pub fn randomDigest(self: *Transcript) poseidon2.Digest {
+        const challenge = self.hasher.sumDigest();
         self.updateElement(field.Element.zero());
         return challenge;
     }
 
     pub fn randomExt(self: *Transcript) ext.Ext {
-        const challenge = self.randomField();
+        const challenge = self.randomDigest();
         return .{
             .B0 = .{ .a0 = challenge[0], .a1 = challenge[1] },
             .B1 = .{ .a0 = challenge[2], .a1 = challenge[3] },

--- a/verifier-ray/src/crypto/poseidon2.zig
+++ b/verifier-ray/src/crypto/poseidon2.zig
@@ -94,7 +94,7 @@ pub const MDHasher = struct {
 
     pub fn getState(self: MDHasher) Digest {
         var copy = self;
-        return copy.sumElement();
+        return copy.sumDigest();
     }
 
     pub fn setState(self: *MDHasher, state: Digest) void {

--- a/verifier-ray/src/crypto/poseidon2.zig
+++ b/verifier-ray/src/crypto/poseidon2.zig
@@ -77,7 +77,7 @@ pub const MDHasher = struct {
         }
     }
 
-    pub fn sumElement(self: *MDHasher) Digest {
+    pub fn sumDigest(self: *MDHasher) Digest {
         if (self.buffer_len != 0) {
             var block: Digest = zeroArray(block_size);
             // Match prover-ray MDHasher: partial blocks are zero-left-padded.
@@ -89,7 +89,7 @@ pub const MDHasher = struct {
     }
 
     pub fn sumBytes(self: *MDHasher) [digest_bytes]u8 {
-        return digestToBytes(self.sumElement());
+        return digestToBytes(self.sumDigest());
     }
 
     pub fn getState(self: MDHasher) Digest {
@@ -106,7 +106,7 @@ pub const MDHasher = struct {
 pub fn hashElements(values: []const field.Element) Digest {
     var h = MDHasher.init();
     h.writeElements(values);
-    return h.sumElement();
+    return h.sumDigest();
 }
 
 fn permutation(comptime width: usize, state: *[width]field.Element) void {

--- a/verifier-ray/test/golden_test.zig
+++ b/verifier-ray/test/golden_test.zig
@@ -155,7 +155,7 @@ test "poseidon2 compression and merkle-damgard match prover-ray golden cases" {
         var message: [32]field.Element = undefined;
         fillElems(&message, case.message);
         h.writeElements(message[0..case.message.len]);
-        try expectDigest(h.sumElement(), case.expected);
+        try expectDigest(h.sumDigest(), case.expected);
     }
 }
 
@@ -171,7 +171,7 @@ test "fiat-shamir transcript matches prover-ray golden cases" {
         fillExts(&ext_updates, case.ext_updates);
         transcript.updateExt(ext_updates[0..case.ext_updates.len]);
 
-        try expectDigest(transcript.randomField(), case.random_field);
+        try expectDigest(transcript.randomDigest(), case.random_field);
         try expectExt(transcript.randomExt(), uintsToExt(case.random_ext));
     }
 }

--- a/verifier-ray/testdata/generate/go.mod
+++ b/verifier-ray/testdata/generate/go.mod
@@ -2,7 +2,7 @@ module github.com/consensys/linea-monorepo/verifier-ray/testdata/generate
 
 go 1.25.7
 
-require github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260519010204-24a53941da53
+require github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260521063207-ab0f753372c8
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/verifier-ray/testdata/generate/go.sum
+++ b/verifier-ray/testdata/generate/go.sum
@@ -6,8 +6,8 @@ github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
 github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08 h1:EdljQKaHxACX5JMSTXlVM9R8qASU/W1husqDsB2b5tU=
 github.com/consensys/gnark-crypto v0.20.2-0.20260514182922-df0578435b08/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
-github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260519010204-24a53941da53 h1:DpSMTgN3kJYo7vbBGnSXGJXQx4yVVR35WUE/NFqYdWY=
-github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260519010204-24a53941da53/go.mod h1:qHFJ8kDpr4/FxFebRGZ1aPg74qHUbSaDv7j1K5yKefY=
+github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260521063207-ab0f753372c8 h1:ZFVPaOu3F7rf8Tv6vtO00jnadeXB2OUopYxrtdqjwMY=
+github.com/consensys/linea-monorepo/prover-ray v0.0.0-20260521063207-ab0f753372c8/go.mod h1:2cEA44vEDPh8MB1huZtKZv//iXB0ZOghXq7idgt4UPc=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=

--- a/verifier-ray/testdata/generate/main.go
+++ b/verifier-ray/testdata/generate/main.go
@@ -322,7 +322,7 @@ func writePoseidonCompressCase(out *bytes.Buffer, left, right field.Octuplet) {
 func writePoseidonMdCase(out *bytes.Buffer, msg []field.Element) {
 	h := poseidon2.NewMDHasher()
 	h.WriteElements(msg...)
-	res := h.SumElement()
+	res := h.SumDigest()
 	fmt.Fprintf(out, "    .{ .message = &%s, .expected = %s },\n", elemSlice(msg), oct8(res))
 }
 
@@ -344,10 +344,10 @@ func writeFiatShamirCase(out *bytes.Buffer, baseUpdates []field.Element, extUpda
 	fs := fiatshamir.NewFiatShamir()
 	fs.Update(baseUpdates...)
 	fs.UpdateExt(extUpdates...)
-	randomField := fs.RandomField()
+	randomDigest := fs.RandomDigest()
 	randomExt := fs.RandomFext()
 	fmt.Fprintf(out, "    .{ .base_updates = &%s, .ext_updates = &%s, .random_field = %s, .random_ext = %s },\n",
-		elemSlice(baseUpdates), extSlice(extUpdates), oct8(randomField), ext6(randomExt))
+		elemSlice(baseUpdates), extSlice(extUpdates), oct8(randomDigest), ext6(randomExt))
 }
 
 func elem(v uint64) field.Element {


### PR DESCRIPTION
This PR mirrors PR #3178 for the verifier-ray side.

Rename misleading Field/Element names to Digest in verifier-ray



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that renames public crypto APIs (`randomField`→`randomDigest`, `sumElement`→`sumDigest`) and updates call sites/tests; behavior should be unchanged but downstream compilation could break if any callers weren’t updated.
> 
> **Overview**
> Renames misleading Poseidon2/Fiat-Shamir API names to reflect that the output is a full `Digest`: `MDHasher.sumElement()`→`sumDigest()` and `Transcript.randomField()`→`randomDigest()`, updating all Zig and Go test-vector generator call sites accordingly.
> 
> Updates golden tests and the `testdata/generate` tool (including bumping the `prover-ray` module version) to use the new names, and adds the generator binary path to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39993b88c094654a11e23379f53dca514bc4e7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->