### PR TITLE
ci(codeql): tune query suite and scope analysis paths

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,3 +10,13 @@ paths-ignore:
   - "**/build/reports/**"
   # Auto-generated Swagger client for load-testing tools
   - "testing-tools/traffic-generator/src/main/java/net/consensys/zkevm/load/swagger/**"
+  # Test and tooling sources (not shipped).
+  - "**/src/test/**"
+  - "**/src/testFixtures/**"
+  - "**/src/integrationTest/**"
+  - "**/*Test.java"
+  - "**/*Tests.java"
+  - "**/*_test.go"
+  - "**/test_*.py"
+  - "testing-tools/**"
+  - "tracer/testing/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -102,7 +102,7 @@ jobs:
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended,security-and-quality
+          queries: security-extended
           config-file: .github/codeql/codeql-config.yml
 
       - name: Setup Java


### PR DESCRIPTION
Tunes CodeQL configuration to reduce low-value findings.

- Use the `security-extended` query suite; drop the redundant `security-and-quality` suite (a superset that additionally runs maintainability/reliability queries).
- Scope test and tooling sources out of analysis (`paths-ignore`).

### Checklist
- [x] Validated YAML locally.
- N/A — CI/config-only change: no app code, no new tests, no E2E impact, no breaking changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only CodeQL config changes; no runtime or application code is affected.
> 
> **Overview**
> Narrows CodeQL to **security-focused** analysis and **production paths** only.
> 
> The workflow now initializes CodeQL with the **`security-extended`** query suite only, dropping **`security-and-quality`** so maintainability/reliability rules no longer run alongside security checks.
> 
> `codeql-config.yml` adds **`paths-ignore`** entries for test trees (`src/test`, `testFixtures`, integration tests, `*Test.java`, Go/Python test patterns), **`testing-tools/**`**, and **`tracer/testing/**`**, so findings target shipped code rather than tests and tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab312e7ba08517e81cced8942be6ec63fc28936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->