### PR TITLE
chore(ci): use npm trusted publishing (OIDC) for sdk packages

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -66,7 +66,11 @@ jobs:
   publish-sdk-core:
     needs: guard
     if: inputs.package == 'sdk-core'
-    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
+    # GitHub-hosted runner required: npm trusted publishing (OIDC) does not support self-hosted runners.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -90,15 +94,9 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Configure npm auth
-        if: ${{ !inputs.dry_run && (steps.check.outputs.skip != 'true' || inputs.dual_publish_legacy) }}
-        run: echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
-
       - name: Publish sdk-core
         if: ${{ !inputs.dry_run && steps.check.outputs.skip != 'true' }}
-        run: pnpm -F @lfdt-lineth/sdk-core publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -F @lfdt-lineth/sdk-core publish --no-git-checks --provenance
 
       - name: Check if legacy sdk-core version already published
         if: ${{ !inputs.dry_run && inputs.dual_publish_legacy }}
@@ -109,6 +107,10 @@ jobs:
             echo "::notice::@consensys/linea-sdk-core@$VERSION already published, skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Configure npm auth for legacy publish
+        if: ${{ !inputs.dry_run && inputs.dual_publish_legacy && steps.legacy_check.outputs.skip != 'true' }}
+        run: echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
 
       - name: Publish legacy sdk-core
         if: ${{ !inputs.dry_run && inputs.dual_publish_legacy && steps.legacy_check.outputs.skip != 'true' }}
@@ -193,7 +195,11 @@ jobs:
   publish-sdk-viem:
     needs: guard
     if: inputs.package == 'sdk-viem'
-    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
+    # GitHub-hosted runner required: npm trusted publishing (OIDC) does not support self-hosted runners.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -236,15 +242,9 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Configure npm auth
-        if: ${{ !inputs.dry_run && (steps.check.outputs.skip != 'true' || inputs.dual_publish_legacy) }}
-        run: echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
-
       - name: Publish sdk-viem
         if: ${{ !inputs.dry_run && steps.check.outputs.skip != 'true' }}
-        run: pnpm -F @lfdt-lineth/sdk-viem publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -F @lfdt-lineth/sdk-viem publish --no-git-checks --provenance
 
       - name: Check if legacy sdk-viem version already published
         if: ${{ !inputs.dry_run && inputs.dual_publish_legacy }}
@@ -255,6 +255,10 @@ jobs:
             echo "::notice::@consensys/linea-sdk-viem@$VERSION already published, skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Configure npm auth for legacy publish
+        if: ${{ !inputs.dry_run && inputs.dual_publish_legacy && steps.legacy_check.outputs.skip != 'true' }}
+        run: echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" >> .npmrc
 
       - name: Publish legacy sdk-viem
         if: ${{ !inputs.dry_run && inputs.dual_publish_legacy && steps.legacy_check.outputs.skip != 'true' }}


### PR DESCRIPTION
Publish @lfdt-lineth/sdk-core and @lfdt-lineth/sdk-viem via npm trusted publishing (OIDC) instead of a long-lived NPM_TOKEN:

- Grant id-token: write (+ contents: write) on both publish jobs
- Run publish jobs on ubuntu-latest; npm trusted publishing does not support self-hosted runners
- pnpm publish with --provenance and no auth token on the OIDC path
- Move the static NPM_TOKEN .npmrc auth to a legacy-only step that runs after the OIDC publish, so it cannot override OIDC; the legacy @consensys/* dual-publish path keeps using the token

pnpm 10.x is required for OIDC (11.x has a known 404 regression).

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release path to npm for primary SDK packages; misconfigured OIDC or runner constraints could block publishes, though legacy dual-publish still relies on NPM_TOKEN.
> 
> **Overview**
> Switches **@lfdt-lineth/sdk-core** and **@lfdt-lineth/sdk-viem** publishing in `sdk-publish.yml` from a long-lived **`NPM_TOKEN`** to **npm trusted publishing (OIDC)**.
> 
> Both publish jobs now run on **`ubuntu-latest`** (instead of self-hosted) with **`id-token: write`** and **`contents: write`**, and the primary `pnpm publish` step adds **`--provenance`** with no token env. The shared pre-publish **`.npmrc` auth step is removed** from that path so OIDC is not overridden.
> 
> **Dual-publish** to legacy **`@consensys/*`** packages is unchanged in behavior but **`.npmrc` + `NPM_TOKEN` are applied only in a legacy-only step** that runs after the OIDC publish, so token auth cannot affect the main scoped package publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6567c472ac6a9cbedabfa074bb7b329e07c8a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->