### PR TITLE
chore(ci): removed unnecessary compute-commit-tag in needs and ensure…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
   lint-latest-commit-messages:
     uses: ./.github/workflows/lint-commit-messages.yml
     permissions:
+      contents: read
       pull-requests: read
     secrets: inherit
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
   
   lint-latest-commit-messages:
     uses: ./.github/workflows/lint-commit-messages.yml
+    permissions:
+      pull-requests: read
     secrets: inherit
 
   component-changelog-upload:

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Commit and push ${{ inputs.component-name }}/CHANGELOG.md
         if: ${{ !inputs.upload_changelog && !inputs.create_pull_request }}
         env:
-          COMPONENT: ${{ inputs.component-name }}
+          SCOPE_NAME: ${{ inputs.component-name == 'linea-besu-package' && 'linea-besu' || inputs.component-name }}
           FOLDER_NAME: ${{ inputs.folder-name }}
           TAG: ${{ steps.prepend-changelog.outputs.next_tag }}
         run: |
@@ -131,7 +131,7 @@ jobs:
             exit 0
           fi
           git add "${FOLDER_NAME}/CHANGELOG.md"
-          git commit -m "chore(${COMPONENT}): update CHANGELOG.md for ${TAG} release [skip ci]"
+          git commit -m "chore(${SCOPE_NAME}): update CHANGELOG.md for ${TAG} release [skip ci]"
 
           # Rebase on top of any commits that landed on the branch between
           # checkout and now (e.g. a concurrent component-changelog-update push),
@@ -157,10 +157,10 @@ jobs:
         id: create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "chore(${{ inputs.component-name }}): update CHANGELOG.md for ${{ steps.prepend-changelog.outputs.next_tag }} release [skip ci]"
-          branch: ci/chore-${{ inputs.component-name }}-changelog-update-release-v${{ steps.prepend-changelog.outputs.next_version }}
+          commit-message: "chore(${{ inputs.component-name == 'linea-besu-package' && 'linea-besu' || inputs.component-name }}): update CHANGELOG.md for ${{ steps.prepend-changelog.outputs.next_tag }} release [skip ci]"
+          branch: ci/chore-${{ inputs.component-name == 'linea-besu-package' && 'linea-besu' || inputs.component-name }}-changelog-update-release-v${{ steps.prepend-changelog.outputs.next_version }}
           base: ${{ github.head_ref || github.ref_name }}
-          title: "chore(${{ inputs.component-name }}): update CHANGELOG.md for ${{ steps.prepend-changelog.outputs.next_tag }} release [skip ci]"
+          title: "chore(${{ inputs.component-name == 'linea-besu-package' && 'linea-besu' || inputs.component-name }}): update CHANGELOG.md for ${{ steps.prepend-changelog.outputs.next_tag }} release [skip ci]"
           add-paths: ${{ inputs.folder-name }}/CHANGELOG.md
 
       - name: Upload CHANGELOG.md artifact

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -110,7 +110,7 @@ jobs:
 
   run-test-prover:
     uses: ./.github/workflows/prover-testing.yml
-    needs: [compute-commit-tag, compute-release-metadata]
+    needs: [compute-release-metadata]
     if: >
       needs.compute-release-metadata.outputs.tag_changed == 'true' && 
       inputs.component-name == 'prover' && 
@@ -119,7 +119,7 @@ jobs:
 
   run-test-transaction-exclusion-api:
     uses: ./.github/workflows/transaction-exclusion-api-testing.yml
-    needs: [compute-commit-tag, compute-release-metadata]
+    needs: [compute-release-metadata]
     if: >
       needs.compute-release-metadata.outputs.tag_changed == 'true' && 
       inputs.component-name == 'tx-exclusion-api' && 


### PR DESCRIPTION
… scope name uses linea-besu

This PR implements issue(s) #2975 #2974

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it modifies GitHub Actions release/test workflow wiring and generated commit/PR metadata, which could break CI/release automation if assumptions about permissions or job ordering are wrong.
> 
> **Overview**
> **Adjusts GitHub Actions workflow permissions and release automation.** The `lint-latest-commit-messages` job in `main.yml` now declares explicit read-only `contents`/`pull-requests` permissions.
> 
> **Refines component release changelog commits/PRs.** The reusable changelog workflow now maps `linea-besu-package` to the `linea-besu` scope for commit messages, PR titles, and branch names.
> 
> **Simplifies release pipeline dependencies.** In `reusable-component-release.yml`, the `prover` and `tx-exclusion-api` test jobs no longer depend on `compute-commit-tag`, relying only on `compute-release-metadata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905d5f731da24c2c9f4c624c5e67d57246c4d7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->