### PR TITLE
chore(maru): remove spring dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,6 @@ import java.time.Duration
 plugins {
   alias(libs.plugins.spotless)
   alias(libs.plugins.docker)
-  // Loaded on the root plugin classpath so maru subprojects can apply it
-  // via `alias(libs.plugins.dependencyManagement)` in their own plugins{}
-  // block. Maru continues to use io.spring.dependency-management for its
-  // BOM-driven version resolution until maru/gradle/versions.gradle is
-  // folded into the catalog (follow-up commit).
-  alias(libs.plugins.dependencyManagement) apply false
 }
 
 tasks.register("compileAll") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ jreleaser = {id = "org.jreleaser", version = "1.23.0"}
 dependencyLicenseReport = { id = "com.github.jk1.dependency-license-report", version = "3.1.1" }
 lombok = { id = "io.freefair.lombok", version = "9.2.0" }
 gradleVersions = { id = "com.github.ben-manes.versions", version = "0.51.0" }
-dependencyManagement = { id = "io.spring.dependency-management", version = "1.1.5" }
 besuPluginLibrary = { id = "net.consensys.besu-plugin-library", version = "0.2.1" }
 besuPluginDistribution = { id = "net.consensys.besu-plugin-distribution", version = "0.2.1" }
 hierynomusLicense = { id = "com.github.hierynomus.license", version = "0.16.1" }

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/build.gradle
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/build.gradle
@@ -16,13 +16,23 @@ plugins {
   alias(libs.plugins.web3jSolidity)
   alias(libs.plugins.lombok)
   alias(libs.plugins.gradleVersions)
-  alias(libs.plugins.dependencyManagement)
   id "org.jetbrains.kotlin.kapt"
 }
 
 def lineaSequencerProject = project(lineaSequencerProjectPath)
 apply from: lineaSequencerProject.file("gradle/java.gradle")
 apply from: lineaSequencerProject.file("gradle/lint.gradle")
+
+// Besu acceptance-test dependencies pull strict Kotlin stdlib constraints that conflict with the repository Kotlin
+// version. Keep stdlib artifacts aligned with the repo version without reintroducing io.spring.dependency-management.
+configurations.configureEach {
+  resolutionStrategy.eachDependency { details ->
+    if (details.requested.group == 'org.jetbrains.kotlin' && details.requested.name.startsWith('kotlin-stdlib')) {
+      details.useVersion("${libs.versions.kotlin.get()}")
+      details.because('Align Kotlin stdlib with the repository Kotlin version')
+    }
+  }
+}
 
 kapt {
   arguments {


### PR DESCRIPTION
This PR implements issue(s) #2540

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Gradle plugin removal with a targeted stdlib alignment; no runtime application logic changes in this diff.
> 
> **Overview**
> Removes **io.spring.dependency-management** from the Gradle setup: the plugin is dropped from `gradle/libs.versions.toml`, no longer applied on the root `build.gradle`, and is no longer applied in `linea-sequencer` acceptance-tests.
> 
> To avoid Kotlin stdlib version clashes from Besu acceptance-test dependencies after that removal, acceptance-tests now use a **resolution strategy** that forces `org.jetbrains.kotlin:kotlin-stdlib*` to the repo Kotlin version from the version catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22cae049eccfaf6cb3b17dfdc957d14eadcd1402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->