### PR TITLE
perf(prover-ray): `Vanishing -> VanishingManual` for lifted local constraint

### DIFF
--- a/prover-ray/wiop/compilers/localvanishing/localvanishing.go
+++ b/prover-ray/wiop/compilers/localvanishing/localvanishing.go
@@ -140,6 +140,16 @@ func reduce(
 	})
 
 	lifted := wiop.Mul(shifted, lagCol.View())
+	// Register with no cancelled positions: the constraint must hold on every
+	// row. That is safe and intentional. The shifted sub-expression may read
+	// out-of-domain (wrap-around) values at rows other than `anchor`, but the
+	// Lagrange factor L_anchor is zero everywhere except at `anchor`, so the
+	// product is trivially zero at every non-anchor row regardless of what
+	// the shift wraps to. Letting NewVanishing auto-cancel those rows would
+	// be redundant and would inflate the constraint's effective degree
+	// (cancellation polynomial degree feeds into computeRatio in the global
+	// compiler, growing the quotient ratio, the FFT coset, and the number of
+	// committed quotient share columns).
 	m.NewVanishingManual(ctx.Childf("global"), lifted)
 
 	v.MarkAsReduced()

--- a/prover-ray/wiop/compilers/localvanishing/localvanishing.go
+++ b/prover-ray/wiop/compilers/localvanishing/localvanishing.go
@@ -140,7 +140,7 @@ func reduce(
 	})
 
 	lifted := wiop.Mul(shifted, lagCol.View())
-	m.NewVanishing(ctx.Childf("global"), lifted)
+	m.NewVanishingManual(ctx.Childf("global"), lifted)
 
 	v.MarkAsReduced()
 }


### PR DESCRIPTION
Since the local-to-global constraint is guarded by a Lagrange indicator, its cancellation list is redundant. This PR removes the cancellation factor and thus reduces the degree of the constraint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registration-path change in the localvanishing compiler with documented algebraic justification; no auth or runtime user-facing behavior.
> 
> **Overview**
> The **localvanishing** pass now registers the Lagrange-lifted global constraint via **`NewVanishingManual`** instead of **`NewVanishing`**, with an **empty** cancellation set so the predicate is enforced on **every** row.
> 
> **`NewVanishing`** would auto-cancel rows implied by shifted column views; for this product that is redundant because **`L_anchor`** is zero off the anchor row, so the constraint is already satisfied there. Skipping those cancellations lowers the effective constraint degree in the global compiler (**`computeRatio`**, FFT coset, quotient share columns).
> 
> An inline comment documents why zero cancellations is sound despite possible wrap-around reads in the shifted part off-anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227825b685390b9d63da319fd9382f491300f92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->