### PR TITLE
fix(arithmetization): fix alert 514

### DIFF
--- a/maru/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
+++ b/maru/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
@@ -13,13 +13,14 @@ import com.palantir.docker.compose.DockerComposeRule
 import com.palantir.docker.compose.configuration.DockerComposeFiles
 import com.palantir.docker.compose.configuration.ProjectName
 import com.palantir.docker.compose.connection.waiting.HealthChecks
+import linea.kotlin.decodeHex
+import linea.kotlin.encodeHex
 import linea.kotlin.toULong
+import linea.testing.web3j.Web3jTransactionsHelper
 import maru.app.MaruApp
 import maru.config.ApiEndpointConfig
 import maru.config.FollowersConfig
 import maru.core.EMPTY_HASH
-import linea.kotlin.encodeHex
-import linea.kotlin.decodeHex
 import net.consensys.linea.async.toSafeFuture
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -39,7 +40,6 @@ import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.protocol.core.methods.response.EthBlock
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import linea.testing.web3j.Web3jTransactionsHelper
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
 import java.io.File

--- a/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
+++ b/tracer/arithmetization/src/main/java/net/consensys/linea/zktracer/module/mmio/Mmio.java
@@ -145,8 +145,8 @@ public class Mmio implements Module {
     final boolean isRamToRamTwoSource = (mmioData.instruction() == MMIO_INST_RAM_TO_RAM_TWO_SOURCE);
     final boolean isRamToRamTwoTarget = (mmioData.instruction() == MMIO_INST_RAM_TO_RAM_TWO_TARGET);
     final boolean isRamVanishes = (mmioData.instruction() == MMIO_INST_RAM_VANISHES);
-    int mmioLineCountingInstruction = lineCountOfMmioInstruction(mmioData.instruction());
-    for (short ct = 0; ct < mmioLineCountingInstruction; ct++) {
+    final int mmioLineCountingInstruction = lineCountOfMmioInstruction(mmioData.instruction());
+    for (int ct = 0; ct < mmioLineCountingInstruction; ct++) {
       trace
           .cnA(Bytes.minimalBytes(mmioData.cnA()))
           .cnB(Bytes.minimalBytes(mmioData.cnB()))
@@ -185,14 +185,8 @@ public class Mmio implements Module {
           .exoIsEcdata(effectiveExoIsEcData)
           .exoIsBlakemodexp(effectiveExoIsBlakeModexp)
           .exoIsRipsha(effectiveExoIsRipSha)
-          .exoIsKec(effectiveExoIsKeccak);
-      try {
-        trace.exoIsBls(effectiveExoIsBls);
-      }
-      // ignore exception, this columns appears in cancun
-      catch (final Exception ignored) {
-      }
-      trace
+          .exoIsKec(effectiveExoIsKeccak)
+          .exoIsBls(effectiveExoIsBls)
           .kecId(mmioData.kecId())
           .phase(mmioData.phase())
           .successBit(mmioData.successBit())


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small tracer wiring change for a trace column plus cosmetic import order in a disabled test; no runtime API or auth changes.
> 
> **Overview**
> **MMIO tracing** in `Mmio.java` now always writes the **`exoIsBls`** column on the trace builder instead of wrapping it in a try/catch that skipped the field when the API was missing (the old “Cancun-only” guard). The per-instruction line loop uses **`int`** for the line count and counter, matching `lineCountOfMmioInstruction()`.
> 
> **`CliqueToPosTest.kt`** only has import reordering; no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666edcfaf0e7a1b4921482e6e418d193634b722e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->