### PR TITLE
chore(coordinator): favour generic name ChainSecurityRuleViolation over specific implementation Phylax

### DIFF
--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsExecutionStatusUpdater.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsExecutionStatusUpdater.kt
@@ -205,9 +205,10 @@ internal class ForcedTransactionsStatusUpdater(
         if (ftxStatus == null) {
           SafeFuture.completedFuture(null)
         } else {
-          if (ftxStatus.inclusionResult == ForcedTransactionInclusionResult.Phylax) {
+          if (ftxStatus.inclusionResult == ForcedTransactionInclusionResult.ChainSecurityRuleViolation) {
             log.warn(
-              "FTX rejected by Phylax: potential security incident, please notify Ops/Support immediately." +
+              "FTX rejected due to ChainSecurityRuleViolation: " +
+                "potential security incident, please notify Ops/Support immediately." +
                 " Stopping conflation. sequencerResult={}",
               ftxStatus,
             )

--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/conflation/InvalidityProofAssembler.kt
@@ -118,8 +118,8 @@ class InvalidityProofAssembler(
       ForcedTransactionInclusionResult.TooManyLogs -> InvalidityReason.TooManyLogs
       ForcedTransactionInclusionResult.FilteredAddressFrom -> InvalidityReason.FilteredAddressFrom
       ForcedTransactionInclusionResult.FilteredAddressTo -> InvalidityReason.FilteredAddressTo
-      ForcedTransactionInclusionResult.Phylax ->
-        throw IllegalArgumentException("Phylax invalidity proofs are not supported yet")
+      ForcedTransactionInclusionResult.ChainSecurityRuleViolation ->
+        throw IllegalStateException("ChainSecurityRuleViolation cannot be mapped to InvalidityReason")
     }
   }
 

--- a/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
+++ b/coordinator/ethereum/forced-transactions/src/test/kotlin/linea/ftx/ForcedTransactionsAppTest.kt
@@ -860,7 +860,7 @@ class ForcedTransactionsAppTest {
     this.ftxClient.setFtxInclusionResultAfterReception(
       ftxNumber = 6UL,
       l2BlockNumber = 160UL,
-      inclusionResult = ForcedTransactionInclusionResult.Phylax,
+      inclusionResult = ForcedTransactionInclusionResult.ChainSecurityRuleViolation,
     )
     this.ftxClient.setFtxInclusionResultAfterReception(
       ftxNumber = 7UL,

--- a/coordinator/persistence/src/integrationTest/kotlin/linea/persistence/ftx/PostgresForcedTransactionsDaoTest.kt
+++ b/coordinator/persistence/src/integrationTest/kotlin/linea/persistence/ftx/PostgresForcedTransactionsDaoTest.kt
@@ -155,7 +155,7 @@ class PostgresForcedTransactionsDaoTest : CleanDbTestSuiteParallel() {
       ForcedTransactionInclusionResult.TooManyLogs,
       ForcedTransactionInclusionResult.FilteredAddressFrom,
       ForcedTransactionInclusionResult.FilteredAddressTo,
-      ForcedTransactionInclusionResult.Phylax,
+      ForcedTransactionInclusionResult.ChainSecurityRuleViolation,
     )
 
     inclusionResults.forEachIndexed { index, inclusionResult ->
@@ -311,7 +311,7 @@ class PostgresForcedTransactionsDaoTest : CleanDbTestSuiteParallel() {
     assertThat(inclusionResultToDbValue(ForcedTransactionInclusionResult.TooManyLogs)).isEqualTo(5)
     assertThat(inclusionResultToDbValue(ForcedTransactionInclusionResult.FilteredAddressFrom)).isEqualTo(6)
     assertThat(inclusionResultToDbValue(ForcedTransactionInclusionResult.FilteredAddressTo)).isEqualTo(7)
-    assertThat(inclusionResultToDbValue(ForcedTransactionInclusionResult.Phylax)).isEqualTo(8)
+    assertThat(inclusionResultToDbValue(ForcedTransactionInclusionResult.ChainSecurityRuleViolation)).isEqualTo(8)
 
     assertThat(dbValueToInclusionResult(1)).isEqualTo(ForcedTransactionInclusionResult.Included)
     assertThat(dbValueToInclusionResult(2)).isEqualTo(ForcedTransactionInclusionResult.BadNonce)
@@ -320,7 +320,7 @@ class PostgresForcedTransactionsDaoTest : CleanDbTestSuiteParallel() {
     assertThat(dbValueToInclusionResult(5)).isEqualTo(ForcedTransactionInclusionResult.TooManyLogs)
     assertThat(dbValueToInclusionResult(6)).isEqualTo(ForcedTransactionInclusionResult.FilteredAddressFrom)
     assertThat(dbValueToInclusionResult(7)).isEqualTo(ForcedTransactionInclusionResult.FilteredAddressTo)
-    assertThat(dbValueToInclusionResult(8)).isEqualTo(ForcedTransactionInclusionResult.Phylax)
+    assertThat(dbValueToInclusionResult(8)).isEqualTo(ForcedTransactionInclusionResult.ChainSecurityRuleViolation)
 
     // Test proof status mappings
     assertThat(proofStatusToDbValue(ForcedTransactionRecord.ProofStatus.UNREQUESTED)).isEqualTo(1)

--- a/coordinator/persistence/src/main/kotlin/linea/persistence/ftx/PostgresForcedTransactionsDao.kt
+++ b/coordinator/persistence/src/main/kotlin/linea/persistence/ftx/PostgresForcedTransactionsDao.kt
@@ -34,7 +34,7 @@ class PostgresForcedTransactionsDao(
         linea.forcedtx.ForcedTransactionInclusionResult.TooManyLogs -> 5
         linea.forcedtx.ForcedTransactionInclusionResult.FilteredAddressFrom -> 6
         linea.forcedtx.ForcedTransactionInclusionResult.FilteredAddressTo -> 7
-        linea.forcedtx.ForcedTransactionInclusionResult.Phylax -> 8
+        linea.forcedtx.ForcedTransactionInclusionResult.ChainSecurityRuleViolation -> 8
       }
     }
 
@@ -47,7 +47,7 @@ class PostgresForcedTransactionsDao(
         5 -> linea.forcedtx.ForcedTransactionInclusionResult.TooManyLogs
         6 -> linea.forcedtx.ForcedTransactionInclusionResult.FilteredAddressFrom
         7 -> linea.forcedtx.ForcedTransactionInclusionResult.FilteredAddressTo
-        8 -> linea.forcedtx.ForcedTransactionInclusionResult.Phylax
+        8 -> linea.forcedtx.ForcedTransactionInclusionResult.ChainSecurityRuleViolation
         else -> throw IllegalArgumentException("Unknown inclusion_result value: $value")
       }
     }

--- a/coordinator/persistence/src/main/resources/db/V005__add_forced_transactions_schema.sql
+++ b/coordinator/persistence/src/main/resources/db/V005__add_forced_transactions_schema.sql
@@ -24,7 +24,7 @@ COMMENT ON TABLE forced_transactions IS 'Stores forced transaction execution sta
 COMMENT ON COLUMN forced_transactions.created_epoch_milli IS 'Timestamp (epoch millis) when record was created';
 COMMENT ON COLUMN forced_transactions.updated_epoch_milli IS 'Timestamp (epoch millis) when record was last updated';
 COMMENT ON COLUMN forced_transactions.ftx_number IS 'Forced transaction number (unique identifier)';
-COMMENT ON COLUMN forced_transactions.inclusion_result IS 'Result of forced transaction inclusion attempt (1=Included, 2=BadNonce, 3=BadBalance, 4=BadPrecompile, 5=TooManyLogs, 6=FilteredAddressFrom, 7=FilteredAddressTo, 8=Phylax)';
+COMMENT ON COLUMN forced_transactions.inclusion_result IS 'Result of forced transaction inclusion attempt (1=Included, 2=BadNonce, 3=BadBalance, 4=BadPrecompile, 5=TooManyLogs, 6=FilteredAddressFrom, 7=FilteredAddressTo, 8=ChainSecurityRuleViolation)';
 COMMENT ON COLUMN forced_transactions.simulated_execution_block_number IS 'Block number where FTX was simulated for execution';
 COMMENT ON COLUMN forced_transactions.simulated_execution_block_timestamp IS 'Timestamp (epoch millis) of simulated execution block';
 COMMENT ON COLUMN forced_transactions.ftx_block_number_deadline IS 'Block number deadline for the forced transaction';

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/forcedtx/ForcedTransactionsClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/forcedtx/ForcedTransactionsClient.kt
@@ -14,7 +14,7 @@ enum class ForcedTransactionInclusionResult {
   TooManyLogs,
   FilteredAddressFrom,
   FilteredAddressTo,
-  Phylax,
+  ChainSecurityRuleViolation,
 }
 
 data class ForcedTransactionInclusionStatus(


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enum rename can break any remaining callers or RPC layers still emitting Phylax until aligned; security-rule handling still stops conflation without saving the FTX.
> 
> **Overview**
> Renames the forced-transaction inclusion enum value **`Phylax`** to **`ChainSecurityRuleViolation`** across the coordinator client API, persistence mappings (still DB value **8**), schema comment, and tests.
> 
> **`ForcedTransactionsExecutionStatusUpdater`** still treats this result as a security stop: it logs with the new name and halts conflation without persisting the FTX. **`InvalidityProofAssembler`** maps the new enum case and throws **`IllegalStateException`** (was **`IllegalArgumentException`**) because it cannot become an invalidity proof reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df409dc4cc2556973c1dfff6e335cb531075e534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->