### PR TITLE
feat(prover-ray): export vanishing check verifier

### DIFF
--- a/prover-ray/wiop/compilers/global/global.go
+++ b/prover-ray/wiop/compilers/global/global.go
@@ -101,11 +101,11 @@ type proverBucket struct {
 	scratchAgg []field.Ext // aggregate[j], length N = n*ratio
 }
 
-// verifierBucket holds everything the verifier needs for one ratio bucket.
-type verifierBucket struct {
-	ratio          int
-	vanishings     []*wiop.Vanishing
-	quotientClaims []*wiop.Cell // Q_k(r) claim cells, length = ratio
+// VerifierBucket holds everything the verifier needs for one ratio bucket.
+type VerifierBucket struct {
+	Ratio          int
+	Vanishings     []*wiop.Vanishing
+	QuotientClaims []*wiop.Cell // Q_k(r) claim cells, length = ratio
 }
 
 // ---------------------------------------------------------------------------
@@ -229,22 +229,22 @@ func compileModule(
 	})
 
 	// --- Step 10: register verifier action ---
-	vBuckets := make([]verifierBucket, len(rawBuckets))
+	vBuckets := make([]VerifierBucket, len(rawBuckets))
 	for i, bkt := range rawBuckets {
-		vBuckets[i] = verifierBucket{
-			ratio:          bkt.ratio,
-			vanishings:     bkt.vanishings,
-			quotientClaims: quotientBucketClaims[i],
+		vBuckets[i] = VerifierBucket{
+			Ratio:          bkt.ratio,
+			Vanishings:     bkt.vanishings,
+			QuotientClaims: quotientBucketClaims[i],
 		}
 	}
 	evalRound.RegisterVerifierAction(&Verifier{
-		m:             m,
-		mergeCoin:     mergeCoin,
-		evalCoin:      evalCoin,
-		witnessViews:  views,
-		witnessClaims: witnessClaims,
+		Module:        m,
+		MergeCoin:     mergeCoin,
+		EvalCoin:      evalCoin,
+		WitnessViews:  views,
+		WitnessClaims: witnessClaims,
 		viewKeyToIdx:  viewKeyToIdx,
-		buckets:       vBuckets,
+		Buckets:       vBuckets,
 	})
 }
 
@@ -622,44 +622,44 @@ func (a *EvalProverAction) Run(rt wiop.Runtime) {
 // Verifier checks the PLONK quotient identity for one module.
 // It runs in evalRound.
 type Verifier struct {
-	m             *wiop.Module
-	mergeCoin     *wiop.CoinField
-	evalCoin      *wiop.CoinField
-	witnessViews  []*wiop.ColumnView
-	witnessClaims []*wiop.Cell
+	Module        *wiop.Module
+	MergeCoin     *wiop.CoinField
+	EvalCoin      *wiop.CoinField
+	WitnessViews  []*wiop.ColumnView
+	WitnessClaims []*wiop.Cell
 	viewKeyToIdx  map[colViewKey]int
-	buckets       []verifierBucket
+	Buckets       []VerifierBucket
 }
 
 // Check verifies the PLONK quotient identity for the module using the runtime's claimed values.
 func (gv *Verifier) Check(rt wiop.Runtime) error {
-	n := gv.m.RuntimeSize(rt)
+	n := gv.Module.RuntimeSize(rt)
 
-	if !gv.m.IsDynamic() && n != gv.m.Size() {
+	if !gv.Module.IsDynamic() && n != gv.Module.Size() {
 		panic(fmt.Sprintf(
 			"wiop/compilers: global quotient Check called with runtime size %d but module size is %d",
 			n,
-			gv.m.Size(),
+			gv.Module.Size(),
 		))
 	}
-	r := rt.GetCoinValue(gv.evalCoin)
-	coinExt := rt.GetCoinValue(gv.mergeCoin).Ext
+	r := rt.GetCoinValue(gv.EvalCoin)
+	coinExt := rt.GetCoinValue(gv.MergeCoin).Ext
 
 	// Build the map from column-view key → evaluation at r.
-	viewEvals := make(map[colViewKey]field.Gen, len(gv.witnessViews))
-	for i, cv := range gv.witnessViews {
+	viewEvals := make(map[colViewKey]field.Gen, len(gv.WitnessViews))
+	for i, cv := range gv.WitnessViews {
 		key := colViewKey{id: cv.Column.Context.ID, shift: cv.ShiftingOffset}
-		viewEvals[key] = rt.GetCellValue(gv.witnessClaims[i])
+		viewEvals[key] = rt.GetCellValue(gv.WitnessClaims[i])
 	}
 
 	// Compute annihilator r^n − 1.
 	annihilator := computeAnnihilator(r, n)
 
-	for _, bkt := range gv.buckets {
+	for _, bkt := range gv.Buckets {
 		// --- Recombine quotient shares: Q(r) = Σ_k r^{kn} · Q_k(r) ---
 		qr := field.ElemZero()
 		rPowKN := field.ElemOne() // r^{kn}, starts at r^0 = 1
-		for k, claim := range bkt.quotientClaims {
+		for k, claim := range bkt.QuotientClaims {
 			_ = k
 			qk := rt.GetCellValue(claim) // Q_k(r)
 			qr = qr.Add(rPowKN.Mul(qk))
@@ -673,7 +673,7 @@ func (gv *Verifier) Check(rt wiop.Runtime) error {
 		pagg := field.ElemZero()
 		var coinPow field.Ext
 		coinPow.SetOne()
-		for _, v := range bkt.vanishings {
+		for _, v := range bkt.Vanishings {
 			pr := evalExprAtPoint(v.Expression, viewEvals, rt)
 			cr := evalCancellationAtPoint(v.CancelledPositions, n, r)
 			pTimesC := pr.Mul(cr)
@@ -697,7 +697,7 @@ func (gv *Verifier) Check(rt wiop.Runtime) error {
 		if !diff.IsZero() {
 			return fmt.Errorf(
 				"wiop/compilers: global quotient check failed for module (n=%d, ratio=%d): P_agg(r) ≠ (r^n−1)·Q(r)",
-				n, bkt.ratio,
+				n, bkt.Ratio,
 			)
 		}
 	}


### PR DESCRIPTION
Exports the fields in the prover-ray global verifier struct so that verifier-ray is able to access for code generating the structure of the system.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only API export with identical runtime behavior; risk is limited to compile-time breakage if anything relied on unexported names outside this package.
> 
> **Overview**
> Exports the global PLONK quotient **verifier** surface in `prover-ray/wiop/compilers/global` so other packages (e.g. verifier-ray) can read compiled system structure.
> 
> **`verifierBucket`** is renamed to **`VerifierBucket`** with exported fields **`Ratio`**, **`Vanishings`**, and **`QuotientClaims`**. The **`Verifier`** action struct now exposes **`Module`**, **`MergeCoin`**, **`EvalCoin`**, **`WitnessViews`**, **`WitnessClaims`**, and **`Buckets`**; **`viewKeyToIdx`** stays internal. **`Check`** and module registration are updated to use the new names only—**no change to verification math or behavior**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe125c5d86b6ece4ca3c28dc5bd6d71fd0a27d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->