### PR TITLE
feat: prover workflow + deep fri

### DIFF
--- a/prover-ray/docs/multi_degree_fri.txt
+++ b/prover-ray/docs/multi_degree_fri.txt
@@ -1,0 +1,346 @@
+Multi-degree FRI
+================
+
+Goal
+----
+Standard FRI tests proximity for a single polynomial of degree < D evaluated on
+a domain of size N. When a proof system needs to certify several polynomials of
+*different* degrees, the naive approach pads all of them to the maximum degree
+(by evaluating on the full domain of size N) and commits to them before round 0.
+
+Multi-degree FRI avoids this cost: a polynomial of degree D_l < D is committed
+and batched into the running FRI polynomial exactly at the folding round where
+the running polynomial's degree has been reduced to D_l. That polynomial is then
+*never* evaluated on the full-size domain, only on its natural domain of size
+N_l = N * D_l / D (same blowup factor as the initial polynomial).
+
+This is the protocol needed in loom because, after the STARK quotient
+computation, the prover holds polynomials of several different degrees: the
+trace polynomials (degree N_module for each module) and the AIR quotient chunks
+(degree N_module / chunks). Rather than padding all of them to the largest
+module domain, multi-degree FRI lets each polynomial be committed and folded
+at its own level.
+
+
+Terminology
+-----------
+  N       = 2^n : full evaluation domain size (shared across all levels)
+  D       = 2^m : maximum degree (degree of the initial polynomial)
+  r = m   : total number of folding rounds
+  ρ = N/D : common blowup factor (must be the same for all levels)
+
+Domain at round j (j = 0..r):
+  Nⱼ = N / 2^j     (domain size)
+  Dⱼ = D / 2^j     (degree bound of the running polynomial after j folds)
+
+Pairing property (inherited from standard FRI): for any x = ωⱼ^i,
+its sibling is -x = ωⱼ^(i + Nⱼ/2).
+
+
+Level concept
+-------------
+A Level is one polynomial with degree bound D_l, introduced into the FRI
+protocol at the folding round where the running polynomial has the same degree
+bound. Callers that have several same-degree polynomials must batch/fold them
+before calling FRI.
+
+  type Level struct {
+      D     int         // degree bound; must divide D and D must divide N
+      Evals LevelEvals  // exactly one Base or Ext evaluation vector, size N_l = N * D_l / D
+      Tree  *merkle.Tree
+  }
+
+Key property: D_l must equal Dⱼ for some j ∈ {0..r}. The introduction round is:
+
+  j_l = log₂(D / D_l)
+
+At round j_l, the running polynomial has been folded j_l times and lives on
+domain Dⱼ_l = D / 2^{j_l} = D_l. The level polynomials share this domain, so
+they can be linearly combined with the running polynomial without any
+intermediate commitment to the combined result.
+
+The first level (j_l = 0) contains exactly ONE polynomial — the initial
+polynomial. All subsequent levels (j_l > 0) also contain exactly one polynomial.
+
+
+Commit phase (Prover)
+---------------------
+Input:
+  levels  : []Level, sorted in *decreasing* order of Level.D
+            levels[0].D = D (the initial polynomial)
+            levels[1].D > levels[2].D > ... (strictly decreasing)
+
+State: running = levels[0].Evals   (evaluation vector of size N)
+
+For j = 0 .. r-1:
+
+  ── Level batching step (if any level l has j_l = j, i.e. levels[l].D = Dⱼ) ──
+  Note: j = 0 is handled as the "initial polynomial" and there is no batching
+  step at j = 0 (levels[0] simply initialises `running`).
+  For j > 0 and any level l with j_l = j:
+
+    1. The caller provides the Merkle tree T_l over levels[l].Evals
+       (using the same paired-leaf scheme as standard FRI:
+        leaf k = hash( encode(evals[k]) || encode(evals[k + N_l/2]) )).
+       Bind its root to the transcript:
+         ts.Bind("fri_level_{l}_gamma", R_l)
+
+    2. Compute batching challenge:
+         ts.NewChallenge("fri_level_{l}_gamma")
+         b = ts.ComputeChallenge("fri_level_{l}_gamma")
+         γ_l.SetBytes(b)
+
+    3. Mix the level polynomial into running (pointwise):
+         running = running + γ_l * levels[l].Evals
+
+  ── Standard FRI commit step ────────────────────────────────────────────────
+
+  4. Build Merkle tree T_j over running (the current, possibly batched, vector):
+       ts.Bind("fri_fold_{j}", root(T_j))
+
+  5. Compute fold challenge:
+       b = ts.ComputeChallenge("fri_fold_{j}")
+       α_j.SetBytes(b)
+
+  6. Fold:
+       running = foldLayer(running, α_j, domains[j])
+     (standard FRI folding: halves the domain and degree)
+
+After all r rounds, running has size N_r = N/D (= blowup factor, the number
+of constant evaluations). This is FinalPoly.
+
+  7. Send FinalPoly explicitly.
+       ts.Bind("fri_query_0", serialise(FinalPoly))
+
+
+Query phase (Prover and Verifier)
+----------------------------------
+Query indices are derived the same way as in standard FRI:
+
+  For k = 0..Q-1:
+    b = ts.ComputeChallenge("fri_query_{k}")
+    s_k = BigEndian.Uint64(b[:8]) mod (N/2)
+    ts.Bind("fri_query_{k+1}", b)      (if k < Q-1)
+
+For each query k with index s_k, the proof must provide:
+
+  (A) For each level l at round j_l (l = 1..numLevels-1):
+        Open the pair at position s_k in T_l:
+          base_l = s_k mod (N_l / 2)
+          LeafP_l = levels[l].Evals[ base_l ]
+          LeafQ_l = levels[l].Evals[ base_l + N_l/2 ]
+        Provide Merkle proof against R_l.
+
+  (B) For each round j = 0..r-1 (the standard FRI path):
+        Open the pair at position s_k in T_j:
+          base_j = s_k mod (N_j / 2)
+          LeafP_j = running_j[ base_j ]
+          LeafQ_j = running_j[ base_j + N_j/2 ]
+        Provide Merkle proof against root(T_j).
+
+        (Note: running_j is the evaluation vector of the running polynomial
+         AFTER all level batching at round j, BEFORE folding. It is what
+         T_j was built from.)
+
+
+Verification
+------------
+The verifier replays the Fiat-Shamir transcript (same challenge names and Bind
+sequence as the prover) to derive γ_l, α_j, and s_k.
+
+For each query k with index s_k:
+
+  1. Authenticate all level openings (part A):
+     For each level l with j_l > 0:
+       leafData = encode(LeafP_l) || encode(LeafQ_l)
+       Verify Merkle proof against R_l.
+
+  2. Authenticate and fold along the FRI path (part B):
+     For j = 0..r-1:
+       base_j = s_k mod (N_j / 2)
+       leafData = encode(LeafP_j) || encode(LeafQ_j)
+       Verify Merkle proof against root(T_j).
+
+       Compute expected folded value:
+         x^{-1} = ωⱼ^{N_j - base_j}
+         expected_j = (LeafP_j + LeafQ_j) * invTwo
+                    + α_j * (LeafP_j - LeafQ_j) * invTwo * x^{-1}
+
+       If j < r-1:  check expected_j == Layers[j+1].LeafP (or LeafQ)
+       If j == r-1: check expected_j == FinalPoly[ s_k mod N_r ]
+
+  3. Check batching consistency at each level boundary:
+     For each level l with j_l > 0, at positions base_l = s_k mod (N_l / 2):
+
+       Let "pre_P" = the value of the running polynomial at base_l
+         BEFORE level l was added. This is derived from the previous folding
+         step: it is expected_{j_l - 1} that was computed in step 2 when
+         j = j_l - 1.
+
+         (More precisely, if base_{j_l} = base_l in the lower half of T_{j_l},
+          then pre_P = expected_{j_l - 1}. The "upper half" case uses the fact
+          that running_{j_l}[base_l] = LeafP_{j_l} and checking involves LeafQ.)
+
+       Verify that the committed running_j_l value is the linear combination:
+
+         LeafP_{j_l} = pre_P + γ_l * LeafP_l
+         LeafQ_{j_l} = pre_Q + γ_l * LeafQ_l
+
+       where pre_Q is the corresponding upper-half value derived analogously.
+
+     This check ties the Merkle-authenticated level polynomial openings to the
+     Merkle-authenticated running polynomial openings.
+
+Caveat: for j = 0 (the initial polynomial) there is no batching check — the
+running polynomial IS levels[0].Evals, and its Merkle root R_0 = root(T_0)
+is provided separately to Verify (same convention as standard FRI).
+
+
+Proof structure
+---------------
+  type Proof struct {
+      // Level roots are not stored here. Verify receives one root per Level
+      // from the caller; root[0] is the root of the initial running polynomial.
+
+      // ── Standard FRI fields (running polynomial path) ──────────────────────
+      FRIRoots  [][]byte             // Merkle roots of running polynomial T_1..T_{r-1}
+      FinalPoly []koalabear.Element  // explicit final folded evaluations
+
+      // Query phase
+      // LevelQueries[l][k] = opening of level-(l+1) at query k
+      //   (indexed from l=0 for levels[1])
+      LevelQueries [][]QueryLayer    // [numLevels-1][NumQueries]
+
+      // FRIQueries[k] = standard FRI query path for query k
+      FRIQueries []Query             // [NumQueries]
+  }
+
+Challenge naming convention
+----------------------------
+Building on the existing fri naming:
+
+  Level batching challenges:
+    "fri_level_{l}_gamma"       bind the level root, then derive γ_l
+
+  Standard fold challenges (unchanged):
+    "fri_fold_{j}"              for j = 0..r-1
+
+  Query challenges (unchanged):
+    "fri_query_{k}"             for k = 0..Q-1
+
+Both Prove and Verify register these names at the start (ts.NewChallenge).
+The registration order must be identical in prover and verifier.
+
+Registration order:
+  1. For j = 0..r-1:
+       if a level is introduced at j: ts.NewChallenge("fri_level_{l}_gamma")
+       ts.NewChallenge("fri_fold_{j}")
+  2. For k = 0..Q-1: ts.NewChallenge("fri_query_{k}")
+
+The Bind/Compute interleaving during the commit phase must follow the same
+order as above — level l's roots are bound before the fold challenge for
+round j_l, and fold challenges are derived in round order j = 0..r-1.
+
+
+Relationship to standard FRI
+------------------------------
+Standard FRI is the special case with a single level:
+  levels = []Level{ {D: D, Evals: LevelEvals{Base: a₀}, Tree: T_0} }
+
+There are no "fri_level_*" challenges, and multi-degree Prove reduces to
+standard FRI. The Proof type also reduces to the standard proof shape.
+
+
+Go API
+------
+
+// Prove runs multi-degree FRI. It requires:
+//   p      : Params built with the MAXIMUM degree D and domain N
+//   levels : []Level sorted in decreasing order of Level.D
+//            levels[0].D must equal p.D
+//            Each levels[l].Evals must have length N * levels[l].D / p.D
+//            Each levels[l].Tree must commit to levels[l].Evals
+//   ts     : transcript already initialised with outer context
+//
+// Returns the Proof and the query positions s_0..s_{Q-1}.
+func Prove(p Params, levels []Level, ts *fiatshamir.Transcript) (Proof, []int, error)
+
+// Verify checks a multi-degree FRI proof.
+//   p      : same Params used in Prove
+//   roots  : one Merkle root per Level, in the same order as levelDs
+//   levelDs: one D value per Level, in the same order used by Prove
+//   proof  : Proof produced by Prove
+//   ts     : transcript in the same state as when Prove was called
+func Verify(p Params, roots [][]byte, levelDs []int, proof Proof, ts *fiatshamir.Transcript) error
+
+
+Implementation notes
+---------------------
+1. Level ordering: Prove must sort levels by decreasing D before proceeding.
+   Verify that levels[0].D == p.D and levels[0].Evals has length p.N.
+   Each levels[l].D must be a power of two dividing p.D; j_l = log₂(D/levels[l].D)
+   must be in {1..r-1}.
+
+2. Domain reuse: domain[j_l] in p.Params is already precomputed and has
+   cardinality N_l = N / 2^{j_l} = N * levels[l].D / D. No new domain is needed.
+
+3. Merkle tree construction: same paired-leaf scheme as standard FRI.
+   leaf k = hash( encode(evals[k]) || encode(evals[k + N_l/2]) )
+   Applied to each levels[l].Evals.
+
+4. Batching challenge: each non-initial level contributes γ_l * levels[l].Evals.
+
+5. Pre-computation of running polynomial at level boundaries: the running
+   polynomial at the START of round j_l is the result of foldLayer applied
+   j_l times to levels[0].Evals. It is NOT separately committed; only
+   the POST-batching running polynomial is committed (T_{j_l} builds over
+   the combined vector).
+
+   For the verifier's batching check, "pre_P" is reconstructed from the
+   folding consistency chain: expected_{j_l - 1} gives the folded value
+   that equals running_{j_l} MINUS the level contributions. Rearranging:
+     pre_P = LeafP_{j_l} - γ_l * LeafP_l
+   and the verifier checks this equals expected_{j_l - 1}.
+
+6. Edge case — multiple levels at the same round: the spec allows at most one
+   level per folding round. If two sets of polynomials have the same degree,
+   the caller must batch them before FRI. The Prove precondition check should
+   reject duplicate D values in levels.
+
+7. The query for a level polynomial has a single paired-leaf opening, since the
+   polynomial is only committed at its natural domain level. The subsequent FRI
+   folding consistency is ensured through the running polynomial path (the
+   standard FRIQueries), not through another per-level folding path.
+
+
+Design decisions
+-----------------
+[1] COMMIT BEFORE OR AFTER BATCHING?
+  Option A (chosen): commit to each level polynomial separately (T_l over
+    levels[l].Evals), then mix it into the running polynomial. The running
+    polynomial T_{j_l} commits to the POST-batching vector.
+  Option B: batch first (without committing level polys separately), then commit
+    the combined running polynomial. Verification cannot check batching without
+    the separate commitments, so option B is unsound.
+
+[2] SINGLE γ PER LEVEL VS PER POLYNOMIAL
+  There is one challenge γ_l per non-initial level. It is derived after binding
+  that level's root and is used as γ_l * levels[l].Evals.
+
+[3] LEVEL POLYNOMIAL QUERY DEPTH
+  Each level polynomial only needs a single Merkle opening (at its natural
+  domain level). It is NOT folded through subsequent rounds in its own tree.
+  The folding consistency from round j_l onward is entirely captured by the
+  running polynomial path.
+
+[4] INTERACTION WITH OUTER PROOF SYSTEM (loom)
+  In loom, the outer proof system calls Prove with:
+    - levels[0]: the deep-quotient polynomial DQ (degree N_max, the largest
+      module domain size), evaluated on a domain of size N_max * RATE
+    - Additional levels for each distinct module/chunk degree
+
+  The query positions returned by Prove are the same s_k used in loom's
+  PointSamplings. The FS transcript is shared with loom's outer protocol
+  (same *fiatshamir.Transcript). The "check FRI bridge" verifier step must
+  verify that DQ(ω^{s_k}) computed from PointSamplings equals the Layer-0
+  LeafP/LeafQ of each FRIQuery, as in the single-degree case.

