### PR TITLE
chore(ci): migrate amd64 runners to gha-lfdt-lineth-ss scale sets

### DIFF
--- a/.github/workflows/all-tools.yml
+++ b/.github/workflows/all-tools.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   changes:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Filter commit changes
     outputs:
       all-tools: ${{ steps.filter.outputs['all-tools'] }}
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/reusable-store-image-name-and-tags.yml
 
   check_image_tags_exist:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Check image tags exist
     needs: [changes, store_image_name_and_tags]
     if: ${{ needs.changes.outputs['all-tools'] == 'false' }}
@@ -61,7 +61,7 @@ jobs:
           image_name: consensys/linea-alltools
 
   all-tools-tag-only:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: All tools tag only
     needs: [changes, store_image_name_and_tags, check_image_tags_exist]
     if: ${{ github.event_name != 'pull_request' && needs.changes.outputs['all-tools'] == 'false' }}
@@ -86,7 +86,7 @@ jobs:
     needs: [changes, store_image_name_and_tags, all-tools-tag-only]
     if: ${{ always() && needs.store_image_name_and_tags.outputs.commit_tag != '' && (needs.changes.outputs['all-tools'] == 'true' || needs.all-tools-tag-only.result != 'success' || needs.all-tools-tag-only.outputs.image_tagged != 'true') }}
     # ~0.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     env:
       COMMIT_TAG: ${{ needs.store_image_name_and_tags.outputs.commit_tag }}
       DEVELOP_TAG: ${{ needs.store_image_name_and_tags.outputs.develop_tag }}

--- a/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
@@ -74,7 +74,7 @@ permissions:
 
 jobs:
   bench:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     timeout-minutes: 120
     steps:
       - name: Checkout repository

--- a/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
@@ -82,7 +82,12 @@ jobs:
               opt)  ref="${{ inputs.zkc_optim_ref || 'b1af3445bfc4b3a3254a52b1929aadd07ad7fa3e' }}" ;;
             esac
             tmpbin=$(mktemp -d)
-            GOBIN="$tmpbin" go install "github.com/consensys/go-corset/cmd/zkc@${ref}"
+            # go-corset was renamed/moved to github.com/LFDT-Lineth/zkc. The module
+            # path must match the ref's own go.mod: post-rename refs (e.g. main) use
+            # the new path, pre-rename refs/tags still declare the old path. Try the
+            # new path first and fall back to the old one so both sides resolve.
+            GOBIN="$tmpbin" go install "github.com/LFDT-Lineth/zkc/cmd/zkc@${ref}" \
+              || GOBIN="$tmpbin" go install "github.com/consensys/go-corset/cmd/zkc@${ref}"
             mv "$tmpbin/zkc" "/tmp/zkc-${variant}"
             rmdir "$tmpbin"
             echo "::group::zkc-${variant} version (${ref})"

--- a/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
@@ -59,7 +59,7 @@ permissions:
 
 jobs:
   bench:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     timeout-minutes: 120
     steps:
       - name: Checkout repository

--- a/.github/workflows/arithmetization-riscv-act4-test.yml
+++ b/.github/workflows/arithmetization-riscv-act4-test.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   act4-reference-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/arithmetization-sample-guest-programs-run.yml
+++ b/.github/workflows/arithmetization-sample-guest-programs-run.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   sample-guest-programs-run:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     ## Override with a custom go-corset repo commit here in the event zkc on main is failing
     env:
       GO_CORSET_REF_FOR_ZKC: ${{ inputs.go-corset-ref || 'main' }}

--- a/.github/workflows/arithmetization-simple-zkc-binary-run-and-go-corset-check.yml
+++ b/.github/workflows/arithmetization-simple-zkc-binary-run-and-go-corset-check.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   binary-run-and-go-corset-check:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/arithmetization-zkc-riscv-check-compilation.yml
+++ b/.github/workflows/arithmetization-zkc-riscv-check-compilation.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   check-compilation:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-lib-versions-changes.yml
+++ b/.github/workflows/check-lib-versions-changes.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   check_lib_version_change:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     outputs:
       besu_commit_changed: ${{ steps.check_besu_commit.outputs.version_changed }}
 

