### PR TITLE
chore(prover): update gnark dependency to include fix gnark/#1770

### DIFF
--- a/prover/go.mod
+++ b/prover/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/consensys/compress v0.3.0
-	github.com/consensys/gnark v0.15.1-0.20260515142004-ae23035f9957
+	github.com/consensys/gnark v0.15.1-0.20260526132122-c62f696e965f
 	github.com/consensys/gnark-crypto v0.20.2-0.20260518142632-dffbd6f30adb
 	github.com/consensys/go-corset v1.2.10
 	github.com/crate-crypto/go-kzg-4844 v1.1.0

--- a/prover/go.sum
+++ b/prover/go.sum
@@ -75,8 +75,8 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/consensys/compress v0.3.0 h1:HRIcHvWkW9C9req0ZWg7mhYHzBarohXhcszIwHONVkM=
 github.com/consensys/compress v0.3.0/go.mod h1:pyM+ZXiNUh7/0+AUjUf9RKUM6vSH7T/fsn5LLS0j1Tk=
-github.com/consensys/gnark v0.15.1-0.20260515142004-ae23035f9957 h1:4/+bXhNAly5nBf/kfCp2OXWnin/qh3rOrbCjIFiMjYE=
-github.com/consensys/gnark v0.15.1-0.20260515142004-ae23035f9957/go.mod h1:RIWXG9Gl+Ls2enSayeA/NdcM/FI3OOf6AqNdI2Jv8QU=
+github.com/consensys/gnark v0.15.1-0.20260526132122-c62f696e965f h1:jDznn3tPCxRdqfsL+VBZcUSbDmo8zUWCDCd0zv49NJM=
+github.com/consensys/gnark v0.15.1-0.20260526132122-c62f696e965f/go.mod h1:RIWXG9Gl+Ls2enSayeA/NdcM/FI3OOf6AqNdI2Jv8QU=
 github.com/consensys/gnark-crypto v0.20.2-0.20260518142632-dffbd6f30adb h1:62p/9G5DyYLN5gF1QnyGFV4p2md/zTTthyN01jgMSQo=
 github.com/consensys/gnark-crypto v0.20.2-0.20260518142632-dffbd6f30adb/go.mod h1:NzeBHSZ49bIM7RtrNTYYR2kymTqwvI/A4eTgQlyQc+Q=
 github.com/consensys/go-corset v1.2.10 h1:uKUICiHmERuMWzDRiRJr285fV2WncNGiCENSdNcQodY=


### PR DESCRIPTION
See https://github.com/Consensys/gnark/pull/1770

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Gnark underpins ZK circuit compilation and PLONK proving in the prover; a library bugfix can change proof behavior even when this diff is only go.mod/go.sum.
> 
> **Overview**
> Bumps the prover module’s **`github.com/consensys/gnark`** dependency to pseudo-version `v0.15.1-0.20260526132122-c62f696e965f` (from `…20260515142004-ae23035f9957`) and refreshes the matching entries in **`prover/go.sum`**. There are no other file changes in this PR.
> 
> The intent is to pick up the upstream fix from [Consensys/gnark#1770](https://github.com/Consensys/gnark/pull/1770). **`gnark-crypto`** and the rest of the module graph are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887bae8387fababed25cba4a20718597be6d39f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->