### PR TITLE
feat(linea-besu): forced transactions security policy integration

### DIFF
--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/linea/plugin/acc/test/FakeChainSecurityPolicyTxValidatorPlugin.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/kotlin/linea/plugin/acc/test/FakeChainSecurityPolicyTxValidatorPlugin.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package linea.plugin.acc.test
+
+import linea.plugin.acc.test.FakeChainSecurityPolicyTxValidatorPlugin.Companion.PLUGIN_NAME
+import linea.plugin.acc.test.FakeChainSecurityPolicyTxValidatorPlugin.Companion.blockByHash
+import linea.plugin.acc.test.FakeChainSecurityPolicyTxValidatorPlugin.Companion.blockBySender
+import linea.plugin.acc.test.FakeChainSecurityPolicyTxValidatorPlugin.Companion.reset
+import linea.security.ChainSecurityPolicy
+import linea.txselection.LineaTransactionSelectionResult
+import linea.txselection.LineaTransactionSelectionResult.chainSecurityRuleViolated
+import org.apache.tuweni.bytes.Bytes
+import org.hyperledger.besu.plugin.BesuPlugin
+import org.hyperledger.besu.plugin.ServiceManager
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader
+import org.hyperledger.besu.plugin.data.TransactionProcessingResult
+import org.hyperledger.besu.plugin.data.TransactionSelectionResult
+import org.hyperledger.besu.plugin.services.TransactionSelectionService
+import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector
+import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory
+import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Acceptance-test fixture plugin that registers a [ChainSecurityPolicy] BesuService and a
+ * [PluginTransactionSelector] that can block transactions by hash or sender address.
+ *
+ * Use [blockByHash] / [blockBySender] to populate the blocklists before a test, and [reset] to
+ * clear them between tests.
+ *
+ * Activate by adding [PLUGIN_NAME] to the test's `requestedPlugins`.
+ */
+class FakeChainSecurityPolicyTxValidatorPlugin : BesuPlugin {
+
+  private lateinit var transactionSelectionService: TransactionSelectionService
+  private lateinit var serviceManager: ServiceManager
+
+  override fun register(serviceManager: ServiceManager) {
+    this.serviceManager = serviceManager
+    transactionSelectionService =
+      serviceManager
+        .getService(TransactionSelectionService::class.java)
+        .orElseThrow { RuntimeException("TransactionSelectionService not found in ServiceManager") }
+  }
+
+  override fun start() {
+    val chainSecurityPolicy = serviceManager
+      .getService(ChainSecurityPolicy::class.java)
+      .orElseThrow { RuntimeException("ChainSecurityPolicy not found in ServiceManager") }
+    transactionSelectionService.registerPluginTransactionSelectorFactory(
+      object : PluginTransactionSelectorFactory {
+        override fun create(
+          pendingBlockHeader: ProcessableBlockHeader,
+          selectorsStateManager: SelectorsStateManager,
+        ): PluginTransactionSelector = BlocklistTransactionSelector(chainSecurityPolicy)
+      },
+    )
+  }
+
+  override fun stop() {}
+
+  private class BlocklistTransactionSelector(
+    val chainSecurityPolicy: ChainSecurityPolicy,
+  ) : PluginTransactionSelector {
+
+    override fun evaluateTransactionPreProcessing(
+      evaluationContext: TransactionEvaluationContext,
+    ): TransactionSelectionResult {
+      val tx = evaluationContext.pendingTransaction.transaction
+      if (chainSecurityPolicy.shallForceIncludeTransaction(evaluationContext)) {
+        return TransactionSelectionResult.SELECTED
+      }
+      if (blockedHashes.contains(tx.hash.bytes)) return TX_BLOCKED_BY_SECURITY_POLICY
+      if (blockedSenders.contains(tx.sender.bytes)) return TX_BLOCKED_BY_SECURITY_POLICY
+      return TransactionSelectionResult.SELECTED
+    }
+
+    override fun evaluateTransactionPostProcessing(
+      evaluationContext: TransactionEvaluationContext,
+      processingResult: TransactionProcessingResult,
+    ): TransactionSelectionResult = TransactionSelectionResult.SELECTED
+  }
+
+  companion object {
+    const val PLUGIN_NAME = "FakeChainSecurityPolicyTxValidatorPlugin"
+
+    val TX_BLOCKED_BY_SECURITY_POLICY: LineaTransactionSelectionResult =
+      chainSecurityRuleViolated("Blocked by FakeChainSecurityPolicyPlugin")
+
+    val blockedHashes: MutableSet<Bytes> = ConcurrentHashMap.newKeySet()
+    val blockedSenders: MutableSet<Bytes> = ConcurrentHashMap.newKeySet()
+
+    fun blockByHash(hash: Bytes) {
+      blockedHashes.add(hash)
+    }
+
+    fun blockBySender(address: Bytes) {
+      blockedSenders.add(address)
+    }
+
+    fun blockBySender(address: String) {
+      blockedSenders.add(Bytes.fromHexString(address))
+    }
+
+    fun reset() {
+      blockedHashes.clear()
+      blockedSenders.clear()
+    }
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/resources/META-INF/services/org.hyperledger.besu.plugin.BesuPlugin
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/main/resources/META-INF/services/org.hyperledger.besu.plugin.BesuPlugin
@@ -1,1 +1,2 @@
 linea.plugin.acc.test.RecordingTransactionSelectorPlugin
+linea.plugin.acc.test.FakeChainSecurityPolicyTxValidatorPlugin

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/LineaPluginPoSTestBase.kt
@@ -60,6 +60,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
+import kotlin.time.Duration
 
 /**
  * Record containing all parameters required for engine_newPayloadV4 API calls.
@@ -209,18 +210,26 @@ abstract class LineaPluginPoSTestBase : LineaPluginTestBase() {
    * (with stale txpool state) absorbs our fcu and getPayload returns its cached
    * selection, missing any txs the test sent after the background tick fired.
    */
-  protected fun buildNewBlockAndWait(blockBuildingTimeMs: Long) {
+  protected fun buildNewBlockAndWait(blockBuildingTimeMs: Long): Long {
     val initialBlockNumber = getLatestBlockNumber()
     val latestTimestamp = minerNode.execute(ethTransactions.block()).timestamp
     buildNewBlock(
       latestTimestamp.toLong() + blockTimeSeconds!! + 1L,
       blockBuildingTimeMs,
     ) { false }
+    var latestBlockNumber = getLatestBlockNumber()
     await()
       .atMost(3 * blockTimeSeconds!!, TimeUnit.SECONDS)
       .pollInterval(100, TimeUnit.MILLISECONDS)
-      .untilAsserted { assertThat(getLatestBlockNumber()).isGreaterThan(initialBlockNumber) }
+      .untilAsserted {
+        latestBlockNumber = getLatestBlockNumber()
+        assertThat(latestBlockNumber).isGreaterThan(initialBlockNumber)
+      }
+    return latestBlockNumber
   }
+
+  protected fun buildNewBlockAndWait(blockBuildingTime: Duration): Long =
+    buildNewBlockAndWait(blockBuildingTime.inWholeMilliseconds)
 
   /**
    * Creates and sends a blob transaction. This method is designed to be stateless and should not

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/ForcedTransactionRequestResponse.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/ForcedTransactionRequestResponse.kt
@@ -23,7 +23,13 @@ data class ForcedTransactionParam(
   val forcedTransactionNumber: Long,
   val transaction: String,
   val deadlineBlockNumber: String,
-)
+) {
+  constructor(
+    forcedTransactionNumber: Long,
+    transaction: String,
+    deadlineBlockNumber: Long,
+  ) : this(forcedTransactionNumber, transaction, deadlineBlockNumber.toString())
+}
 
 /**
  * Request to send forced transactions.

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/ForcedTransactionChainSecurityPolicyTest.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/linea/plugin/acc/test/rpc/linea/ForcedTransactionChainSecurityPolicyTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package linea.plugin.acc.test.rpc.linea
+
+import linea.plugin.acc.test.FakeChainSecurityPolicyTxValidatorPlugin
+import linea.plugin.acc.test.RawTransactionHelper
+import linea.plugin.acc.test.TestCommandLineOptionsBuilder
+import linea.plugin.acc.test.rpc.ForcedTransactionParam
+import linea.plugin.acc.test.rpc.GetForcedTransactionInclusionStatusRequest
+import linea.plugin.acc.test.rpc.SendForcedRawTransactionRequest
+import net.consensys.linea.config.LineaForcedTransactionCliOptions
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.web3j.crypto.Hash
+import kotlin.time.Duration.Companion.milliseconds
+
+class ForcedTransactionChainSecurityPolicyTest : AbstractForcedTransactionTest() {
+  private val chainSecurityViolationBeforeDeadlineInclusionAllowance = 3
+
+  override fun getRequestedPlugins(): List<String> =
+    DEFAULT_REQUESTED_PLUGINS + FakeChainSecurityPolicyTxValidatorPlugin.PLUGIN_NAME
+
+  override fun getTestCliOptions(): List<String> =
+    TestCommandLineOptionsBuilder()
+      .set("--plugin-linea-module-limit-file-path=", getResourcePath("/moduleLimitsLimitless.toml"))
+      .set("--plugin-linea-limitless-enabled=", "true")
+      .set(
+        LineaForcedTransactionCliOptions.FORCED_TX_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE + "=",
+        chainSecurityViolationBeforeDeadlineInclusionAllowance.toString(),
+      )
+      .build()
+
+  @BeforeEach
+  override fun setup() {
+    FakeChainSecurityPolicyTxValidatorPlugin.reset()
+    super.setup()
+  }
+
+  @Test
+  fun `should include forced tx when not blocked by security policy`() {
+    buildBlocksInBackground = false
+
+    val rawTx = createSignedTransfer(accounts.primaryBenefactor, accounts.secondaryBenefactor, 0)
+    val ftxNumber = nextForcedTxNumber()
+
+    val response = SendForcedRawTransactionRequest(
+      listOf(ForcedTransactionParam(ftxNumber, rawTx, DEADLINE)),
+    ).execute(minerNode.nodeRequests())
+    assertThat(response.hasError()).isFalse()
+
+    buildNewBlockAndWait(500.milliseconds)
+
+    assertThat(ftxInclusionStatus(ftxNumber)).isEqualTo("Included")
+  }
+
+  @Test
+  fun `should not mine tx rejected by security layer before deadline toleration window`() {
+    val account1 = accounts.primaryBenefactor
+    val account2 = accounts.secondaryBenefactor
+    val account3 = accounts.thirdBenefactor
+    val recipient = accounts.createAccount("recipient")
+
+    val ftx1 = RawTransactionHelper.createSignedTransfer(CHAIN_ID, account1, recipient, 0)
+    val ftx2 = RawTransactionHelper.createSignedTransfer(CHAIN_ID, account2, recipient, 0)
+    val ftx3 = RawTransactionHelper.createSignedTransfer(CHAIN_ID, account3, recipient, 0)
+    val ftx4 = RawTransactionHelper.createSignedTransfer(CHAIN_ID, account1, recipient, 1)
+    val ftx5 = RawTransactionHelper.createSignedTransfer(CHAIN_ID, account2, recipient, 1)
+
+    val ftxs = listOf(ftx1, ftx2, ftx3, ftx4, ftx5)
+    val ftxHashes = ftxs.map(Hash::sha3)
+    val ftxNumbers = ftxs.map { nextForcedTxNumber() }
+
+    // Mark ftx3 as rejected by 3rd SecurityTransaction validator
+    FakeChainSecurityPolicyTxValidatorPlugin.blockBySender(account3.address)
+
+    val deadline = 10L
+    val sendResponse = SendForcedRawTransactionRequest(
+      listOf(
+        ForcedTransactionParam(ftxNumbers[0], ftx1, deadline),
+        ForcedTransactionParam(ftxNumbers[1], ftx2, deadline),
+        ForcedTransactionParam(ftxNumbers[2], ftx3, deadline),
+        ForcedTransactionParam(ftxNumbers[3], ftx4, deadline),
+        ForcedTransactionParam(ftxNumbers[4], ftx5, deadline),
+      ),
+    ).execute(minerNode.nodeRequests())
+
+    assertThat(sendResponse.hasError()).isFalse()
+    assertThat(sendResponse.result).hasSize(5)
+
+    buildNewBlockAndWait(blockBuildingTime = 300.milliseconds)
+    buildNewBlockAndWait(blockBuildingTime = 300.milliseconds)
+    buildNewBlockAndWait(blockBuildingTime = 300.milliseconds)
+    // assert that first ellegible tx get included but the rest are on hold because of the security layer rejection
+    assertThat(getFtxInclusionStatus(ftxNumbers))
+      .containsExactly("Included", "Included", null, null, null)
+
+    await()
+      .untilAsserted {
+        val blockNumber = buildNewBlockAndWait(blockBuildingTime = 300.milliseconds)
+        assertThat(blockNumber).isEqualTo(deadline - chainSecurityViolationBeforeDeadlineInclusionAllowance - 1)
+      }
+
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(ftxHashes[0]))
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(ftxHashes[1]))
+    assertThat(findTransactionReceipt(ftxHashes[2])).isNull()
+    assertThat(findTransactionReceipt(ftxHashes[3])).isNull()
+    assertThat(findTransactionReceipt(ftxHashes[4])).isNull()
+    assertThat(getFtxInclusionStatus(ftxNumbers))
+      .containsExactly("Included", "Included", null, null, null)
+
+    // mine 1 extra block to be within (deadline - chainSecurityViolationBeforeDeadlineInclusionAllowance)
+    buildNewBlockAndWait(blockBuildingTime = 300.milliseconds)
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(ftxHashes[2]))
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(ftxHashes[3]))
+    minerNode.verify(eth.expectSuccessfulTransactionReceipt(ftxHashes[4]))
+    assertThat(getFtxInclusionStatus(ftxNumbers))
+      .containsExactly("Included", "Included", "Included", "Included", "Included")
+  }
+
+  fun getFtxInclusionStatus(ftxNumbers: List<Long>): List<String?> {
+    return ftxNumbers.map { ftxNumber ->
+      GetForcedTransactionInclusionStatusRequest(ftxNumber)
+        .execute(minerNode.nodeRequests())
+        .let { response ->
+          response.result?.inclusionResult
+            ?: response.error?.message?.let { throw RuntimeException(it) }
+        }
+    }
+  }
+
+  private fun ftxInclusionStatus(ftxNumber: Long): String? =
+    GetForcedTransactionInclusionStatusRequest(ftxNumber)
+      .execute(minerNode.nodeRequests())
+      .let { response ->
+        response.result?.inclusionResult
+          ?: response.error?.message?.let { throw RuntimeException(it) }
+      }
+
+  companion object {
+    private const val DEADLINE = 1_000_000L
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.kt
+++ b/linea-besu/plugins/linea-sequencer/acceptance-tests/src/test/kotlin/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.kt
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.LoggerFactory
 import org.web3j.protocol.core.DefaultBlockParameter
+import org.web3j.protocol.core.methods.response.TransactionReceipt
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.lang.ProcessBuilder.Redirect
@@ -52,6 +53,7 @@ import java.math.BigInteger
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.jvm.optionals.getOrNull
 
 /** Base class for acceptance tests. */
 @ExtendWith(AcceptanceTestBaseTestWatcher::class)
@@ -216,5 +218,15 @@ abstract class AcceptanceTestBase {
     }
 
     return newAccounts
+  }
+
+  fun findTransactionReceipt(txHash: String): TransactionReceipt? = ethTransactions
+    .getTransactionReceipt(txHash)
+    .execute(minerNode.nodeRequests())
+    .getOrNull()
+
+  fun getTransactionReceipt(txHash: String): TransactionReceipt {
+    return findTransactionReceipt(txHash)
+      ?: throw AssertionError("Transaction $txHash not found in node ${minerNode.name}")
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/linea/security/LineaChainSecurityPolicy.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/linea/security/LineaChainSecurityPolicy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package linea.security;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
+
+public class LineaChainSecurityPolicy implements ChainSecurityPolicy {
+  private Function<TransactionEvaluationContext, Boolean> shallForceIncludeTransactionFn;
+
+  public LineaChainSecurityPolicy() {}
+
+  public void init(Function<TransactionEvaluationContext, Boolean> shallForceIncludeTransactionFn) {
+    requireNonNull(
+        shallForceIncludeTransactionFn, "shallForceIncludeTransactionFn must not be null");
+    this.shallForceIncludeTransactionFn = shallForceIncludeTransactionFn;
+  }
+
+  @Override
+  public boolean shallForceIncludeTransaction(TransactionEvaluationContext txContext) {
+    return shallForceIncludeTransactionFn.apply(txContext);
+  }
+}

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/AbstractLineaSharedPrivateOptionsPlugin.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/AbstractLineaSharedPrivateOptionsPlugin.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import linea.blob.BlobCompressorSelectorByTimestamp;
+import linea.security.ChainSecurityPolicy;
+import linea.security.LineaChainSecurityPolicy;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.bl.TransactionProfitabilityCalculator;
 import net.consensys.linea.bundles.BundlePoolService;
@@ -91,6 +93,7 @@ public abstract class AbstractLineaSharedPrivateOptionsPlugin
   protected static BlobCompressorSelectorByTimestamp blobCompressorSelectorByTimestamp;
   protected static TransactionCompressor transactionCompressor;
   protected static TransactionProfitabilityCalculator transactionProfitabilityCalculator;
+  protected static LineaChainSecurityPolicy lineaChainSecurityPolicyService;
 
   public static final int DEFAULT_COMPRESSED_SIZE_LIMIT = 128 * 1024;
   // Shared reloadable deny lists - centralized management for all plugins
@@ -242,6 +245,10 @@ public abstract class AbstractLineaSharedPrivateOptionsPlugin
                 () ->
                     new RuntimeException(
                         "Failed to obtain RpcEndpointService from the ServiceManager."));
+
+    // needs to be registered early to be available to other plugins on start()
+    lineaChainSecurityPolicyService = new LineaChainSecurityPolicy();
+    serviceManager.addService(ChainSecurityPolicy.class, lineaChainSecurityPolicyService);
   }
 
   @Override
@@ -298,7 +305,13 @@ public abstract class AbstractLineaSharedPrivateOptionsPlugin
 
     forcedTransactionPoolService =
         new LineaForcedTransactionPool(
-            forcedTransactionConfiguration().statusCacheSize(), metricsSystem, besuEvents);
+            forcedTransactionConfiguration().statusCacheSize(),
+            forcedTransactionConfiguration().chainSecurityViolationHoldOffBeforeDeadline(),
+            metricsSystem,
+            besuEvents);
+
+    lineaChainSecurityPolicyService.init(
+        forcedTransactionPoolService::shallForceIncludeTransaction);
 
     invalidTransactionByLineCountCache =
         new InvalidTransactionByLineCountCache(
@@ -426,5 +439,6 @@ public abstract class AbstractLineaSharedPrivateOptionsPlugin
     sharedBundleDeniedAddresses = null;
     sharedDeniedEvents = null;
     sharedDeniedBundleEvents = null;
+    lineaChainSecurityPolicyService = null;
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaForcedTransactionCliOptions.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaForcedTransactionCliOptions.java
@@ -20,6 +20,9 @@ public class LineaForcedTransactionCliOptions implements LineaCliOptions {
 
   public static final String FORCED_TX_STATUS_CACHE_SIZE =
       "--plugin-linea-forced-tx-status-cache-size";
+  public static final String
+      FORCED_TX_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE =
+          "--plugin-linea-forced-tx-chain-security-violation-before-deadline-inclusion-allowance";
 
   @Positive
   @CommandLine.Option(
@@ -29,6 +32,17 @@ public class LineaForcedTransactionCliOptions implements LineaCliOptions {
       description =
           "Maximum number of forced transaction statuses to keep in cache (default: ${DEFAULT-VALUE})")
   private int statusCacheSize = LineaForcedTransactionPool.DEFAULT_STATUS_CACHE_SIZE;
+
+  @Positive
+  @CommandLine.Option(
+      names = {FORCED_TX_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE},
+      hidden = true,
+      paramLabel = "<INTEGER>",
+      description =
+          "Number of blocks before ftx deadline that ftx can be included if rejected security plugins (default: ${DEFAULT-VALUE})")
+  private int chainSecurityViolationBeforeDeadlineInclusionAllowance =
+      LineaForcedTransactionPool
+          .DEFAULT_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE;
 
   private LineaForcedTransactionCliOptions() {}
 
@@ -51,6 +65,7 @@ public class LineaForcedTransactionCliOptions implements LineaCliOptions {
       final LineaForcedTransactionConfiguration config) {
     final LineaForcedTransactionCliOptions options = create();
     options.statusCacheSize = config.statusCacheSize();
+    options.chainSecurityViolationBeforeDeadlineInclusionAllowance = config.statusCacheSize();
     return options;
   }
 
@@ -61,13 +76,20 @@ public class LineaForcedTransactionCliOptions implements LineaCliOptions {
    */
   @Override
   public LineaForcedTransactionConfiguration toDomainObject() {
-    return LineaForcedTransactionConfiguration.builder().statusCacheSize(statusCacheSize).build();
+    return LineaForcedTransactionConfiguration.builder()
+        .statusCacheSize(statusCacheSize)
+        .chainSecurityViolationHoldOffBeforeDeadline(
+            chainSecurityViolationBeforeDeadlineInclusionAllowance)
+        .build();
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add(FORCED_TX_STATUS_CACHE_SIZE, statusCacheSize)
+        .add(
+            FORCED_TX_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE,
+            chainSecurityViolationBeforeDeadlineInclusionAllowance)
         .toString();
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaForcedTransactionConfiguration.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaForcedTransactionConfiguration.java
@@ -14,11 +14,15 @@ import net.consensys.linea.sequencer.forced.LineaForcedTransactionPool;
 
 /** Configuration for the forced transaction pool. */
 @Builder
-public record LineaForcedTransactionConfiguration(int statusCacheSize)
+public record LineaForcedTransactionConfiguration(
+    int statusCacheSize, long chainSecurityViolationHoldOffBeforeDeadline)
     implements LineaOptionsConfiguration {
 
   public static final LineaForcedTransactionConfiguration DEFAULT =
       LineaForcedTransactionConfiguration.builder()
           .statusCacheSize(LineaForcedTransactionPool.DEFAULT_STATUS_CACHE_SIZE)
+          .chainSecurityViolationHoldOffBeforeDeadline(
+              LineaForcedTransactionPool
+                  .DEFAULT_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE)
           .build();
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/forced/ForcedTransactionInclusionResult.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/forced/ForcedTransactionInclusionResult.java
@@ -31,8 +31,8 @@ public enum ForcedTransactionInclusionResult {
   /** Transaction failed because recipient address is on deny list. */
   FilteredAddressTo,
 
-  /** Transaction was rejected by Phylax filtering. */
-  Phylax,
+  /** Transaction was rejected by the security policy rules filtering. */
+  ChainSecurityRuleViolation,
 
   /**
    * Transaction failed for an unrecognized reason. This is a transient status - the transaction
@@ -46,6 +46,6 @@ public enum ForcedTransactionInclusionResult {
    * @return true if the transaction should be retried
    */
   public boolean shouldRetry() {
-    return this == Other;
+    return this == Other || this == ChainSecurityRuleViolation;
   }
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/forced/ForcedTransactionPoolService.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/forced/ForcedTransactionPoolService.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import org.hyperledger.besu.plugin.services.BesuService;
 import org.hyperledger.besu.plugin.services.txselection.BlockTransactionSelectionService;
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
 
 /**
  * Service for managing forced transactions. Forced transactions are submitted via
@@ -53,4 +54,6 @@ public interface ForcedTransactionPoolService extends BesuService {
    * @return The number of pending transactions
    */
   int pendingCount();
+
+  boolean shallForceIncludeTransaction(final TransactionEvaluationContext txContext);
 }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/forced/LineaForcedTransactionPool.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/sequencer/forced/LineaForcedTransactionPool.java
@@ -13,6 +13,7 @@ import static linea.txselection.LineaTransactionSelectionResult.TX_FILTERED_ADDR
 import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.BadBalance;
 import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.BadNonce;
 import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.BadPrecompile;
+import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.ChainSecurityRuleViolation;
 import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.FilteredAddressFrom;
 import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.FilteredAddressTo;
 import static net.consensys.linea.sequencer.forced.ForcedTransactionInclusionResult.Included;
@@ -34,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import linea.txselection.LineaTransactionSelectionResult;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.linea.metrics.LineaMetricCategory;
 import org.hyperledger.besu.datatypes.Hash;
@@ -46,6 +48,8 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.txselection.BlockTransactionSelectionService;
+import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
+import org.slf4j.event.Level;
 
 /**
  * Implementation of the forced transaction pool. Maintains a queue of pending forced transactions
@@ -60,11 +64,21 @@ public class LineaForcedTransactionPool
     implements ForcedTransactionPoolService, BesuEvents.BlockAddedListener {
 
   public static final int DEFAULT_STATUS_CACHE_SIZE = 10_000;
+  // 2H of 1s block time = 7_200s (2 hours)  before ftx deadline
+  public static final int DEFAULT_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE =
+      7_200;
 
   private final Deque<ForcedTransaction> pendingQueue = new ConcurrentLinkedDeque<>();
   private final Cache<Long, ForcedTransactionStatus> statusCache;
   private final Map<ForcedTransactionInclusionResult, AtomicLong> inclusionResultCounters =
       new EnumMap<>(ForcedTransactionInclusionResult.class);
+
+  /**
+   * Number of blocks before the ftx.deadline that the FTX will be put on hold when it violates
+   * security policy rejected with a chain security violation status
+   */
+  private long chainSecurityViolationBeforeDeadlineInclusionAllowance =
+      DEFAULT_CHAIN_SECURITY_VIOLATION_BEFORE_DEADLINE_INCLUSION_ALLOWANCE;
 
   /**
    * Tracks tentative rejections during block building, separated by block number. Only rejections
@@ -83,16 +97,19 @@ public class LineaForcedTransactionPool
   private record TentativeRejection(
       ForcedTransaction transaction, ForcedTransactionInclusionResult inclusionResult) {}
 
-  public LineaForcedTransactionPool() {
-    this(DEFAULT_STATUS_CACHE_SIZE, null, null);
-  }
-
-  public LineaForcedTransactionPool(final int statusCacheSize, final MetricsSystem metricsSystem) {
-    this(statusCacheSize, metricsSystem, null);
-  }
-
   public LineaForcedTransactionPool(
-      final int statusCacheSize, final MetricsSystem metricsSystem, final BesuEvents besuEvents) {
+      final int statusCacheSize,
+      final long chainSecurityViolationHoldOffBeforeDeadline,
+      final MetricsSystem metricsSystem,
+      final BesuEvents besuEvents) {
+    if (chainSecurityViolationHoldOffBeforeDeadline < 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "chainSecurityViolationHoldOffBeforeDeadline=%s must be non-negative!",
+              chainSecurityViolationHoldOffBeforeDeadline));
+    }
+    this.chainSecurityViolationBeforeDeadlineInclusionAllowance =
+        chainSecurityViolationHoldOffBeforeDeadline;
     this.statusCache = Caffeine.newBuilder().maximumSize(statusCacheSize).build();
 
     for (ForcedTransactionInclusionResult result : ForcedTransactionInclusionResult.values()) {
@@ -226,7 +243,9 @@ public class LineaForcedTransactionPool
         } else {
           // Retry - keep in queue, will try again next block (e.g. unknown rejection reason;
           // status is not recorded so getInclusionStatus returns absent)
-          log.atInfo()
+          final Level logLevel =
+              inclusionResult == ChainSecurityRuleViolation ? Level.WARN : Level.INFO;
+          log.atLevel(logLevel)
               .setMessage(
                   "action=forced_tx_retry_scheduled forcedTxNumber={} txHash={} blockNumber={} index={} inclusionResult={}")
               .addArgument(ftx::forcedTransactionNumber)
@@ -248,6 +267,11 @@ public class LineaForcedTransactionPool
         .addArgument(pendingQueue::size)
         .addArgument(blockRejections::size)
         .log();
+  }
+
+  private boolean isCloseToDeadline(ForcedTransaction ftx, long blockNumber) {
+    return blockNumber + chainSecurityViolationBeforeDeadlineInclusionAllowance
+        >= ftx.deadlineBlockNumber();
   }
 
   @Override
@@ -314,6 +338,20 @@ public class LineaForcedTransactionPool
     return pendingQueue.size();
   }
 
+  @Override
+  public boolean shallForceIncludeTransaction(final TransactionEvaluationContext txContext) {
+    if (pendingQueue.isEmpty()) {
+      return false;
+    }
+
+    var txHash = txContext.getPendingTransaction().getTransaction().getHash().getBytes();
+    return pendingQueue.stream()
+        .filter(ftx -> ftx.txHash().getBytes().equals(txHash))
+        .findFirst()
+        .map(ftx -> isCloseToDeadline(ftx, txContext.getPendingBlockHeader().getNumber()))
+        .orElse(false);
+  }
+
   private void recordStatus(
       final ForcedTransaction ftx,
       final long blockNumber,
@@ -351,11 +389,15 @@ public class LineaForcedTransactionPool
    */
   private ForcedTransactionInclusionResult mapToInclusionResult(
       final TransactionSelectionResult result) {
+    System.out.println("SELECTION_RESULT: " + result.toString());
     if (result.equals(TX_FILTERED_ADDRESS_FROM)) {
       return FilteredAddressFrom;
     }
     if (result.equals(TX_FILTERED_ADDRESS_TO)) {
       return FilteredAddressTo;
+    }
+    if (result.equals(LineaTransactionSelectionResult.CHAIN_SECURITY_RULE_VIOLATED)) {
+      return ChainSecurityRuleViolation;
     }
 
     if (result.maybeInvalidReason().isPresent()) {

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaGetForcedTransactionInclusionStatusTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaGetForcedTransactionInclusionStatusTest.java
@@ -43,7 +43,7 @@ class LineaGetForcedTransactionInclusionStatusTest {
 
   @BeforeEach
   void setUp() {
-    pool = new LineaForcedTransactionPool(100, null);
+    pool = new LineaForcedTransactionPool(100, 0, null, null);
     method = new LineaGetForcedTransactionInclusionStatus().init(pool);
     txFactory = new TestTransactionFactory();
     forcedTxNumberGenerator = new AtomicLong(1);

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendForcedRawTransactionTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/rpc/methods/LineaSendForcedRawTransactionTest.java
@@ -42,7 +42,7 @@ class LineaSendForcedRawTransactionTest {
 
   @BeforeEach
   void setUp() {
-    pool = new LineaForcedTransactionPool(100, null);
+    pool = new LineaForcedTransactionPool(100, 0L, null, null);
     method = new LineaSendForcedRawTransaction().init(pool);
     txFactory = new TestTransactionFactory();
   }

--- a/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/forced/LineaForcedTransactionPoolTest.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/test/java/net/consensys/linea/sequencer/forced/LineaForcedTransactionPoolTest.java
@@ -39,7 +39,7 @@ class LineaForcedTransactionPoolTest {
 
   @BeforeEach
   void setUp() {
-    pool = new LineaForcedTransactionPool(100, null);
+    pool = new LineaForcedTransactionPool(100, 0L, null, null);
     txFactory = new TestTransactionFactory();
     forcedTxNumberGenerator = new AtomicLong(1);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes forced-tx inclusion and security bypass near deadlines in block building; misconfiguration or the fromConfig mapping bug could widen force-include behavior unexpectedly.
> 
> **Overview**
> Integrates **chain security policy** with **forced transactions (FTX)**: a `ChainSecurityPolicy` Besu service (`LineaChainSecurityPolicy`) is registered at plugin startup and delegates `shallForceIncludeTransaction` to the forced-tx pool so security selectors can **override rejections** when an FTX is within a configurable block window of its deadline.
> 
> **Forced-tx pool behavior** adds CLI/config `--plugin-linea-forced-tx-chain-security-violation-before-deadline-inclusion-allowance` (default 7200 blocks). Security rejections map to `ChainSecurityRuleViolation` (replacing the old Phylax naming) and are **retried** like transient failures until the deadline window, then force-include applies. Acceptance coverage uses `FakeChainSecurityPolicyTxValidatorPlugin` and `ForcedTransactionChainSecurityPolicyTest`.
> 
> Test harness tweaks: `buildNewBlockAndWait` returns the new block number (with `Duration` overload), optional `findTransactionReceipt` helpers, and `ForcedTransactionParam` accepts a `Long` deadline.
> 
> **Note:** `LineaForcedTransactionCliOptions.fromConfig` appears to assign the hold-off allowance from `statusCacheSize()` instead of the new config field—worth verifying. `mapToInclusionResult` also adds a `System.out.println` debug line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a085b346723d57c2cf3f35d6b766ab44e36ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->