### PR TITLE
feat(arithmetization): added `SKIP_INSTALL_ZKC` flag to `Makefile`

### DIFF
--- a/arithmetization/src/test/examples/Makefile
+++ b/arithmetization/src/test/examples/Makefile
@@ -71,6 +71,7 @@ IN_BYTES_OFFSET_FROM_ELF = $(shell LANG=C riscv64-unknown-elf-nm $(BIN) | grep _
 ENTRY_POINT_FROM_ELF     = $(shell LANG=C riscv64-unknown-elf-readelf -h $(BIN) | grep 'Entry point' | awk '{print $$4}')
 SP_FROM_ELF              = $(shell LANG=C riscv64-unknown-elf-nm $(BIN) | grep _stack_start | awk '{print "0x"$$1}')
 VERIFY_ELF               ?= false             
+SKIP_INSTALL_ZKC         ?= false
 
 # ACT4 testing framework specific variables
 ACT4_CONFIG_DIR := $(MAKEFILE_DIR)act4/config
@@ -171,7 +172,11 @@ elf-to-json: require-bin-ext
 	$(call ELF_TO_JSON,$(BIN_EXT),$(JSON_EXT))
 
 install-zkc:
+ifeq ($(SKIP_INSTALL_ZKC),true)
+	@echo "Skipping zkc installation because SKIP_INSTALL_ZKC=true"
+else
 	$(MAKE) -C $(ARITHMETIZATION_DIR) install-zkc
+endif
 
 zkc-exec: require-test install-zkc
 	zkc exec $(JSON) $(ZKC_MAIN)

--- a/arithmetization/src/test/examples/README.md
+++ b/arithmetization/src/test/examples/README.md
@@ -116,6 +116,8 @@ riscv-test debug <name>.<ext>
 riscv-test debug <name>.<ext> IN_BYTES="0xAABB"
 # Compile and execute with input bytes at a custom offset
 riscv-test <name>.<ext> IN_BYTES="0xAABB" IN_BYTES_OFFSET=0x08800008
+# Compile and execute using an already installed zkc
+SKIP_INSTALL_ZKC=true riscv-test <name>.<ext>
 # Compile only
 riscv-test compile <name>.<ext>
 # Convert an already compiled ELF to JSON
@@ -180,6 +182,7 @@ riscv-test compile <name>.<ext> VERIFY_ELF=true
 | `IN_BYTES_OFFSET`| `0x08800000`                                                                            | Memory address where input bytes are written (up to 1 GiB)                      |
 | `SP`             | `0x08800000`                                                                            | Top of the stack region, stack grows downward from this address (8 MiB)         |
 | `VERIFY_ELF`     | `false`                                                                                 | Set to `true` to verify offsets, entry point and sp match the ELF ones          |
+| `SKIP_INSTALL_ZKC`| `false`                                                                                 | Set to `true` to skip `install-zkc` when `zkc` is already installed             |
 | `ACT4_BUILD_MODE`| `host`                                                                                  | Build ACT4 ELFs with `host` or `docker`                                         |
 | `ACT4_REF`       | `9798a554ce4139f472c9ccd3a18c9061d0f7024d`                                              | `riscv-arch-test` tag or commit used to build ACT4 ELFs                         |
 | `ACT4_REPO`      | `../riscv-arch-test`                                                                    | Local `riscv-arch-test` checkout used for ACT4 builds                           |


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile and documentation only; no changes to zkVM execution, auth, or production paths.
> 
> **Overview**
> Adds optional **`SKIP_INSTALL_ZKC`** (default `false`) to the RISC-V examples **`Makefile`**, so **`install-zkc`** can skip delegating to `arithmetization`’s `install-zkc` when **`zkc` is already on PATH**.
> 
> When set to `true`, the target only prints a skip message instead of running the install. **`README.md`** documents the flag in the usage examples and options table (e.g. `SKIP_INSTALL_ZKC=true riscv-test <name>.<ext>`).
> 
> Targets that depend on **`install-zkc`** (`zkc-exec`, `zkc-debug`, `blake-rust-exec`, `run-act4`, etc.) behave the same except they no longer trigger a reinstall on each run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e198b336c7139e3375f621f92c54199576dbbab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->