--- a/prover-ray/docs/prove_workflow.md
+++ b/prover-ray/docs/prove_workflow.md
@@ -1,0 +1,517 @@
+# Prover Workflow
+
+This note describes the current `Prove` workflow, with emphasis on the
+DEEP quotient and on the bridge between FRI openings and the commitments to the
+trace/setup/AIR polynomials.
+
+It is a first draft for readers who already know STARK-style polynomial IOPs and
+FRI. The multi-degree FRI protocol is only summarized here; see
+`internal/fri/multi_degree_fri.txt` for the dedicated protocol note.
+
+## Main Objects
+
+A statement contains:
+
+- a compiled `board.Program`;
+- a `VerificationKey`, i.e. setup Merkle roots for fixed/setup columns;
+- public inputs.
+
+A witness contains:
+
+- a witness `trace.Trace`;
+- a `ProvingKey`, i.e. setup trace columns in Lagrange form plus the setup
+  Merkle trees.
+
+The prover and verifier both build the same canonical commitment layout:
+
+```text
+setup trees, decreasing N
+trace round 0 trees, decreasing N
+trace round 1 trees, decreasing N
+...
+AIR quotient trees, decreasing N
+```
+
+Each tree groups polynomials with the same native domain size `N`. Base-field
+and extension-field rails share one tree for a given size. Inside a tree, a
+Merkle leaf stores the paired evaluations
+
+```text
+{ f(w^i), f(-w^i) }
+```
+
+over the Reed-Solomon encoded domain of size `RATE * N`. Therefore a tree for
+size `N` has `RATE * N / 2` leaves.
+
+This paired-leaf convention is used both by the trace/setup/AIR commitments and
+by FRI level commitments.
+
+## High-Level Prove Sequence
+
+The prover sequence is:
+
+1. Initialize the prover runtime.
+2. Execute witness-generation steps and commit trace columns at Fiat-Shamir
+   boundaries.
+3. Compute and commit AIR quotient chunks.
+4. Derive `zeta`.
+5. Compute all evaluations at `zeta` needed by the verifier.
+6. Derive `alpha_DEEP` from those evaluation claims.
+7. Build one DEEP quotient polynomial per distinct module size.
+8. Commit the DEEP quotients and prove them with multi-degree FRI.
+9. Open all original commitments at the FRI query positions.
+
+The final proof contains:
+
+- trace/AIR commitment roots, excluding setup roots;
+- claimed values at `zeta`;
+- exposed values;
+- DEEP quotient commitment roots;
+- the multi-degree FRI proof;
+- Merkle openings of setup, trace, and AIR trees at the FRI query positions.
+
+## Transcript Order
+
+The transcript is shared by the main protocol and FRI.
+
+During runtime initialization:
+
+- the hash backend identifier is bound;
+- setup roots are bound;
+- public inputs are bound;
+- the challenge names for trace rounds, `zeta`, and `alpha_DEEP` are registered.
+
+During `ExecuteSteps`, each Fiat-Shamir boundary commits the columns that must
+exist before the corresponding challenge:
+
+```text
+commit roots for round r dependencies
+bind those roots to challenge_r
+derive challenge_r
+write challenge_r into the trace as an extension-field column
+```
+
+After all witness-generation steps, `ComputeAIRQuotients` commits the AIR
+quotient chunks and binds their roots to the `zeta` challenge. Then `zeta` is
+derived.
+
+After the prover has computed all values at `zeta`, it binds those values to
+`alpha_DEEP` and derives `alpha_DEEP`. No new commitment is created between
+`zeta` and `alpha_DEEP`; the binding data is the set of claimed evaluations that
+the DEEP quotient will batch.
+
+FRI then appends its own challenges to the same transcript.
+
+## Trace Commitments
+
+The program is divided into Fiat-Shamir rounds. Each round has a list of column
+dependencies, `program.FScolumnsDependencies[round]`. When a round is reached,
+the prover:
+
+1. groups the dependent columns by module size `N`;
+2. commits each group with `RSCommit`;
+3. records the tree in the canonical layout;
+4. stores the Merkle root in `proof.Commitments`;
+5. binds the root before deriving the round challenge.
+
+Setup columns are not stored in `proof.Commitments`. Their roots come from the
+verification key. On the prover side, setup columns are merged into the trace so
+that expression evaluation can treat setup and witness columns uniformly.
+
+## AIR Quotients
+
+Each module has a vanishing relation `V_m(X)` over its native domain of size
+`N_m`. The intended AIR statement is:
+
+```text
+V_m(X) = 0 on X^N_m - 1
+```
+
+Equivalently, there exists a quotient polynomial `Q_m(X)` such that:
+
+```text
+V_m(X) = (X^N_m - 1) * Q_m(X)
+```
+
+`ComputeAIRQuotients` computes this quotient from the trace. If the quotient is
+larger than the native module size, it is split into chunks of size `N_m`:
+
+```text
+Q_m(X) = q_0(X) + X^N_m q_1(X) + X^(2N_m) q_2(X) + ...
+```
+
+Each chunk is committed like any other polynomial, grouped by size. These AIR
+chunk roots are bound before deriving `zeta`.
+
+The prover then evaluates each AIR chunk at `zeta` and stores the values in
+`proof.ValuesAtZeta`.
+
+The verifier reconstructs:
+
+```text
+Q_m(zeta) = q_0(zeta) + zeta^N_m q_1(zeta) + zeta^(2N_m) q_2(zeta) + ...
+```
+
+and checks:
+
+```text
+V_m(zeta) = (zeta^N_m - 1) * Q_m(zeta)
+```
+
+This check is purely algebraic in the claimed `ValuesAtZeta`. The DEEP quotient
+and FRI bridge are what tie those claimed values back to the committed
+polynomials.
+
+## Values At Zeta
+
+After `zeta` is sampled, the prover computes every value needed to evaluate the
+AIR relations at `zeta`.
+
+For an unrotated column `c`, it stores:
+
+```text
+c(zeta)
+```
+
+For a rotated column `c[k]`, it stores:
+
+```text
+c(zeta * omega^k)
+```
+
+where `omega` is the generator of the module domain.
+
+The verifier also populates some `ValuesAtZeta` entries by itself:
+
+- challenge columns are recomputed from the transcript;
+- Lagrange columns are evaluated directly;
+- public-input columns are reconstructed from the public input entries;
+- exposed columns are reconstructed from values carried in the proof.
+
+## DEEP Quotient Layout
+
+The prover and verifier both call `BuildDeepQuotientLayout(program)`. This
+layout fixes a deterministic order for all polynomials batched by the DEEP
+quotient.
+
+For each distinct size `N`, in decreasing order, the layout contains:
+
+1. all trace/setup columns appearing in vanishing relations, grouped by rotation
+   shift;
+2. all AIR quotient chunks of size `N`.
+
+Columns are deduplicated by their expression leaf key, so the same column/shift
+claim is bound once per size.
+
+The same layout is used for three things:
+
+- binding claimed evaluations before deriving `alpha_DEEP`;
+- building the prover's DEEP quotient polynomials;
+- recomputing the bridge checks in the verifier.
+
+## Alpha Deep
+
+`alpha_DEEP` batches all DEEP evaluation claims. Before sampling it, the prover
+binds every claimed evaluation that will enter the DEEP quotient:
+
+```text
+for each size N
+  for each rotation shift
+    bind c(zeta * omega^shift) for every selected column c
+  bind q_i(zeta) for every AIR quotient chunk q_i of size N
+derive alpha_DEEP
+```
+
+The verifier repeats the same binding order. This prevents the prover from
+choosing `alpha_DEEP` before fixing the claimed evaluations.
+
+## DEEP Quotient Construction
+
+Fix a size `N`. We should build one extension-field DEEP quotient polynomial
+`DQ_N` for all claims of that size.
+
+### Rotated Trace And Setup Columns
+
+For a fixed rotation shift `s`, define:
+
+```text
+z_s = zeta * omega^s
+```
+
+Let the selected columns at this size and shift be:
+
+```text
+c_0, c_1, ..., c_t
+```
+
+and let their claimed evaluations be:
+
+```text
+v_i = c_i(z_s)
+```
+
+Using powers of `alpha_DEEP`, the prover forms the linear combination:
+
+```text
+C_s(X) = c_0(X) + alpha c_1(X) + alpha^2 c_2(X) + ...
+v_s    = v_0    + alpha v_1    + alpha^2 v_2    + ...
+```
+
+Then it computes the DEEP quotient:
+
+```text
+DQ_s(X) = (v_s - C_s(X)) / (z_s - X)
+```
+
+This is done in Lagrange form over the native domain of size `N`.
+
+### AIR Quotient Chunks
+
+AIR quotient chunks are not rotated. If the chunks of size `N` are:
+
+```text
+q_0, q_1, ..., q_u
+```
+
+and their claimed evaluations are:
+
+```text
+w_i = q_i(zeta)
+```
+
+the prover continues the same powers of `alpha_DEEP` and forms:
+
+```text
+C_air(X) = alpha^a q_0(X) + alpha^(a+1) q_1(X) + ...
+v_air    = alpha^a w_0    + alpha^(a+1) w_1    + ...
+```
+
+Then:
+
+```text
+DQ_air(X) = (v_air - C_air(X)) / (zeta - X)
+```
+
+### One Polynomial Per Size
+
+The per-size DEEP quotient is:
+
+```text
+DQ_N(X) = sum over shifts s of DQ_s(X) + DQ_air(X)
+```
+
+The prover Reed-Solomon encodes `DQ_N` on the domain of size `RATE * N` and
+builds a paired-leaf Merkle tree. The root is stored in
+`proof.DeepQuotientCommitment`.
+
+There is one such polynomial for every distinct module size. These polynomials
+are the levels passed to multi-degree FRI.
+
+## Same-Degree Folding
+
+We fold same-degree objects before invoking FRI.
+
+For a fixed size `N`, all trace/setup columns and AIR quotient chunks that need
+to be linked to `zeta` are folded into one DEEP quotient polynomial `DQ_N` using
+the random powers of `alpha_DEEP`.
+
+This includes AIR quotient chunks. They are not treated as a separate PCS
+object after this point: their committed openings enter the same DEEP quotient
+bridge as trace/setup column openings.
+
+The result is:
+
+```text
+one DEEP quotient polynomial per distinct size N
+```
+
+The remaining different sizes are handled by multi-degree FRI. The largest
+`DQ_N` starts as FRI level 0. Smaller `DQ_N` polynomials are introduced at the
+FRI round where the running degree has been folded down to their degree bound.
+At that round, FRI samples a batching challenge and mixes the level polynomial
+pointwise into the running polynomial.
+
+This note does not try to explain the full multi-degree FRI protocol. The
+important point here is that FRI checks low-degree proximity for the folded
+collection of all `DQ_N` polynomials without forcing every size to be padded to
+the largest domain.
+
+## Opening The Original Commitments
+
+FRI proves low degree of the DEEP quotient codewords. It does not, by itself,
+prove that those codewords were computed from the committed trace/setup/AIR
+polynomials. We should therefore add a bridge.
+
+After `fri.Prove`, the prover knows the FRI query positions. For each query
+position `s`, it opens every original commitment tree in the canonical layout:
+
+```text
+setup trees
+trace-round trees
+AIR quotient trees
+```
+
+For a tree with native size `N`, the prover opens:
+
+```text
+s mod (RATE * N / 2)
+```
+
+and sends the paired leaf:
+
+```text
+{ f(X), f(-X) }
+```
+
+for every polynomial in that tree, plus the Merkle path.
+
+These openings are stored in:
+
+```text
+proof.PointSamplings[query][tree]
+```
+
+The verifier first checks all these Merkle paths against the setup roots and the
+proof commitment roots. This authenticates the local values of the committed
+trace/setup/AIR codewords at the same points used by FRI.
+
+## FRI Bridge Check
+
+The verifier then recomputes the DEEP quotient locally at each FRI query point.
+
+For a query and size `N`, let:
+
+```text
+X  = the sampled point on the RATE * N domain
+-X = the paired sibling point
+```
+
+Using `proof.PointSamplings`, the verifier reads the committed values:
+
+```text
+c_i(X), c_i(-X)
+q_j(X), q_j(-X)
+```
+
+Using `proof.ValuesAtZeta`, it reads the claimed out-of-domain values:
+
+```text
+c_i(zeta * omega^s)
+q_j(zeta)
+```
+
+Using the same `alpha_DEEP` powers and the same layout, it recomputes:
+
+```text
+DQ_N(X)
+DQ_N(-X)
+```
+
+from the quotient formulas above.
+
+It then compares these values against the DEEP quotient values opened by the
+FRI proof:
+
+- for the largest size, against the level-0 FRI query;
+- for smaller sizes, against the corresponding multi-degree FRI level query.
+
+This is the explicit bridge:
+
+```text
+original Merkle commitments
+        |
+        | PointSamplings + checkFRIBridge
+        v
+DEEP quotient codewords
+        |
+        | multi-degree FRI
+        v
+low-degree claim
+```
+
+## Why The Bridge Is Sound
+
+The verifier checks three different kinds of evidence:
+
+1. Merkle openings bind sampled values to committed codewords.
+2. The DEEP quotient bridge checks that those sampled values and the claimed
+   `ValuesAtZeta` satisfy the DEEP quotient identities at the FRI sample
+   points.
+3. Multi-degree FRI checks that the DEEP quotient codewords are close to
+   low-degree polynomials.
+
+The soundness intuition is:
+
+- If a committed column is close to a low-degree polynomial `c`, and a claimed
+  value `v` is really `c(z)`, then `(v - c(X)) / (z - X)` is also low degree.
+- If `v` is not the value of the low-degree polynomial committed by the prover,
+  the resulting quotient is not a low-degree polynomial correlated with the
+  committed codeword except with small probability.
+- The random `alpha_DEEP` combines many such claims into one relation, so the
+  prover cannot choose cancellations between different bad claims after seeing
+  the challenge.
+- The verifier samples the same points in the original commitments and in the
+  DEEP quotient FRI proof. Therefore the prover must make the committed
+  codewords and the FRI-proven quotient agree under the DEEP relation at random
+  locations.
+
+This is the role of the Correlated Agreement Theorem. Informally, it says that
+if the DEEP quotient codeword is low-degree and agrees at the sampled points
+with the quotient relation induced by the committed codewords, then the claimed
+out-of-domain evaluations are jointly consistent with the same low-degree
+objects, except with the usual proximity/query soundness error.
+
+This theorem is what justifies using the bridge checks to connect:
+
+```text
+AIR relation checks at zeta
+```
+
+to:
+
+```text
+Merkle commitments to trace/setup/AIR codewords
+```
+
+without opening every committed polynomial at `zeta` through a separate PCS
+proof.
+
+## Verifier Workflow Summary
+
+The verifier mirrors the prover:
+
+1. Rebuild the canonical layout.
+2. Reconstruct the flat root list:
+
+   ```text
+   setup roots from VerificationKey ++ proof.Commitments
+   ```
+
+3. Replay transcript bindings to derive trace challenges and `zeta`.
+4. Reconstruct verifier-owned `ValuesAtZeta`: challenges, public inputs,
+   exposed values, and Lagrange columns.
+5. Check logup buses.
+6. Check AIR equations at `zeta`.
+7. Bind all DEEP evaluation claims and derive `alpha_DEEP`.
+8. Verify the multi-degree FRI proof for the DEEP quotient commitments.
+9. Verify Merkle openings in `proof.PointSamplings`.
+10. Run `checkFRIBridge` to tie the FRI-proven DEEP quotients to the original
+    trace/setup/AIR commitments.
+
+The order matters: `alpha_DEEP` is derived before FRI appends its own
+challenges, and after all evaluation claims entering the DEEP quotient have
+been transcript-bound.
+
+## Current Limitations And Notes
+
+- This document treats multi-degree FRI as a black box. It only states where
+  smaller-degree DEEP quotient polynomials enter the FRI folding process.
+- The DEEP quotient is currently built on the extension rail.
+- Setup columns are committed once in `Setup`; the prover carries the setup
+  trace in the proving key so it can evaluate setup columns when building the
+  DEEP quotient and query openings.
+- Public input columns are materialized in the prover trace, while the verifier
+  reconstructs their value at `zeta` from the public input entries.
+- Exposed values are proof-carried values reconstructed by the verifier at
+  `zeta`; they are distinct from statement public inputs even though they share
+  similar data representation.


