### PR TITLE
chore(maru): follow up for pr 3236

### DIFF
--- a/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/ByteArrayExtensions.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/ByteArrayExtensions.kt
@@ -69,7 +69,9 @@ fun ByteArray.encodeHex(prefix: Boolean = true): String {
 }
 
 fun ByteArray.xor(other: ByteArray): ByteArray {
-  require(this.size == other.size) { "ByteArrays must have the same length" }
+  require(this.size == other.size) {
+    "ByteArrays must have the same length. Array sizes: ${this.size}, ${other.size}"
+  }
   return ByteArray(this.size) { i -> this[i].xor(other[i]) }
 }
 

--- a/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/ULongExtensions.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/ULongExtensions.kt
@@ -79,9 +79,9 @@ fun ULong.minusCoercingUnderflow(other: ULong): ULong {
 fun ULong.clampedAdd(other: ULong): ULong {
   val result = this + other
   return if (result < this || result < other) {
-    ULong.MAX_VALUE
+    ULong.MAX_VALUE // Overflow occurred, return max value
   } else {
-    result
+    result // No overflow, return the result
   }
 }
 

--- a/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/ByteArrayExtensionsTest.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/ByteArrayExtensionsTest.kt
@@ -23,7 +23,7 @@ class ByteArrayExtensionsTest {
       .isEqualTo(byteArrayOf(0xff.toByte(), 0xff.toByte()))
     assertThatThrownBy { byteArrayOf(0x01).xor(byteArrayOf(0x01, 0x02)) }
       .isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessage("ByteArrays must have the same length")
+      .hasMessageContaining("ByteArrays must have the same length")
   }
 
   @Test

--- a/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/ULongExtensionsTest.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/ULongExtensionsTest.kt
@@ -12,13 +12,6 @@ class ULongExtensionsTest {
     ULong.MAX_VALUE to "0xffffffffffffffff",
   )
 
-  private fun String.toByteArray(): ByteArray =
-    this
-      .removePrefix("0x")
-      .chunked(2)
-      .map { it.toInt(16).toByte() }
-      .toByteArray()
-
   @Test
   fun `toHexString`() {
     uLongParsingTestCases.forEach { (number: ULong, hexString: String) ->
@@ -30,11 +23,11 @@ class ULongExtensionsTest {
   fun `ULong#toBytes32`() {
     val testCases =
       mapOf(
-        1UL to "0x0000000000000000000000000000000000000000000000000000000000000001".toByteArray(),
-        16UL to "0x0000000000000000000000000000000000000000000000000000000000000010".toByteArray(),
-        0xABCDEF1234567890UL to "0x000000000000000000000000000000000000000000000000abcdef1234567890".toByteArray(),
-        ULong.MIN_VALUE to "0x0000000000000000000000000000000000000000000000000000000000000000".toByteArray(),
-        ULong.MAX_VALUE to "0x000000000000000000000000000000000000000000000000ffffffffffffffff".toByteArray(),
+        1UL to "0x0000000000000000000000000000000000000000000000000000000000000001".decodeHex(),
+        16UL to "0x0000000000000000000000000000000000000000000000000000000000000010".decodeHex(),
+        0xABCDEF1234567890UL to "0x000000000000000000000000000000000000000000000000abcdef1234567890".decodeHex(),
+        ULong.MIN_VALUE to "0x0000000000000000000000000000000000000000000000000000000000000000".decodeHex(),
+        ULong.MAX_VALUE to "0x000000000000000000000000000000000000000000000000ffffffffffffffff".decodeHex(),
       )
 
     testCases.forEach { (number, byteArray) ->
@@ -154,17 +147,33 @@ class ULongExtensionsTest {
 
   @Test
   fun `clampedAdd returns sum when no overflow`() {
-    assertThat(10UL.clampedAdd(20UL)).isEqualTo(30UL)
+    val a = 10uL
+    val b = 20uL
+    val result = a.clampedAdd(b)
+    assertThat(result).isEqualTo(30uL)
   }
 
   @Test
   fun `clampedAdd returns ULong_MAX_VALUE on overflow`() {
-    assertThat(ULong.MAX_VALUE.clampedAdd(1UL)).isEqualTo(ULong.MAX_VALUE)
-    assertThat((ULong.MAX_VALUE - 1UL).clampedAdd(ULong.MAX_VALUE - 2UL)).isEqualTo(ULong.MAX_VALUE)
+    val a = ULong.MAX_VALUE
+    val b = 1uL
+    val result = a.clampedAdd(b)
+    assertThat(result).isEqualTo(ULong.MAX_VALUE)
+  }
+
+  @Test
+  fun `clampedAdd returns ULong_MAX_VALUE when both operands are large`() {
+    val a = ULong.MAX_VALUE - 1uL
+    val b = ULong.MAX_VALUE - 2uL
+    val result = a.clampedAdd(b)
+    assertThat(result).isEqualTo(ULong.MAX_VALUE)
   }
 
   @Test
   fun `clampedAdd works with zero`() {
-    assertThat(0UL.clampedAdd(0UL)).isEqualTo(0UL)
+    val a = 0uL
+    val b = 0uL
+    val result = a.clampedAdd(b)
+    assertThat(result).isEqualTo(0uL)
   }
 }

--- a/maru/app/build.gradle
+++ b/maru/app/build.gradle
@@ -47,7 +47,10 @@ dependencies {
   // :jvm-libs:generic:vertx-helper (Vert.x 5) because Besu 26.5's acceptance-tests-dsl
   // and besu-ethereum-p2p call removed Vert.x 4 methods/internals at runtime.
   // Tracked in libs.versions.toml `lineaPackages`.
-  implementation "build.linea.internal:vertx-helper:${libs.versions.lineaPackages.get()}"
+  implementation("build.linea.internal:vertx-helper:${libs.versions.lineaPackages.get()}") {
+    exclude group: "build.linea.internal", module: "kotlin"
+    exclude group: "build.linea.internal", module: "futures"
+  }
   implementation "io.vertx:vertx-micrometer-metrics"
 
   implementation "info.picocli:picocli:${libs.versions.picoli.get()}"


### PR DESCRIPTION
This PR implements issue(s) #2540 
Followup to PR #3236

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Classpath exclusions and test/documentation tweaks; no production logic changes beyond a clearer XOR validation message.
> 
> **Overview**
> Follow-up to Maru dependency work: **`maru/app`** now excludes **`build.linea.internal:kotlin`** and **`futures`** from the pinned published **`vertx-helper`** artifact so those libraries come only from the local **`jvm-libs`** projects already on the classpath.
> 
> In **`jvm-libs` Kotlin extensions**, **`ByteArray#xor`** reports both operand lengths when sizes differ; **`ULong#clampedAdd`** only gains clarifying comments (behavior unchanged). Tests align with the new XOR message, use shared **`decodeHex()`** instead of a test-only hex helper, and split **`clampedAdd`** cases for readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7615a9a779ddb63231451b44bfe1d265a8cca9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->