### PR TITLE
feat(prover-ray): Add LagrangeSelectors in the wizard framework

### DIFF
--- a/prover-ray/wiop/compilers/global/global.go
+++ b/prover-ray/wiop/compilers/global/global.go
@@ -353,6 +353,98 @@ func computeCancellationCoset(cancelled []int, n, N int) []field.Element {
 	return cVals
 }
 
+// computeLagrangeSelectorCoset returns the base-field evaluation of the
+// Lagrange selector polynomial
+//
+//	L_p(X) = ω^p · (X^n − 1) / (n · (X − ω^p))
+//
+// at all N = n·ratio coset points {g · ω_N^j : j = 0…N-1}, where ω =
+// RootOfUnityBy(n), ω_N = RootOfUnityBy(N), g = MultiplicativeGen, and p is
+// `position` normalised into [0, n). This is the polynomial that
+// [wiop.LagrangeSelector] represents (1 at row p, 0 elsewhere on the domain);
+// the same closed form is used pointwise by
+// [wiop.LagrangeSelector.EvaluateOutOfDomain].
+//
+// The coset parametrisation mirrors [computeCancellationCoset] exactly so the
+// result lines up with the FFT-coset evaluations of the witness columns. The
+// denominator never vanishes: a coset point g·ω_N^j is never a pure n-th root
+// of unity, so X − ω^p ≠ 0.
+func computeLagrangeSelectorCoset(position, n, N int) []field.Element {
+	// Normalise the anchor into [0, n).
+	p := ((position % n) + n) % n
+
+	omega := field.RootOfUnityBy(n)
+	var omegaP field.Element
+	field.ExpToInt(&omegaP, omega, p)
+
+	// Constant numerator coefficient ω^p / n.
+	var nInv field.Element
+	nInv.SetUint64(uint64(n))
+	nInv.Inverse(&nInv)
+	var numCoef field.Element
+	numCoef.Mul(&omegaP, &nInv)
+
+	omegaN := field.RootOfUnityBy(N)
+	var g field.Element
+	g.SetUint64(field.MultiplicativeGen)
+
+	// x_j^n = (g·ω_N^j)^n = g^n · (ω_N^n)^j cycles with period ratio = N/n,
+	// advanced incrementally to avoid a per-point exponentiation.
+	var gPowN, omegaNPowN field.Element
+	field.ExpToInt(&gPowN, g, n)           // g^n
+	field.ExpToInt(&omegaNPowN, omegaN, n) // ω_N^n
+	var one field.Element
+	one.SetOne()
+
+	denom := make([]field.Element, N) // x_j − ω^p
+	num := make([]field.Element, N)   // x_j^n − 1
+	x := g
+	xPowN := gPowN
+	for j := 0; j < N; j++ {
+		denom[j].Sub(&x, &omegaP)
+		num[j].Sub(&xPowN, &one)
+		x.Mul(&x, &omegaN)
+		xPowN.Mul(&xPowN, &omegaNPowN)
+	}
+
+	invDenom := make([]field.Element, N)
+	field.VecBatchInvBase(invDenom, denom)
+
+	res := make([]field.Element, N)
+	for j := 0; j < N; j++ {
+		res[j].Mul(&numCoef, &num[j])
+		res[j].Mul(&res[j], &invDenom[j])
+	}
+	return res
+}
+
+// collectLagrangeSelectorPositions records the Position of every
+// [wiop.LagrangeSelector] leaf reachable from expr into out.
+func collectLagrangeSelectorPositions(expr wiop.Expression, out map[int]struct{}) {
+	switch e := expr.(type) {
+	case *wiop.LagrangeSelector:
+		out[e.Position] = struct{}{}
+	case *wiop.ArithmeticOperation:
+		for _, op := range e.Operands {
+			collectLagrangeSelectorPositions(op, out)
+		}
+	}
+}
+
+// bktVanishings returns the Vanishing constraints of a bucket, regardless of
+// whether it is a static bucket (size-dependent data precomputed into entries)
+// or a dynamic bucket (raw vanishings deferred to runtime).
+func bktVanishings(bkt *proverBucket) []*wiop.Vanishing {
+	if bkt.entries != nil {
+		vs := make([]*wiop.Vanishing, len(bkt.entries))
+		for i, e := range bkt.entries {
+			vs[i] = e.v
+		}
+		return vs
+	}
+	return bkt.vanishings
+}
+
 // ---------------------------------------------------------------------------
 // Prover actions
 // ---------------------------------------------------------------------------
@@ -437,6 +529,18 @@ func (a *QuotientProverAction) Run(rt wiop.Runtime) {
 			}
 		}
 
+		// --- Evaluate every distinct Lagrange selector on the large coset ---
+		// Selectors are not committed columns, so they are computed analytically
+		// rather than re-FFT'd. selectorCosets[position][j] = L_position(coset_j).
+		selectorPositions := make(map[int]struct{})
+		for _, v := range bktVanishings(&bkt) {
+			collectLagrangeSelectorPositions(v.Expression, selectorPositions)
+		}
+		selectorCosets := make(map[int][]field.Element, len(selectorPositions))
+		for pos := range selectorPositions {
+			selectorCosets[pos] = computeLagrangeSelectorCoset(pos, n, N)
+		}
+
 		// --- Compute the aggregate extension-field polynomial on the coset ---
 		// aggregate[j] = Σ_i coin^i · P_i(coset_j) · C_i(coset_j)
 		//