### PR DESCRIPTION
Documentation on multi degree FRI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no executable code, configuration, or cryptographic implementation modified.
> 
> **Overview**
> Adds two **documentation-only** specs under `prover-ray/docs/` (no runtime or protocol code in this diff).
> 
> **`multi_degree_fri.txt`** defines **multi-degree FRI**: polynomials of different degree bounds are committed on their natural (smaller) domains and **batched into the running FRI codeword at the folding round** where degrees match, instead of padding everything to the maximum domain. It specifies `Level` inputs, Fiat–Shamir challenge names (`fri_level_*`, `fri_fold_*`, `fri_query_*`), commit/query/verify steps (including batching consistency checks), proof shape, proposed `Prove`/`Verify` Go API, and how **loom** should feed per-size DEEP quotients as FRI levels with shared query indices.
> 
> **`prove_workflow.md`** walks through the intended **`Prove` / verifier flow**: canonical Merkle layout, transcript ordering, AIR quotients and `ValuesAtZeta`, **`alpha_DEEP`** binding, per-module-size **DEEP quotient** construction, multi-degree FRI on those quotients, **`PointSamplings`** openings at FRI query positions, and **`checkFRIBridge`** linking committed trace/setup/AIR codewords to FRI-opened DEEP quotients (with a short soundness sketch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb892f27c091d8b384c75d922b25d7325cd9c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->