### PR TITLE
chore(ci): migrate arm64 runner to new scale set

### DIFF
--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -75,7 +75,7 @@ jobs:
 
   build-linux-arm64:
     needs: [validate]
-    runs-on: gha-runner-scale-set-ubuntu-24-arm64-med
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-arm64-med
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Points the arm64 build job at the new scale set: `gha-runner-scale-set-ubuntu-24-arm64-med` -> `gha-lfdt-lineth-ss-ubuntu-24-arm64-med`.

Completes the runner migration (the amd64 part landed in #3280). No old `gha-runner-scale-set-*` references remain after this.

Note: requires the new arm64 scale sets (w3f-github-runners #25) to be deployed before merge, otherwise the arm64 job has no runner.