### PR TITLE
chore(misc): point references at in-tree paths for previously-external repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It serves developers by making the Linea tech stack open source under the [Apach
 
 [Linea](https://linea.build) is a developer-ready layer 2 network scaling Ethereum. It's secured with a zero-knowledge rollup, built on lattice-based cryptography, and powered by [Consensys](https://consensys.io).
 
-Linea is compatible with the execution clients [Besu](https://github.com/besu-eth/besu/) or [Geth](https://github.com/ethereum/go-ethereum). To run a full node, an execution client is paired with the consensus client [Maru](https://github.com/Consensys/maru).
+Linea is compatible with the execution clients [Besu](https://github.com/besu-eth/besu/) or [Geth](https://github.com/ethereum/go-ethereum). To run a full node, an execution client is paired with the consensus client [Maru](./maru/).
 
 ## Get started
 
@@ -105,9 +105,10 @@ Linea's stack is made up of multiple repositories, these include:
 
 - This repo, [linea-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): The main repository for the Linea stack & network
 > Also maintains a set of Linea-Besu plugins for the sequencer and RPC nodes.
-- [linea-besu-upstream](https://github.com/Consensys/linea-besu-upstream/): Besu build configured for Linea
-- [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
-- [linea-constraints](https://github.com/Consensys/linea-constraints): Implementation of the constraint system from the specification
+- [linea-besu](./linea-besu/): Besu build configured for Linea (now in-tree; previously `Consensys/linea-besu-upstream`)
+- [tracer](./tracer/): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover (now in-tree; previously `Consensys/linea-tracer`)
+- [tracer-constraints](./tracer-constraints/): Implementation of the constraint system from the specification (now in-tree; previously `Consensys/linea-constraints`)
+- [maru](./maru/): Consensus client for the Linea sequencer (now in-tree; previously `Consensys/maru`)
 - [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
 
 Linea abstracts away the complexity of this technical architecture to allow developers to:

--- a/docs/architecture-description.md
+++ b/docs/architecture-description.md
@@ -89,7 +89,7 @@ A script automatically removes all files that are more than one week old.
 
 ## Sequencer
 
-> **Note**: The consensus protocol has since moved from Clique to QBFT via the [Maru](https://github.com/Consensys/maru) consensus client. See the [official architecture docs](https://docs.linea.build/protocol/architecture) for the current design.
+> **Note**: The consensus protocol has since moved from Clique to QBFT via the [Maru](../maru/) consensus client. See the [official architecture docs](https://docs.linea.build/protocol/architecture) for the current design.
 
 There is a unique instance of Sequencer. It’s a special instance of a consensus client based on Besu. The consensus protocol used is Clique.
 
@@ -970,4 +970,4 @@ Any party (e.g. via an npm package we provide for the bridge/partners etc) does 
 
 # Finalized Block Tag on L2
 
-[Maru](https://github.com/Consensys/maru), a consensus client developed by Linea team, will be responsible on updating the execution clients for `finalized` block tag on L1
+[Maru](../maru/), a consensus client developed by Linea team, will be responsible on updating the execution clients for `finalized` block tag on L1

--- a/docs/features/sequencer.md
+++ b/docs/features/sequencer.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The sequencer is a Linea Besu node with QBFT consensus (via the [Maru](https://github.com/Consensys/maru) consensus client) that serves as the block producer. It uses a plugin architecture (`linea-besu/plugins/linea-sequencer/`) to enforce Linea-specific transaction selection and validation rules beyond standard Ethereum mempool logic. The sequencer is not directly accessible externally; RPC nodes forward transactions to it via P2P.
+The sequencer is a Linea Besu node with QBFT consensus (via the [Maru](../../maru/) consensus client) that serves as the block producer. It uses a plugin architecture (`linea-besu/plugins/linea-sequencer/`) to enforce Linea-specific transaction selection and validation rules beyond standard Ethereum mempool logic. The sequencer is not directly accessible externally; RPC nodes forward transactions to it via P2P.
 
 Blocks are only produced when transactions exist — no empty blocks are created.
 

--- a/docs/tech/architecture/EXTERNAL-DEPENDENCIES.md
+++ b/docs/tech/architecture/EXTERNAL-DEPENDENCIES.md
@@ -6,7 +6,9 @@ This document describes external components that are used by the Linea stack but
 
 ## Maru Engine
 
-**Repository**: [Consensys/maru](https://github.com/Consensys/maru) (private/separate repo)
+**Source**: [`maru/`](../../../maru/) (in-tree; previously `Consensys/maru`, merged into this monorepo).
+
+> This section pre-dates the merge of Maru into the monorepo and is no longer strictly an "external dependency". The architecture description below remains accurate; a future docs pass may move this content out of `EXTERNAL-DEPENDENCIES.md` into the main architecture docs.
 
 ### Overview
 

--- a/linea-besu/plugins/linea-sequencer/README.md
+++ b/linea-besu/plugins/linea-sequencer/README.md
@@ -21,8 +21,8 @@ Discover [existing plugins](docs/plugins.md) and understand the [plugin release 
 Linea's stack is made up of multiple repositories, these include:
 - This repo, [linea-monorepo](https://github.com/LFDT-Lineth/lineth-monorepo): main repository for the Linea stack & network
 - [besu](https://github.com/besu-eth/besu): Besu client
-- [linea-tracer](https://github.com/Consensys/linea-tracer): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover
-- [linea-constraints](https://github.com/Consensys/linea-constraints): Implementation of the constraint system from the specification
+- [tracer](../../../tracer/): Linea-Besu plugin which produces the traces that the constraint system applies and that serve as inputs to the prover (in-tree; previously `Consensys/linea-tracer`)
+- [tracer-constraints](../../../tracer-constraints/): Implementation of the constraint system from the specification (in-tree; previously `Consensys/linea-constraints`)
 - [linea-specification](https://github.com/Consensys/linea-specification): Specification of the constraint system defining Linea's zkEVM
 
 Linea abstracts away the complexity of this technical architecture to allow developers to:

--- a/tracer-constraints/README.md
+++ b/tracer-constraints/README.md
@@ -13,7 +13,7 @@ the [Apache 2.0 license](LICENSE).
 
 [Linea](https://linea.build) is a developer-ready layer 2 network scaling Ethereum. It's secured with a zero-knowledge rollup, built on lattice-based cryptography, and powered by [Consensys](https://consensys.io).
 
-Linea is compatible with the execution clients [Besu](https://github.com/besu-eth/besu/) or [Geth](https://github.com/ethereum/go-ethereum). To run a full node, an execution client is paired with [Maru](https://github.com/Consensys/maru).
+Linea is compatible with the execution clients [Besu](https://github.com/besu-eth/besu/) or [Geth](https://github.com/ethereum/go-ethereum). To run a full node, an execution client is paired with [Maru](../maru/).
 
 <!-- ## Get started
 
@@ -45,12 +45,12 @@ Contributions are welcome!
 
 Please keep in mind that we do not accept non-code contributions like fixing comments, typos or some other trivial fixes. Although we appreciate the extra help, managing lots of these small contributions is unfeasible, and puts extra pressure in our continuous delivery systems (running all tests, etc). Feel free to open an issue pointing to any of those errors, and we will batch them into a single change.
 
-1. [Create an issue](https://github.com/Consensys/linea-constraints/issues).
+1. [Create an issue](https://github.com/LFDT-Lineth/lineth-monorepo/issues).
 > If the proposed update requires input, also tag us for discussion.
 2. Submit the update as a pull request from your [fork of this repo](https://github.com/LFDT-Lineth/lineth-monorepo/fork), and tag us for review.
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
-Consider starting with a ["good first issue"](https://github.com/Consensys/linea-constraints/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Consider starting with a ["good first issue"](https://github.com/LFDT-Lineth/lineth-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 Before contributing, ensure you're familiar with:
 

--- a/tracer/README.md
+++ b/tracer/README.md
@@ -51,7 +51,7 @@ Contributions are welcome!
 
 Please keep in mind that we do not accept non-code contributions like fixing comments, typos or some other trivial fixes. Although we appreciate the extra help, managing lots of these small contributions is unfeasible, and puts extra pressure in our continuous delivery systems (running all tests, etc). Feel free to open an issue pointing to any of those errors, and we will batch them into a single change.
 
-1. [Create an issue](https://github.com/Consensys/linea-tracer/issues).
+1. [Create an issue](https://github.com/LFDT-Lineth/lineth-monorepo/issues).
 
 > If the proposed update requires input, also tag us for discussion.
 
@@ -59,7 +59,7 @@ Please keep in mind that we do not accept non-code contributions like fixing com
 
 > Include the issue number in the pull request description and (optionally) in the branch name.
 
-Consider starting with a ["good first issue"](https://github.com/Consensys/linea-tracer/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Consider starting with a ["good first issue"](https://github.com/LFDT-Lineth/lineth-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 Before contributing, ensure you're familiar with:
 

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationAndAccessListTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationAndAccessListTests.java
@@ -43,8 +43,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * These tests address issue <a
- * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2437">[ZkTracer] Test delegation lists +
- * access lists</a>
+ * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2437">[ZkTracer] Test delegation
+ * lists + access lists</a>
  */
 public class DelegationAndAccessListTests extends TracerTestBase {
 

--- a/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationsMakingAccountsExecutableAndViceVersaTests.java
+++ b/tracer/arithmetization/src/test/java/net/consensys/linea/zktracer/delegation/DelegationsMakingAccountsExecutableAndViceVersaTests.java
@@ -38,8 +38,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * These tests address issue <a
- * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2355">[ZkTracer] Test transactions where
- * delegations swap the recipient from executable to non-executable and vice versa</a>
+ * href="https://github.com/LFDT-Lineth/lineth-monorepo/issues/2355">[ZkTracer] Test transactions
+ * where delegations swap the recipient from executable to non-executable and vice versa</a>
  */
 public class DelegationsMakingAccountsExecutableAndViceVersaTests extends TracerTestBase {
 

--- a/tracer/docs/get-started.md
+++ b/tracer/docs/get-started.md
@@ -25,13 +25,11 @@ echo "net.git-fetch-with-cli=true" >> .cargo/config.toml
 cargo install --git ssh://git@github.com/Consensys/corset --locked --force
 ```
 
-#### Step 5: Update constraints [submodule](https://github.com/Consensys/linea-constraints)
+#### Step 5: Constraints
 
-```shell
-git submodule update --init --recursive
-```
+The constraint system lives in-tree at [`tracer-constraints/`](../../tracer-constraints/) (previously the `Consensys/linea-constraints` submodule, now merged into this monorepo). No additional setup is required — it is checked out alongside the rest of the monorepo.
 
-Note: Windows user may have to run 'git config core.protectNTFS false' command within the linea-constraints folder to bypass CON.* file names being reserved.
+Note: Windows users may need to run `git config core.protectNTFS false` within the `tracer-constraints/` folder to bypass CON.* file names being reserved.
 
 #### Step 6: Install [pre-commit](https://pre-commit.com/)
 


### PR DESCRIPTION
Fixes a Spotless formatting violation that was causing the tracer build CI job to fail. Two Javadoc comments in delegation test files had lines exceeding the maximum allowed line length enforced by Spotless.

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [ ] I have informed the team of any breaking changes if there are any.