### PR TITLE
chore(ci): update codecov action to v7

### DIFF
--- a/.github/workflows/codecov-external-pr.yml
+++ b/.github/workflows/codecov-external-pr.yml
@@ -74,7 +74,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Gets run id of the precedeing workflow that triggered this workflow_run
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.coordinator-report-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -105,7 +105,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Gets run id of the precedeing workflow that triggered this workflow_run
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.smc-report-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -134,7 +134,7 @@ jobs:
             ${{ github.workspace }}/ci-ts-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.ts-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -144,7 +144,7 @@ jobs:
           name: codecov-linea-native-libs-fork
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.ts-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -154,7 +154,7 @@ jobs:
           name: codecov-postman
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.ts-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -183,7 +183,7 @@ jobs:
             ${{ github.workspace }}/ci-native-yield-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.native-yield-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -193,7 +193,7 @@ jobs:
           name: codecov-linea-shared-utils-native-yield-fork
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.native-yield-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -222,7 +222,7 @@ jobs:
             ${{ github.workspace }}/ci-lido-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.lido-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -232,7 +232,7 @@ jobs:
           name: codecov-linea-shared-utils-lido-fork
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.lido-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -261,7 +261,7 @@ jobs:
             ${{ github.workspace }}/ci-sdk-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.sdk-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -271,7 +271,7 @@ jobs:
           name: codecov-sdk-core-fork
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.sdk-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true
@@ -281,7 +281,7 @@ jobs:
           name: codecov-sdk-viem-sdk-testing-fork
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         if: ${{ steps.sdk-coverage-download.outcome == 'success' }}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/lido-governance-monitor-testing.yml
+++ b/.github/workflows/lido-governance-monitor-testing.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload linea-shared-utils coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/linea-shared-utils/coverage/lcov.info
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload lido-governance-monitor coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./operations/native-yield/lido-governance-monitor/coverage/lcov.info

--- a/.github/workflows/native-yield-automation-service-testing.yml
+++ b/.github/workflows/native-yield-automation-service-testing.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload linea-shared-utils coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/linea-shared-utils/coverage/lcov.info
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload native-yield-automation-service coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./operations/native-yield/automation-service/coverage/lcov.info

--- a/.github/workflows/postman-testing.yml
+++ b/.github/workflows/postman-testing.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload linea-native-libs coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/linea-native-libs/coverage/lcov.info
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload postman coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./postman/coverage/lcov.info
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload sdk-viem coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/sdk/sdk-viem/coverage/lcov.info

--- a/.github/workflows/reusable-tracer-unit-tests.yml
+++ b/.github/workflows/reusable-tracer-unit-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload tracer unit-test coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: tracer/arithmetization/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./contracts/coverage/coverage-final.json

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload sdk-core coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/sdk/sdk-core/coverage/lcov.info
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload sdk-viem coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/sdk/sdk-viem/coverage/lcov.info
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload sdk-ethers coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ./ts-libs/sdk/sdk-ethers/coverage/lcov.info

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -205,7 +205,7 @@ jobs:
             ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
       - name: Upload coverage to Codecov
         if: ${{ env.CODECOV_TOKEN != '' }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
         with:
           fail_ci_if_error: true
           files: ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin bump with no application or runtime code changes; main risk is a possible Codecov upload regression if v7 behavior differs.
> 
> **Overview**
> Bumps **`codecov/codecov-action`** from **v6.0.0** to **v7.0.0** (pinned commit `fb8b3582…`) everywhere coverage is uploaded to Codecov.
> 
> The change is limited to the action reference in **nine** workflow files: fork PR aggregation (`codecov-external-pr.yml`), JVM Jacoco (`testing.yml`), smart contracts, tracer unit tests, postman/SDK, native-yield, Lido monitor, and standalone `sdk-testing.yml`. Upload step inputs (`files`, `flags`, `token`, `fail_ci_if_error`, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c98eec83f3cebeee736f65d06cb1cd675ddce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->