### PR TITLE
fix(contracts): fixed oz version and clean pnpm i

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean-environment:
 		make clean-local-folders;
 		$(MAKE) seed-deny-list; # truncate runtime deny-list and drop any stale lockfile from a crashed run
 		docker volume rm linea-local-dev linea-logs || true; # ignore failure if volumes do not exist already
-		docker system prune -f || true;
+		docker image prune -f || true;
 
 # Ensure the runtime sequencer deny-list exists (empty) before docker compose
 # bind-mounts it. Gitignored; may be mutated at test time by withDenyListAddresses.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test:script": "jest --config ./jest.script.config.ts",
+    "pretest:local:run": "pnpm --filter @consensys/linea-shared-utils run build",
     "test:local:run": "TEST_ENV=local jest",
     "test:local": "pnpm run test:local:run --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts && pnpm run test:liveness:local",
     "test:local-core": "pnpm run test:local:run --testPathIgnorePatterns=linea-besu-fleet.spec.ts --testPathIgnorePatterns=liveness.spec.ts --testPathIgnorePatterns=messaging.spec.ts --testPathIgnorePatterns=bridge-tokens.spec.ts --testPathIgnorePatterns=shomei-get-proof.spec.ts --testPathIgnorePatterns=transaction-exclusion.spec.ts",

--- a/operations/native-yield/lido-governance-monitor/package.json
+++ b/operations/native-yield/lido-governance-monitor/package.json
@@ -10,7 +10,7 @@
     "postinstall": "DATABASE_URL=postgresql://localhost:5432/dummy prisma generate",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "clean": "rimraf dist node_modules coverage tsconfig.build.tsbuildinfo",
+    "clean": "rimraf dist node_modules coverage tsconfig.build.tsbuildinfo prisma/client",
     "build": "tsc -p tsconfig.build.json",
     "test": "jest --bail --detectOpenHandles --forceExit",
     "test:watch": "jest --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,8 @@ catalogs:
       version: 18.0.0
 
 overrides:
+  '@openzeppelin/contracts@<4.9.6': 4.9.6
+  '@openzeppelin/contracts-upgradeable@<4.9.6': 4.9.6
   '@hono/node-server@<1.19.10': '>=1.19.10'
   '@hono/node-server@<1.19.13': 1.19.13
   axios@<0.30.0: '>=0.30.0'
@@ -3284,9 +3286,6 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-
-  '@openzeppelin/contracts-upgradeable@4.7.3':
-    resolution: {integrity: sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==}
 
   '@openzeppelin/contracts-upgradeable@4.9.6':
     resolution: {integrity: sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==}
@@ -10844,8 +10843,8 @@ snapshots:
   '@arbitrum/nitro-contracts@3.0.0':
     dependencies:
       '@offchainlabs/upgrade-executor': 1.1.0-beta.0
-      '@openzeppelin/contracts': 4.7.3
-      '@openzeppelin/contracts-upgradeable': 4.7.3
+      '@openzeppelin/contracts': 4.9.6
+      '@openzeppelin/contracts-upgradeable': 4.9.6
       patch-package: 6.5.1
       solady: 0.0.182
 
@@ -14119,12 +14118,10 @@ snapshots:
 
   '@offchainlabs/upgrade-executor@1.1.0-beta.0':
     dependencies:
-      '@openzeppelin/contracts': 4.7.3
-      '@openzeppelin/contracts-upgradeable': 4.7.3
+      '@openzeppelin/contracts': 4.9.6
+      '@openzeppelin/contracts-upgradeable': 4.9.6
 
   '@opentelemetry/api@1.9.0': {}
-
-  '@openzeppelin/contracts-upgradeable@4.7.3': {}
 
   '@openzeppelin/contracts-upgradeable@4.9.6': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,6 +62,8 @@ onlyBuiltDependencies:
   - c-kzg
 
 overrides:
+  '@openzeppelin/contracts@<4.9.6': '4.9.6'
+  '@openzeppelin/contracts-upgradeable@<4.9.6': '4.9.6'
   "@hono/node-server@<1.19.10": ">=1.19.10"
   '@hono/node-server@<1.19.13': '1.19.13'
   axios@<0.30.0: ">=0.30.0"


### PR DESCRIPTION
This PR does a few things:

1. overrides and pins the OpenZeppelin version for Hardhat at 4.9.6
2. cleans the prisma client folder in the native yield folder to avoid `pnpm i` issues post `pnpm run clean`
3. builds the shared utils on running the end to end test post `pnpm clean && pnpm i` to avoid errors
4. changes docker pruning to not be the entire system so that running containers outside the scope of the Linea stack are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and transitive dependency version alignment with minor Docker prune scope change; no application auth or on-chain deployment logic changes in this diff.
> 
> **Overview**
> Pins **OpenZeppelin** `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradeable` to **4.9.6** via workspace `pnpm` overrides (and lockfile refresh), so transitive packages such as Nitro/upgrade-executor no longer pull **4.7.3**.
> 
> Improves **clean → install → test** flows: Lido governance monitor **`clean`** also deletes **`prisma/client`**; e2e **`pretest:local:run`** builds **`@consensys/linea-shared-utils`** before local Jest. **`clean-environment`** uses **`docker image prune`** instead of full **`docker system prune`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63ac2807d2efb17fdcdbd427e099ecfc7176b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->