### PR TITLE
chore(misc): rename Consensys/linea-monorepo URLs to LFDT-Lineth/lineth-monorepo

### DIFF
--- a/.github/workflows/reusable-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reusable-linea-besu-package-build-test-push.yml
@@ -209,7 +209,7 @@ jobs:
           echo "# Release Artifact: Linea Besu Package" > output.md
           echo "**Name:** linea-besu-package-${{ steps.build-plugins-and-assemble.outputs.dockertag }}.tar.gz" >> output.md
           echo "**SHA256:** $(sha256sum linea-besu-package-${{ steps.build-plugins-and-assemble.outputs.dockertag }}.tar.gz | awk '{ print $1 }' )" >> output.md
-          echo "**From:** [${{ github.ref_name }} (${{ github.event_name }})](https://github.com/Consensys/linea-monorepo/actions/runs/${{ github.run_id }})" >> output.md
+          echo "**From:** [${{ github.ref_name }} (${{ github.event_name }})](https://github.com/LFDT-Lineth/lineth-monorepo/actions/runs/${{ github.run_id }})" >> output.md
           echo "" >> output.md
 
           echo "### Besu and Plugin Details" >> output.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 ## Setup
 
 ```bash
-git clone https://github.com/Consensys/linea-monorepo.git
+git clone https://github.com/LFDT-Lineth/lineth-monorepo.git
 cd linea-monorepo
 nvm use          # or install Node 24.14.1
 pnpm install     # installs all workspaces + sets up Husky hooks

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 <a href="https://x.com/LineaBuild">
   <img src="https://img.shields.io/twitter/follow/LineaBuild?style=for-the-badge" alt="X (formerly Twitter) Follow" height="20">
 </a>
-<a href="https://github.com/Consensys/linea-monorepo/blob/main/LICENSE-APACHE">
+<a href="https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/LICENSE-APACHE">
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 License" height="20">
 </a>
-<a href="https://github.com/Consensys/linea-monorepo/blob/main/LICENSE-MIT">
+<a href="https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/LICENSE-MIT">
   <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" height="20">
 </a>
-<a href="https://codecov.io/gh/Consensys/linea-monorepo">
-  <img src="https://codecov.io/gh/Consensys/linea-monorepo/graph/badge.svg?token=2TM55P0CGJ" alt="Codecov" height="20">
+<a href="https://codecov.io/gh/LFDT-Lineth/lineth-monorepo">
+  <img src="https://codecov.io/gh/LFDT-Lineth/lineth-monorepo/graph/badge.svg?token=2TM55P0CGJ" alt="Codecov" height="20">
 </a>
 
 This is the principal Linea repository. It mainly includes the smart contracts covering Linea's core functions, the prover in charge of generating ZK proofs, the coordinator responsible for multiple orchestrations, and the Postman to execute bridge messages.
@@ -53,12 +53,12 @@ Each component has its own release workflow. Run the one that matches the compon
 
 | Component        | Workflow                                         | Release tag pattern              |
 | ---------------- | ------------------------------------------------ | -------------------------------- |
-| linea-besu       | [.github/workflows/linea-besu-release.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/linea-besu-release.yml)       | `releases/linea-besu-package/v[semver]` |
-| coordinator      | [.github/workflows/coordinator-release.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/coordinator-release.yml)      | `releases/coordinator/v[semver]`        |
-| maru             | [.github/workflows/maru-release-manual.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/maru-release-manual.yml)      | `releases/maru/v[semver]`        |
-| postman          | [.github/workflows/postman-release.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/postman-release.yml)          | `releases/postman/v[semver]`            |
-| prover           | [.github/workflows/prover-release.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/prover-release.yml)           | `releases/prover/v[semver]`             |
-| tx-exclusion-api | [.github/workflows/tx-exclusion-api-release.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/tx-exclusion-api-release.yml) | `releases/tx-exclusion-api/v[semver]`   |
+| linea-besu       | [.github/workflows/linea-besu-release.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/linea-besu-release.yml)       | `releases/linea-besu-package/v[semver]` |
+| coordinator      | [.github/workflows/coordinator-release.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/coordinator-release.yml)      | `releases/coordinator/v[semver]`        |
+| maru             | [.github/workflows/maru-release-manual.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/maru-release-manual.yml)      | `releases/maru/v[semver]`        |
+| postman          | [.github/workflows/postman-release.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/postman-release.yml)          | `releases/postman/v[semver]`            |
+| prover           | [.github/workflows/prover-release.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/prover-release.yml)           | `releases/prover/v[semver]`             |
+| tx-exclusion-api | [.github/workflows/tx-exclusion-api-release.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/tx-exclusion-api-release.yml) | `releases/tx-exclusion-api/v[semver]`   |
 
 Notes:
 
@@ -71,7 +71,7 @@ Notes:
 
 Milestone releases bundle every component into a single Linea release.
 
-- **Workflow:** [.github/workflows/linea-milestone-release-with-dry-run.yml](https://github.com/Consensys/linea-monorepo/actions/workflows/linea-milestone-release-with-dry-run.yml)
+- **Workflow:** [.github/workflows/linea-milestone-release-with-dry-run.yml](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/linea-milestone-release-with-dry-run.yml)
 - **Release tag pattern:** `releases/linea/v[semver]`
 - **Branch:** can only be run from `main`.
 
@@ -103,7 +103,7 @@ The milestone workflow defaults to running a **dry run on a temporary branch for
 
 Linea's stack is made up of multiple repositories, these include:
 
-- This repo, [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network
+- This repo, [linea-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): The main repository for the Linea stack & network
 > Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.
 - [linea-besu-upstream](https://github.com/Consensys/linea-besu-upstream/): Besu build configured for Linea
 - [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
@@ -126,12 +126,12 @@ Contributions are welcome!
 
 Please keep in mind that we do not accept non-code contributions like fixing comments, typos or some other trivial fixes. Although we appreciate the extra help, managing lots of these small contributions is unfeasible, and puts extra pressure in our continuous delivery systems (running all tests, etc). Feel free to open an issue pointing to any of those errors, and we will batch them into a single change.
 
-1. [Create an issue](https://github.com/Consensys/linea-monorepo/issues)
+1. [Create an issue](https://github.com/LFDT-Lineth/lineth-monorepo/issues)
 > If the proposed update is non-trivial, also tag us for discussion.
-2. Submit the update as a pull request from your [fork of this repo](https://github.com/Consensys/linea-monorepo/fork), and tag us for review.
+2. Submit the update as a pull request from your [fork of this repo](https://github.com/LFDT-Lineth/lineth-monorepo/fork), and tag us for review.
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
-Consider starting with a ["good first issue"](https://github.com/Consensys/linea-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Consider starting with a ["good first issue"](https://github.com/LFDT-Lineth/lineth-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ### Commit message format
 
@@ -219,7 +219,7 @@ chore(linea-besu,sequencer): bump dependency versions
 feat(coordinator)!: rename public API method (BREAKING CHANGE)
 ```
 
