### PR TITLE
refactor(prover-ray): export logderivativesum internals for verifier-ray codegen

### DIFF
--- a/prover-ray/wiop/codegen/codegen.go
+++ b/prover-ray/wiop/codegen/codegen.go
@@ -189,7 +189,7 @@ func (v *ActionVars) sortedVerifier() []namedVerifier {
 // For *pkg.Type it returns "*alias.Type" where alias is the last path segment.
 func concreteTypeName(v any) string {
 	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		alias := pkgAlias(t.Elem().PkgPath())
 		if alias == "" {
 			return "*" + t.Elem().Name()
@@ -204,7 +204,7 @@ func collectActionImports(vars ActionVars) []string {
 	seen := make(map[string]bool)
 	add := func(v any) {
 		t := reflect.TypeOf(v)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			path := t.Elem().PkgPath()
 			if path != "" {
 				seen[path] = true

--- a/prover-ray/wiop/codegen/codegen_test.go
+++ b/prover-ray/wiop/codegen/codegen_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testPackageName = "generated"
+
 // compiledFibSystem builds the Fibonacci scenario, runs the global compiler,
 // and returns the compiled system together with collected ActionVars.
 func compiledFibSystem(t *testing.T) (*wiop.System, codegen.ActionVars) {
@@ -37,7 +39,7 @@ func generate(t *testing.T, sys *wiop.System, vars codegen.ActionVars, opts code
 // TestGenerate_ValidGoSyntax verifies that the output parses as valid Go source.
 func TestGenerate_ValidGoSyntax(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	src := generate(t, sys, vars, codegen.Options{Package: "generated"})
+	src := generate(t, sys, vars, codegen.Options{Package: testPackageName})
 
 	fset := token.NewFileSet()
 	_, err := parser.ParseFile(fset, "prove_gen.go", src, parser.AllErrors)
@@ -54,7 +56,7 @@ func TestGenerate_FuncName(t *testing.T) {
 // TestGenerate_DefaultFuncName verifies that the default function name is "Prove".
 func TestGenerate_DefaultFuncName(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	src := generate(t, sys, vars, codegen.Options{Package: "generated"})
+	src := generate(t, sys, vars, codegen.Options{Package: testPackageName})
 	assert.Contains(t, src, "func Prove(")
 }
 
@@ -64,7 +66,7 @@ func TestGenerate_DefaultFuncName(t *testing.T) {
 //   - there is exactly one .Check(rt) call per registered VerifierAction
 func TestGenerate_RoundStructure(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	src := generate(t, sys, vars, codegen.Options{Package: "generated"})
+	src := generate(t, sys, vars, codegen.Options{Package: testPackageName})
 
 	var wantProver, wantVerifier int
 	for _, r := range sys.Rounds {
@@ -83,7 +85,7 @@ func TestGenerate_RoundStructure(t *testing.T) {
 // TestGenerate_RoundComments verifies that each round has a section comment.
 func TestGenerate_RoundComments(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	src := generate(t, sys, vars, codegen.Options{Package: "generated"})
+	src := generate(t, sys, vars, codegen.Options{Package: testPackageName})
 
 	for i := range sys.Rounds {
 		assert.Contains(t, src, "=== Round", "round %d must have a section comment", i)
@@ -165,7 +167,7 @@ func normaliseSource(t *testing.T, src string) string {
 // imports, var block (with concrete action types), and Prove function body.
 func TestGenerate_GoldenFibonacci(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	actual := generate(t, sys, vars, codegen.Options{Package: "generated"})
+	actual := generate(t, sys, vars, codegen.Options{Package: testPackageName})
 
 	assert.Equal(t,
 		normaliseSource(t, fibExpectedSource),
@@ -177,7 +179,7 @@ func TestGenerate_GoldenFibonacci(t *testing.T) {
 // system with the same vars produces identical output (modulo the timestamp).
 func TestGenerate_Idempotent(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	opts := codegen.Options{Package: "generated"}
+	opts := codegen.Options{Package: testPackageName}
 
 	src1 := generate(t, sys, vars, opts)
 	src2 := generate(t, sys, vars, opts)

--- a/prover-ray/wiop/codegen/codegen_test.go
+++ b/prover-ray/wiop/codegen/codegen_test.go
@@ -49,7 +49,7 @@ func TestGenerate_ValidGoSyntax(t *testing.T) {
 // TestGenerate_FuncName verifies the generated function uses Options.FuncName.
 func TestGenerate_FuncName(t *testing.T) {
 	sys, vars := compiledFibSystem(t)
-	src := generate(t, sys, vars, codegen.Options{Package: "generated", FuncName: "ProveBlock"})
+	src := generate(t, sys, vars, codegen.Options{Package: testPackageName, FuncName: "ProveBlock"})
 	assert.Contains(t, src, "func ProveBlock(")
 }
 

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
@@ -135,7 +135,7 @@ func fractionModule(f wiop.Fraction) *wiop.Module {
 type ZEntry struct {
 	zCol   *wiop.Column
 	packed []wiop.Fraction // raw fractions used by the prover for filter-aware evaluation
-	ZFinal *wiop.Cell // coordinate (round, slot) locating the Z[n-1] opening in the proof transcript; carries no witness value
+	ZFinal *wiop.Cell      // coordinate (round, slot) locating the Z[n-1] opening in the proof transcript; carries no witness value
 }
 
 // buildZ allocates one Z column for a packed fraction group, registers the

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
@@ -135,7 +135,8 @@ func fractionModule(f wiop.Fraction) *wiop.Module {
 type ZEntry struct {
 	zCol   *wiop.Column
 	packed []wiop.Fraction // raw fractions used by the prover for filter-aware evaluation
-	ZFinal *wiop.Cell      // coordinate (round, slot) locating the Z[n-1] opening in the proof transcript; carries no witness value
+	// ZFinal is the (round, slot) coordinate of the Z[n-1] opening in the proof transcript; carries no witness value.
+	ZFinal *wiop.Cell
 }
 
 // buildZ allocates one Z column for a packed fraction group, registers the

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
@@ -65,7 +65,7 @@ func compileQuery(ld *wiop.LogDerivativeSum) {
 
 	buckets := bucketByModule(ld.Fractions)
 
-	var entries []zEntry
+	var entries []ZEntry
 	for bIdx, b := range buckets {
 		groups := packFractions(b.fractions)
 		for kIdx, packed := range groups {
@@ -75,7 +75,7 @@ func compileQuery(ld *wiop.LogDerivativeSum) {
 	}
 
 	resultRound.RegisterAction(&proverAction{ld: ld, entries: entries})
-	resultRound.RegisterVerifierAction(&verifierAction{ld: ld, entries: entries})
+	resultRound.RegisterVerifierAction(&VerifierAction{Ld: ld, Entries: entries})
 }
 
 // fractionBucket groups fractions whose vector-valued side lives on the same
@@ -127,13 +127,15 @@ func fractionModule(f wiop.Fraction) *wiop.Module {
 	return f.Denominator.Module()
 }
 
-// zEntry collects the per-Z artefacts shared by the prover and verifier
+// ZEntry collects the per-Z artefacts shared by the prover and verifier
 // actions: the Z column, the raw fractions (filter, num, den) used by the
 // prover for filter-aware row skipping, and the column endpoint opening.
-type zEntry struct {
+// ZFinal is exported so out-of-package consumers (e.g. the verifier-ray
+// codegen) can read the endpoint opening coordinate.
+type ZEntry struct {
 	zCol   *wiop.Column
 	packed []wiop.Fraction // raw fractions used by the prover for filter-aware evaluation
-	zFinal *wiop.Cell      // lazily-assigned opening of Z[n-1]
+	ZFinal *wiop.Cell // coordinate (round, slot) locating the Z[n-1] opening in the proof transcript; carries no witness value
 }
 
 // buildZ allocates one Z column for a packed fraction group, registers the
@@ -152,7 +154,7 @@ func buildZ(
 	round *wiop.Round,
 	ctx *wiop.ContextFrame,
 	bIdx, kIdx int,
-) zEntry {
+) ZEntry {
 	zNum, zDen := buildZExpressions(packed)
 
 	zCol := m.NewExtensionColumn(
@@ -212,10 +214,10 @@ func buildZ(
 	}
 	zFinal := zCol.At(endpointPos).Open(ctx.Childf("z-final-b%d-k%d", bIdx, kIdx))
 
-	return zEntry{
+	return ZEntry{
 		zCol:   zCol,
 		packed: packed,
-		zFinal: zFinal,
+		ZFinal: zFinal,
 	}
 }
 
@@ -257,7 +259,7 @@ func buildZExpressions(packed []wiop.Fraction) (zNum, zDen wiop.Expression) {
 // ld.Result.
 type proverAction struct {
 	ld      *wiop.LogDerivativeSum
-	entries []zEntry
+	entries []ZEntry
 }
 
 // Run implements [wiop.ProverAction].
@@ -393,32 +395,38 @@ func genToExt(v field.Gen) field.Ext {
 	return v.AsExt()
 }
 
-// verifierAction enforces the only boundary identity that is not already
+// VerifierAction enforces the only boundary identity that is not already
 // pinned in-circuit: the sum of all Z[n-1] endpoint openings equals the
 // claimed Result cell value. The per-Z initial condition is enforced by the
 // row-0 local constraint registered in buildZ, so this action reads only
 // local openings (cells) — never the oracle witness columns.
-type verifierAction struct {
-	ld      *wiop.LogDerivativeSum
-	entries []zEntry
+//
+// Exported (with exported fields) so out-of-package consumers — notably the
+// verifier-ray codegen — can read the endpoint openings and the Result cell.
+type VerifierAction struct {
+	// Ld is exported so codegen can read Result (cell coordinate) and use the
+	// pointer as a map key to correlate with ResultIsZeroVerifierAction.
+	Ld *wiop.LogDerivativeSum
+	// Entries is exported so codegen can iterate ZFinal cell coordinates.
+	Entries []ZEntry
 }
 
 // Check implements [wiop.VerifierAction].
-func (a *verifierAction) Check(rt wiop.Runtime) error {
+func (a *VerifierAction) Check(rt wiop.Runtime) error {
 	var sum field.Ext
 
-	for _, e := range a.entries {
-		zFinal := genToExt(rt.GetCellValue(e.zFinal))
+	for _, e := range a.Entries {
+		zFinal := genToExt(rt.GetCellValue(e.ZFinal))
 		sum.Add(&sum, &zFinal)
 	}
 
-	claimed := genToExt(rt.GetCellValue(a.ld.Result))
+	claimed := genToExt(rt.GetCellValue(a.Ld.Result))
 	var diff field.Ext
 	diff.Sub(&sum, &claimed)
 	if !diff.IsZero() {
 		return fmt.Errorf(
 			"wiop/compilers/logderivativesum: final-sum check failed for query %q",
-			a.ld.Context().Path(),
+			a.Ld.Context().Path(),
 		)
 	}
 	return nil

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
@@ -75,7 +75,7 @@ func compileQuery(ld *wiop.LogDerivativeSum) {
 	}
 
 	resultRound.RegisterAction(&proverAction{ld: ld, entries: entries})
-	resultRound.RegisterVerifierAction(&VerifierAction{Ld: ld, Entries: entries})
+	resultRound.RegisterVerifierAction(&VerifierAction{LogDerivativeSum: ld, Entries: entries})
 }
 
 // fractionBucket groups fractions whose vector-valued side lives on the same
@@ -130,8 +130,6 @@ func fractionModule(f wiop.Fraction) *wiop.Module {
 // ZEntry collects the per-Z artefacts shared by the prover and verifier
 // actions: the Z column, the raw fractions (filter, num, den) used by the
 // prover for filter-aware row skipping, and the column endpoint opening.
-// ZFinal is exported so out-of-package consumers (e.g. the verifier-ray
-// codegen) can read the endpoint opening coordinate.
 type ZEntry struct {
 	zCol   *wiop.Column
 	packed []wiop.Fraction // raw fractions used by the prover for filter-aware evaluation
@@ -405,11 +403,8 @@ func genToExt(v field.Gen) field.Ext {
 // Exported (with exported fields) so out-of-package consumers — notably the
 // verifier-ray codegen — can read the endpoint openings and the Result cell.
 type VerifierAction struct {
-	// Ld is exported so codegen can read Result (cell coordinate) and use the
-	// pointer as a map key to correlate with ResultIsZeroVerifierAction.
-	Ld *wiop.LogDerivativeSum
-	// Entries is exported so codegen can iterate ZFinal cell coordinates.
-	Entries []ZEntry
+	LogDerivativeSum *wiop.LogDerivativeSum
+	Entries          []ZEntry
 }
 
 // Check implements [wiop.VerifierAction].
@@ -421,13 +416,13 @@ func (a *VerifierAction) Check(rt wiop.Runtime) error {
 		sum.Add(&sum, &zFinal)
 	}
 
-	claimed := genToExt(rt.GetCellValue(a.Ld.Result))
+	claimed := genToExt(rt.GetCellValue(a.LogDerivativeSum.Result))
 	var diff field.Ext
 	diff.Sub(&sum, &claimed)
 	if !diff.IsZero() {
 		return fmt.Errorf(
 			"wiop/compilers/logderivativesum: final-sum check failed for query %q",
-			a.Ld.Context().Path(),
+			a.LogDerivativeSum.Context().Path(),
 		)
 	}
 	return nil

--- a/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
@@ -149,7 +149,7 @@ func Compile(sys *wiop.System) {
 	ld := sys.NewLogDerivativeSum(compCtx.Childf("aggregated"), fractions)
 
 	// The verifier check: the aggregated log-derivative sum must be zero.
-	ld.Result.Round().RegisterVerifierAction(&resultIsZeroVerifierAction{ld: ld})
+	ld.Result.Round().RegisterVerifierAction(&ResultIsZeroVerifierAction{Ld: ld})
 
 	// Mark every consumed query as reduced so subsequent compiler passes skip
 	// them. We deliberately wait until the LogDerivativeSum has been
@@ -411,22 +411,28 @@ func viewExprs(cols []*wiop.ColumnView) []wiop.Expression {
 	return out
 }
 
-// resultIsZeroVerifierAction asserts that the aggregated [wiop.LogDerivativeSum]
+// ResultIsZeroVerifierAction asserts that the aggregated [wiop.LogDerivativeSum]
 // result cell holds the zero field element. This is the standard
 // log-derivative identity: the sum of A-side fractions cancels the sum of
 // T-side fractions exactly when every selected A row is in the union of
 // selected B rows.
-type resultIsZeroVerifierAction struct {
-	ld *wiop.LogDerivativeSum
+//
+// Exported (with an exported field) so out-of-package consumers — notably the
+// verifier-ray codegen — can recognise a lookup-reduced LogDerivativeSum and
+// flag that its Result must be zero.
+type ResultIsZeroVerifierAction struct {
+	// Ld is exported so codegen can use the pointer as a map key to flag the
+	// corresponding LogDerivativeSum query's Result as required to be zero.
+	Ld *wiop.LogDerivativeSum
 }
 
 // Check implements [wiop.VerifierAction].
-func (a *resultIsZeroVerifierAction) Check(rt wiop.Runtime) error {
-	v := rt.GetCellValue(a.ld.Result)
+func (a *ResultIsZeroVerifierAction) Check(rt wiop.Runtime) error {
+	v := rt.GetCellValue(a.Ld.Result)
 	if !v.IsZero() {
 		return fmt.Errorf(
 			"wiop/compilers/lookuptologderivsum: aggregated lookup result for query %q must be zero",
-			a.ld.Context().Path(),
+			a.Ld.Context().Path(),
 		)
 	}
 	return nil

--- a/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
+++ b/prover-ray/wiop/compilers/lookuptologderivsum/lookuptologderivsum.go
@@ -149,7 +149,7 @@ func Compile(sys *wiop.System) {
 	ld := sys.NewLogDerivativeSum(compCtx.Childf("aggregated"), fractions)
 
 	// The verifier check: the aggregated log-derivative sum must be zero.
-	ld.Result.Round().RegisterVerifierAction(&ResultIsZeroVerifierAction{Ld: ld})
+	ld.Result.Round().RegisterVerifierAction(&ResultIsZeroVerifierAction{LogDerivativeSum: ld})
 
 	// Mark every consumed query as reduced so subsequent compiler passes skip
 	// them. We deliberately wait until the LogDerivativeSum has been
@@ -421,18 +421,16 @@ func viewExprs(cols []*wiop.ColumnView) []wiop.Expression {
 // verifier-ray codegen — can recognise a lookup-reduced LogDerivativeSum and
 // flag that its Result must be zero.
 type ResultIsZeroVerifierAction struct {
-	// Ld is exported so codegen can use the pointer as a map key to flag the
-	// corresponding LogDerivativeSum query's Result as required to be zero.
-	Ld *wiop.LogDerivativeSum
+	LogDerivativeSum *wiop.LogDerivativeSum
 }
 
 // Check implements [wiop.VerifierAction].
 func (a *ResultIsZeroVerifierAction) Check(rt wiop.Runtime) error {
-	v := rt.GetCellValue(a.Ld.Result)
+	v := rt.GetCellValue(a.LogDerivativeSum.Result)
 	if !v.IsZero() {
 		return fmt.Errorf(
 			"wiop/compilers/lookuptologderivsum: aggregated lookup result for query %q must be zero",
-			a.Ld.Context().Path(),
+			a.LogDerivativeSum.Context().Path(),
 		)
 	}
 	return nil

--- a/prover-ray/wiop/wioptest/helpers.go
+++ b/prover-ray/wiop/wioptest/helpers.go
@@ -5,6 +5,8 @@ import (
 	"github.com/consensys/linea-monorepo/prover-ray/wiop"
 )
 
+const multiModuleScenarioName = "MultiModule"
+
 // baseVec returns a ConcreteVector of length n where every element equals val.
 func baseVec(n int, val uint64) *wiop.ConcreteVector {
 	elems := make([]field.Element, n)

--- a/prover-ray/wiop/wioptest/local_vanishing_scenarios.go
+++ b/prover-ray/wiop/wioptest/local_vanishing_scenarios.go
@@ -450,7 +450,7 @@ func NewLocalMultiModuleScenario() *LocalVanishingScenario {
 	modB.NewLocalConstraint(sys.Context.Childf("b-zero"), colB.View(), -1)
 
 	return &LocalVanishingScenario{
-		Name: "MultiModule",
+		Name: multiModuleScenarioName,
 		Sys:  sys,
 		AssignHonest: func(rt *wiop.Runtime) {
 			rt.AssignColumn(colA, makeVec(0, 9, 9, 9))

--- a/prover-ray/wiop/wioptest/range_check_scenarios.go
+++ b/prover-ray/wiop/wioptest/range_check_scenarios.go
@@ -114,7 +114,7 @@ func NewRangeCheckMultiModuleScenario() *RangeCheckCompilerScenario {
 	modB.NewRangeCheck(sys.Context.Childf("rcB"), colB, 4)
 
 	return &RangeCheckCompilerScenario{
-		Name: "MultiModule",
+		Name: multiModuleScenarioName,
 		Sys:  sys,
 		AssignWitness: func(rt *wiop.Runtime) {
 			rt.AssignColumn(colA, makeVec(0, 1, 2, 3))

--- a/prover-ray/wiop/wioptest/vanishing_scenarios.go
+++ b/prover-ray/wiop/wioptest/vanishing_scenarios.go
@@ -462,7 +462,7 @@ func NewMultiModuleVanishingScenario() *VanishingScenario {
 	)
 
 	return &VanishingScenario{
-		Name: "MultiModule",
+		Name: multiModuleScenarioName,
 		Sys:  sys,
 		AssignHonest: func(rt *wiop.Runtime) {
 			rt.AssignColumn(colA, makeVec(0, 1, 0, 1))

--- a/prover/backend/invalidity/prove_test.go
+++ b/prover/backend/invalidity/prove_test.go
@@ -169,6 +169,7 @@ func TestProveBadPrecompile(t *testing.T) {
 	builder := invalidity.NewBuilder(
 		invalidity.Config{
 			ZkEvmComp: comp,
+			MaxL2Logs: 16,
 		},
 		&invalidity.BadPrecompileCircuit{},
 	)

--- a/prover/backend/invalidity/prove_test.go
+++ b/prover/backend/invalidity/prove_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/consensys/linea-monorepo/prover/circuits"
 	"github.com/consensys/linea-monorepo/prover/circuits/invalidity"
 	keccakDummy "github.com/consensys/linea-monorepo/prover/circuits/pi-interconnection/keccak/prover/protocol/compiler/dummy"
+	"github.com/consensys/linea-monorepo/prover/config"
 	"github.com/consensys/linea-monorepo/prover/maths/field"
 	public_input "github.com/consensys/linea-monorepo/prover/public-input"
 	linTypes "github.com/consensys/linea-monorepo/prover/utils/types"
@@ -169,7 +170,7 @@ func TestProveBadPrecompile(t *testing.T) {
 	builder := invalidity.NewBuilder(
 		invalidity.Config{
 			ZkEvmComp: comp,
-			MaxL2Logs: 16,
+			MaxL2Logs: config.GetTestTracesLimits().BlockL2L1Logs(),
 		},
 		&invalidity.BadPrecompileCircuit{},
 	)

--- a/prover/circuits/invalidity/setup_test.go
+++ b/prover/circuits/invalidity/setup_test.go
@@ -59,6 +59,7 @@ func TestSetupRoundTripPrecompileLogs(t *testing.T) {
 	builder := invalidity.NewBuilder(
 		invalidity.Config{
 			ZkEvmComp: comp,
+			MaxL2Logs: 16,
 		},
 		&invalidity.BadPrecompileCircuit{},
 	)

--- a/prover/circuits/invalidity/setup_test.go
+++ b/prover/circuits/invalidity/setup_test.go
@@ -59,7 +59,7 @@ func TestSetupRoundTripPrecompileLogs(t *testing.T) {
 	builder := invalidity.NewBuilder(
 		invalidity.Config{
 			ZkEvmComp: comp,
-			MaxL2Logs: 16,
+			MaxL2Logs: config.GetTestTracesLimits().BlockL2L1Logs(),
 		},
 		&invalidity.BadPrecompileCircuit{},
 	)


### PR DESCRIPTION
Exported `zEntry` → `ZEntry`, `ZFinal`, `verifierAction` → `VerifierAction` with `Ld` and `Entries`, and `resultIsZeroVerifierAction` → `ResultIsZeroVerifierAction` with `Ld`, in both `logderivativesum` and `lookuptologderivsum`.

No behavioral change — this is purely a visibility refactor. All exported fields carry the same values as before, and the rename follows Go’s capitalization convention for exported identifiers.