--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   get-commit-tag:
     if: github.event.workflow_run.head_repository.fork == true
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: get-commit-tag
     permissions: {}
     outputs:
@@ -56,7 +56,7 @@ jobs:
 
   upload-codecov-coordinator:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: upload-codecov-coordinator
     permissions:
       actions: read    # download artifacts from another workflow run
@@ -87,7 +87,7 @@ jobs:
 
   upload-codecov-smart-contracts:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: upload-codecov-smart-contracts
     permissions:
       actions: read    # download artifacts from another workflow run
@@ -118,7 +118,7 @@ jobs:
 
   upload-codecov-ts:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: upload-codecov-ts
     permissions:
       actions: read    # download artifacts from another workflow run
@@ -167,7 +167,7 @@ jobs:
 
   upload-codecov-native-yield-ts:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: upload-codecov-native-yield-ts
     permissions:
       actions: read    # download artifacts from another workflow run
@@ -206,7 +206,7 @@ jobs:
 
   upload-codecov-lido-ts:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: upload-codecov-lido-ts
     permissions:
       actions: read    # download artifacts from another workflow run
@@ -245,7 +245,7 @@ jobs:
 
   upload-codecov-sdk-ts:
     needs: [ get-commit-tag ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: upload-codecov-sdk-ts
     permissions:
       actions: read    # download artifacts from another workflow run

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     outputs:
       languages: ${{ steps.set-matrix.outputs.languages }}
     permissions:
@@ -81,7 +81,7 @@ jobs:
 
   analyze:
     name: Analyze
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     needs: changes
     if: ${{ needs.changes.outputs.languages != '[]' }}
     permissions:

--- a/.github/workflows/component-changelog-commit.yml
+++ b/.github/workflows/component-changelog-commit.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   push-component-changelog:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes 
       # directly bypassin the branch-protection or for PR bot GitHub App to create PR with the changelog changes.

--- a/.github/workflows/component-changelog-upload.yml
+++ b/.github/workflows/component-changelog-upload.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   filter-commit-changes:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Filter commit changes
     outputs:
       coordinator: ${{ steps.filter.outputs.coordinator }}
@@ -61,7 +61,7 @@ jobs:
 
   upload-component-changelog:
     needs: [filter-commit-changes]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coordinator-build-and-publish.yml
+++ b/.github/workflows/coordinator-build-and-publish.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     name: Coordinator build
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -28,7 +28,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # ? Seems to fail more often on xl
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     name: Coordinator tests
     steps:
       - name: Checkout

--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   get-has-changes-requiring-e2e-testing:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     outputs:
       has_changes_requiring_e2e_testing: ${{ steps.evaluate.outputs.result }}
     steps:

--- a/.github/workflows/github-release-besu-plugin.yml
+++ b/.github/workflows/github-release-besu-plugin.yml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   release:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Validate inputs
         env:

--- a/.github/workflows/lido-governance-monitor-build-and-publish.yml
+++ b/.github/workflows/lido-governance-monitor-build-and-publish.yml
@@ -56,7 +56,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: lido-governance-monitor
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/lido-governance-monitor-testing.yml
+++ b/.github/workflows/lido-governance-monitor-testing.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: lido-governance-monitor-testing
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     environment: publish
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/linea-besu-package-build-and-upload.yml
+++ b/.github/workflows/linea-besu-package-build-and-upload.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   build-and-upload-artifact:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     outputs:
       linea_besu_package_tag: ${{ steps.build-plugins-and-assemble.outputs.dockertag }}
       dockerimage: ${{ steps.build-plugins-and-assemble.outputs.dockerimage }}

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-upload-images:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     concurrency:
       group: build-images-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/linea-besu-release.yml
+++ b/.github/workflows/linea-besu-release.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   check-branch-and-release-tag-suffix:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Enforce non-main branch must have custom release tag suffix
         if: github.ref_name != 'main' && inputs.release_tag_suffix == ''

--- a/.github/workflows/linea-milestone-release-with-dry-run.yml
+++ b/.github/workflows/linea-milestone-release-with-dry-run.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   release-branch-check:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Enforce main branch
         if: ${{ github.ref != 'refs/heads/main' }}
@@ -42,7 +42,7 @@ jobs:
   create-temp-branch-and-dispatch-release:
     needs: [release-branch-check]
     if: ${{ inputs.dry_run_release_on_branch }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     permissions:
       actions: write
     outputs:
@@ -136,7 +136,7 @@ jobs:
           exit 1
 
   manual-run-release-on-main:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     needs: [create-temp-branch-and-dispatch-release]
     if: ${{ always() && !cancelled() && inputs.dry_run_release_on_branch }}
     environment: ${{ inputs.dry_run_release_on_branch && 'run-release-on-main' || '' }}
@@ -155,7 +155,7 @@ jobs:
     # branch / tags / releases / docker tags. The only skip case is when
     # create-temp-branch-and-dispatch-release didn't succeed (nothing to clean).
     if: ${{ always() && inputs.dry_run_release_on_branch && needs.create-temp-branch-and-dispatch-release.outputs.branch != '' }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     # Generous timeout — the milestone release workflow can run for a while
     # (build + e2e + per-component releases). Bump if you hit it in practice.
     timeout-minutes: 240

--- a/.github/workflows/linea-sequencer-plugin-testing.yml
+++ b/.github/workflows/linea-sequencer-plugin-testing.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   run-linea-sequencer-plugins-unit-tests:
     name: "Sequencer Plugin Unit Tests"
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -48,7 +48,7 @@ jobs:
 
   run-linea-sequencer-plugins-acceptance-tests:
     name: "Sequencer Plugin Acceptance Tests"
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/linea-tracer-plugin-release.yml
+++ b/.github/workflows/linea-tracer-plugin-release.yml
@@ -20,7 +20,7 @@ jobs:
   # Build - for release and for tests
   # ==================================================================
   build:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     outputs:
       versionTag: ${{ steps.config.outputs.VERSION_TAG }}
     steps:
@@ -72,7 +72,7 @@ jobs:
   # ==================================================================
   replay-tests:
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,7 +116,7 @@ jobs:
   publish:
     needs: [ build ]
     if: github.event_name != 'pull_request'
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     env:
       architecture: "amd64"
       GRADLE_OPTS: "-Xmx6g -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"

--- a/.github/workflows/lint-commit-messages.yml
+++ b/.github/workflows/lint-commit-messages.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   lint-commit-messages:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Lint PR title and commit messages
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   run-load-test:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Run Load Test
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
   filter-commit-changes:
     needs: [lint-latest-commit-messages]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Filter commit changes
     outputs:
       coordinator: ${{ steps.filter.outputs.coordinator }}
@@ -225,7 +225,7 @@ jobs:
     uses: ./.github/workflows/get-has-changes-requiring-e2e-testing.yml
 
   manual-docker-build-and-e2e-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     needs: [compute-commit-tags, get-has-changes-requiring-e2e-testing]
     if: ${{ needs.get-has-changes-requiring-e2e-testing.outputs.has-changes-requiring-e2e-testing == 'true' }}
     environment: ${{ github.ref != 'refs/heads/main' && 'docker-build-and-e2e' || '' }}
@@ -293,7 +293,7 @@ jobs:
   cleanup-deployments:
     needs: [run-e2e-tests]
     if: ${{ always() && github.event.pull_request.head.repo.fork == false }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/maru-build-and-publish.yml
+++ b/.github/workflows/maru-build-and-publish.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     name: Maru build and publish
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/maru-chaos-testing.yml
+++ b/.github/workflows/maru-chaos-testing.yml
@@ -52,7 +52,7 @@ jobs:
       COMMIT_TAG: ${{ inputs.commit_tag }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-    runs-on: [ gha-runner-scale-set-ubuntu-24-amd64-large ]
+    runs-on: [ gha-lfdt-lineth-ss-ubuntu-24-amd64-large ]
     name: chaos tests
     # useful for debugging flaky tests.
     #    strategy:

--- a/.github/workflows/maru-e2e-tests.yml
+++ b/.github/workflows/maru-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     outputs:
       tests_outcome: ${{ steps.run_e2e_tests.outcome }}
-    runs-on: [gha-runner-scale-set-ubuntu-24-amd64-med]
+    runs-on: [gha-lfdt-lineth-ss-ubuntu-24-amd64-med]
     name: e2e tests
     steps:
       - name: Setup upterm session

--- a/.github/workflows/maru-testing.yml
+++ b/.github/workflows/maru-testing.yml
@@ -27,7 +27,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: maru tests
     # useful for debugging flaky tests. Comment out Jacoco and Codecov steps because they override the test results.
     #    strategy:

--- a/.github/workflows/maven-release-all.yml
+++ b/.github/workflows/maven-release-all.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   release:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Set version
         id: name

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   release:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Validate inputs
         env:

--- a/.github/workflows/native-yield-automation-service-build-and-publish.yml
+++ b/.github/workflows/native-yield-automation-service-build-and-publish.yml
@@ -56,7 +56,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Native yield automation service build
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/native-yield-automation-service-testing.yml
+++ b/.github/workflows/native-yield-automation-service-testing.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: native-yield-automation-service-testing
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   download-images-and-run-e2e-tests-with-partial-prover:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     concurrency:
       group: run-e2e-tests-${{ github.workflow }}-${{ github.ref }}-${{ matrix.test }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/postman-build-and-publish.yml
+++ b/.github/workflows/postman-build-and-publish.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Postman build
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/postman-testing.yml
+++ b/.github/workflows/postman-testing.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     name: Postman & SDK tests
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/prover-build-and-publish.yml
+++ b/.github/workflows/prover-build-and-publish.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Prover build
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -26,7 +26,7 @@ on:
 jobs:
 
   validate:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Validate version
         id: validate_version
@@ -40,7 +40,7 @@ jobs:
 
   build-linux:
     needs: [validate]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -148,7 +148,7 @@ jobs:
   release_artefacts:
     name: Release artefacts
     needs: [validate, build-linux, build-linux-arm64, build-mac-os]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     env:
       VERSION: ${{ github.event.inputs.version }}
     steps:

--- a/.github/workflows/prover-ray-testing.yml
+++ b/.github/workflows/prover-ray-testing.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   staticcheck:
     # ~1.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Prover static check
     steps:
     - name: checkout code
@@ -62,7 +62,7 @@ jobs:
       matrix:
         go-version: [1.25.7]
     # ~1 min saved vs large
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     name: Prover testing
     needs:
       - staticcheck

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   staticcheck:
     # ~1.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Prover static check
     steps:
     - name: checkout code
@@ -59,7 +59,7 @@ jobs:
       matrix:
         go-version: [1.25.7]
     # ~1 min saved vs large
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     name: Prover testing
     needs:
       - staticcheck

--- a/.github/workflows/reusable-component-docker-tag.yml
+++ b/.github/workflows/reusable-component-docker-tag.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   compute-docker-image-tag:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Compute docker image tag
     outputs:
       docker_tag: ${{ steps.dockertag.outputs.dockertag }}

--- a/.github/workflows/reusable-component-gh-release.yml
+++ b/.github/workflows/reusable-component-gh-release.yml
@@ -143,7 +143,7 @@ jobs:
        needs.build-and-publish-image-prover.result            == 'success' ||
        needs.build-and-publish-image-tx-exclusion-api.result  == 'success' ||
        needs.build-and-publish-image-maru.result              == 'success'))
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-component-release-metadata.yml
+++ b/.github/workflows/reusable-component-release-metadata.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   compute-release-metadata:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Compute ${{ inputs.component-name }} release metadata (changelog + tag)
     outputs:
       release_tag: ${{ steps.changelog.outputs.next_tag }}

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   release-component:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -57,7 +57,7 @@ on:
 
 jobs:
   check-branch-and-release-tag-suffix:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Enforce non-main branch must have custom release tag suffix
         if: github.ref_name != 'main' && inputs.release_tag_suffix == ''
@@ -67,7 +67,7 @@ jobs:
 
   compute-commit-tag:
     needs: [check-branch-and-release-tag-suffix]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     outputs:
        commit_tag: ${{ steps.compute-version-tags.outputs.commit_tag }}
     steps:

--- a/.github/workflows/reusable-compute-commit-tags.yml
+++ b/.github/workflows/reusable-compute-commit-tags.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   compute_commit_tags:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Check image tags exist
     env:
       # REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/reusable-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reusable-linea-besu-package-build-test-push.yml
@@ -96,7 +96,7 @@ jobs:
   build-and-push-dockerhub:
     needs: [ run-test, run-e2e-tests ]
     if: ${{ always() && !cancelled() && (!inputs.run_e2e_test || needs.run-e2e-tests.outputs.tests_outcome == 'success') && (!inputs.run-test || needs.run-test.result == 'success') }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     environment: dockerhub
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/reusable-linea-besu-package-run-e2e-tests.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
     outputs:
       tests_outcome: ${{ steps.run_e2e_tests.outcome }}
     # xl saves ~0 mins
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xl
     steps:
       - name: Setup upterm session
         if: ${{ inputs.e2e-tests-with-ssh }}

--- a/.github/workflows/reusable-linea-besu-package-run-test.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   list-profiles:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     outputs:
       profile-files: ${{ steps.list-profiles.outputs.files }}
     steps:
@@ -26,7 +26,7 @@ jobs:
 
   test-profile:
     timeout-minutes: 4
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     continue-on-error: true
     needs: [ list-profiles ]
     strategy:

--- a/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
+++ b/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   check-branch-and-compute-tag:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     outputs:
       release_version: ${{ steps.compute-release-tag.outputs.next_version }}
       release_tag: ${{ steps.compute-release-tag.outputs.next_tag }}

--- a/.github/workflows/reusable-milestone-component-latest-docker-tags.yml
+++ b/.github/workflows/reusable-milestone-component-latest-docker-tags.yml
@@ -72,7 +72,7 @@ on:
 
 jobs:
   component-latest-docker-tags:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/reusable-milestone-component-release-metadata.yml
+++ b/.github/workflows/reusable-milestone-component-release-metadata.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   component-release-metadata:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-milestone-gh-release.yml
+++ b/.github/workflows/reusable-milestone-gh-release.yml
@@ -103,7 +103,7 @@ on:
 
 jobs:
   linea-milestone-gh-release:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
@@ -52,7 +52,7 @@ permissions:
 
 jobs:
   update-linea-milestone-changelog:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     outputs:
       changelog: ${{ steps.prepend-milestone-header.outputs.changelog }}
     env:

--- a/.github/workflows/reusable-milestone-retag-latest-docker-tags.yml
+++ b/.github/workflows/reusable-milestone-retag-latest-docker-tags.yml
@@ -55,7 +55,7 @@ on:
 
 jobs:
   retag-latest-docker-tags:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -98,7 +98,7 @@ jobs:
     outputs:
       tests_outcome: ${{ steps.run_e2e_tests.outcome }}
     # xl saves ~0 mins
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xl
     steps:
       - name: Setup upterm session
         if: ${{ inputs.e2e-tests-with-ssh }}

--- a/.github/workflows/reusable-store-image-name-and-tags.yml
+++ b/.github/workflows/reusable-store-image-name-and-tags.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   store_image_name_and_tags:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: Compute version tags
     env:
       # REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -40,7 +40,7 @@ jobs:
   # Blockchain ref Tests
   # ==================================================================
   blockchain-reference-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     outputs:
       success: ${{ steps.metrics.outputs.success }}
       failed: ${{ steps.metrics.outputs.failed }}

--- a/.github/workflows/reusable-tracer-nightly-tests.yml
+++ b/.github/workflows/reusable-tracer-nightly-tests.yml
@@ -18,7 +18,7 @@ jobs:
   # Nightly Tests
   # ==================================================================
   nightly-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,7 +61,7 @@ jobs:
   # Nightly Modexp Tests are treated separately while fixing performance issue on compile time
   # ==================================================================
   nightly-modexp-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-tracer-unit-tests.yml
+++ b/.github/workflows/reusable-tracer-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
   # Unit Tests
   # ==================================================================
   unit-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:

--- a/.github/workflows/reusable-tracer-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-prc-tests.yml
@@ -15,7 +15,7 @@ jobs:
   # Weekly PRC Call Tests
   # ==================================================================
   weekly-prc-calltests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-tracer-weekly-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-tests.yml
@@ -15,7 +15,7 @@ jobs:
   # Weekly Tests
   # ==================================================================
   weekly-unit-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   run-contract-tests:
     # ~2 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Run smart contracts tests
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -91,7 +91,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   solidity-format-check:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Solidity format check
     steps:
       - name: Checkout

--- a/.github/workflows/run-validium-e2e-tests.yml
+++ b/.github/workflows/run-validium-e2e-tests.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run-validium-e2e-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xl
     steps:
       - name: Setup upterm session
         if: ${{ inputs.e2e-tests-with-ssh }}

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   guard:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Ensure running on main
         if: github.ref != 'refs/heads/main'
@@ -61,7 +61,7 @@ jobs:
   publish-sdk-core:
     needs: guard
     if: inputs.package == 'sdk-core'
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -152,7 +152,7 @@ jobs:
   publish-sdk-viem:
     needs: guard
     if: inputs.package == 'sdk-viem'
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   guard:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Ensure running on main
         if: github.ref != 'refs/heads/main'
@@ -37,7 +37,7 @@ jobs:
 
   create-release-pr:
     needs: guard
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     name: SDK Build, Test, Lint
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/security-report-to-csv.yml
+++ b/.github/workflows/security-report-to-csv.yml
@@ -8,7 +8,7 @@ permissions:
 on: workflow_dispatch
 jobs:
   data_gathering:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: CSV export
         uses: advanced-security/ghas-to-csv@8c2ad35efb234e8e1bd12efaced0f0609ad8afbb # v3

--- a/.github/workflows/slack-notify-e2e-runtime-report.yml
+++ b/.github/workflows/slack-notify-e2e-runtime-report.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   generate-report:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -44,7 +44,7 @@ on:
 jobs:
   ai-analysis:
     if: ${{ inputs.enable_ai_analysis }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     timeout-minutes: 15
     permissions:
       contents: read
@@ -262,7 +262,7 @@ jobs:
     # always() so Slack still runs when ai-analysis is skipped, fails, or succeeds; needs still gates ordering.
     needs: [ai-analysis]
     if: always()
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Compute context values
         id: ctx

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:

--- a/.github/workflows/staterecovery-testing.yml
+++ b/.github/workflows/staterecovery-testing.yml
@@ -28,7 +28,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       # CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # ~2.5 mins saved vs large
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     name: Staterecovery tests
     steps:
       - name: Checkout

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -134,7 +134,7 @@ jobs:
 
   # Run Jacoco report after all JVM tests complete
   jacoco-report:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Generate Jacoco Coverage Report
     # Run if at least one JVM test job completed (whether passed, failed, or cancelled)
     # Don't run if all test jobs were skipped due to no changes

--- a/.github/workflows/tracer-constraints-check-compilation.yml
+++ b/.github/workflows/tracer-constraints-check-compilation.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tracer-gradle-besu-node-tests.yml
+++ b/.github/workflows/tracer-gradle-besu-node-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   unit-tests-with-besu-node:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tracer-gradle-nightly-tests.yml
+++ b/.github/workflows/tracer-gradle-nightly-tests.yml
@@ -24,7 +24,7 @@ jobs:
   # Replay Tests
   # ==================================================================
   nightly-replay-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tracer-gradle-tests.yml
+++ b/.github/workflows/tracer-gradle-tests.yml
@@ -26,7 +26,7 @@ jobs:
     # if: github.event.pull_request.draft == false && github.base_ref != 'main'
     # if: ${{ github.ref != 'refs/heads/main' }}
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Show metadata
         run: |
@@ -77,7 +77,7 @@ jobs:
     # if: ${{ github.ref != 'refs/heads/main' }}
     if: ${{ github.event.pull_request.draft == false }}
     needs: [ build ]
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tracer-gradle-weekly-tests.yml
+++ b/.github/workflows/tracer-gradle-weekly-tests.yml
@@ -25,7 +25,7 @@ jobs:
       zkevm_fork: OSAKA
 
   weekly-replay-tests:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-xxl
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/transaction-exclusion-api-build-and-publish.yml
+++ b/.github/workflows/transaction-exclusion-api-build-and-publish.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   build-and-publish:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Transaction exclusion api build
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/transaction-exclusion-api-testing.yml
+++ b/.github/workflows/transaction-exclusion-api-testing.yml
@@ -29,7 +29,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     # ~1.5 mins saved vs small
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     name: Transaction exclusion api tests
     steps:
       - name: Checkout

--- a/.github/workflows/valid-audit-pr-has-tags.yml
+++ b/.github/workflows/valid-audit-pr-has-tags.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   check:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
 
     steps:
     - name: Checkout code

--- a/.github/workflows/verifier-ray.yml
+++ b/.github/workflows/verifier-ray.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/prover/utils/test_utils/test_utils.go
+++ b/prover/utils/test_utils/test_utils.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"math"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/consensys/gnark/frontend"
 	snarkHash "github.com/consensys/gnark/std/hash"
@@ -67,19 +67,24 @@ type ReaderHashSnark struct {
 	api frontend.API
 }
 
-// GetRepoRootPath assumes that current working directory is within the repo
+// GetRepoRootPath returns the monorepo root by walking up from the current
+// working directory until it finds the .git marker. Independent of the
+// checkout directory name.
 func GetRepoRootPath() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
-	const repoName = "linea-monorepo"
-	i := strings.LastIndex(wd, repoName)
-	if i == -1 {
-		return "", errors.New("could not find repo root")
+	for dir := wd; ; {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("could not find repo root")
+		}
+		dir = parent
 	}
-	i += len(repoName)
-	return wd[:i], nil
 }
 
 // GetZkevmWitness returns a [zkevm.Witness]


### PR DESCRIPTION
Renames all amd64 self-hosted runners from `gha-runner-scale-set-ubuntu-24-amd64-*` to `gha-lfdt-lineth-ss-ubuntu-24-amd64-*` across the workflows.

- Pure prefix rename; size suffixes (small/med/large/xl/xxl) unchanged.
- 85 files, 117 `runs-on:` values updated.
- The single arm64 runner in `prover-native-lib-blob-compressor-release.yml` is left unchanged (no arm64 variant in the new naming).

Also fixes the zkc native keccak benchmark: go-corset moved to `github.com/LFDT-Lineth/zkc`. The remote `go install` now tries the new module path first and falls back to the old one, so refs on either side of the rename (base=main vs. pinned pre-rename opt commit) resolve.

Also fixes prover compressor tests after the `linea-monorepo` → `lineth-monorepo` directory rename: `GetRepoRootPath` matched the hardcoded `linea-monorepo` string in the working-dir path ("could not find repo root"). It now walks up to the `.git` marker, independent of the checkout dir name.