### PR TITLE
fix(prover): make MAX_L2_LOGS configurable via traces_limits BLOCK_L2_L1_LOGS

### DIFF
--- a/prover/backend/invalidity/limitless/prove.go
+++ b/prover/backend/invalidity/limitless/prove.go
@@ -101,6 +101,7 @@ func Prove(cfg *config.Config, req *backendInvalidity.Request) (*backendInvalidi
 			proof,
 			*funcInput,
 			req.InvalidityType,
+			cfg.TracesLimits.BlockL2L1Logs(),
 			config.ProverModeLimitless,
 		); err != nil {
 			utils.Panic("outer proof constraint check failed (DEBUG MODE): %v", err)

--- a/prover/backend/invalidity/prove.go
+++ b/prover/backend/invalidity/prove.go
@@ -108,6 +108,7 @@ func Prove(cfg *config.Config, req *Request, large bool) (*Response, error) {
 			InvalidityType: req.InvalidityType,
 			FuncInputs:     *funcInput,
 			MaxRlpByteSize: cfg.Invalidity.MaxRlpByteSize,
+			MaxL2Logs:      cfg.TracesLimits.BlockL2L1Logs(),
 		}
 
 		switch req.InvalidityType {

--- a/prover/circuits/invalidity/bad_precompile.go
+++ b/prover/circuits/invalidity/bad_precompile.go
@@ -13,8 +13,6 @@ import (
 	invalidity "github.com/consensys/linea-monorepo/prover/zkevm/prover/publicInput/invalidity_pi"
 )
 
-const MAX_L2_LOGS = 16
-
 // BadPrecompileCircuit defines the circuit for the transaction with a bad precompile.
 type BadPrecompileCircuit struct {
 	//  simulated execution context.
@@ -29,6 +27,9 @@ type BadPrecompileCircuit struct {
 	// Derived from execution PI extractor (gnark:"-" = no wires, set during Define)
 	stateRootHash      [2]frontend.Variable `gnark:"-"`
 	initialBlockNumber frontend.Variable    `gnark:"-"`
+
+	// MaxL2Logs from config (compile-time constant, not a wire)
+	MaxL2Logs int `gnark:"-"`
 
 	// Witness fields, cross-checked against extraction
 	// when the extracted value is non-zero.
@@ -62,6 +63,11 @@ type ExecutionCtx struct {
 }
 
 func (circuit *BadPrecompileCircuit) Allocate(config Config) {
+
+	if config.MaxL2Logs <= 0 {
+		panic("MaxL2Logs must be set in config (from BLOCK_L2_L1_LOGS traces limit)")
+	}
+	circuit.MaxL2Logs = config.MaxL2Logs
 
 	wverifier := wizard.AllocateWizardCircuit(
 		config.ZkEvmComp,
@@ -105,13 +111,13 @@ func (circuit *BadPrecompileCircuit) Define(api frontend.API) error {
 			binaryType),
 		0)
 
-	// check that NbL2Logs is greater than MAX_L2_LOGS, if invalidityType == 3 (TooManyLogs)
-	// When binaryType=1: 17 <= 1*NbL2Logs + 0 = NbL2Logs
-	// When binaryType=0: 17 <= 0*NbL2Logs + 17 = 17  (always passes)
-	api.AssertIsLessOrEqual(MAX_L2_LOGS+1,
+	// check that NbL2Logs is greater than MaxL2Logs, if invalidityType == 3 (TooManyLogs)
+	// When binaryType=1: MaxL2Logs+1 <= 1*NbL2Logs + 0 = NbL2Logs
+	// When binaryType=0: MaxL2Logs+1 <= 0*NbL2Logs + MaxL2Logs+1 = MaxL2Logs+1  (always passes)
+	api.AssertIsLessOrEqual(circuit.MaxL2Logs+1,
 		api.Add(
 			api.Mul(binaryType, circuit.NbL2Logs),
-			api.Mul(api.Sub(1, binaryType), MAX_L2_LOGS+1),
+			api.Mul(api.Sub(1, binaryType), circuit.MaxL2Logs+1),
 		),
 	)
 

--- a/prover/circuits/invalidity/check_native.go
+++ b/prover/circuits/invalidity/check_native.go
@@ -24,13 +24,14 @@ import (
 // The inner wizard constraints are already validated by the dummy compiler
 // during ProveInner/VerifyInner. This checks:
 //   - PI values extracted from the wizard proof match funcInputs
-//   - hasBadPrecompile != 0 (type 2) or NbL2Logs > MAX_L2_LOGS (type 3)
+//   - hasBadPrecompile != 0 (type 2) or NbL2Logs > maxL2Logs (type 3)
 //   - The public input hash is consistent
 func CheckOnlyNativeBadPrecompile(
 	comp *wizard.CompiledIOP,
 	proof wizard.Proof,
 	funcInputs public_input.Invalidity,
 	invalidityType InvalidityType,
+	maxL2Logs int,
 	proverMode ...config.ProverMode,
 ) error {
 	invExtractor, err := getInvalidityExtractor(comp)
@@ -63,9 +64,9 @@ func CheckOnlyNativeBadPrecompile(
 		}
 	case TooManyLogs:
 		var threshold field.Element
-		threshold.SetUint64(MAX_L2_LOGS + 1)
+		threshold.SetUint64(uint64(maxL2Logs) + 1)
 		if nbL2Logs.Cmp(&threshold) < 0 {
-			return fmt.Errorf("nbL2Logs=%v is not > %d for TooManyLogs invalidity type", nbL2Logs, MAX_L2_LOGS)
+			return fmt.Errorf("nbL2Logs=%v is not > %d for TooManyLogs invalidity type", nbL2Logs, maxL2Logs)
 		}
 	default:
 		return fmt.Errorf("unsupported invalidity type for bad-precompile native check: %s", invalidityType)

--- a/prover/circuits/invalidity/invalidity.go
+++ b/prover/circuits/invalidity/invalidity.go
@@ -56,6 +56,7 @@ type AssigningInputs struct {
 	// inputs related to zkevm-wizard
 	ZkEvmComp        *wizard.CompiledIOP
 	ZkEvmWizardProof wizard.Proof
+	MaxL2Logs        int
 
 	// CachedProofPath, if set, enables proof caching: on first run the proof
 	// is written to this path; on subsequent runs with the same witness the
@@ -184,7 +185,7 @@ func (c *CircuitInvalidity) CheckOnly(assi AssigningInputs) error {
 		if assi.ZkEvmComp == nil {
 			return fmt.Errorf("ZkEvmComp is nil for %s", assi.InvalidityType)
 		}
-		err = CheckOnlyNativeBadPrecompile(assi.ZkEvmComp, assi.ZkEvmWizardProof, assi.FuncInputs, assi.InvalidityType)
+		err = CheckOnlyNativeBadPrecompile(assi.ZkEvmComp, assi.ZkEvmWizardProof, assi.FuncInputs, assi.InvalidityType, assi.MaxL2Logs)
 
 	case BadNonce, BadBalance:
 		err = CheckOnlyNativeNonceBalance(assi)
@@ -207,6 +208,9 @@ type Config struct {
 	KeccakCompiledIOP *wizardk.CompiledIOP
 	MaxRlpByteSize    int
 	ZkEvmComp         *wizard.CompiledIOP
+	// MaxL2Logs is the maximum number of L2->L1 logs allowed.
+	// Used by the BadPrecompile/TooManyLogs circuit.
+	MaxL2Logs int
 }
 
 type builder struct {
@@ -230,10 +234,11 @@ func (b *builder) Compile() (constraint.ConstraintSystem, error) {
 type limitlessBuilder struct {
 	congWIOP     *wizard.CompiledIOP
 	vkMerkleRoot field.Octuplet
+	maxL2Logs    int
 }
 
-func NewBuilderLimitless(congWIOP *wizard.CompiledIOP, vkMerkleRoot field.Octuplet) *limitlessBuilder {
-	return &limitlessBuilder{congWIOP: congWIOP, vkMerkleRoot: vkMerkleRoot}
+func NewBuilderLimitless(congWIOP *wizard.CompiledIOP, vkMerkleRoot field.Octuplet, maxL2Logs int) *limitlessBuilder {
+	return &limitlessBuilder{congWIOP: congWIOP, vkMerkleRoot: vkMerkleRoot, maxL2Logs: maxL2Logs}
 }
 
 func (b *limitlessBuilder) Compile() (constraint.ConstraintSystem, error) {
@@ -249,7 +254,7 @@ func (b *limitlessBuilder) Compile() (constraint.ConstraintSystem, error) {
 			},
 		},
 	}
-	circuit.Allocate(Config{ZkEvmComp: b.congWIOP})
+	circuit.Allocate(Config{ZkEvmComp: b.congWIOP, MaxL2Logs: b.maxL2Logs})
 
 	ccs, err := frontend.Compile(ecc.BLS12_377.ScalarField(), scs.NewBuilder, circuit, frontend.WithCapacity(1<<24))
 	if err != nil {

--- a/prover/cmd/prover/cmd/setup.go
+++ b/prover/cmd/prover/cmd/setup.go
@@ -349,6 +349,7 @@ func createCircuitBuilder(c circuits.CircuitID, cfg *config.Config, args SetupAr
 		zkEvm := zkevm.FullZkEvm(&limits, cfg)
 		return invalidity.NewBuilder(invalidity.Config{
 			ZkEvmComp: zkEvm.RecursionCompiledIOP,
+			MaxL2Logs: limits.BlockL2L1Logs(),
 		}, &invalidity.BadPrecompileCircuit{}), extraFlags, nil
 
 	case circuits.InvalidityPrecompileLogsLargeCircuitID:
@@ -358,6 +359,7 @@ func createCircuitBuilder(c circuits.CircuitID, cfg *config.Config, args SetupAr
 		zkEvm := zkevm.FullZkEvmLarge(&limits, cfg)
 		return invalidity.NewBuilder(invalidity.Config{
 			ZkEvmComp: zkEvm.RecursionCompiledIOP,
+			MaxL2Logs: limits.BlockL2L1Logs(),
 		}, &invalidity.BadPrecompileCircuit{}), extraFlags, nil
 
 	case circuits.InvalidityPrecompileLogsLimitlessCircuitID:
@@ -377,7 +379,7 @@ func createCircuitBuilder(c circuits.CircuitID, cfg *config.Config, args SetupAr
 				return nil, nil, fmt.Errorf("failed to load VK merkle tree for invalidity limitless: %w", err)
 			}
 			vkMerkleRoot := vkTree.GetRoot()
-			return invalidity.NewBuilderLimitless(conglo.RecursionCompBLS, vkMerkleRoot), extraFlags, nil
+			return invalidity.NewBuilderLimitless(conglo.RecursionCompBLS, vkMerkleRoot, cfg.TracesLimits.BlockL2L1Logs()), extraFlags, nil
 		}
 
 		logrus.Info("execution-limitless assets not found; generating them now for invalidity limitless setup")
@@ -392,7 +394,7 @@ func createCircuitBuilder(c circuits.CircuitID, cfg *config.Config, args SetupAr
 		asset = nil
 		runtime.GC()
 
-		return invalidity.NewBuilderLimitless(compCong.RecursionCompBLS, vkMerkleRoot), extraFlags, nil
+		return invalidity.NewBuilderLimitless(compCong.RecursionCompBLS, vkMerkleRoot, cfg.TracesLimits.BlockL2L1Logs()), extraFlags, nil
 	case circuits.InvalidityFilteredAddressCircuitID:
 		keccakComp := invalidity.MakeKeccakCompiledIOP(cfg.Invalidity.MaxRlpByteSize, keccak.WizardCompilationParameters()...)
 		return invalidity.NewBuilder(


### PR DESCRIPTION
Make `MAX_L2_LOGS` configurable via `traces_limits.BLOCK_L2_L1_LOGS` in the prover TOML file.

This enables different `MAX_L2_LOGS` values for different environments (e.g., e2e and prod) rather than always using the hardcoded value.


### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
