### PR TITLE
ci(maru): split testing workflow

### DIFF
--- a/.github/workflows/maru-testing.yml
+++ b/.github/workflows/maru-testing.yml
@@ -40,9 +40,12 @@ jobs:
           submodules: false
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
-      - name: Build maru and run unit + integration tests
+      - name: Build maru and Unit tests
         run: |
-          ./gradlew -V :maru:app:buildNeeded
+          ./gradlew -V maru:app:buildNeeded
+      - name: Run integration tests
+        run: |
+          ./gradlew maru:app:integrationTest
       - name: Store reports
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/maru/app/build.gradle
+++ b/maru/app/build.gradle
@@ -153,5 +153,3 @@ afterEvaluate {
     }.flatten()
   }
 }
-
-check.dependsOn(integrationTest)


### PR DESCRIPTION
This PR implements issue(s) #2540 

### Summary

* Split the Maru CI workflow into separate build/unit and integration-test steps, aligned with coordinator's two-step CI shape.
* Removed `integrationTest` from `check` so `maru:app:buildNeeded` remains build/unit-test focused.
* Kept integration-test coverage scoped to the prior Maru app suite by running `maru:app:integrationTest` directly.

### Validation

* [x] `git diff --check`
* [x] `./gradlew -m maru:app:buildNeeded --console=plain` confirmed Maru integration-test tasks are not in `buildNeeded`.
* [x] `./gradlew -m maru:app:integrationTest --console=plain` confirmed the integration step invokes `:maru:app:integrationTest` and does not run `:jvm-libs:linea:web3j-extensions:integrationTest`.
* [ ] `./gradlew -V maru:app:buildNeeded` currently fails in existing upstream test `:jvm-libs:generic:json-rpc:test`, `VertxHttpJsonRpcClientTest > makesRequest_connectionFailure()` timing out after 15s. Rerunning that single test reproduced the same failure.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Gradle task wiring only; no application runtime or security logic changes.
> 
> **Overview**
> Maru CI now runs **build/unit** and **integration tests** as separate workflow steps, matching the coordinator testing layout: first `maru:app:buildNeeded`, then `maru:app:integrationTest`.
> 
> In `maru/app/build.gradle`, **`integrationTest` is no longer wired into `check`**, so default verification/`buildNeeded` stays focused on compile and unit tests instead of always running integration tests. The existing `mustRunAfter` ordering for `integrationTest` relative to other modules' `test` tasks is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2e2ed45061d8f74e769e7249722acf98d2415b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->