-Please note that the linea-monorepo GitHub [CI](https://github.com/Consensys/linea-monorepo/actions/workflows/main.yml) will lint the PR title when new commits pushed to the PR branch, and the whole CI will fail if the PR title doesn't conform.
+Please note that the linea-monorepo GitHub [CI](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/main.yml) will lint the PR title when new commits pushed to the PR branch, and the whole CI will fail if the PR title doesn't conform.
 
 ### Useful links
 

--- a/docs/architecture-description.md
+++ b/docs/architecture-description.md
@@ -472,7 +472,7 @@ Corset is hosted inside the same process as the short-running component of the p
   * Reduce the probability of incompatibility between Corset/Prover versions and their input/output formats;
 * Reduce latency of the overall system (rather a beneficial side effect than a driving motivation);
 
-The paragraphs highlight the roles of the different proofs that are generated. Please refer to the prover backend codebase [here](https://github.com/Consensys/linea-monorepo/tree/main/prover/backend) for details on the objects and attributes for various types of proof requests and responses 
+The paragraphs highlight the roles of the different proofs that are generated. Please refer to the prover backend codebase [here](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/prover/backend) for details on the objects and attributes for various types of proof requests and responses 
 
 ### Execution proofs
 
@@ -845,7 +845,7 @@ Internally, the message service computes a rolling hash. It’s computed recursi
 
 Linea’s coordinator, which is subscribing to L1 events, detects the L1 finalized (2 epochs to avoid reorgs) cross-chain MessageSent event and anchors it on L2. The coordinator anchors the messages by batches.
 
-Anchoring (Anchoring is the process for placing a "cross-chain validity reference", that must exist for any message to be claimed) of messages is done through the executed via [anchorL1L2MessageHashes](https://github.com/Consensys/linea-monorepo/blob/main/contracts/src/messaging/l2/L2MessageManager.sol#L41) which is inherited by the [L2MessageService](https://github.com/Consensys/linea-monorepo/blob/main/contracts/src/messaging/l2/L2MessageService.sol) smart contract.
+Anchoring (Anchoring is the process for placing a "cross-chain validity reference", that must exist for any message to be claimed) of messages is done through the executed via [anchorL1L2MessageHashes](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/contracts/src/messaging/l2/L2MessageManager.sol#L41) which is inherited by the [L2MessageService](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/contracts/src/messaging/l2/L2MessageService.sol) smart contract.
 
 To anchor a message, the coordinator collects all L1-L2 message logs from which it gets the message hash, the rolling hash, the nonce (unique message number) and the L1 block number. Note that the L1 block number facilitates the processing but is not anchored on L2.
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -3,7 +3,7 @@
 ## Prover, Gnark-Crypto, and Verifier Audits
 
 **2025**
-* [LeastAuthority - August 2025 - Limitless prover](https://github.com/Consensys/linea-monorepo/blob/4d5e19c4161acfba12fcabc7e9db4a624f39690b/docs/audits/2025%20August%20-%20Least%20Authority%20-%20Linea%20zkEVM%20Limitless%20Prover%20Final%20Audit%20Report.pdf)
+* [LeastAuthority - August 2025 - Limitless prover](https://github.com/LFDT-Lineth/lineth-monorepo/blob/4d5e19c4161acfba12fcabc7e9db4a624f39690b/docs/audits/2025%20August%20-%20Least%20Authority%20-%20Linea%20zkEVM%20Limitless%20Prover%20Final%20Audit%20Report.pdf)
 
 **2024**
 * [ZKSecurity.xyz - May 2024 - gnark standard library](https://github.com/Consensys/gnark/blob/53ce9b74e7ab372aa7358f1eac7fe3d689743f5f/audits/2024-05%20-%20zksecurity%20-%20gnark%20std.pdf)

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -98,7 +98,7 @@ Configuration changes that are part of ops are not considered releases. This inc
 
 ### Release to testnet
 We release on a weekly basis. The standard internal contributor's day-by-day process is as follows:
-1. **Create a testnet PR**: Create a new pull request to deploy the changes, once your PR has been merged. Only release changes that were merged in `Consensys/linea-monorepo/main`. Include a detailed description of your changes and link the related issue number.
+1. **Create a testnet PR**: Create a new pull request to deploy the changes, once your PR has been merged. Only release changes that were merged in `LFDT-Lineth/lineth-monorepo/main`. Include a detailed description of your changes and link the related issue number.
 2. **Prepare deployment with Release Manager**: Contributor reaches out to the Release Manager with the PR to prepare its inclusion in the next batch of releases. Use the next Testnet release, and add a tentative deployment to Mainnet at least 1 week after.
 3. **Open a maintenance window for releases having an impact on user experience**: Internal contributors, reach out to NOC to share the expected maintenance window so it can be added to the [status page](https://linea.statuspage.io/). Maintenance windows can be requested by adding a ticket to the NOC board.
 4. **Merge PR**: Contributor releases changes and follows instructions on the Testnet PR template. DevOps and SRE teams should be involved in the deployment activities. Major releases should include a detailed release plan that also includes a study of risks, mitigations, and revert plans.

--- a/docs/l1-dynamic-gas-pricing.md
+++ b/docs/l1-dynamic-gas-pricing.md
@@ -32,16 +32,16 @@ There are global caps for maxFeePerGas and maxPriorityFeePerGas (i.e. set by `l1
 
 The `adjustmentConstant` is used to adjust the exponential increase in gas price. The higher the constant the faster the gas price increases as the `elapsedTimeSinceAggregationFirstBlock` increases = 25 (configurable)
 
-`TDM` stands for "Time of Day Mutliplier" and has a range of values between 0.25 - 1.75. When we expect the L1 gas price to be low, for example on a Saturday night, the `TDM` will be at it's highest because we want to increase the rate at which we increase the threshold to try and settle within this time window. The value will be at it's lowest during peak L1 gas price times, for example, on a Tuesday afternoon, because we know it is likely to be expensive during this window. (Here's the [toml file in repo](https://github.com/Consensys/linea-monorepo/blob/main/docker/config/common/gas-price-cap-time-of-day-multipliers.toml#L16))
+`TDM` stands for "Time of Day Mutliplier" and has a range of values between 0.25 - 1.75. When we expect the L1 gas price to be low, for example on a Saturday night, the `TDM` will be at it's highest because we want to increase the rate at which we increase the threshold to try and settle within this time window. The value will be at it's lowest during peak L1 gas price times, for example, on a Tuesday afternoon, because we know it is likely to be expensive during this window. (Here's the [toml file in repo](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docker/config/common/gas-price-cap-time-of-day-multipliers.toml#L16))
 
 
-The implementation of the above equation can be found [here](https://github.com/Consensys/linea-monorepo/blob/main/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapCalculatorImpl.kt)
+The implementation of the above equation can be found [here](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapCalculatorImpl.kt)
 
 ### Here's the final version of the formulas:
 - *Assuming the "percentile" is set as 10th*
 
 #### Aggregation Finalization
-[implementation](https://github.com/Consensys/linea-monorepo/blob/main/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForFinalization.kt)
+[implementation](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForFinalization.kt)
 ``` 
 baseFeeCap = p10(baseFeePastWeek) * (1 + adjustmentConstant * TDM * (elapsedTimeSinceAggregationFirstBlock / SLA)^2 )
 priorityFeeCap = average(p10rewardsPastWeek) * (1 + adjustmentConstant * TDM * (elapsedTimeSinceAggregationFirstBlock / SLA)^2 )
@@ -51,7 +51,7 @@ maxFeePerGas = min(baseFeeCap + maxPriorityFeePerGas, max-fee-per-gas-cap-for-ag
 ```
 
 #### Blob Submission 
-[implementation](https://github.com/Consensys/linea-monorepo/blob/main/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForDataSubmission.kt)
+[implementation](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForDataSubmission.kt)
 ```
 baseFeeCap = p10(baseFeePastWeek) * (1 + adjustmentConstant * TDM * (elapsedTimeSinceAggregationFirstBlock / SLA)^2 )
 priorityFeeCap = average(p10rewardsPastWeek) * (1 + adjustmentConstant * TDM * (elapsedTimeSinceAggregationFirstBlock / SLA)^2 )

--- a/docs/linea-besu-package-releases.md
+++ b/docs/linea-besu-package-releases.md
@@ -70,20 +70,20 @@ This builds tracer and sequencer from source (and besu if needed), assembles the
 - To build Besu locally before running any Github workflow, run `./gradlew linea-besu:build` or `cd linea-besu/package && make build-besu`
 2. Make necessary changes in tracer and seqeuencer to accommodate the besu version change (Please note that tracer and sequencer version will be set as `linea-[7_char_commit_hash]`)
 3. Once the testing workflows of tracer and sequencer are all passed, the CI pipeline will build the `linea-besu-package` image using **locally built** tracer and sequencer plugins and runs e2e tests against that image
-4. When the PR merged into `main`, manually trigger the manual release [workflow](https://github.com/Consensys/linea-monorepo/actions/workflows/linea-besu-package-release.yml) and the release will be found in the linea-monorepo release [page](https://github.com/Consensys/linea-monorepo/releases)
+4. When the PR merged into `main`, manually trigger the manual release [workflow](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/linea-besu-package-release.yml) and the release will be found in the linea-monorepo release [page](https://github.com/LFDT-Lineth/lineth-monorepo/releases)
 
 ### When arithmetization version needs to be updated
 
 1. Create a PR to make necessary changes in tracer (and seqeuencer if needed) (Please note that tracer and sequencer version will be set as `linea-[7_char_commit_hash]`)
 2. Once the testing workflows of tracer and sequencer are all passed, the CI pipeline will build the `linea-besu-package` image using **locally built** tracer and sequencer plugins and runs e2e tests against that image
-3. When the PR merged into `main`, manually trigger the manual release [workflow](https://github.com/Consensys/linea-monorepo/actions/workflows/linea-besu-package-release.yml) and the release will be found in the linea-monorepo release [page](https://github.com/Consensys/linea-monorepo/releases)
+3. When the PR merged into `main`, manually trigger the manual release [workflow](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/linea-besu-package-release.yml) and the release will be found in the linea-monorepo release [page](https://github.com/LFDT-Lineth/lineth-monorepo/releases)
 
 ### When hotfix of besu version is needed on a production image
 
 1. Create a hotfix PR based on the **same commit tag** as the production image, and update the `besuCommit` field in [libs.versions.toml](../gradle/libs.versions.toml)
 2. Make necessary changes in tracer and seqeuencer to accommodate the besu version change
 3. The CI pipeline will build the `linea-besu-package` image using **locally built** tracer and sequencer plugins and runs e2e tests against that image
-4. Trigger manual release [workflow](https://github.com/Consensys/linea-monorepo/actions/workflows/linea-besu-package-release.yml) on the hotfix branch and the release of linea-besu-package will be found in the linea-monorepo release [page](https://github.com/Consensys/linea-monorepo/releases)
+4. Trigger manual release [workflow](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/linea-besu-package-release.yml) on the hotfix branch and the release of linea-besu-package will be found in the linea-monorepo release [page](https://github.com/LFDT-Lineth/lineth-monorepo/releases)
 
 ---
 

--- a/docs/local-development-guide.md
+++ b/docs/local-development-guide.md
@@ -24,7 +24,7 @@ The coordinator is a Java-based service that orchestrates the Linea protocol's o
 If you haven't already, clone the repository and navigate to the project directory:
 
 ```bash
-git clone https://github.com/Consensys/linea-monorepo.git
+git clone https://github.com/LFDT-Lineth/lineth-monorepo.git
 cd linea-monorepo
 ```
 

--- a/docs/tech/development/README.md
+++ b/docs/tech/development/README.md
@@ -25,7 +25,7 @@
 
 ```bash
 # 1. Clone repository
-git clone https://github.com/Consensys/linea-monorepo.git
+git clone https://github.com/LFDT-Lineth/lineth-monorepo.git
 cd linea-monorepo
 
 # 2. Install Node dependencies
@@ -460,7 +460,7 @@ pnpm clean
 ### Getting Help
 
 - Check [existing documentation](../README.md) in the tech documentation index
-- Review [GitHub issues](https://github.com/Consensys/linea-monorepo/issues)
+- Review [GitHub issues](https://github.com/LFDT-Lineth/lineth-monorepo/issues)
 
 ## IDE Setup
 

--- a/e2e/scripts/helpers/parse-jest-log.test.ts
+++ b/e2e/scripts/helpers/parse-jest-log.test.ts
@@ -1,7 +1,7 @@
 import { parseJestLog } from "./parse-jest-log";
 
 // Raw log fixture copied from the GitHub Actions E2E job below.
-// Source: https://github.com/Consensys/linea-monorepo/actions/runs/23834802065/job/69476754215
+// Source: https://github.com/LFDT-Lineth/lineth-monorepo/actions/runs/23834802065/job/69476754215
 const RAW_LOG = `pnpm run -F e2e test:local
   shell: /usr/bin/bash -e {0}
   env:

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -38,9 +38,9 @@ publishing {
         }
 
         scm {
-          url = 'https://github.com/Consensys/linea-monorepo'
-          connection = 'scm:git://github.com/Consensys/linea-monorepo.git'
-          developerConnection = 'scm:git:ssh://github.com:Consensys/linea-monorepo.git'
+          url = 'https://github.com/LFDT-Lineth/lineth-monorepo'
+          connection = 'scm:git://github.com/LFDT-Lineth/lineth-monorepo.git'
+          developerConnection = 'scm:git:ssh://github.com:LFDT-Lineth/lineth-monorepo.git'
         }
 
         developers {

--- a/jvm-libs/linea/blob-compressor/build.gradle
+++ b/jvm-libs/linea/blob-compressor/build.gradle
@@ -34,8 +34,8 @@ test {
 downloadNativeLibs {
   fetchLibs {
     urls = [
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v2.1.0-rc1/linea-blob-libs-v2.1.0-rc1.zip",
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v4.0.1/linea-blob-libs-v4.0.1.zip",
+      "https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/blob-libs-v2.1.0-rc1/linea-blob-libs-v2.1.0-rc1.zip",
+      "https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/blob-libs-v4.0.1/linea-blob-libs-v4.0.1.zip",
     ]
     libs = ["blob_compressor"]
   }

--- a/jvm-libs/linea/blob-decompressor/build.gradle
+++ b/jvm-libs/linea/blob-decompressor/build.gradle
@@ -27,9 +27,9 @@ jar {
 downloadNativeLibs {
   fetchLibs {
     urls = [
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v1.2.0/linea-blob-libs-v1.2.0.zip",
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v2.1.0-rc1/linea-blob-libs-v2.1.0-rc1.zip",
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v3.0.1/linea-blob-libs-v3.0.1.zip",
+      "https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/blob-libs-v1.2.0/linea-blob-libs-v1.2.0.zip",
+      "https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/blob-libs-v2.1.0-rc1/linea-blob-libs-v2.1.0-rc1.zip",
+      "https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/blob-libs-v3.0.1/linea-blob-libs-v3.0.1.zip",
     ]
     libs = ["blob_decompressor"]
   }

--- a/jvm-libs/linea/blob-shnarf-calculator/build.gradle
+++ b/jvm-libs/linea/blob-shnarf-calculator/build.gradle
@@ -27,7 +27,7 @@ test {
 downloadNativeLibs {
   fetchLibs {
     urls = [
-      "https://github.com/Consensys/linea-monorepo/releases/download/blob-libs-v3.0.1/linea-blob-libs-v3.0.1.zip",
+      "https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/blob-libs-v3.0.1/linea-blob-libs-v3.0.1.zip",
     ]
     libs = ["shnarf_calculator"]
   }

--- a/linea-besu/package/README.md
+++ b/linea-besu/package/README.md
@@ -8,7 +8,7 @@ used to run a node with a specific profile.
 
 ### Step 1. Download configuration files
 
-You can start with the Docker Compose files located in the [docker](https://github.com/Consensys/linea-monorepo/tree/main/linea-besu/package/docker) directory.
+You can start with the Docker Compose files located in the [docker](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/linea-besu/package/docker) directory.
 
 ### Step 2. Update the Docker Compose file
 In the docker-compose.yaml file, update the --p2p-host command to include your public IP address. For example:
@@ -42,7 +42,7 @@ docker run -e BESU_PROFILE=basic-mainnet consensys/linea-besu-package:2.1.0-2025
 ## Run with a binary distribution
 
 ### Step 1. Install Linea Besu from packaged binaries
-* Download the [linea-besu-package-&lt;release&gt;.tar.gz](https://github.com/Consensys/linea-monorepo/releases?q=linea-besu-package&expanded=true)
+* Download the [linea-besu-package-&lt;release&gt;.tar.gz](https://github.com/LFDT-Lineth/lineth-monorepo/releases?q=linea-besu-package&expanded=true)
 from the assets.
 * Unpack the downloaded files and change directory into the `linea-besu/besu`
 directory.
@@ -97,11 +97,11 @@ BESU_PACKAGE_TAG=xxx make run-e2e-test
 
 1. Make a branch with changes to tracer/sequencer codes and update `gradle/libs.versions.toml` with desired besu commit tag (if needed)
 
-2. Go to the [actions tab](https://github.com/Consensys/linea-monorepo/actions) and click on the workflow `linea-besu-package-release` and select the target branch for making a release
+2. Go to the [actions tab](https://github.com/LFDT-Lineth/lineth-monorepo/actions) and click on the workflow `linea-besu-package-release` and select the target branch for making a release
 
 3. Provide the `releasePrefix` input for the workflow, and the resultant release tag would be `linea-besu-package-[releasePrefix]-[YYYYMMDDHHMMSS]-[shortenCommitHash]` and the docker image tag would be `[releasePrefix]-[YYYYMMDDHHMMSS]-[shortenCommitHash]`
 
-4. Once the workflow is done successfully, go to the [releases page](https://github.com/Consensys/linea-monorepo/releases?q=linea-besu-package&expanded=true) and you should find the corresponding release info along with the docker image tag
+4. Once the workflow is done successfully, go to the [releases page](https://github.com/LFDT-Lineth/lineth-monorepo/releases?q=linea-besu-package&expanded=true) and you should find the corresponding release info along with the docker image tag
 
 Additionally, the `latest` tag will be updated to match this manual release. Please note that running the manual release workflow with `main` branch, the `develop` tag (along with the `latest` tag) will also be updated to match the release.
 
@@ -109,7 +109,7 @@ Additionally, the `latest` tag will be updated to match this manual release. Ple
 
 This project leverages [Besu Profiles](https://besu.hyperledger.org/public-networks/how-to/use-configuration-file/profile) to enable multiple startup configurations for different node types.
 
-During the build process, all TOML files located in the [linea-besu/package/linea-besu/profiles](https://github.com/Consensys/linea-monorepo/tree/main/linea-besu/package/linea-besu/profiles) directory will be incorporated into the package. These profiles are crucial for configuring the node, as each one specifies the necessary plugins and CLI options to ensure Besu operates correctly.
+During the build process, all TOML files located in the [linea-besu/package/linea-besu/profiles](https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/linea-besu/package/linea-besu/profiles) directory will be incorporated into the package. These profiles are crucial for configuring the node, as each one specifies the necessary plugins and CLI options to ensure Besu operates correctly.
 
 Each profile is a TOML file that outlines the plugins and CLI options to be used when starting the node. For example:
 
@@ -130,7 +130,7 @@ Currently, the following profiles are available:
 
 | Profile Name                                                                                                              | Description                                                               | Network |
 |---------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|---------|
-| [`basic-mainnet`](https://github.com/Consensys/linea-monorepo/blob/main/linea-besu/package/linea-besu/profiles/basic-mainnet.toml)       | Creates a basic Linea Node.                                               | Mainnet |
-| [`advanced-mainnet`](https://github.com/Consensys/linea-monorepo/blob/main/linea-besu/package/linea-besu/profiles/advanced-mainnet.toml) | Creates a Linea Node with extra features such as `linea_estimateGas`. | Mainnet |
-| [`basic-sepolia`](https://github.com/Consensys/linea-monorepo/blob/main/linea-besu/package/linea-besu/profiles/basic-sepolia.toml)       | Creates a basic Linea Node.                                               | Sepolia |
-| [`advanced-sepolia`](https://github.com/Consensys/linea-monorepo/blob/main/linea-besu/package/linea-besu/profiles/advanced-mainnet.toml) | Creates a Linea Node with extra features such as `linea_estimateGas`. | Sepolia |
+| [`basic-mainnet`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/linea-besu/package/linea-besu/profiles/basic-mainnet.toml)       | Creates a basic Linea Node.                                               | Mainnet |
+| [`advanced-mainnet`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/linea-besu/package/linea-besu/profiles/advanced-mainnet.toml) | Creates a Linea Node with extra features such as `linea_estimateGas`. | Mainnet |
+| [`basic-sepolia`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/linea-besu/package/linea-besu/profiles/basic-sepolia.toml)       | Creates a basic Linea Node.                                               | Sepolia |
+| [`advanced-sepolia`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/linea-besu/package/linea-besu/profiles/advanced-mainnet.toml) | Creates a Linea Node with extra features such as `linea_estimateGas`. | Sepolia |

--- a/linea-besu/package/scripts/assemble-packages.sh
+++ b/linea-besu/package/scripts/assemble-packages.sh
@@ -51,7 +51,7 @@ echo "using JAR files under local tracer distribution folder: $LOCAL_TRACER_DIST
 cp -a $LOCAL_TRACER_DIST_FOLDER/. .
 
 echo "getting linea_staterecovery_plugin_version: $LINEA_STATERECOVERY_PLUGIN_VERSION"
-wget -nv https://github.com/Consensys/linea-monorepo/releases/download/linea-staterecovery-v$LINEA_STATERECOVERY_PLUGIN_VERSION/linea-staterecovery-besu-plugin-v$LINEA_STATERECOVERY_PLUGIN_VERSION.jar
+wget -nv https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/linea-staterecovery-v$LINEA_STATERECOVERY_PLUGIN_VERSION/linea-staterecovery-besu-plugin-v$LINEA_STATERECOVERY_PLUGIN_VERSION.jar
 
 echo "getting shomei_plugin_version: $SHOMEI_PLUGIN_VERSION"
 wget -nv https://github.com/Consensys/besu-shomei-plugin/releases/download/v$SHOMEI_PLUGIN_VERSION/besu-shomei-plugin-v$SHOMEI_PLUGIN_VERSION.zip

--- a/linea-besu/plugins/linea-sequencer/README.md
+++ b/linea-besu/plugins/linea-sequencer/README.md
@@ -19,7 +19,7 @@ Discover [existing plugins](docs/plugins.md) and understand the [plugin release 
 ## Looking for the Linea code?
 
 Linea's stack is made up of multiple repositories, these include:
-- This repo, [linea-monorepo](https://github.com/Consensys/linea-monorepo): main repository for the Linea stack & network
+- This repo, [linea-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): main repository for the Linea stack & network
 - [besu](https://github.com/besu-eth/besu): Besu client
 - [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
 - [linea-constraints](https://github.com/Consensys/linea-constraints): Implementation of the constraint system from the specification
@@ -40,19 +40,19 @@ Contributions are welcome!
 ### Guidelines for Non-Code and other Trivial Contributions
 Please keep in mind that we do not accept non-code contributions like fixing comments, typos or some other trivial fixes. Although we appreciate the extra help, managing lots of these small contributions is unfeasible, and puts extra pressure in our continuous delivery systems (running all tests, etc). Feel free to open an issue pointing any of those errors, and we will batch them into a single change.
 
-1. [Create an issue](https://github.com/Consensys/linea-monorepo/issues).
+1. [Create an issue](https://github.com/LFDT-Lineth/lineth-monorepo/issues).
 > If the proposed update requires input, also tag us for discussion.
-2. Submit the update as a pull request from your [fork of this repo](https://github.com/Consensys/linea-monorepo/fork), and tag us for review. 
+2. Submit the update as a pull request from your [fork of this repo](https://github.com/LFDT-Lineth/lineth-monorepo/fork), and tag us for review. 
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
-Consider starting with a ["good first issue"](https://github.com/Consensys/linea-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Consider starting with a ["good first issue"](https://github.com/LFDT-Lineth/lineth-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 Before contributing, ensure you're familiar with:
 
-- Our [Linea contribution guide](https://github.com/Consensys/linea-monorepo/blob/main/docs/contribute.md)
-- Our [Linea code of conduct](https://github.com/Consensys/linea-monorepo/blob/main/docs/code-of-conduct.md)
+- Our [Linea contribution guide](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/contribute.md)
+- Our [Linea code of conduct](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/code-of-conduct.md)
 - The [Besu contribution guide](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md), for Besu:Linea related contributions
-- Our [Security policy](https://github.com/Consensys/linea-monorepo/blob/main/docs/security.md)
+- Our [Security policy](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/security.md)
 
 
 ### Useful links

--- a/linea-besu/plugins/state-recovery/besu-plugin/jreleaser.yml
+++ b/linea-besu/plugins/state-recovery/besu-plugin/jreleaser.yml
@@ -3,7 +3,7 @@ project:
   description: Linea State Recovery Besu Plugin
   longDescription: Besu Plugin to allow Linea rollup state recovery from L1 Blob data
   links:
-    homepage: https://github.com/Consensys/linea-monorepo
+    homepage: https://github.com/LFDT-Lineth/lineth-monorepo
   authors:
     - Linea automations
   license: (MIT OR Apache-2.0)

--- a/tracer-constraints/README.md
+++ b/tracer-constraints/README.md
@@ -23,7 +23,7 @@ tbd -->
 
 Linea's stack is made up of multiple components, these include:
 
-- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network
+- [linea-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): The main repository for the Linea stack & network
 - In which, this folder, [tracer-constraints](../tracer-constraints): Implementation of the constraint system from the specification
 > Also maintains a set of Linea-Besu plugins for the sequencer, tracer, and RPC nodes.
 - In which, the [tracer](../tracer) component: Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
@@ -47,17 +47,17 @@ Please keep in mind that we do not accept non-code contributions like fixing com
 
 1. [Create an issue](https://github.com/Consensys/linea-constraints/issues).
 > If the proposed update requires input, also tag us for discussion.
-2. Submit the update as a pull request from your [fork of this repo](https://github.com/Consensys/linea-monorepo/fork), and tag us for review.
+2. Submit the update as a pull request from your [fork of this repo](https://github.com/LFDT-Lineth/lineth-monorepo/fork), and tag us for review.
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
 Consider starting with a ["good first issue"](https://github.com/Consensys/linea-constraints/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 Before contributing, ensure you're familiar with:
 
-- Our [Linea contribution guide](https://github.com/Consensys/linea-monorepo/blob/main/docs/contribute.md)
-- Our [Linea code of conduct](https://github.com/Consensys/linea-monorepo/blob/main/docs/code-of-conduct.md)
+- Our [Linea contribution guide](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/contribute.md)
+- Our [Linea code of conduct](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/code-of-conduct.md)
 - The [Besu contribution guide](https://wiki.hyperledger.org/display/BESU/Coding+Conventions), for Besu:Linea related contributions
-- Our [Security policy](https://github.com/Consensys/linea-monorepo/blob/main/docs/security.md)
+- Our [Security policy](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/security.md)
 
 
 ### Useful links

--- a/tracer/README.md
+++ b/tracer/README.md
@@ -29,7 +29,7 @@ Linea's stack is made up of multiple components, these include:
 
 > This repository contains the elements of the Linea stack responsible for this process.
 
-- [linea-monorepo](https://github.com/Consensys/linea-monorepo): The main repository for the Linea stack & network in which this folder lives
+- [linea-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): The main repository for the Linea stack & network in which this folder lives
 - [besu](https://github.com/besu-eth/besu): Besu client
 - [linea-sequencer](https://github.com/Consensys/linea-sequencer): A set of Linea-Besu plugins for the sequencer and RPC nodes
 - [tracer-constraints](../tracer-constraints) folder: Implementation of the constraint system from the specification
@@ -55,7 +55,7 @@ Please keep in mind that we do not accept non-code contributions like fixing com
 
 > If the proposed update requires input, also tag us for discussion.
 
-2. Submit the update as a pull request from your [fork of this repo](https://github.com/Consensys/linea-monorepo/fork), and tag us for review.
+2. Submit the update as a pull request from your [fork of this repo](https://github.com/LFDT-Lineth/lineth-monorepo/fork), and tag us for review.
 
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
@@ -63,10 +63,10 @@ Consider starting with a ["good first issue"](https://github.com/Consensys/linea
 
 Before contributing, ensure you're familiar with:
 
-- Our [Linea contribution guide](https://github.com/Consensys/linea-monorepo/blob/main/docs/contribute.md)
-- Our [Linea code of conduct](https://github.com/Consensys/linea-monorepo/blob/main/docs/code-of-conduct.md)
+- Our [Linea contribution guide](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/contribute.md)
+- Our [Linea code of conduct](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/code-of-conduct.md)
 - The [Besu contribution guide](https://wiki.hyperledger.org/display/BESU/Coding+Conventions), for Besu:Linea related contributions
-- Our [Security policy](https://github.com/Consensys/linea-monorepo/blob/main/docs/security.md)
+- Our [Security policy](https://github.com/LFDT-Lineth/lineth-monorepo/blob/main/docs/security.md)
 
 ### Useful links
 
@@ -91,7 +91,7 @@ To update the reference tests, follow the steps below:
     ./gradlew tracer:reference-tests:generateExecutionSpecBlockchainTests
     ```
 - Commit the changes
-- You can launch all tests to ensure everything is passing locally with the command line below or on the CI with this [GitHub Action](https://github.com/Consensys/linea-monorepo/actions/workflows/tracer-reference-blockchain-daily-tests.yml)
+- You can launch all tests to ensure everything is passing locally with the command line below or on the CI with this [GitHub Action](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/tracer-reference-blockchain-daily-tests.yml)
   - ```shell
     ./gradlew tracer:reference-tests:referenceExecutionSpecBlockchainTests
     ```

--- a/tracer/SETUP.md
+++ b/tracer/SETUP.md
@@ -120,7 +120,7 @@ Plugins are documented [here](PLUGINS.md).
 Here are the steps for releasing a new version of the plugins:
 
 1. Update [tracer/build.gradle](../tracer/build.gradle) property `targetReleaseVersion`with the release version number's expected tag in the format vX.Y.Z (e.g., v0.2.0 creates a release version 0.2.0).
-2. Launch [Linea tracer release Github action](https://github.com/Consensys/linea-monorepo/actions/workflows/linea-tracer-plugin-release.yml) with the chosen tag
+2. Launch [Linea tracer release Github action](https://github.com/LFDT-Lineth/lineth-monorepo/actions/workflows/linea-tracer-plugin-release.yml) with the chosen tag
 3. Once the release workflow completes, check and update the release notes.
 
 Note: Release tags (of the form v\*) are protected and can only be pushed by organization and/or repository owners.

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/osakaReplayTests/FastReplayTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/osakaReplayTests/FastReplayTests.java
@@ -55,7 +55,7 @@ public class FastReplayTests extends TracerTestBase {
     replay(MAINNET_TESTCONFIG(OSAKA, false), "osaka/6569423.mainnet.json.gz", testInfo);
   }
 
-  @Disabled("https://github.com/Consensys/linea-monorepo/issues/1912")
+  @Disabled("https://github.com/LFDT-Lineth/lineth-monorepo/issues/1912")
   @Test
   void incident777zkGethMainnet(TestInfo testInfo) {
     replay(MAINNET_TESTCONFIG(OSAKA, false), "osaka/7461019-7461030.mainnet.json.gz", testInfo);
@@ -103,7 +103,7 @@ public class FastReplayTests extends TracerTestBase {
         false);
   }
 
-  @Disabled("https://github.com/Consensys/linea-monorepo/issues/1912")
+  @Disabled("https://github.com/LFDT-Lineth/lineth-monorepo/issues/1912")
   @Test
   void negativeNumberOfMmioInstruction(TestInfo testInfo) {
     replay(
@@ -122,7 +122,7 @@ public class FastReplayTests extends TracerTestBase {
         false);
   }
 
-  @Disabled("https://github.com/Consensys/linea-monorepo/issues/1912")
+  @Disabled("https://github.com/LFDT-Lineth/lineth-monorepo/issues/1912")
   @Test
   void failedCreate2(TestInfo testInfo) {
     replay(
@@ -187,7 +187,7 @@ public class FastReplayTests extends TracerTestBase {
         false);
   }
 
-  @Disabled("https://github.com/Consensys/linea-monorepo/issues/1912")
+  @Disabled("https://github.com/LFDT-Lineth/lineth-monorepo/issues/1912")
   @Test
   void stateManagerIntegrationTest(TestInfo testInfo) {
     replay(

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/osakaReplayTests/Incident1445.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/osakaReplayTests/Incident1445.java
@@ -55,7 +55,7 @@ public class Incident1445 extends TracerTestBase {
   // as in prod
 
   // TODO: reenable when Besu 25.12.0-linea4 contains the fix for incident 1445
-  // https://github.com/Consensys/linea-monorepo/issues/2194
+  // https://github.com/LFDT-Lineth/lineth-monorepo/issues/2194
   /*
     @Test
     void block_28279180_runWithBesu(TestInfo testInfo) {
@@ -71,7 +71,7 @@ public class Incident1445 extends TracerTestBase {
   }
 
   // TODO: reenable when Besu 25.12.0-linea4 contains the fix for incident 1445
-  // https://github.com/Consensys/linea-monorepo/issues/2194
+  // https://github.com/LFDT-Lineth/lineth-monorepo/issues/2194
   /*  @Test
   void block_23985771_runWithBesu(TestInfo testInfo) {
     replay(SEPOLIA_TESTCONFIG(OSAKA), "osaka/incident-1445-23985771.sepolia.json.gz", testInfo, false, true);

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/AccountDelegationAndRevertTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/AccountDelegationAndRevertTests.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * These tests address issue <a
- * href="https://github.com/Consensys/linea-monorepo/issues/2322">[ZkTracer] Test refunds for
+ * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2322">[ZkTracer] Test refunds for
  * EIP-7702</a>
  */
 public class AccountDelegationAndRevertTests extends TracerTestBase {

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationAndAccessListTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationAndAccessListTests.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * These tests address issue <a
- * href="https://github.com/Consensys/linea-monorepo/issues/2437">[ZkTracer] Test delegation lists +
+ * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2437">[ZkTracer] Test delegation lists +
  * access lists</a>
  */
 public class DelegationAndAccessListTests extends TracerTestBase {

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationsMakingAccountsExecutableAndViceVersaTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationsMakingAccountsExecutableAndViceVersaTests.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * These tests address issue <a
- * href="https://github.com/Consensys/linea-monorepo/issues/2355">[ZkTracer] Test transactions where
+ * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2355">[ZkTracer] Test transactions where
  * delegations swap the recipient from executable to non-executable and vice versa</a>
  */
 public class DelegationsMakingAccountsExecutableAndViceVersaTests extends TracerTestBase {

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/multiDelegation/MultiDelegationTest.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/multiDelegation/MultiDelegationTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-// https://github.com/Consensys/linea-monorepo/issues/2455
+// https://github.com/LFDT-Lineth/lineth-monorepo/issues/2455
 
 @ExtendWith(UnitTestWatcher.class)
 public class MultiDelegationTest extends TracerTestBase {

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/multiDelegation/TrivialMultiDelegationTest.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/multiDelegation/TrivialMultiDelegationTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-// https://github.com/Consensys/linea-monorepo/issues/2455
+// https://github.com/LFDT-Lineth/lineth-monorepo/issues/2455
 
 @ExtendWith(UnitTestWatcher.class)
 public class TrivialMultiDelegationTest extends TracerTestBase {

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/CallDelegationTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/CallDelegationTests.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class CallDelegationTests extends TracerTestBase {
 
   /*
-  https://github.com/Consensys/linea-monorepo/issues/2470
+  https://github.com/LFDT-Lineth/lineth-monorepo/issues/2470
 
   In this test, a sender account sends a transaction to a root account, which executes a CALL instruction to a caller
   account, which itself executes a CALL instruction to a callee account.

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/DoubleCallDelegationTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/instructionprocessing/callTests/DoubleCallDelegationTests.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class DoubleCallDelegationTests extends TracerTestBase {
 
   /*
-  https://github.com/Consensys/linea-monorepo/issues/2470
+  https://github.com/LFDT-Lineth/lineth-monorepo/issues/2470
 
   In this test, a sender account sends a transaction to a root account, which executes a two CALL or STATICCALL
   instruction to a caller account, which itself executes a CALL instruction to a callee account. Then the root

--- a/ts-libs/linea-native-libs/src/scripts/build.ts
+++ b/ts-libs/linea-native-libs/src/scripts/build.ts
@@ -35,7 +35,7 @@ const architectureResourceDirMapping: Record<string, string> = {
 };
 
 async function downloadReleaseAsset(nativeLibReleaseTag: string): Promise<string> {
-  const assetReleaseUrl = `https://github.com/Consensys/linea-monorepo/releases/download/${nativeLibReleaseTag}/linea-${nativeLibReleaseTag}.zip`;
+  const assetReleaseUrl = `https://github.com/LFDT-Lineth/lineth-monorepo/releases/download/${nativeLibReleaseTag}/linea-${nativeLibReleaseTag}.zip`;
   const fileName = `${nativeLibReleaseTag}.zip`;
   const destPath = path.resolve("build", fileName);
   console.log(`Downloading ${fileName} from ${assetReleaseUrl} to ${destPath}`);

--- a/ts-libs/sdk/sdk-core/package.json
+++ b/ts-libs/sdk/sdk-core/package.json
@@ -6,12 +6,12 @@
   "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Consensys/linea-monorepo.git",
+    "url": "https://github.com/LFDT-Lineth/lineth-monorepo.git",
     "directory": "ts-libs/sdk/sdk-core"
   },
-  "homepage": "https://github.com/Consensys/linea-monorepo/tree/main/ts-libs/sdk/sdk-core#readme",
+  "homepage": "https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/ts-libs/sdk/sdk-core#readme",
   "bugs": {
-    "url": "https://github.com/Consensys/linea-monorepo/issues"
+    "url": "https://github.com/LFDT-Lineth/lineth-monorepo/issues"
   },
   "keywords": [
     "linea",

--- a/ts-libs/sdk/sdk-viem/package.json
+++ b/ts-libs/sdk/sdk-viem/package.json
@@ -6,12 +6,12 @@
   "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Consensys/linea-monorepo.git",
+    "url": "https://github.com/LFDT-Lineth/lineth-monorepo.git",
     "directory": "ts-libs/sdk/sdk-viem"
   },
-  "homepage": "https://github.com/Consensys/linea-monorepo/tree/main/ts-libs/sdk/sdk-viem#readme",
+  "homepage": "https://github.com/LFDT-Lineth/lineth-monorepo/tree/main/ts-libs/sdk/sdk-viem#readme",
   "bugs": {
-    "url": "https://github.com/Consensys/linea-monorepo/issues"
+    "url": "https://github.com/LFDT-Lineth/lineth-monorepo/issues"
   },
   "keywords": [
     "linea",


### PR DESCRIPTION
## Summary

- Mechanical find-and-replace of `Consensys/linea-monorepo` → `LFDT-Lineth/lineth-monorepo` across 34 files: documentation, source comments, CI workflows, Gradle build files, `package.json` metadata, and shell scripts.
- Reflects the repo move from `github.com/Consensys/linea-monorepo` to `github.com/LFDT-Lineth/lineth-monorepo`.
- Lines balance (92 ins / 92 del). No logic changes.

## Out of scope (tracked separately)

| Category | Issue |
|---|---|
| Go module paths in `prover/`, `prover-ray/`, `verifier-ray/` | #3288 |
| `net.consensys.linea.*` Java package namespace | #3289 |
| `consensys/linea-*` Docker image registry | #3290 |
| `@consensys/*` npm package scope | #3291 |
| Internal `Linea*` / `LINEA_*` identifiers | #3292 |
| References to deprecated Consensys repos merged into this monorepo (`linea-tracer`, `linea-besu-upstream`, `linea-constraints`, `maru`) | #3293 |

Also untouched: `Consensys Software Inc.` copyright headers (legal attribution, separate from GitHub org name) and `linea_*` JSON-RPC method names (public protocol surface).

## Notes for reviewers

- The codecov badge token in `README.md` is bound to the old repo and will likely need regenerating after registry switchover.
- `<scm>` URLs in `gradle/publishing.gradle` now point at the new repo; previously-published Gradle metadata is unaffected.

## Test plan

- [ ] `git grep -nE "[Cc]onsensys/linea-monorepo"` outside `prover/`, `prover-ray/`, `verifier-ray/`, `go.mod`, `go.sum`, `*.pdf` returns zero hits
- [ ] References to *other* Consensys-owned repos (`linea-tracer`, `linea-besu-upstream`, `linea-constraints`, `maru`, `linea-besu`, `linea-geth`, `shomei`) are untouched
- [ ] Click through README badges to confirm they resolve at the new URL (codecov token may need regen)
- [ ] Spot-check a few documentation links from `docs/` to confirm they 200 at the new URL