### PR TITLE
chore(maru): per-test log isolation + bounded integration-test concurrency

### DIFF
--- a/.github/workflows/maru-testing.yml
+++ b/.github/workflows/maru-testing.yml
@@ -53,6 +53,8 @@ jobs:
           name: test reports
           path: |
             maru/**/build/reports/tests/
+            maru/**/build/integrationTest-logs/
+          if-no-files-found: ignore
       - name: Upload Jacoco execution data
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/maru/app/build.gradle
+++ b/maru/app/build.gradle
@@ -123,11 +123,23 @@ task integrationTest(type: Test) {
   classpath = sourceSets.integrationTest.runtimeClasspath
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
 
-  // To make room for Besu threads
-  systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "fixed"
-  int maxThreads = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-  systemProperties["junit.jupiter.execution.parallel.config.fixed.max-pool-size"] = maxThreads
-  systemProperties["junit.jupiter.execution.parallel.config.fixed.parallelism"] = maxThreads
+  // Limit concurrency to max(2, nCpu/4) and run one test class per JVM (forkEvery = 1) so each class is
+  // fully isolated (own statics, singletons, ForkJoinPool, log4j2 context). This overrides the root
+  // build.gradle default. The concurrency cap lives at the process
+  // level, so methods within a fork run sequentially (same_thread), overriding the root's concurrent mode.
+  // nCpu/4 (rather than nCpu/2) leaves headroom: each class spins up several Besu+Maru nodes with real
+  // P2P, and over-subscribing the host makes timing-sensitive peer-discovery awaits flake.
+  maxParallelForks = Math.max(2, Runtime.runtime.availableProcessors().intdiv(4))
+  forkEvery = 1
+  systemProperties["junit.jupiter.execution.parallel.mode.default"] = "same_thread"
+  systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "same_thread"
+
+  // Isolate each test's logs into their own file under build/integrationTest-logs/. PerTestLoggingExtension
+  // (auto-registered, see src/integrationTest/resources) tags each test thread via the log4j2 ThreadContext
+  // (per-method file) and publishes the running class name as a system property (per-class fallback file for
+  // untagged logs from JVM-global pools such as ForkJoinPool.commonPool). Make the context map inheritable so
+  // the Besu/Maru worker threads a test spawns inherit its tag and log to the same file.
+  systemProperties["log4j2.isThreadContextMapInheritable"] = "true"
 
   testLogging {
     events TestLogEvent.FAILED,

--- a/maru/app/src/integrationTest/kotlin/testutils/PerTestLoggingExtension.kt
+++ b/maru/app/src/integrationTest/kotlin/testutils/PerTestLoggingExtension.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package testutils
+
+import org.apache.logging.log4j.ThreadContext
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Routes every integration test's logs to its own file so they stay readable when tests run
+ * concurrently. The RoutingAppender in `log4j2-test.xml` resolves the destination per log event:
+ *
+ *  - `testId` ([ThreadContext]) -> per-method file. Set on the test's worker thread in
+ *    [beforeEach]; because `log4j2.isThreadContextMapInheritable=true` for the integrationTest JVM,
+ *    Besu/Maru worker threads the test spawns inherit it and log into the same file.
+ *  - `maru.test.class` (system property) -> per-class fallback file. Set once per fork in
+ *    [beforeAll]. It is JVM-global (not thread-local), so it captures logs from JVM-global pools
+ *    like `ForkJoinPool.commonPool`, whose threads are created outside any test's [ThreadContext]
+ *    scope and so never inherit a `testId`. This is reliable because the build runs one test class
+ *    per JVM (`forkEvery = 1`) with methods executing sequentially (`same_thread`).
+ *
+ * Auto-registered for the integrationTest source set via
+ * `META-INF/services/org.junit.jupiter.api.extension.Extension` together with
+ * `junit.jupiter.extensions.autodetection.enabled=true` (see junit-platform.properties), so no test
+ * class needs to opt in.
+ */
+class PerTestLoggingExtension :
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback,
+  AfterEachCallback {
+  override fun beforeAll(context: ExtensionContext) {
+    context.testClass.ifPresent { System.setProperty(TEST_CLASS_KEY, sanitize(it.simpleName)) }
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    System.clearProperty(TEST_CLASS_KEY)
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    ThreadContext.put(TEST_ID_KEY, testIdOf(context))
+  }
+
+  override fun afterEach(context: ExtensionContext) {
+    ThreadContext.remove(TEST_ID_KEY)
+  }
+
+  private fun testIdOf(context: ExtensionContext): String {
+    val className = context.testClass.map { it.simpleName }.orElse("UnknownClass")
+    return sanitize("$className.${context.displayName}")
+  }
+
+  private fun sanitize(name: String): String = name.replace(UNSAFE_FILENAME_CHARS, "_").trim('_')
+
+  companion object {
+    private const val TEST_ID_KEY = "testId"
+    private const val TEST_CLASS_KEY = "maru.test.class"
+    private val UNSAFE_FILENAME_CHARS = Regex("[^A-Za-z0-9._-]+")
+  }
+}

--- a/maru/app/src/integrationTest/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/maru/app/src/integrationTest/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+testutils.PerTestLoggingExtension

--- a/maru/app/src/integrationTest/resources/junit-platform.properties
+++ b/maru/app/src/integrationTest/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+# Auto-register classpath extensions (PerTestLoggingExtension, declared via
+# META-INF/services/org.junit.jupiter.api.extension.Extension) so per-test log isolation applies
+# to every integration test without each class opting in.
+junit.jupiter.extensions.autodetection.enabled=true

--- a/maru/app/src/integrationTest/resources/log4j2-test.xml
+++ b/maru/app/src/integrationTest/resources/log4j2-test.xml
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="warn">
+  <Properties>
+    <!-- Override with -Dmaru.integrationTest.logDir=... ; defaults to the Gradle build dir. -->
+    <Property name="logDir">${sys:maru.integrationTest.logDir:-build/integrationTest-logs}</Property>
+    <Property name="pattern">[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n</Property>
+  </Properties>
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
-    </Console>
+    <!-- Route each test's logs to its own file. Resolution order (per log event):
+           1. ctx:testId            - per-method file, set on the test thread by PerTestLoggingExtension
+           2. sys:maru.test.class   - per-class fallback for untagged logs from JVM-global pools
+                                      (e.g. ForkJoinPool.commonPool), set once per fork by the extension
+           3. _unrouted-worker-N    - last resort before any class starts (N = Gradle test worker id) -->
+    <Routing name="perTest">
+      <Routes pattern="$${ctx:testId:-$${sys:maru.test.class:-_unrouted-worker-$${sys:org.gradle.test.worker:-0}}}">
+        <Route>
+          <File name="testLog-${ctx:testId:-${sys:maru.test.class:-_unrouted-worker-${sys:org.gradle.test.worker:-0}}}"
+                fileName="${logDir}/${ctx:testId:-${sys:maru.test.class:-_unrouted-worker-${sys:org.gradle.test.worker:-0}}}.log"
+                append="false">
+            <PatternLayout pattern="${pattern}"/>
+          </File>
+        </Route>
+      </Routes>
+    </Routing>
   </Appenders>
   <Loggers>
     <Logger name="maru" level="INFO" additivity="false">
-      <AppenderRef ref="console"/>
+      <AppenderRef ref="perTest"/>
     </Logger>
 <!--    <Logger name="org.hyperledger.besu.ethereum.blockcreation" level="TRACE"/>-->
     <Logger name="org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod"
@@ -21,7 +39,7 @@
     <Logger name="org.hyperledger.besu.consensus.qbft" level="INFO"/>
     <Logger name="maru.p2p" level="TRACE"/>
     <Root level="INFO" additivity="false">
-      <appender-ref ref="console"/>
+      <AppenderRef ref="perTest"/>
     </Root>
   </Loggers>
 </Configuration>


### PR DESCRIPTION

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect only integration-test execution and logging/CI artifacts, not production runtime behavior.
> 
> **Overview**
> Maru **integration tests** now run with **tighter, more isolated Gradle workers** and **per-test log files** instead of interleaved console output.
> 
> **Concurrency:** Replaces JUnit’s fixed parallel pool (`nCpu/2`) with `maxParallelForks = max(2, nCpu/4)`, `forkEvery = 1` (one class per JVM), and `same_thread` execution so methods in a fork run sequentially—aimed at reducing flakes from Besu/Maru P2P load and shared statics/singletons.
> 
> **Logging:** Adds auto-registered `PerTestLoggingExtension` (ThreadContext `testId` + `maru.test.class` fallback) and a log4j2 **RoutingAppender** writing to `build/integrationTest-logs/`, with inheritable thread context so spawned Besu/Maru threads share the same file. CI failure artifacts now include those logs (`if-no-files-found: ignore` on report upload).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1013f8310c639296b5b44911d50d5ba3c8c90590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->