@@ -456,7 +560,7 @@ func (a *QuotientProverAction) Run(rt wiop.Runtime) {
 			// Static module: use precomputed cancellation cosets.
 			for _, entry := range bkt.entries {
 				accumulateOnCoset(
-					rt, entry.v.Expression, cosetEvals, cosetEvalsExt,
+					rt, entry.v.Expression, cosetEvals, cosetEvalsExt, selectorCosets,
 					entry.cancellationCoset, &coinPow, aggregate, ratio, N,
 				)
 				// advance coinPow: coinPow *= coinExt
@@ -467,7 +571,7 @@ func (a *QuotientProverAction) Run(rt wiop.Runtime) {
 			for _, v := range bkt.vanishings {
 				cancellationCoset := computeCancellationCoset(v.CancelledPositions, n, N)
 				accumulateOnCoset(
-					rt, v.Expression, cosetEvals, cosetEvalsExt,
+					rt, v.Expression, cosetEvals, cosetEvalsExt, selectorCosets,
 					cancellationCoset, &coinPow, aggregate, ratio, N,
 				)
 				coinPow.Mul(&coinPow, &coinExt)
@@ -674,7 +778,7 @@ func (gv *Verifier) Check(rt wiop.Runtime) error {
 		var coinPow field.Ext
 		coinPow.SetOne()
 		for _, v := range bkt.Vanishings {
-			pr := evalExprAtPoint(v.Expression, viewEvals, rt)
+			pr := evalExprAtPoint(v.Expression, viewEvals, r, rt)
 			cr := evalCancellationAtPoint(v.CancelledPositions, n, r)
 			pTimesC := pr.Mul(cr)
 			// coinPow · pTimesC  (coinPow is Ext, pTimesC may be base or ext)
@@ -743,12 +847,13 @@ func evalCancellationAtPoint(cancelled []int, n int, r field.Gen) field.Gen {
 	return result
 }
 
-// evalExprAtPoint evaluates a symbolic expression at a pre-computed scalar
-// point using the witness column evaluation map (from LagrangeEval claim cells).
-// Coins and cells are looked up directly from the runtime.
+// evalExprAtPoint evaluates a symbolic expression at the point r using the
+// witness column evaluation map (from LagrangeEval claim cells). Coins and
+// cells are looked up directly from the runtime.
 func evalExprAtPoint(
 	expr wiop.Expression,
 	viewEvals map[colViewKey]field.Gen,
+	r field.Gen,
 	rt wiop.Runtime,
 ) field.Gen {
 	switch e := expr.(type) {
@@ -762,9 +867,11 @@ func evalExprAtPoint(
 			))
 		}
 		return v
+	case *wiop.LagrangeSelector:
+		return e.EvaluateOutOfDomain(rt, r)
 	case *wiop.ArithmeticOperation:
 		eval := func(i int) field.Gen {
-			return evalExprAtPoint(e.Operands[i], viewEvals, rt)
+			return evalExprAtPoint(e.Operands[i], viewEvals, r, rt)
 		}
 		a0 := eval(0)
 		switch e.Operator {
@@ -818,6 +925,7 @@ func accumulateOnCoset(
 	expr wiop.Expression,
 	cosetEvals map[wiop.ObjectID][]field.Element,
 	cosetEvalsExt map[wiop.ObjectID][]field.Ext,
+	selectorCosets map[int][]field.Element,
 	cancellationCoset []field.Element,
 	coinPow *field.Ext,
 	aggregate []field.Ext,
@@ -825,7 +933,7 @@ func accumulateOnCoset(
 ) {
 	if isBaseExpr(expr) {
 		for j := 0; j < N; j++ {
-			pVal := evalExprOnCoset(rt, expr, cosetEvals, j, ratio, N)
+			pVal := evalExprOnCoset(rt, expr, cosetEvals, selectorCosets, j, ratio, N)
 			var pTimesC field.Element
 			if cancellationCoset != nil {
 				pTimesC.Mul(&pVal, &cancellationCoset[j])
@@ -839,7 +947,7 @@ func accumulateOnCoset(
 		return
 	}
 	for j := 0; j < N; j++ {
-		pVal := evalExprOnCosetExt(rt, expr, cosetEvals, cosetEvalsExt, j, ratio, N)
+		pVal := evalExprOnCosetExt(rt, expr, cosetEvals, cosetEvalsExt, selectorCosets, j, ratio, N)
 		var pTimesC field.Ext
 		if cancellationCoset != nil {
 			pTimesC.MulByElement(&pVal, &cancellationCoset[j])
@@ -862,6 +970,8 @@ func isBaseExpr(expr wiop.Expression) bool {
 	switch e := expr.(type) {
 	case *wiop.ColumnView:
 		return !e.Column.IsExtension
+	case *wiop.LagrangeSelector:
+		return true
 	case *wiop.Constant:
 		return true
 	case *wiop.Cell:
@@ -895,6 +1005,7 @@ func evalExprOnCoset(
 	rt wiop.Runtime,
 	expr wiop.Expression,
 	cosetEvals map[wiop.ObjectID][]field.Element,
+	selectorCosets map[int][]field.Element,
 	j, ratio, N int,
 ) field.Element {
 	switch e := expr.(type) {
@@ -902,6 +1013,9 @@ func evalExprOnCoset(
 		k := e.ShiftingOffset
 		idx := ((j+k*ratio)%N + N) % N
 		return cosetEvals[e.Column.Context.ID][idx]
+	case *wiop.LagrangeSelector:
+		// Selectors are unshifted, so the coset index is j directly.
+		return selectorCosets[e.Position][j]
 	case *wiop.Cell:
 		if e.IsExtension() {
 			panic(fmt.Sprintf(
@@ -922,7 +1036,7 @@ func evalExprOnCoset(
 		return e.Value
 	case *wiop.ArithmeticOperation:
 		eval := func(i int) field.Element {
-			return evalExprOnCoset(rt, e.Operands[i], cosetEvals, j, ratio, N)
+			return evalExprOnCoset(rt, e.Operands[i], cosetEvals, selectorCosets, j, ratio, N)
 		}
 		a0 := eval(0)
 		var res field.Element
@@ -979,6 +1093,7 @@ func evalExprOnCosetExt(
 	expr wiop.Expression,
 	cosetEvals map[wiop.ObjectID][]field.Element,
 	cosetEvalsExt map[wiop.ObjectID][]field.Ext,
+	selectorCosets map[int][]field.Element,
 	j, ratio, N int,
 ) field.Ext {
 	switch e := expr.(type) {
@@ -989,6 +1104,9 @@ func evalExprOnCosetExt(
 			return cosetEvalsExt[e.Column.Context.ID][idx]
 		}
 		return field.Lift(cosetEvals[e.Column.Context.ID][idx])
+	case *wiop.LagrangeSelector:
+		// Selectors are base-field and unshifted: lift L_pos(coset_j) into 𝔽_{p^6}.
+		return field.Lift(selectorCosets[e.Position][j])
 	case *wiop.Cell:
 		return rt.GetCellValue(e).AsExt()
 	case *wiop.CoinField:
@@ -997,7 +1115,7 @@ func evalExprOnCosetExt(
 		return field.Lift(e.Value)
 	case *wiop.ArithmeticOperation:
 		eval := func(i int) field.Ext {
-			return evalExprOnCosetExt(rt, e.Operands[i], cosetEvals, cosetEvalsExt, j, ratio, N)
+			return evalExprOnCosetExt(rt, e.Operands[i], cosetEvals, cosetEvalsExt, selectorCosets, j, ratio, N)
 		}
 		a0 := eval(0)
 		var res field.Ext

--- a/prover-ray/wiop/compilers/global/global_test.go
+++ b/prover-ray/wiop/compilers/global/global_test.go
@@ -3,6 +3,7 @@ package global_test
 import (
 	"testing"
 
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
 	"github.com/consensys/linea-monorepo/prover-ray/wiop"
 	"github.com/consensys/linea-monorepo/prover-ray/wiop/compilers/global"
 	"github.com/consensys/linea-monorepo/prover-ray/wiop/wioptest"
@@ -40,4 +41,82 @@ func TestCompile_Soundness(t *testing.T) {
 				"compiled verifier must reject an invalid witness")
 		})
 	}
+}
+
+// colVec builds a length-n base-field ConcreteVector filled with 9 everywhere
+// except valAtPos at row pos.
+func colVec(n, pos int, valAtPos uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, n)
+	for i := range elems {
+		elems[i].SetUint64(9)
+	}
+	elems[pos].SetUint64(valAtPos)
+	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
+}
+
+// TestCompile_GlobalConstraintWithLagrangeSelector exercises the global compiler
+// directly on a multi-valued Vanishing whose expression contains a
+// LagrangeSelector leaf — not one produced by the localvanishing lift, but
+// hand-written. This isolates the global layer's selector handling: analytic
+// coset evaluation on the prover side and EvaluateOutOfDomain at the verifier's
+// point.
+//
+// The constraint expr · L_pos must vanish on every row, which holds exactly when
+// expr is zero at row pos. Both the linear case (ratio == 1) and the quadratic
+// case (ratio > 1, so the selector is evaluated on the large coset) are covered.
+func TestCompile_GlobalConstraintWithLagrangeSelector(t *testing.T) {
+	const size = 8
+	const pos = 3
+
+	t.Run("linear", func(t *testing.T) {
+		build := func() (*wiop.System, *wiop.Column) {
+			sys := wiop.NewSystemf("gl-ls-lin")
+			r0 := sys.NewRound()
+			mod := sys.NewSizedModule(sys.Context.Childf("mod"), size, wiop.PaddingDirectionNone)
+			col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+			ls := wiop.NewLagrangeSelector(mod, pos)
+			// col · L_pos == 0 on every row  ⇔  col[pos] == 0.
+			mod.NewVanishingManual(sys.Context.Childf("v"), wiop.Mul(col.View(), ls))
+			global.Compile(sys)
+			return sys, col
+		}
+
+		sys, col := build()
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(col, colVec(size, pos, 0))
+		require.NoError(t, wioptest.RunAndVerify(&rt), "honest: col[pos]=0 must verify")
+
+		sys, col = build()
+		rt = wiop.NewRuntime(sys)
+		rt.AssignColumn(col, colVec(size, pos, 5))
+		assert.Error(t, wioptest.RunAndVerify(&rt), "invalid: col[pos]=5 must be rejected")
+	})
+
+	t.Run("quadratic", func(t *testing.T) {
+		// (a · b) · L_pos: degree factor 3 → ratio > 1, so the selector is
+		// evaluated on the large coset (N = n·ratio).
+		build := func() (*wiop.System, *wiop.Column, *wiop.Column) {
+			sys := wiop.NewSystemf("gl-ls-quad")
+			r0 := sys.NewRound()
+			mod := sys.NewSizedModule(sys.Context.Childf("mod"), size, wiop.PaddingDirectionNone)
+			a := mod.NewColumn(sys.Context.Childf("a"), wiop.VisibilityOracle, r0)
+			b := mod.NewColumn(sys.Context.Childf("b"), wiop.VisibilityOracle, r0)
+			ls := wiop.NewLagrangeSelector(mod, pos)
+			mod.NewVanishingManual(sys.Context.Childf("v"), wiop.Mul(wiop.Mul(a.View(), b.View()), ls))
+			global.Compile(sys)
+			return sys, a, b
+		}
+
+		sys, a, b := build()
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(a, colVec(size, pos, 0)) // a[pos]=0 → product 0 at pos
+		rt.AssignColumn(b, colVec(size, pos, 5))
+		require.NoError(t, wioptest.RunAndVerify(&rt), "honest: (a·b)[pos]=0 must verify")
+
+		sys, a, b = build()
+		rt = wiop.NewRuntime(sys)
+		rt.AssignColumn(a, colVec(size, pos, 3)) // a[pos]·b[pos]=15 ≠ 0
+		rt.AssignColumn(b, colVec(size, pos, 5))
+		assert.Error(t, wioptest.RunAndVerify(&rt), "invalid: (a·b)[pos]=15 must be rejected")
+	})
 }

--- a/prover-ray/wiop/compilers/localvanishing/localvanishing.go
+++ b/prover-ray/wiop/compilers/localvanishing/localvanishing.go
@@ -15,16 +15,19 @@
 //     [wiop.ColumnPosition] leaf.
 //  2. Determines the anchor row min = the smallest position seen across
 //     those leaves.
-//  3. Creates (or reuses, via a per-(module, anchor) cache) a precomputed
-//     Lagrange column L_min on the module: values [0, …, 0, 1, 0, …, 0]
-//     with the 1 at row min.
+//  3. Creates (or reuses, via a per-(module, anchor) cache) a
+//     [wiop.LagrangeSelector] L_min on the module: the public indicator that
+//     is 1 at row min and 0 elsewhere. Unlike a committed column, the selector
+//     carries no assignment — it is evaluated from the module's runtime size,
+//     so the lift works for dynamic-size modules as well as static ones.
 //  4. Rewrites the expression: every [wiop.ColumnPosition]{c, p} leaf
 //     becomes c.View().Shift(p − min). Evaluating the rewritten expression
 //     at row x of the domain reads column c at row (x + p − min) mod n;
 //     at the anchor x = min that is exactly c[p].
-//  5. Multiplies the rewritten expression by L_min.View() and registers
-//     the product as a new multi-valued [wiop.Vanishing] on the module —
-//     to be discharged by the global-quotient compiler.
+//  5. Multiplies the rewritten expression by L_min and registers the product
+//     as a new multi-valued [wiop.Vanishing] on the module — to be discharged
+//     by the global-quotient compiler, which evaluates the selector
+//     analytically on the quotient coset and at the verifier's point.
 //  6. Marks the original scalar vanishing as reduced.
 //
 // At row min the product evaluates to the original local predicate; at
@@ -51,7 +54,6 @@ package localvanishing
 import (
 	"fmt"
 
-	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
 	"github.com/consensys/linea-monorepo/prover-ray/wiop"
 )
 
@@ -91,11 +93,11 @@ func Compile(sys *wiop.System) {
 	}
 
 	compCtx := sys.Context.Childf("local-vanishing")
-	lagrangeCols := make(map[lagrangeKey]*wiop.Column)
+	selectors := make(map[lagrangeKey]*wiop.LagrangeSelector)
 
 	for _, w := range work {
 		ctx := compCtx.Childf("m%d-v%d", w.mIdx, w.vIdx)
-		reduce(ctx, w.m, w.mIdx, w.v, lagrangeCols)
+		reduce(ctx, w.m, w.mIdx, w.v, selectors)
 	}
 }
 
@@ -106,7 +108,7 @@ func reduce(
 	m *wiop.Module,
 	mIdx int,
 	v *wiop.Vanishing,
-	cache map[lagrangeKey]*wiop.Column,
+	cache map[lagrangeKey]*wiop.LagrangeSelector,
 ) {
 	positions := collectColumnPositions(v.Expression)
 	if len(positions) == 0 {
@@ -124,10 +126,10 @@ func reduce(
 	}
 
 	key := lagrangeKey{mIdx, anchor}
-	lagCol, ok := cache[key]
+	lagSel, ok := cache[key]
 	if !ok {
-		lagCol = newLagrangeColumn(ctx, m, anchor)
-		cache[key] = lagCol
+		lagSel = wiop.NewLagrangeSelector(m, anchor)
+		cache[key] = lagSel
 	}
 
 	shifted := wiop.EditExpression(v.Expression, func(
@@ -139,7 +141,7 @@ func reduce(
 		return wiop.DefaultConstruct(curr, newChildren)
 	})
 
-	lifted := wiop.Mul(shifted, lagCol.View())
+	lifted := wiop.Mul(shifted, lagSel)
 	// Register with no cancelled positions: the constraint must hold on every
 	// row. That is safe and intentional. The shifted sub-expression may read
 	// out-of-domain (wrap-around) values at rows other than `anchor`, but the
@@ -175,34 +177,4 @@ func collectColumnPositions(expr wiop.Expression) []int {
 	}
 	walk(expr)
 	return positions
-}
-
-// newLagrangeColumn creates a precomputed base-field column of length
-// m.Size() whose value is 1 at row anchor and 0 elsewhere — the Lagrange-basis
-// indicator polynomial at the anchor row.
-//
-// Precondition: anchor must lie in [0, m.Size()). Callers obtain it from
-// [collectColumnPositions], which sources positions from *ColumnPosition.Position
-// leaves; for ColumnPositions produced by [wiop.Module.NewLocalConstraint],
-// [wiop.columnViewAtRow] normalises positions to [0, n). Hand-constructed
-// ColumnPositions (via [wiop.Column.At]) skip that normalisation, so an
-// explicit bounds check here turns the resulting "index out of range" runtime
-// crash into a localised message that names the offender.
-func newLagrangeColumn(ctx *wiop.ContextFrame, m *wiop.Module, anchor int) *wiop.Column {
-	n := m.Size()
-	if anchor < 0 || anchor >= n {
-		panic(fmt.Sprintf(
-			"wiop/compilers/localvanishing: Lagrange anchor %d out of range [0, %d) for module %q; "+
-				"all *ColumnPosition.Position leaves must be normalised to the domain",
-			anchor, n, m.Context.Path(),
-		))
-	}
-	elems := make([]field.Element, n)
-	elems[anchor].SetOne()
-	cv := &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
-	return m.NewPrecomputedColumn(
-		ctx.Childf("lagrange-row%d", anchor),
-		wiop.VisibilityOracle,
-		cv,
-	)
 }

--- a/prover-ray/wiop/compilers/localvanishing/localvanishing_test.go
+++ b/prover-ray/wiop/compilers/localvanishing/localvanishing_test.go
@@ -264,7 +264,22 @@ func TestCompile_IsIdempotent(t *testing.T) {
 			"already reduced and the lifted one is multi-valued")
 }
 
-func TestCompile_SharesLagrangeColumnsByAnchor(t *testing.T) {
+// findSelector returns the first LagrangeSelector leaf in expr, or nil.
+func findSelector(expr wiop.Expression) *wiop.LagrangeSelector {
+	switch t := expr.(type) {
+	case *wiop.LagrangeSelector:
+		return t
+	case *wiop.ArithmeticOperation:
+		for _, op := range t.Operands {
+			if s := findSelector(op); s != nil {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+func TestCompile_SharesSelectorsByAnchor(t *testing.T) {
 	sys := wiop.NewSystemf("lv-share")
 	r0 := sys.NewRound()
 	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
@@ -276,15 +291,32 @@ func TestCompile_SharesLagrangeColumnsByAnchor(t *testing.T) {
 
 	colsBefore := len(mod.Columns)
 	localvanishing.Compile(sys)
-	assert.Len(t, mod.Columns, colsBefore+1,
-		"both vanishings share anchor 0, so only one Lagrange column should be created")
+
+	// Selectors are not committed columns, so the lift creates none.
+	assert.Len(t, mod.Columns, colsBefore,
+		"LagrangeSelectors are not committed, so no column should be created")
+
+	// Both lifted vanishings share anchor 0, so the per-(module, anchor) cache
+	// must hand them the same selector instance.
+	var selectors []*wiop.LagrangeSelector
+	for _, v := range mod.Vanishings {
+		if !v.IsReduced() && v.Expression.IsMultiValued() {
+			if s := findSelector(v.Expression); s != nil {
+				selectors = append(selectors, s)
+			}
+		}
+	}
+	require.Len(t, selectors, 2, "expected one lifted vanishing per local constraint")
+	assert.Same(t, selectors[0], selectors[1],
+		"both vanishings share anchor 0, so they must reuse one selector")
 }
 
-// TestCompile_PanicsOnOutOfRangePosition ensures the Lagrange-column constructor
-// rejects an out-of-range anchor with a localised panic instead of an opaque
-// "index out of range" crash deep inside the runtime. The expression
-// hand-constructs a *ColumnPosition with a negative Position via Column.At,
-// bypassing the normalisation that NewLocalConstraint would otherwise apply.
+// TestCompile_PanicsOnOutOfRangePosition ensures an out-of-range anchor is
+// rejected with a localised panic instead of an opaque "index out of range"
+// crash deep inside the runtime. The expression hand-constructs a
+// *ColumnPosition with a negative Position via Column.At, bypassing the
+// normalisation that NewLocalConstraint would otherwise apply; the negative
+// anchor then flows into NewLagrangeSelector, which validates it.
 func TestCompile_PanicsOnOutOfRangePosition(t *testing.T) {
 	sys := wiop.NewSystemf("lv-oob")
 	r0 := sys.NewRound()
@@ -297,16 +329,13 @@ func TestCompile_PanicsOnOutOfRangePosition(t *testing.T) {
 	badExpr := col.At(-1)
 	mod.NewLocalConstraint(sys.Context.Childf("lc"), badExpr, 0)
 
-	assert.PanicsWithValue(t, true, func() {
-		defer func() {
-			if r := recover(); r != nil {
-				msg, _ := r.(string)
-				assert.Contains(t, msg, "Lagrange anchor -1 out of range")
-				panic(true) // re-raise so PanicsWithValue sees a panic
-			}
-		}()
-		localvanishing.Compile(sys)
-	}, "out-of-range anchor must trigger the explicit precondition message")
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "out-of-range anchor must trigger a panic")
+		msg, _ := r.(string)
+		assert.Contains(t, msg, "position must be non-negative")
+	}()
+	localvanishing.Compile(sys)
 }
 
 // elementFromUint64 converts a literal uint64 into a koalabear field.Element.

--- a/prover-ray/wiop/expression.go
+++ b/prover-ray/wiop/expression.go
@@ -456,10 +456,14 @@ func (c *Constant) IsSized() bool {
 }
 
 // Size implements [Expression]. Delegates to the bound module. Panics if
-// scalar; check [Constant.IsMultiValued] first.
+// scalar (check [Constant.IsMultiValued] first) or if the bound module is
+// dynamic or unsized (check [Constant.IsSized] first).
 func (c *Constant) Size() int {
 	if c.module == nil {
 		panic("wiop: Size() cannot be called on a scalar Constant; check IsMultiValued() first")
+	}
+	if !c.module.IsSized() {
+		panic("wiop: Size() called on a vector Constant with an unsized or dynamic module; check IsSized() first")
 	}
 	return c.module.Size()
 }

--- a/prover-ray/wiop/wiop_column.go
+++ b/prover-ray/wiop/wiop_column.go
@@ -225,6 +225,9 @@ func (c *Column) Round() *Round { return c.round }
 // Degree returns the polynomial degree of the column over its domain, which
 // is Size() - 1. Panics if the owning module has not been sized yet.
 func (c *Column) Degree() int {
+	if c.Module.IsDynamic() {
+		panic(fmt.Sprintf("wiop: Degree() called on dynamic-sized column %q", c.Context.Path()))
+	}
 	if !c.Module.IsSized() {
 		panic(fmt.Sprintf("wiop: Degree() called on unsized column %q", c.Context.Path()))
 	}
@@ -293,8 +296,20 @@ func (cv *ColumnView) IsMultiValued() bool { return true }
 func (cv *ColumnView) IsSized() bool { return cv.Column.Module.IsSized() }
 
 // Size implements [Expression]. Returns the domain size of the owning module.
-// Returns 0 if the module has not been sized yet.
-func (cv *ColumnView) Size() int { return cv.Column.Module.Size() }
+//
+// Panics if the owning module is dynamic (its size is per-Runtime; use the
+// module's RuntimeSize instead) or has not yet been sized. Check IsSized()
+// first.
+func (cv *ColumnView) Size() int {
+	m := cv.Column.Module
+	if m.IsDynamic() {
+		panic(fmt.Sprintf("wiop: Size() called on dynamic-sized column view of %q", cv.Column.Context.Path()))
+	}
+	if !m.IsSized() {
+		panic(fmt.Sprintf("wiop: Size() called on unsized column view of %q", cv.Column.Context.Path()))
+	}
+	return m.Size()
+}
 
 // Degree implements [Expression]. Returns Size() - 1. Panics if the owning
 // module has not been sized yet.

--- a/prover-ray/wiop/wiop_lagrange_selector.go
+++ b/prover-ray/wiop/wiop_lagrange_selector.go
@@ -1,0 +1,141 @@
+package wiop
+
+import (
+	"fmt"
+	"math/bits"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+)
+
+// LagrangeSelector is a special type of vector promises representing a column
+// of the form (0, 0, 1, 0, 0); e.g. zero everywhere and one in single position.
+// Such a column is used to lower local constraints into global constraints. It
+// has the property that its Lagrange representation can be evaluated in
+// logarithmic time by the verifier. Therefore, it is generally not useful
+// committing to the column.
+//
+// The structure implements [VectorPromise] and
+type LagrangeSelector struct {
+	// Module is the module in which the selector is meant to be used as part
+	// of global constraints.
+	module   *Module
+	Position int
+}
+
+// Compile-time check that *LagrangeSelector satisfies the [VectorPromise]
+// (and thereby [Expression]) interface.
+var _ VectorPromise = (*LagrangeSelector)(nil)
+
+// NewLagrangeSelector returns a new LagrangeSelector.
+func NewLagrangeSelector(module *Module, position int) *LagrangeSelector {
+	return &LagrangeSelector{module: module, Position: position}
+}
+
+// IsExtension implements [VectorPromise]. Always returns false: a Lagrange
+// selector is always base-field.
+func (ls *LagrangeSelector) IsExtension() bool { return false }
+
+// IsMultiValued implements [VectorPromise]. Always returns true: a Lagrange
+// selector is always vector-valued.
+func (ls *LagrangeSelector) IsMultiValued() bool { return true }
+
+// Degree implements [VectorPromise]. Always returns 0: a Lagrange selector is
+// a degree-0 vector.
+func (ls *LagrangeSelector) Degree() int {
+	return ls.Size() - 1
+}
+
+// DegreeFactor implements [VectorPromise].
+func (ls *LagrangeSelector) DegreeFactor() int { return 1 }
+
+// Size implements [VectorPromise].
+//
+// TODO: @alex: should we return 0 as for the columns?
+func (ls *LagrangeSelector) Size() int {
+	if ls.module.IsDynamic() {
+		panic(fmt.Sprintf("wiop: Size() called on dynamic-sized module: %s", ls.module.Context.Path()))
+	}
+	if !ls.module.IsSized() {
+		panic(fmt.Sprintf("wiop: Size() called on unsized module: %s", ls.module.Context.Path()))
+	}
+	return ls.module.Size()
+}
+
+// IsSized implements [VectorPromise].
+func (ls *LagrangeSelector) IsSized() bool { return ls.module.IsSized() }
+
+// Module implements [VectorPromise].
+func (ls *LagrangeSelector) Module() *Module { return ls.module }
+
+// Visibility implements [VectorPromise].
+func (ls *LagrangeSelector) Visibility() Visibility { return VisibilityPublic }
+
+// EvaluateSingle is a placeholder implementation of [VectorPromise].
+func (ls *LagrangeSelector) EvaluateSingle(_ Runtime) ConcreteField {
+	panic("wiop: EvaluateSingle() cannot be called on a VectorPromise")
+}
+
+// EvaluateVector returns the evaluation of the Lagrange selector.
+func (ls *LagrangeSelector) EvaluateVector(rt Runtime) ConcreteVector {
+
+	size := ls.module.RuntimeSize(rt)
+
+	// @alex: we could use a better memory representation for this as this
+	// used size * 4 bytes to represent a sequence of 0s with a 1 somewhere.
+	res := ConcreteVector{
+		promise: ls,
+		Plain:   field.VecFromBase(make([]field.Element, size)),
+		Padding: field.Zero(),
+	}
+
+	res.Plain.AsBase()[ls.Position] = field.One()
+	return res
+}
+
+// EvaluateOutOfDomain evaluates the low-degree extension of the Lagrange
+// selector at a point x lying outside the evaluation domain.
+//
+// The selector is the column (0, …, 0, 1, 0, …, 0) holding a single 1 at row
+// Position. Its Lagrange interpolant over the n-th roots-of-unity domain is the
+// Lagrange basis polynomial
+//
+//	L_Position(X) = ω^Position · (X^n − 1) / (n · (X − ω^Position))
+//
+// where ω is the canonical n-th root of unity and n is the module size. The
+// result lies in the base field iff x does.
+//
+// Panics if x equals ω^Position (i.e. the point is in the domain at the
+// selector's own row): the denominator X−ω^Position vanishes there, so the
+// out-of-domain contract is violated.
+func (ls *LagrangeSelector) EvaluateOutOfDomain(rt Runtime, x field.Gen) field.Gen {
+
+	n := ls.module.RuntimeSize(rt)
+
+	// omegaPos = ω^Position, the domain point at which the selector is 1.
+	var omegaPos field.Element
+	omegaPos.ExpInt64(field.RootOfUnityBy(n), int64(ls.Position))
+
+	// numerator = ω^Position · (x^n − 1). Since n is a power of two, x^n is
+	// computed by squaring log2(n) times.
+	xPowN := x
+	for i := 0; i < bits.TrailingZeros(uint(n)); i++ {
+		xPowN = xPowN.Square()
+	}
+	numerator := xPowN.Sub(field.ElemOne()).Mul(field.ElemFromBase(omegaPos))
+
+	// denominator = n · (x − ω^Position). Guard against an in-domain point
+	// explicitly: the field defines 1/0 = 0, so without this check Div would
+	// silently return 0 instead of signalling the contract violation.
+	var nElem field.Element
+	nElem.SetUint64(uint64(n))
+	xMinusOmega := x.Sub(field.ElemFromBase(omegaPos))
+	if xMinusOmega.IsZero() {
+		panic(fmt.Sprintf(
+			"wiop: LagrangeSelector.EvaluateOutOfDomain called at ω^%d, which is inside the domain",
+			ls.Position,
+		))
+	}
+	denominator := xMinusOmega.Mul(field.ElemFromBase(nElem))
+
+	return numerator.Div(denominator)
+}

--- a/prover-ray/wiop/wiop_lagrange_selector.go
+++ b/prover-ray/wiop/wiop_lagrange_selector.go
@@ -26,8 +26,23 @@ type LagrangeSelector struct {
 // (and thereby [Expression]) interface.
 var _ VectorPromise = (*LagrangeSelector)(nil)
 
-// NewLagrangeSelector returns a new LagrangeSelector.
+// NewLagrangeSelector returns a new LagrangeSelector that is 1 at the given
+// row position and 0 elsewhere.
+//
+// Panics if position is negative, or — when the module is statically sized — if
+// position is outside [0, module.Size()). For dynamic modules the upper bound
+// cannot be checked at construction time and is enforced lazily by
+// [LagrangeSelector.EvaluateVector] against the runtime size.
 func NewLagrangeSelector(module *Module, position int) *LagrangeSelector {
+	if position < 0 {
+		panic(fmt.Sprintf("wiop: NewLagrangeSelector: position must be non-negative, got %d", position))
+	}
+	if module.IsSized() && position >= module.Size() {
+		panic(fmt.Sprintf(
+			"wiop: NewLagrangeSelector: position %d out of range [0, %d) for module %q",
+			position, module.Size(), module.Context.Path(),
+		))
+	}
 	return &LagrangeSelector{module: module, Position: position}
 }
 
@@ -49,8 +64,6 @@ func (ls *LagrangeSelector) Degree() int {
 func (ls *LagrangeSelector) DegreeFactor() int { return 1 }
 
 // Size implements [VectorPromise].
-//
-// TODO: @alex: should we return 0 as for the columns?
 func (ls *LagrangeSelector) Size() int {
 	if ls.module.IsDynamic() {
 		panic(fmt.Sprintf("wiop: Size() called on dynamic-sized module: %s", ls.module.Context.Path()))

--- a/prover-ray/wiop/wiop_lagrange_selector_test.go
+++ b/prover-ray/wiop/wiop_lagrange_selector_test.go
@@ -1,0 +1,92 @@
+package wiop_test
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/polynomials"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/stretchr/testify/require"
+)
+
+// newLagrangeSelector builds a single-round system with one sized, unpadded
+// module of the given size and returns a LagrangeSelector at position pos
+// together with a fresh runtime.
+func newLagrangeSelector(t *testing.T, size, pos int) (*wiop.LagrangeSelector, wiop.Runtime) {
+	t.Helper()
+	sys := wiop.NewSystemf("ls")
+	sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("lsMod"), size, wiop.PaddingDirectionNone)
+	ls := wiop.NewLagrangeSelector(mod, pos)
+	return ls, wiop.NewRuntime(sys)
+}
+
+// TestLagrangeSelector_EvaluateOutOfDomain checks that EvaluateOutOfDomain
+// agrees with the barycentric Lagrange evaluation of the selector's own
+// materialised vector, for both base-field and extension-field evaluation
+// points, across every position of the domain.
+func TestLagrangeSelector_EvaluateOutOfDomain(t *testing.T) {
+	const size = 8
+
+	// An out-of-domain base point (7 is not an 8-th root of unity) and a
+	// random extension point.
+	baseX := field.ElemFromBase(field.NewFromString("7"))
+	extX := field.RandomElemExt()
+
+	for pos := 0; pos < size; pos++ {
+		ls, rt := newLagrangeSelector(t, size, pos)
+
+		// Reference: materialise the selector vector (0,…,1,…,0) and evaluate
+		// it in Lagrange basis at the same point.
+		vec := ls.EvaluateVector(rt).Plain
+
+		for name, x := range map[string]field.Gen{"base": baseX, "ext": extX} {
+			want := polynomials.EvalLagrange(vec, x)
+			got := ls.EvaluateOutOfDomain(rt, x)
+			diff := got.Sub(want)
+			require.Truef(t, diff.IsZero(),
+				"pos=%d point=%s: EvaluateOutOfDomain disagrees with EvalLagrange", pos, name)
+		}
+
+		// The base result must stay in the base field when the point does.
+		require.Truef(t, ls.EvaluateOutOfDomain(rt, baseX).IsBase(),
+			"pos=%d: base evaluation point must yield a base result", pos)
+	}
+}
+
+// TestLagrangeSelector_EvaluateOutOfDomain_ZeroAtOtherRows checks that the
+// selector evaluates to 0 at every domain row other than its own (the
+// numerator Xⁿ−1 vanishes there).
+func TestLagrangeSelector_EvaluateOutOfDomain_ZeroAtOtherRows(t *testing.T) {
+	const size = 8
+	const pos = 3
+
+	ls, rt := newLagrangeSelector(t, size, pos)
+	omega := field.RootOfUnityBy(size)
+
+	for j := 0; j < size; j++ {
+		if j == pos {
+			continue // denominator vanishes at the selector's own row
+		}
+		var omegaJ field.Element
+		omegaJ.ExpInt64(omega, int64(j))
+		got := ls.EvaluateOutOfDomain(rt, field.ElemFromBase(omegaJ))
+		require.Truef(t, got.IsZero(), "selector at pos=%d must vanish at domain row %d", pos, j)
+	}
+}
+
+// TestLagrangeSelector_EvaluateOutOfDomain_PanicsOnOwnRow checks that
+// evaluating at ω^Position panics, since the denominator X−ω^Position is zero
+// and an in-domain point violates the out-of-domain contract.
+func TestLagrangeSelector_EvaluateOutOfDomain_PanicsOnOwnRow(t *testing.T) {
+	const size = 8
+	const pos = 5
+
+	ls, rt := newLagrangeSelector(t, size, pos)
+	var omegaPos field.Element
+	omegaPos.ExpInt64(field.RootOfUnityBy(size), int64(pos))
+
+	require.Panics(t, func() {
+		ls.EvaluateOutOfDomain(rt, field.ElemFromBase(omegaPos))
+	})
+}

--- a/prover-ray/wiop/wiop_lagrange_selector_test.go
+++ b/prover-ray/wiop/wiop_lagrange_selector_test.go
@@ -90,3 +90,75 @@ func TestLagrangeSelector_EvaluateOutOfDomain_PanicsOnOwnRow(t *testing.T) {
 		ls.EvaluateOutOfDomain(rt, field.ElemFromBase(omegaPos))
 	})
 }
+
+// TestLagrangeSelector_InExpression checks that a LagrangeSelector composes as
+// an ordinary leaf inside an arithmetic expression and is evaluated correctly
+// by the expression compiler on the runtime (in-domain) path. The product
+// col · L_pos must equal col[pos] at row pos and 0 at every other row.
+func TestLagrangeSelector_InExpression(t *testing.T) {
+	const size = 8
+	const pos = 5
+
+	sys := wiop.NewSystemf("ls-expr")
+	r0 := sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), size, wiop.PaddingDirectionNone)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	ls := wiop.NewLagrangeSelector(mod, pos)
+
+	expr := wiop.Mul(col.View(), ls)
+
+	rt := wiop.NewRuntime(sys)
+	elems := make([]field.Element, size)
+	for i := range elems {
+		elems[i].SetUint64(uint64(i + 1)) // col[i] = i+1, so col[pos] = pos+1
+	}
+	rt.AssignColumn(col, &wiop.ConcreteVector{Plain: field.VecFromBase(elems)})
+
+	out := expr.EvaluateVector(rt).Plain
+	require.Equal(t, size, out.Len())
+	for i := 0; i < size; i++ {
+		got := out.AsBase()[i]
+		var want field.Element
+		if i == pos {
+			want.SetUint64(uint64(pos + 1))
+		}
+		require.Truef(t, got.Equal(&want), "row %d: got %v want %v", i, got, want)
+	}
+}
+
+// TestLagrangeSelector_InVanishing checks that a LagrangeSelector works inside a
+// Vanishing constraint, mirroring the shape produced by the localvanishing lift
+// (predicate · L_pos). The constraint holds across the whole domain exactly when
+// the pinned predicate holds at row pos.
+func TestLagrangeSelector_InVanishing(t *testing.T) {
+	const size = 8
+	const pos = 3
+
+	build := func(rowPosVal uint64) (*wiop.Vanishing, wiop.Runtime) {
+		sys := wiop.NewSystemf("ls-vanish")
+		r0 := sys.NewRound()
+		mod := sys.NewSizedModule(sys.Context.Childf("mod"), size, wiop.PaddingDirectionNone)
+		col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+		ls := wiop.NewLagrangeSelector(mod, pos)
+
+		// Lifted local predicate "col == 0 at row pos": col · L_pos must vanish.
+		v := mod.NewVanishingManual(sys.Context.Childf("v"), wiop.Mul(col.View(), ls))
+
+		rt := wiop.NewRuntime(sys)
+		elems := make([]field.Element, size)
+		for i := range elems {
+			elems[i].SetUint64(7) // non-zero everywhere by default
+		}
+		elems[pos].SetUint64(rowPosVal)
+		rt.AssignColumn(col, &wiop.ConcreteVector{Plain: field.VecFromBase(elems)})
+		return v, rt
+	}
+
+	// Honest: col[pos] = 0 → the product vanishes on every row.
+	v, rt := build(0)
+	require.NoError(t, v.Check(rt))
+
+	// Invalid: col[pos] = 5 → non-zero at row pos.
+	v, rt = build(5)
+	require.Error(t, v.Check(rt))
+}

--- a/prover-ray/wiop/wioptest/local_vanishing_scenario.go
+++ b/prover-ray/wiop/wioptest/local_vanishing_scenario.go
@@ -53,5 +53,8 @@ func LocalVanishingScenarios() []func() *LocalVanishingScenario {
 		NewLocalMultiAnchorMultiColumnScenario,
 		NewLocalCubeAtFirstRowScenario,
 		NewLocalMultiModuleScenario,
+		NewLocalDynamicFirstRowZeroScenario,
+		NewLocalDynamicShiftedScenario,
+		NewLocalDynamicProductIsZeroScenario,
 	}
 }

--- a/prover-ray/wiop/wioptest/local_vanishing_scenarios.go
+++ b/prover-ray/wiop/wioptest/local_vanishing_scenarios.go
@@ -491,3 +491,84 @@ func NewLocalProductIsZeroScenario() *LocalVanishingScenario {
 		},
 	}
 }
+
+// NewLocalDynamicFirstRowZeroScenario pins col at row 0 to zero on a
+// dynamic-size module. The module declares no size; its domain size is fixed by
+// the column assignment at runtime. This exercises the localvanishing →
+// global pipeline against a module whose size is unknown at compile time —
+// only possible because the lift uses a [wiop.LagrangeSelector] (computed from
+// the runtime size) rather than a static precomputed column.
+//
+//   - Valid: col = [0, 9, …]; row 0 satisfies col[0] = 0.
+//   - Invalid: col = [7, 9, …]; row 0 violates.
+func NewLocalDynamicFirstRowZeroScenario() *LocalVanishingScenario {
+	sys := wiop.NewSystemf("lv-dyn-row0")
+	r0 := sys.NewRound()
+	mod := sys.NewDynamicModule(sys.Context.Childf("dynmod"), wiop.PaddingDirectionRight)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	mod.NewLocalConstraint(sys.Context.Childf("lc"), col.View(), 0)
+
+	return &LocalVanishingScenario{
+		Name: "DynamicFirstRowZero",
+		Sys:  sys,
+		AssignHonest: func(rt *wiop.Runtime) {
+			rt.AssignColumn(col, makeVec(0, 9, 9, 9, 9, 9, 9, 9)) // size 8, row 0 = 0
+		},
+		AssignInvalid: func(rt *wiop.Runtime) {
+			rt.AssignColumn(col, makeVec(7, 9, 9, 9, 9, 9, 9, 9))
+		},
+	}
+}
+
+// NewLocalDynamicShiftedScenario pins col at row 1 to zero (read via a +1 shift
+// from a row-0 anchor) on a dynamic-size module.
+//
+//   - Valid: col = [9, 0, …]; col[0 + 1] = 0.
+//   - Invalid: col = [9, 7, …]; col[1] != 0.
+func NewLocalDynamicShiftedScenario() *LocalVanishingScenario {
+	sys := wiop.NewSystemf("lv-dyn-shift")
+	r0 := sys.NewRound()
+	mod := sys.NewDynamicModule(sys.Context.Childf("dynmod"), wiop.PaddingDirectionRight)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	mod.NewLocalConstraint(sys.Context.Childf("lc"), col.View().Shift(1), 0)
+
+	return &LocalVanishingScenario{
+		Name: "DynamicShifted",
+		Sys:  sys,
+		AssignHonest: func(rt *wiop.Runtime) {
+			rt.AssignColumn(col, makeVec(9, 0, 9, 9, 9, 9, 9, 9))
+		},
+		AssignInvalid: func(rt *wiop.Runtime) {
+			rt.AssignColumn(col, makeVec(9, 7, 9, 9, 9, 9, 9, 9))
+		},
+	}
+}
+
+// NewLocalDynamicProductIsZeroScenario asserts (a · b)[0] = 0 on a dynamic-size
+// module. The quadratic predicate lifts to a degree-(2·(n-1)+1) vanishing whose
+// quotient ratio exceeds 1, so it exercises the selector's coset evaluation on
+// the *large* coset (N = n·ratio) for a module sized only at runtime.
+//
+//   - Valid: a[0] = 0, b[0] = 5; product 0.
+//   - Invalid: a[0] = 3, b[0] = 5; product 15.
+func NewLocalDynamicProductIsZeroScenario() *LocalVanishingScenario {
+	sys := wiop.NewSystemf("lv-dyn-prod")
+	r0 := sys.NewRound()
+	mod := sys.NewDynamicModule(sys.Context.Childf("dynmod"), wiop.PaddingDirectionRight)
+	a := mod.NewColumn(sys.Context.Childf("a"), wiop.VisibilityOracle, r0)
+	b := mod.NewColumn(sys.Context.Childf("b"), wiop.VisibilityOracle, r0)
+	mod.NewLocalConstraint(sys.Context.Childf("lc"), wiop.Mul(a.View(), b.View()), 0)
+
+	return &LocalVanishingScenario{
+		Name: "DynamicProductIsZero",
+		Sys:  sys,
+		AssignHonest: func(rt *wiop.Runtime) {
+			rt.AssignColumn(a, makeVec(0, 9, 9, 9, 9, 9, 9, 9))
+			rt.AssignColumn(b, makeVec(5, 9, 9, 9, 9, 9, 9, 9))
+		},
+		AssignInvalid: func(rt *wiop.Runtime) {
+			rt.AssignColumn(a, makeVec(3, 9, 9, 9, 9, 9, 9, 9))
+			rt.AssignColumn(b, makeVec(5, 9, 9, 9, 9, 9, 9, 9))
+		},
+	}
+}


### PR DESCRIPTION
## Use `LagrangeSelector` to lift local constraints, fixing local constraints on dynamic-size modules

### Summary

Introduces `LagrangeSelector` as a first-class expression leaf — the public indicator polynomial that is `1` at one row and `0` elsewhere — and rewires the local-constraint compiler to lift via a selector instead of a **precomputed, statically-sized** Lagrange column. This removes a latent limitation: local constraints on **dynamic-size modules** previously could not compile at all.

### Motivation / the bug

The `localvanishing` pass lifts a row-pinned (scalar) predicate into a domain-wide identity by multiplying with a Lagrange indicator. It did this by creating a **precomputed column** of length `m.Size()` with a single `1`. Precomputed columns require a statically-known size, so this approach is fundamentally incompatible with dynamic modules.

This never surfaced because **no test ever combined a local constraint with a dynamic module** — every `NewLocalConstraint` call site targets a `NewSizedModule`, and the dynamic-module tests only use *global* (multi-valued) `NewVanishing`. Run against a dynamic module, the pass panics (`m.Size() == 0` → precomputed column rejected). It was a coverage gap, not a silent miscompilation.

The fix is the `LagrangeSelector`: it carries no assignment and is evaluated from `RuntimeSize`, so it works for both static and dynamic modules.

### What changed

**`LagrangeSelector` (`wiop`)**
- A `VectorPromise` leaf evaluating to `(0,…,1,…,0)`; not committed.
- `EvaluateOutOfDomain(rt, x)` evaluates its low-degree extension `L_p(x) = ω^p·(xⁿ−1)/(n·(x−ωᵖ))`, with an explicit panic if `x` is the in-domain point `ωᵖ` (rather than silently returning `0` via the field's `1/0 = 0`).
- `NewLagrangeSelector` validates the position (non-negative; bounded by size when statically sized).

**Global-quotient compiler (`compilers/global`)**
- Treats `LagrangeSelector` as an expression leaf. Prover: `computeLagrangeSelectorCoset` evaluates `L_p` analytically over the quotient coset (batch-inverted, same parametrization as the cancellation polynomial). Verifier: evaluates it at the random point via `EvaluateOutOfDomain` — **no commitment and no `LagrangeEval` claim** (a net reduction vs. the old committed Lagrange column).

**Local-vanishing compiler (`compilers/localvanishing`)**
- Lifts via `NewLagrangeSelector(m, anchor)` instead of a precomputed column; `newLagrangeColumn` removed. Now size-agnostic.

**`Size()` made fail-fast (`wiop`)**
- `ColumnView.Size()` and `Constant.Size()` now panic on dynamic/unsized modules instead of silently returning `0`, matching `Degree()` and the scalar promises. (`IsSized()` remains the gate callers check first.)

### Tests
- **Unit:** `EvaluateOutOfDomain` (vs. barycentric reference, base + extension points), selector inside an expression, selector inside a `Vanishing`.
- **Global layer in isolation:** hand-written global constraint containing a selector leaf, linear (`ratio == 1`) and quadratic (`ratio > 1`, large-coset path), completeness + soundness.
- **Pipeline:** three new dynamic-module `LocalVanishingScenarios` (first-row, shifted, quadratic) running the full `localvanishing → global` pipeline, completeness + soundness.

### Notes
- No behavior change for static-module local constraints; the lifted polynomial is identical, just computed analytically rather than via FFT of a committed column.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core quotient prover/verifier expression evaluation and local-constraint lowering; behavior on static modules is intended to be equivalent but the proof path is security-sensitive.
> 
> **Overview**
> Introduces **`LagrangeSelector`** as an uncommitted expression leaf (1 at one domain row, 0 elsewhere) with in-domain **`EvaluateVector`** and out-of-domain **`EvaluateOutOfDomain`** via the Lagrange basis closed form.
> 
> **Local constraints** no longer allocate static precomputed Lagrange columns; **`localvanishing`** lifts row-pinned predicates with **`NewLagrangeSelector`**, which fixes **local constraints on dynamic-size modules** (size comes from **`RuntimeSize`**).
> 
> The **global quotient compiler** treats selectors as expression leaves: the prover evaluates them on the large quotient coset via **`computeLagrangeSelectorCoset`** (no FFT/commitment); the verifier uses **`EvaluateOutOfDomain`** at the random point instead of witness **`LagrangeEval`** claims for a committed indicator column.
> 
> **`ColumnView`**, **`Constant`**, and related **`Size()`** paths now **panic** on dynamic/unsized modules instead of returning 0. Tests cover selector math, hand-written global vanishings (linear and large-coset), and **dynamic-module** local→global pipeline scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e066250a770ef153cf6b1f3e111b21f5224cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->