### PR TITLE
fix(maru): wire image handoff into e2e

### DIFF
--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -31,6 +31,7 @@ jobs:
               - 'transaction-exclusion-api/**/src/main/**'
               - 'config/**/*.toml'
               - 'linea-besu/**'
+              - 'maru/**/src/main/**'
               - 'gradle/libs.versions.toml'
               - 'postman/src/**'
               - 'postman/package.json'

--- a/.github/workflows/maru-build-and-publish.yml
+++ b/.github/workflows/maru-build-and-publish.yml
@@ -122,4 +122,4 @@ jobs:
             libs=./maru/app/build/install/app/lib/
             maru=./maru/app/build/libs/
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
-          artifact_name: linea-maru
+          artifact_name: maru

--- a/.github/workflows/maru-smoke-tests.yml
+++ b/.github/workflows/maru-smoke-tests.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Download local docker image artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: linea-maru
+          name: maru
+          path: ${{ github.workspace }}/tmp/artifacts
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -42,7 +43,7 @@ jobs:
       - name: Load Docker images
         run: |
           pwd && ls -la && echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" &&
-          gunzip -c $GITHUB_WORKSPACE/linea-maru/linea-maru-docker-image.tar.gz | docker load
+          gunzip -c "$GITHUB_WORKSPACE/tmp/artifacts/maru-docker-image.tar.gz" | docker load
       - name: Run Docker with maru container
         working-directory: maru
         run: |

--- a/.github/workflows/reuse-run-e2e-tests.yml
+++ b/.github/workflows/reuse-run-e2e-tests.yml
@@ -135,6 +135,13 @@ jobs:
           path: ${{ github.workspace }}/tmp/artifacts
           merge-multiple: true
 
+      - name: Download Maru docker image artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        continue-on-error: true
+        with:
+          name: maru
+          path: ${{ github.workspace }}/tmp/artifacts
+
       - name: Load Docker images from artifacts or pull develop for unchanged services
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
         with:
@@ -143,23 +150,37 @@ jobs:
           retry_wait_seconds: 30
           timeout_minutes: 10
           command: |
-            set -eo pipefail
-            for service in coordinator postman transaction-exclusion-api prover; do
-              artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
+            set -euo pipefail
+            for service in coordinator postman transaction-exclusion-api prover maru; do
+              if [ "$service" = "maru" ]; then
+                artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/maru-docker-image.tar.gz"
+                image_name="consensys/maru"
+              else
+                artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
+                image_name="consensys/linea-${service}"
+              fi
+
               if [ -f "$artifact_path" ]; then
-                echo "Loading ${service} from build artifact..."
+                echo "Loading ${service} from build artifact ${artifact_path}..."
                 gunzip -c "$artifact_path" | docker load
               else
                 echo "No artifact found for ${service}, falling back develop tag from registry..."
-                # docker pull "consensys/linea-${service}:develop"
+                # docker pull "${image_name}:develop"
               fi
             done
       - name: Set Docker image tags
         shell: bash
         run: |
-          for service in coordinator postman transaction-exclusion-api prover; do
-            artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
-            env_var="LINEA_$(echo "${service}" | tr '[:lower:]-' '[:upper:]_')_TAG"
+          set -euo pipefail
+          for service in coordinator postman transaction-exclusion-api prover maru; do
+            if [ "$service" = "maru" ]; then
+              artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/maru-docker-image.tar.gz"
+              env_var="MARU_TAG"
+            else
+              artifact_path="$GITHUB_WORKSPACE/tmp/artifacts/linea-${service}-docker-image.tar.gz"
+              env_var="LINEA_$(echo "${service}" | tr '[:lower:]-' '[:upper:]_')_TAG"
+            fi
+
             if [ -f "$artifact_path" ]; then
               echo "${env_var}=${{ inputs.image_tag }}" >> "$GITHUB_ENV"
             elif [ -z "${!env_var:-}" ]; then


### PR DESCRIPTION
## Summary

- Normalize the Maru Docker image artifact name to `maru` and update the Maru smoke test consumer.
- Add Maru to the reusable E2E Docker image load/tag loops while preserving `MARU_TAG`.
- Trigger protocol E2E for `maru/**/src/main/**` changes.

Ticket: [#2540](https://github.com/Consensys/linea-monorepo/issues/2540)

## Testing

- `git diff --check`
- YAML parse for edited workflow files
- `bash -n` for the changed shell blocks in `.github/workflows/reuse-run-e2e-tests.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes to artifact naming and Docker image loading/tagging; main failure mode is CI/E2E jobs not finding or loading the Maru image artifact.
> 
> **Overview**
> Ensures Maru participates in the CI image handoff by **standardizing the Docker image artifact name to `maru`** and updating `maru-smoke-tests` to download/load it from `tmp/artifacts`.
> 
> Updates the reusable E2E workflow to **also download, load, and tag Maru** alongside other services (including setting `MARU_TAG`), and extends the E2E path filter to trigger runs for changes under `maru/**/src/main/**`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c67931e1cc79791728b97b0725744ad968ce7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->