### PR TITLE
fix(ci): update sdk release ci workflow

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -209,5 +209,6 @@ jobs:
           commit-message: "release(${{ inputs.package }}): v${{ steps.version.outputs.next }}"
           branch: release-${{ inputs.package }}-v${{ steps.version.outputs.next }}
           base: main
-          title: "release(${{ inputs.package }}): v${{ steps.version.outputs.next }}"
+          title: "chore(${{ inputs.package }}): release v${{ steps.version.outputs.next }}"
           body-path: ${{ steps.pr_body.outputs.path }}
+          signoff: true


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tweaks to PR title and sign-off; no application, auth, or release publish logic changes.
> 
> **Overview**
> Updates the **sdk-release** workflow’s auto-created release PR metadata only.
> 
> The **Create pull request** step now uses a **chore**-scoped title (`chore(<package>): release v<version>`) instead of `release(<package>): v<version>`, while the commit message stays `release(<package>): v<version>`. It also enables **`signoff: true`** on that action so the bot PR gets a Signed-off-by trailer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab6ae463bb463c30c9e8747e76a1986e93db3aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->