### PR TITLE
feat(prover-ray): add message bus logic

### DIFF
--- a/prover-ray/docs/message-bus.md
+++ b/prover-ray/docs/message-bus.md
@@ -1,0 +1,39 @@
+## Summary
+
+Add a `LogBus` query type to `prover-ray` to support the logup message-bus of the R5 VM, which is used as the inter-table communication mechanism.
+
+Semantically, the LogUp bus can be seen as a tool in the implementation of conditional fractional lookups (at a high level). If we want to perform a fractional lookup over source tables S1, S2, S3 and target tables T1, T2, T3, where each (S_i, T_i) belongs to a different segment i, the semantics of the fractional lookup are expressed by the relation S1∪S2∪S3⊆T1∪T2∪T3.  
+When the tables belong to the same segment, we do not need to provide multiplicity information to the LogUp bus query .
+LogUp bus queries can be complete or incomplete, depending on whether the log derivative sum is zero or non-zero. Both will be supported. 
+
+## API
+
+`go-corset` is expected to surface this via the `binfile` with roughly the following shape:
+
+```go
+Multiplicities []Column // multiplicity columns at the receiving end
+Sender         []Table  // sending end of the bus
+Receiver       []Table  // receiving end of the bus
+ResultClaim    ...      // claim produced by the bus
+```
+
+In GoCorset, we need an additional query for the LogUp bus. LogUp bus queries can be associated to handles. Similarly to lookups, we write source and target tables, which are then sent and received to/from a LogUp handle.
+
+At some point, LogUp queries end up being compiled into a single unified query. This can be done on the arithmetization side, by clustering multiple function calls using padding and selectors. However, for debugging purposes, we could keep different bus queries on the arithmetization side and in corset, leaving them to be compiled later in the prover. 
+
+### Multiplicity: 
+The multiplicity can be represented as an optional column given to the LogUp query. 
+
+## Multiplicity Concerns:
+It might be that there exist cases where the multiplicity exceeds 2^31. A potential solution would be to split large multiplicities into multiple trace entries. To do: flag any cases in which this happens in practice. It might not be an issue cryptographically if everything remains on KoalaBear elements, but this remains to be discussed. 
+Computing a lot of multiplicity columns is expected to have an impact on performance, by affecting the latency of the fast tracer. When appropriate, replace bus queries with local lookups for static tables (by replicating small reference tables across segments). 
+
+### Note for registers: 
+Olivier clarified that register files don't need multiplicity due to timestamping.
+
+
+
+
+
+
+

--- a/prover-ray/wiop/compilers/localvanishing/localvanishing_test.go
+++ b/prover-ray/wiop/compilers/localvanishing/localvanishing_test.go
@@ -294,28 +294,85 @@ func TestCompile_SharesSelectorsByAnchor(t *testing.T) {
 // TestCompile_PanicsOnOutOfRangePosition ensures an out-of-range anchor is
 // rejected with a localised panic instead of an opaque "index out of range"
 // crash deep inside the runtime. The expression hand-constructs a
-// *ColumnPosition with a negative Position via Column.At, bypassing the
-// normalisation that NewLocalConstraint would otherwise apply; the negative
-// anchor then flows into NewLagrangeSelector, which validates it.
+// *ColumnPosition with a Position beyond the module's domain via Column.At,
+// bypassing the normalisation that NewLocalConstraint would otherwise apply;
+// the out-of-range anchor then flows into NewLagrangeSelector, which validates
+// it against the static [−size, size) bound.
+//
+// Note: negative positions inside [−size, size) are valid (they index from the
+// end), so the out-of-range case uses Position = size.
 func TestCompile_PanicsOnOutOfRangePosition(t *testing.T) {
 	sys := wiop.NewSystemf("lv-oob")
 	r0 := sys.NewRound()
 	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 4, wiop.PaddingDirectionNone)
 	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
 
-	// Hand-built ColumnPosition with Position = -1; Column.At does no
-	// validation, so this slips past the lowerToRow normalisation that
-	// NewLocalConstraint normally applies.
-	badExpr := col.At(-1)
+	// Hand-built ColumnPosition with Position = 4 (== size, so out of range);
+	// Column.At does no validation, so this slips past the lowerToRow
+	// normalisation that NewLocalConstraint normally applies.
+	badExpr := col.At(mod.Size())
 	mod.NewLocalConstraint(sys.Context.Childf("lc"), badExpr, 0)
 
 	defer func() {
 		r := recover()
 		require.NotNil(t, r, "out-of-range anchor must trigger a panic")
 		msg, _ := r.(string)
-		assert.Contains(t, msg, "position must be non-negative")
+		assert.Contains(t, msg, "out of range")
 	}()
 	localvanishing.Compile(sys)
+}
+
+// TestCompile_DynamicModule_NegativeAnchor exercises the end-to-end lift of a
+// scalar vanishing pinned to the last row (Position −1) of a dynamic-size
+// module — the shape produced by an end-relative opening such as Z[−1] in the
+// logderivativesum compiler. The negative anchor flows through localvanishing
+// into a [wiop.LagrangeSelector] that resolves −1 to RuntimeSize−1 per-Runtime,
+// so a single compiled System verifies at multiple runtime sizes.
+//
+// The predicate is pinned via a raw negative *ColumnPosition (col.At(-1))
+// rather than NewLocalConstraint, which cannot normalise −1 on a dynamic module
+// whose size is unknown at construction time — this mirrors what
+// zCol.At(-1).Open produces in the LDS compiler.
+func TestCompile_DynamicModule_NegativeAnchor(t *testing.T) {
+	build := func() (*wiop.System, *wiop.Column) {
+		sys := wiop.NewSystemf("lv-dyn-neg")
+		r0 := sys.NewRound()
+		mod := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
+		col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+		// Scalar predicate "col[last] == 0".
+		mod.NewVanishing(sys.Context.Childf("lc-last"), col.At(-1))
+		return sys, col
+	}
+
+	lastRowVec := func(n int, last uint64) *wiop.ConcreteVector {
+		vals := make([]uint64, n)
+		for i := range vals {
+			vals[i] = 9
+		}
+		vals[n-1] = last
+		return makeVec(vals...)
+	}
+
+	// Completeness: an honest witness (last entry zero) is accepted at every
+	// runtime size the same compiled System is run with.
+	for _, n := range []int{4, 8} {
+		sys, col := build()
+		localvanishing.Compile(sys)
+		global.Compile(sys)
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(col, lastRowVec(n, 0))
+		require.NoErrorf(t, wioptest.RunAndVerify(&rt), "n=%d: honest witness must be accepted", n)
+	}
+
+	// Soundness: a non-zero last entry must be rejected at every runtime size.
+	for _, n := range []int{4, 8} {
+		sys, col := build()
+		localvanishing.Compile(sys)
+		global.Compile(sys)
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(col, lastRowVec(n, 7))
+		assert.Errorf(t, wioptest.RunAndVerify(&rt), "n=%d: invalid witness must be rejected", n)
+	}
 }
 
 // elementFromUint64 converts a literal uint64 into a koalabear field.Element.

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum.go
@@ -138,7 +138,14 @@ type zEntry struct {
 
 // buildZ allocates one Z column for a packed fraction group, registers the
 // recurrence Vanishing, pins the row-0 boundary with a local constraint, and
-// opens the column endpoint.
+// opens the column endpoint (a lazy [wiop.Cell] returned by
+// [ColumnPosition.Open]). The module's size does not need to be known at
+// compile time: the endpoint opening at Z[last] is addressed via
+// [ColumnPosition]'s negative-row convention (Position = −1 ⇒ last row),
+// and Vanishing's cancelled-positions logic gracefully handles a runtime
+// size of 1 by automatically skipping row 0 (the only row of a one-row
+// module), so the recurrence Vanishing is registered unconditionally for
+// dynamic modules.
 func buildZ(
 	m *wiop.Module,
 	packed []wiop.Fraction,
@@ -146,14 +153,6 @@ func buildZ(
 	ctx *wiop.ContextFrame,
 	bIdx, kIdx int,
 ) zEntry {
-	n := m.Size()
-	if n <= 0 {
-		panic(fmt.Sprintf(
-			"wiop/compilers/logderivativesum: module %q must be sized before Compile",
-			m.Context.Path(),
-		))
-	}
-
 	zNum, zDen := buildZExpressions(packed)
 
 	zCol := m.NewExtensionColumn(
@@ -163,13 +162,21 @@ func buildZ(
 	)
 
 	// The recurrence zNum − (Z − Z<<−1)·zDen carries a −1 shift on Z, so
-	// NewVanishing automatically cancels row 0. For a single-row module the
-	// recurrence is vacuous: skip it.
-	if n > 1 {
+	// NewVanishing automatically cancels row 0; the row-0 boundary is pinned
+	// separately by the local constraint below.
+	//
+	// For a *statically* one-row module the recurrence is vacuous and we
+	// skip it as an optimisation. For a dynamic module we cannot know the
+	// runtime size at compile time, so the Vanishing is registered
+	// unconditionally; Vanishing.Check's cancelled-positions logic makes
+	// the constraint vacuous if RuntimeSize ends up being 1.
+	if m.IsDynamic() || m.Size() > 1 {
 		zView := zCol.View()
 		recurrence := wiop.Sub(
 			zNum,
 			wiop.Mul(
+				// Shift(-1) is load-bearing for the dynamic n=1 corner case: it puts row 0 in NewVanishing's
+				// CancelledPositions, so when RuntimeSize == 1 the only row is cancelled and Check is vacuous.
 				wiop.Sub(zView, zView.Shift(-1)),
 				zDen,
 			),
@@ -183,15 +190,27 @@ func buildZ(
 	// Initial condition at row 0: zNum[0] − Z[0]·zDen[0] = 0. The recurrence
 	// cancels row 0, so the boundary is pinned here as a sound local constraint
 	// (lifted by localvanishing and discharged by global) rather than by the
-	// verifier reading the oracle witness columns. This also covers the
-	// single-row (n == 1) case where the recurrence is skipped.
+	// verifier reading the oracle witness columns. The constraint lives on row
+	// 0, which always exists, so it is well-defined for dynamic modules too;
+	// it also covers the single-row (RuntimeSize == 1) case where the
+	// recurrence is skipped or made vacuous.
 	m.NewLocalConstraint(
 		ctx.Childf("z-init-b%d-k%d", bIdx, kIdx),
 		wiop.Sub(zNum, wiop.Mul(zCol.View(), zDen)),
 		0,
 	)
 
-	zFinal := zCol.At(n - 1).Open(ctx.Childf("z-final-b%d-k%d", bIdx, kIdx))
+	// Endpoint opening Z[last] for the running-sum total. For static modules we
+	// resolve the endpoint to a concrete row index up front so the downstream
+	// localvanishing pass — which lowers each opening's binding Vanishing via a
+	// [LagrangeSelector] — sees only non-negative positions. Dynamic modules
+	// keep the negative-row form (Position = −1 resolved to RuntimeSize−1
+	// per-Runtime by [ColumnPosition.resolvedRow]).
+	endpointPos := -1
+	if !m.IsDynamic() {
+		endpointPos = m.Size() - 1
+	}
+	zFinal := zCol.At(endpointPos).Open(ctx.Childf("z-final-b%d-k%d", bIdx, kIdx))
 
 	return zEntry{
 		zCol:   zCol,

--- a/prover-ray/wiop/compilers/logderivativesum/logderivativesum_test.go
+++ b/prover-ray/wiop/compilers/logderivativesum/logderivativesum_test.go
@@ -612,6 +612,223 @@ func TestCompile_Soundness_WrongInitialZ(t *testing.T) {
 		"the row-0 local constraint must reject a Z whose row-0 value disagrees with zNum[0]/zDen[0]")
 }
 
+// ---- Dynamic-module coverage ----
+
+// newDynamicFilteredSum is the dynamic-module counterpart of
+// [newSimpleFilteredSum]: it builds the same single-fraction Num/1 LDS query
+// but over a [wiop.NewDynamicModule] whose domain size is fixed at runtime
+// by the first column assignment instead of at construction time. The
+// helper does NOT supply a size — every [TestCompile_DynamicModule_*]
+// caller is expected to pick one per [wiop.Runtime] via the witness vector
+// it assigns.
+func newDynamicFilteredSum(t *testing.T) (
+	sys *wiop.System,
+	num *wiop.Column,
+	filter *wiop.Column,
+	ld *wiop.LogDerivativeSum,
+) {
+	t.Helper()
+	sys = wiop.NewSystemf("ld2-dyn-test")
+	r0 := sys.NewRound()
+	sys.NewRound() // hosts ld.Result
+	mod := sys.NewDynamicModule(sys.Context.Childf("mod"), wiop.PaddingDirectionRight)
+	num = mod.NewColumn(sys.Context.Childf("num"), wiop.VisibilityOracle, r0)
+	filter = mod.NewColumn(sys.Context.Childf("filter"), wiop.VisibilityOracle, r0)
+	one := wiop.NewConstantVector(mod, field.NewFromString("1"))
+	ld = sys.NewLogDerivativeSum(
+		sys.Context.Childf("ld2-dyn"),
+		[]wiop.Fraction{{
+			Filter:      filter.View(),
+			Numerator:   num.View(),
+			Denominator: one,
+		}},
+	)
+	return
+}
+
+// TestCompile_DynamicModule_Completeness exercises the completeness path for
+// dynamic-module LDS: the same compiled System is re-driven against two
+// different runtime sizes, and an honest witness must verify both times.
+// This pins down the end-to-end behaviour of [zCol.At(-1)] +
+// [Module.RuntimeSize] driving the endpoint LocalOpening to the correct row.
+func TestCompile_DynamicModule_Completeness(t *testing.T) {
+	sys, num, filter, _ := newDynamicFilteredSum(t)
+	logderivativesum.Compile(sys)
+
+	for _, tc := range []struct {
+		name string
+		n    int
+	}{
+		{"size-4", 4},
+		{"size-8", 8},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nums := make([]uint64, tc.n)
+			fil := make([]uint64, tc.n)
+			for i := range nums {
+				nums[i] = 2
+				fil[i] = 1
+			}
+
+			rt := wiop.NewRuntime(sys)
+			rt.AssignColumn(num, makeVec(nums...))
+			rt.AssignColumn(filter, makeVec(fil...))
+			rt.AdvanceRound()
+			runRound(&rt)
+
+			require.NoError(t, checkAllVerifierActions(&rt),
+				"honest dynamic-module assignment must verify (RuntimeSize=%d)", tc.n)
+		})
+	}
+}
+
+// TestCompile_DynamicModule_RecurrenceCatchesWrongZ is the soundness
+// counterpart focused on the recurrence Vanishing. The honest Z for
+// num=[2,2,2,2], filter=[1,1,1,1] is [2,4,6,8]; we instead pin Z to a
+// constant column and assert the Vanishing rejects it. This proves the
+// unconditional Vanishing emission for dynamic modules ([m.IsDynamic() ||
+// m.Size() > 1]) is actually constraining at runtime — without it, a
+// tampered Z would pass the recurrence and only the LDS verifier action's
+// initial-condition check could catch the error.
+func TestCompile_DynamicModule_RecurrenceCatchesWrongZ(t *testing.T) {
+	sys, num, filter, _ := newDynamicFilteredSum(t)
+	mod := sys.Modules[0]
+	witnessColumns := append([]*wiop.Column{}, mod.Columns...)
+	logderivativesum.Compile(sys)
+	zCol := findZColumn(t, mod, witnessColumns)
+
+	// Three vanishings per LDS: 1 recurrence + 2 endpoint-opening bindings
+	// (one each for Z[0] and Z[last], registered by ColumnPosition.Open).
+	// The recurrence is always Vanishings[0] (registered before the openings).
+	require.Len(t, mod.Vanishings, 3,
+		"dynamic module must emit the recurrence Vanishing unconditionally plus two endpoint-opening bindings")
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(num, makeVec(2, 2, 2, 2))
+	rt.AssignColumn(filter, makeVec(1, 1, 1, 1))
+	rt.AdvanceRound()
+
+	bogus := []field.Ext{
+		field.Lift(field.NewFromString("1")),
+		field.Lift(field.NewFromString("1")),
+		field.Lift(field.NewFromString("1")),
+		field.Lift(field.NewFromString("1")),
+	}
+	rt.AssignColumn(zCol, &wiop.ConcreteVector{Plain: field.VecFromExt(bogus)})
+
+	assert.Error(t, mod.Vanishings[0].Check(rt),
+		"recurrence Vanishing must reject a constant Z on a dynamic module")
+}
+
+// TestCompile_DynamicModule_Soundness_WrongResult is the dynamic-module
+// counterpart of [TestCompile_Soundness_WrongResult]: a tampered Result
+// cell must be caught by the LDS verifier action's claim-vs-running-sum
+// identity, even when the underlying column lives on a dynamic module.
+func TestCompile_DynamicModule_Soundness_WrongResult(t *testing.T) {
+	sys, num, filter, ld := newDynamicFilteredSum(t)
+	logderivativesum.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(num, makeVec(2, 2, 2, 2))
+	rt.AssignColumn(filter, makeVec(1, 1, 1, 1))
+	rt.AdvanceRound()
+	// Pre-assigning Result before the prover action runs short-circuits the
+	// prover-side AssignCell (HasCellAssignment is true), so the bogus value
+	// survives into the verifier action.
+	rt.AssignCell(ld.Result, field.ElemFromBase(field.NewFromString("99")))
+	runRound(&rt)
+
+	assert.Error(t, checkAllVerifierActions(&rt),
+		"a corrupted Result cell on a dynamic-module LDS must be detected by the verifier action")
+}
+
+// TestCompile_DynamicModule_Soundness_WrongInitialZ is the dynamic-module
+// counterpart of [TestCompile_Soundness_WrongInitialZ]: a Z column whose
+// per-row differences satisfy the recurrence but whose row-0 value is
+// shifted away from the honest zNum[0]/zDen[0] must pass the recurrence
+// Vanishing yet be rejected by the row-0 local constraint. This boundary used
+// to be checked by the verifier action; it is now pinned in-circuit by a local
+// constraint, so the verifier action (final-sum only) no longer sees it — on
+// the dynamic-module path just like on the static one.
+func TestCompile_DynamicModule_Soundness_WrongInitialZ(t *testing.T) {
+	sys, num, filter, ld := newDynamicFilteredSum(t)
+	mod := sys.Modules[0]
+	witnessColumns := append([]*wiop.Column{}, mod.Columns...)
+	logderivativesum.Compile(sys)
+	zCol := findZColumn(t, mod, witnessColumns)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(num, makeVec(2, 2, 2, 2))
+	rt.AssignColumn(filter, makeVec(1, 1, 1, 1))
+	rt.AdvanceRound()
+
+	// Honest Z = [2, 4, 6, 8]. A constant-step-of-2 sequence starting at 5
+	// satisfies Z[i] − Z[i−1] = 2 but disagrees with Z[0]·zDen[0] = zNum[0].
+	shifted := []field.Ext{
+		field.Lift(field.NewFromString("5")),
+		field.Lift(field.NewFromString("7")),
+		field.Lift(field.NewFromString("9")),
+		field.Lift(field.NewFromString("11")),
+	}
+	rt.AssignColumn(zCol, &wiop.ConcreteVector{Plain: field.VecFromExt(shifted)})
+
+	// The endpoint opening is lazy: it self-resolves from Z on first read, no
+	// explicit assignment needed.
+	rt.AssignCell(ld.Result, field.ElemFromExt(shifted[3]))
+
+	// The recurrence (multi-valued) accepts the constant-step Z, and the
+	// final-sum verifier action only compares consistent endpoints to Result —
+	// neither catches the shifted base on the dynamic path.
+	rec := mod.Vanishings[0]
+	require.True(t, rec.Expression.IsMultiValued(), "Vanishings[0] must be the recurrence")
+	require.NoError(t, rec.Check(rt), "recurrence must accept a constant-step Z on a dynamic module")
+	require.NoError(t, checkAllVerifierActions(&rt),
+		"the final-sum verifier action only checks endpoints against Result")
+
+	// The row-0 local constraint must reject the shifted base.
+	rejected := false
+	for _, v := range mod.Vanishings {
+		if v.Expression.IsMultiValued() {
+			continue
+		}
+		if err := v.Check(rt); err != nil {
+			rejected = true
+		}
+	}
+	assert.True(t, rejected,
+		"the row-0 local constraint must reject a Z whose row-0 value disagrees with zNum[0]/zDen[0] on a dynamic module")
+}
+
+// TestCompile_DynamicModule_SizeOne pins down the corner case that drives
+// the [m.IsDynamic() || m.Size() > 1] decision in buildZ: the recurrence
+// Vanishing is emitted at compile time even though the runtime size turns
+// out to be 1, and Vanishing.Check must treat the constraint as vacuous on
+// the single row (cancelled by the Shift(-1) on Z). Both the recurrence
+// and the LDS verifier action must accept an honest single-row witness.
+func TestCompile_DynamicModule_SizeOne(t *testing.T) {
+	sys, num, filter, _ := newDynamicFilteredSum(t)
+	mod := sys.Modules[0]
+	logderivativesum.Compile(sys)
+
+	// Three vanishings per LDS: 1 recurrence (Vanishings[0]) + 1 row-0 local
+	// constraint + 1 endpoint-opening binding registered by ColumnPosition.Open.
+	require.Len(t, mod.Vanishings, 3,
+		"dynamic module always emits the recurrence Vanishing at compile time, "+
+			"even when the runtime size will turn out to be 1")
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(num, makeVec(7))
+	rt.AssignColumn(filter, makeVec(1))
+	rt.AdvanceRound()
+	runRound(&rt)
+
+	require.NoError(t, mod.Vanishings[0].Check(rt),
+		"recurrence Vanishing must be vacuous when RuntimeSize == 1 "+
+			"(the only row is cancelled by Z's −1 shift)")
+	require.NoError(t, checkAllVerifierActions(&rt),
+		"honest single-row dynamic-module assignment must verify end-to-end")
+}
+
 // ---- Construction-time validation ----
 
 func TestNewLogDerivativeSum_NilCtxPanic(t *testing.T) {

--- a/prover-ray/wiop/compilers/messagebus/messagebus.go
+++ b/prover-ray/wiop/compilers/messagebus/messagebus.go
@@ -1,0 +1,312 @@
+// Package messagebus implements the LogUp message-bus compiler pass for the
+// wiop protocol framework.
+//
+// A single [Compile] invocation runs inside exactly one shard, so every
+// unreduced [wiop.MessageBus] entry it sees is expected to share the same
+// [wiop.MessageBus.OriginShard] (the compiler panics on a mismatch). The
+// pass consumes those entries and emits, for each Handle, a single
+// [wiop.LogDerivativeSum] holding this shard's running sum on that Handle —
+// i.e. the shard's "residual". By Schwartz–Zippel over two extension-field
+// coins α, β (shared across every participant of every Handle reduced by
+// this pass), the residual is zero, for each Handle h, iff
+//
+//	∑_{Send entries on h}  Σ_row filter(row) ·  1               / d_h(row)
+//	    =
+//	∑_{Recv entries on h}  Σ_row filter(row) ·  Multiplicity(row) / d_h(row)
+//
+// where d_h(row) = β + α^{w_h-1}·c_0(row) + … + c_{w_h-1}(row). Equivalently,
+// the multiset of rows sent into h equals the multiset of rows received from
+// h, weighted by the receiver-side multiplicities. The same α, β are reused
+// across handles (each handle just folds with α raised to powers up to its
+// own width); handles remain independent residuals because each is asserted
+// by its own verifier action. See [wiop.MessageBus] for the per-entry
+// semantics.
+//
+// The pass allocates α and β itself, via [Round.NewCoinField] on a fresh
+// (or reused) coin round immediately after the latest participant round.
+// In a sharded protocol the caller is expected to pre-allocate that coin
+// round and register a [Round.RegisterPreSamplingHook] entry on it that
+// calls [Runtime.SetFSState] with shared randomness derived from a
+// cross-shard handoff. The compiler's ensureRoundAfter reuses any
+// pre-existing tail round at the right position, so messagebus's coin
+// allocation lands on the same round the hook is registered on — and every
+// shard's α, β therefore derive from the seeded FS state instead of the
+// local transcript.
+//
+// Caller order: invoke messagebus.Compile(sys) BEFORE
+// logderivativesum.Compile(sys); the latter discharges the LogDerivativeSums
+// this pass emits.
+package messagebus
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+)
+
+// Compile reduces every unreduced [wiop.MessageBus] entry in sys to a
+// collection of [wiop.LogDerivativeSum] queries (one per handle) plus one
+// [wiop.VerifierAction] per handle that asserts the shard's residual equals
+// the expected value (zero in the unsharded case). See the package
+// documentation for the full reduction.
+//
+// The pass appends up to two fresh interactive rounds to sys.Rounds: a
+// coin round where the shared α and β are declared, and a result round
+// where the [wiop.LogDerivativeSum] result cells and the per-handle
+// verifier action live. Either round may already exist at the right
+// position (e.g. when a sharded protocol pre-allocates the coin round to
+// attach a [Round.RegisterPreSamplingHook]); ensureRoundAfter reuses
+// existing tail rounds rather than appending duplicates.
+//
+// Panics if the unreduced entries do not all share the same
+// [wiop.MessageBus.OriginShard] — Compile is a per-shard operation and
+// mixing shards in one call is a misuse.
+//
+// Already-reduced entries are skipped; remaining unreduced entries are marked
+// reduced on return.
+func Compile(sys *wiop.System) {
+	// Collect every unreduced MessageBus entry in declaration order, indexed by
+	// handle. Sort the handles for deterministic round/coin/cell ordering
+	// across runs.
+	byHandle := map[string][]*wiop.MessageBus{}
+	var anyEntry *wiop.MessageBus
+	for _, mb := range sys.MessageBuses {
+		if mb.IsReduced() {
+			continue
+		}
+		if anyEntry == nil {
+			anyEntry = mb
+		} else if mb.OriginShard != anyEntry.OriginShard {
+			panic(fmt.Sprintf(
+				"wiop/compilers/messagebus: Compile is a per-shard operation but the system contains entries "+
+					"from different shards: %q at %q vs %q at %q",
+				anyEntry.OriginShard, anyEntry.Context().Path(),
+				mb.OriginShard, mb.Context().Path(),
+			))
+		}
+		byHandle[mb.Handle] = append(byHandle[mb.Handle], mb)
+	}
+	if len(byHandle) == 0 {
+		return
+	}
+	handles := make([]string, 0, len(byHandle))
+	for h := range byHandle {
+		handles = append(handles, h)
+	}
+	sort.Strings(handles)
+
+	compCtx := sys.Context.Childf("message-bus")
+
+	// Allocate the shared (α, β) coins on a fresh — or pre-existing — coin
+	// round immediately after the latest participant round. A sharded
+	// protocol typically pre-allocates this round so it can register a
+	// PreSamplingHook that seeds FS with cross-shard shared randomness;
+	// ensureRoundAfter reuses any tail round already at this position
+	// rather than appending a duplicate.
+
+	// Find the highest-ID round any participant column or multiplicity touches.
+	maxParticipantRound := latestParticipantRound(byHandle)
+	// Pick the slot directly after the participants — allocate a fresh round
+	// if empty, reuse any round already sitting there. The reuse path is what
+	// lands α/β on the *same* round a sharded caller pre-allocated for a
+	// PreSamplingHook, so the hook's SetFSState fires immediately before this
+	// round's coin sampling.
+	coinRound := ensureRoundAfter(sys, maxParticipantRound)
+	// Declare α on that round — sampled by AdvanceRound, after any pre-sampling hook fires.
+	alpha := coinRound.NewCoinField(compCtx.Childf("alpha"))
+	// Declare β on the same round, drawn from the same Fiat–Shamir state as α.
+	beta := coinRound.NewCoinField(compCtx.Childf("beta"))
+
+	// The result round (where LDS cells and the verifier action live) sits
+	// strictly after the coin round so the LDS prover action sees α and β
+	// already sampled.
+	resultRound := ensureRoundAfter(sys, coinRound)
+
+	// Per-handle: validate uniform width within a handle. Widths may differ
+	// across handles (each handle just raises the shared α to powers up to
+	// its own width).
+	for _, h := range handles {
+		entries := byHandle[h]
+		width := entries[0].Tab.Width()
+		for _, mb := range entries[1:] {
+			if mb.Tab.Width() != width {
+				panic(fmt.Sprintf(
+					"wiop/compilers/messagebus: handle %q has a participant of width %d at %q "+
+						"but expected %d (set by the first participant at %q); all participants of a handle must share a width",
+					h, mb.Tab.Width(), mb.Context().Path(), width, entries[0].Context().Path(),
+				))
+			}
+		}
+	}
+
+	// Per handle: aggregate every entry's contribution into one
+	// LogDerivativeSum holding this shard's residual on that handle.
+	cellByHandle := make(map[string]*wiop.Cell, len(handles))
+	for _, h := range handles {
+		fractions := buildFractions(alpha, beta, byHandle[h])
+		ld := sys.NewLogDerivativeSum(compCtx.Childf("handle-%s", h), fractions)
+		cellByHandle[h] = ld.Result
+	}
+
+	// One in-shard verifier action per handle: this shard's residual on the
+	// handle must equal Expected (zero in the unsharded case). Suppressed
+	// when System.MessageBusSkipInShardCheck is set, so a downstream
+	// cross-shard layer can own the consistency check instead.
+	if !sys.MessageBusSkipInShardCheck {
+		for _, h := range handles {
+			resultRound.RegisterVerifierAction(&CheckHandleSumInShard{
+				Handle:   h,
+				Cell:     cellByHandle[h],
+				Path:     compCtx.Childf("handle-%s", h).Childf("residual").Path(),
+				Expected: field.ElemZero(),
+			})
+		}
+	}
+
+	// Mark every consumed entry as reduced.
+	for _, h := range handles {
+		for _, mb := range byHandle[h] {
+			mb.MarkAsReduced()
+		}
+	}
+}
+
+// latestParticipantRound returns the [wiop.Round] with the highest ID among
+// the participant columns and multiplicity expressions of every unreduced
+// MessageBus entry, or nil if no entry references a round-bearing leaf.
+func latestParticipantRound(byHandle map[string][]*wiop.MessageBus) *wiop.Round {
+	var best *wiop.Round
+	update := func(r *wiop.Round) {
+		if r != nil && (best == nil || r.ID > best.ID) {
+			best = r
+		}
+	}
+	for _, entries := range byHandle {
+		for _, mb := range entries {
+			update(mb.Round())
+		}
+	}
+	return best
+}
+
+// ensureRoundAfter returns a round with ID > after.ID, reusing the existing
+// tail round when one already sits in that slot; otherwise appending a fresh
+// round via sys.NewRound. after may be nil, in which case the returned round
+// is sys.Rounds[0] (allocated if absent).
+func ensureRoundAfter(sys *wiop.System, after *wiop.Round) *wiop.Round {
+	startID := -1
+	if after != nil {
+		startID = after.ID
+	}
+	for len(sys.Rounds) <= startID+1 {
+		sys.NewRound()
+	}
+	return sys.Rounds[startID+1]
+}
+
+// buildFractions turns every MessageBus entry on one handle into a
+// [wiop.Fraction] suitable for [wiop.System.NewLogDerivativeSum].
+//
+// Each entry contributes one fraction:
+//
+//	Send:    Filter = Tab.Selector, Numerator = +1,             Denominator = d_h(row)
+//	Receive: Filter = Tab.Selector, Numerator = -Multiplicity,  Denominator = d_h(row)
+//
+// where d_h(row) = β + α^{w-1}·c_0(row) + … + c_{w-1}(row). For width-1 tabs
+// the Horner loop is empty and the fold reduces to β + c_0(row); α is still
+// passed in but never multiplied. A nil Multiplicity on the Receive side
+// becomes the constant 1 (so the numerator is just -1).
+func buildFractions(
+	alpha *wiop.CoinField,
+	beta *wiop.CoinField,
+	entries []*wiop.MessageBus,
+) []wiop.Fraction {
+	one := wiop.NewConstantField(field.NewFromString("1"))
+
+	fractions := make([]wiop.Fraction, 0, len(entries))
+	for _, mb := range entries {
+		den := foldDenominator(alpha, beta, mb.Tab.Columns)
+
+		var num wiop.Expression
+		switch mb.Direction {
+		case wiop.BusSend:
+			num = one
+		case wiop.BusReceive:
+			weight := mb.Multiplicity
+			if weight == nil {
+				weight = one
+			}
+			num = wiop.Negate(weight)
+		default:
+			panic(fmt.Sprintf(
+				"wiop/compilers/messagebus: unknown BusDirection %v at %q",
+				mb.Direction, mb.Context().Path(),
+			))
+		}
+
+		var filter wiop.Expression
+		if mb.Tab.Selector != nil {
+			filter = mb.Tab.Selector
+		}
+
+		fractions = append(fractions, wiop.Fraction{
+			Filter:      filter,
+			Numerator:   num,
+			Denominator: den,
+		})
+	}
+	return fractions
+}
+
+// foldDenominator returns the expression β + α^{w-1}·c_0 + … + α·c_{w-2} +
+// c_{w-1}, evaluated as a Horner pass over cols. For width-1 tabs the loop
+// is empty and the result is β + c_0; α is not consulted in that case but
+// must still be non-nil so callers don't need to special-case it.
+func foldDenominator(alpha, beta *wiop.CoinField, cols []*wiop.ColumnView) wiop.Expression {
+	acc := wiop.Expression(cols[0])
+	for _, c := range cols[1:] {
+		acc = wiop.Add(wiop.Mul(acc, alpha), c)
+	}
+	return wiop.Add(beta, acc)
+}
+
+// CheckHandleSumInShard is the verifier action that closes the in-shard half
+// of the message-bus reduction: the LogDerivativeSum cell produced for one
+// handle on this shard — the shard's residual on that handle — must equal
+// [CheckHandleSumInShard.Expected]. For a single-shard protocol the expected
+// value is always zero; the field exists so a sharded protocol can
+// instantiate this action with the residual the cross-shard layer expects
+// to see on this shard.
+type CheckHandleSumInShard struct {
+	// Handle names the bus this check belongs to. Diagnostic-only.
+	Handle string
+	// Cell is the LogDerivativeSum result holding this shard's residual on
+	// Handle. A single Compile call produces exactly one cell per handle —
+	// the action is therefore a single-cell equality check, not a sum.
+	Cell *wiop.Cell
+	// Path is the qualified ContextFrame path of the check, used in error
+	// messages.
+	Path string
+	// Expected is the value Cell must hold on this shard. Constant — fixed
+	// at action-construction time, not derived from any other runtime
+	// state. [Compile] sets this to [field.ElemZero] for the single-shard
+	// case; sharded callers that bypass [Compile]'s built-in registration
+	// may construct the action directly with a non-zero value.
+	Expected field.Gen
+}
+
+// Check implements [wiop.VerifierAction]. Reads the residual cell and
+// returns an error if it differs from [CheckHandleSumInShard.Expected].
+func (h *CheckHandleSumInShard) Check(rt wiop.Runtime) error {
+	got := rt.GetCellValue(h.Cell)
+	diff := got.Sub(h.Expected)
+	if !diff.IsZero() {
+		return fmt.Errorf(
+			"wiop/compilers/messagebus: handle %q (%s): residual is %v, expected %v",
+			h.Handle, h.Path, got, h.Expected,
+		)
+	}
+	return nil
+}

--- a/prover-ray/wiop/compilers/messagebus/messagebus_test.go
+++ b/prover-ray/wiop/compilers/messagebus/messagebus_test.go
@@ -1,0 +1,890 @@
+package messagebus_test
+
+import (
+	"testing"
+
+	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop/compilers/logderivativesum"
+	"github.com/consensys/linea-monorepo/prover-ray/wiop/compilers/messagebus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeVec builds a base-field ConcreteVector from uint64 literals.
+func makeVec(vals ...uint64) *wiop.ConcreteVector {
+	elems := make([]field.Element, len(vals))
+	for i, v := range vals {
+		elems[i].SetUint64(v)
+	}
+	return &wiop.ConcreteVector{Plain: field.VecFromBase(elems)}
+}
+
+// runRound executes every prover action registered on the runtime's current
+// round.
+func runRound(rt *wiop.Runtime) {
+	for _, a := range rt.CurrentRound().ProverActions {
+		a.Run(*rt)
+	}
+}
+
+// checkAllVerifierActions evaluates every verifier action across every round
+// of the runtime and returns the first non-nil error.
+func checkAllVerifierActions(rt *wiop.Runtime) error {
+	for _, r := range rt.System.Rounds {
+		for _, va := range r.VerifierActions {
+			if err := va.Check(*rt); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// fixedSeedHook is a test [wiop.ProverAction] that overrides the runtime's
+// Fiat–Shamir state with a precomputed seed before any coin in the
+// containing round is sampled. It is the test stand-in for the cross-shard
+// layer's SetInitialFSHash-equivalent in production: the cross-shard layer
+// would read the seed from a shared-randomness column; this test version
+// carries the seed inline.
+type fixedSeedHook struct {
+	seed field.Octuplet
+}
+
+func (h *fixedSeedHook) Run(rt wiop.Runtime) {
+	rt.SetFSState(h.seed)
+}
+
+// testMessageBusSeed is the seed every messagebus test uses on the
+// with-hook code path. The concrete value is unimportant — any
+// deterministic non-zero octuplet works.
+var testMessageBusSeed = field.NewOctupletFromStrings(
+	[8]string{"1", "2", "3", "5", "8", "13", "21", "34"},
+)
+
+// setupMessageBusHook pre-allocates the round that [messagebus.Compile]
+// will claim for α and β (immediately after the witness round) and
+// registers a [fixedSeedHook] on it. When Compile later runs,
+// ensureRoundAfter discovers the pre-allocated tail round and reuses it,
+// so α and β get declared on the same round the hook lives on. Subsequent
+// [wiop.Runtime.AdvanceRound] fires the hook before sampling, which means
+// α and β derive deterministically from testMessageBusSeed instead of
+// from the witness columns absorbed on the round before.
+//
+// This mirrors the wiring a sharded protocol uses in production — the
+// only difference is the seed source: a hard-coded octuplet here, a
+// shared-randomness column in the real cross-shard layer.
+func setupMessageBusHook(sys *wiop.System) *wiop.Round {
+	coinRound := sys.NewRound()
+	coinRound.RegisterPreSamplingHook(&fixedSeedHook{seed: testMessageBusSeed})
+	return coinRound
+}
+
+// runWithAndWithoutHook runs body as two subtests covering both coin
+// pathways for any messagebus pipeline: once with the natural Fiat–Shamir
+// transcript driving α/β (no hook registered) and once with
+// [setupMessageBusHook] pre-attached so α/β derive from testMessageBusSeed
+// instead. body receives a fresh [wiop.System] (named after the running
+// subtest), the witness round r0 already allocated, and is expected to
+// declare modules/columns/queries on r0 and drive the proof.
+func runWithAndWithoutHook(t *testing.T, body func(t *testing.T, sys *wiop.System, r0 *wiop.Round)) {
+	t.Helper()
+	for _, tc := range []struct {
+		name     string
+		withHook bool
+	}{
+		{"natural-fs", false},
+		{"with-presampling-hook", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sys := wiop.NewSystemf("%s", t.Name())
+			r0 := sys.NewRound()
+			if tc.withHook {
+				setupMessageBusHook(sys)
+			}
+			body(t, sys, r0)
+		})
+	}
+}
+
+// drive runs the canonical "assign-witness → advance to coin round → advance
+// to result round → run prover" loop for a message-bus pipeline. After this
+// returns, every prover action has executed and the verifier actions are
+// ready to be checked.
+//
+// Round structure produced by [messagebus.Compile] + [logderivativesum.Compile]:
+//
+//   - Round 0: user-witness columns (selectors, value columns, multiplicities).
+//   - Round 1: shared (α, β) coins; no prover actions.
+//   - Round 2: LogDerivativeSum Result cells + Z columns; one prover action
+//     per LogDerivativeSum query that assigns Z and the result.
+func drive(rt *wiop.Runtime) {
+	rt.AdvanceRound() // → coin round, samples α and β
+	rt.AdvanceRound() // → result round
+	runRound(rt)      // assigns Z columns + result cells
+}
+
+// TestCompile_Balanced is the canonical completeness case: one handle, one
+// Send entry, one Receive entry, multiplicities all 1, every sent row
+// matches a received row. The shard's residual on the handle is zero and
+// the verifier must accept.
+func TestCompile_Balanced(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"),
+			"shard", "ping",
+			wiop.NewTable(colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"),
+			"shard", "ping",
+			wiop.NewTable(colB.View()),
+			mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(colB, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(mulB, makeVec(1, 1, 1, 1))
+
+		drive(&rt)
+		require.NoError(t, checkAllVerifierActions(&rt))
+	})
+}
+
+// TestCompile_TamperedMultiplicity exercises the soundness path: with a
+// receiver multiplicity that no longer counts the senders correctly, the
+// shard's residual on the handle is non-zero and the verifier must reject.
+func TestCompile_TamperedMultiplicity(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"),
+			"shard", "ping",
+			wiop.NewTable(colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"),
+			"shard", "ping",
+			wiop.NewTable(colB.View()),
+			mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(colB, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(mulB, makeVec(2, 1, 1, 1)) // wrong: row 0 is counted twice
+
+		drive(&rt)
+		assert.Error(t, checkAllVerifierActions(&rt),
+			"verifier must reject a multiplicity that miscounts the senders")
+	})
+}
+
+// TestCompile_TamperedValueFailsInShardCheck exercises the in-shard sum
+// rejection path through a tampered VALUE column (rather than a tampered
+// multiplicity, which TestCompile_TamperedMultiplicity already covers). The
+// send and receive multisets disagree on a single row's value, so the
+// folded denominators differ and the per-handle sum lands at a non-zero
+// element of the extension field.
+func TestCompile_TamperedValueFailsInShardCheck(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"),
+			"shard", "ping",
+			wiop.NewTable(colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"),
+			"shard", "ping",
+			wiop.NewTable(colB.View()),
+			mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(colB, makeVec(10, 21, 30, 40)) // wrong: row 1 holds 21, not 20
+		rt.AssignColumn(mulB, makeVec(1, 1, 1, 1))
+
+		drive(&rt)
+		assert.Error(t, checkAllVerifierActions(&rt),
+			"verifier must reject when a receive row's value does not appear in the send multiset")
+	})
+}
+
+// TestCompile_TamperedFilterFailsInShardCheck exercises the in-shard sum
+// rejection path through an ASYMMETRIC selector. The send side filters out
+// a row that the receive side still claims, so the multiset on each side
+// has a different cardinality and the per-handle sum is non-zero.
+func TestCompile_TamperedFilterFailsInShardCheck(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		selA := modA.NewColumn(sys.Context.Childf("selA"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"),
+			"shard", "ping",
+			wiop.NewFilteredTable(selA.View(), colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"),
+			"shard", "ping",
+			wiop.NewTable(colB.View()),
+			mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(selA, makeVec(1, 0, 1, 1)) // sender filters out row 1 (value 20)
+		rt.AssignColumn(colB, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(mulB, makeVec(1, 1, 1, 1)) // receiver still claims all four
+
+		drive(&rt)
+		assert.Error(t, checkAllVerifierActions(&rt),
+			"verifier must reject when the send-side selector drops a row the receive side still claims")
+	})
+}
+
+// TestCompile_MultipleSendersOneReceiver verifies that several Send entries
+// on the same handle can balance against a single Receive entry if
+// multiplicities tally them correctly. Sender 1 emits values [10, 20];
+// sender 2 also emits [10, 20]; the receiver holds [10, 20] with
+// multiplicity [2, 2]. All three entries live on the same shard.
+func TestCompile_MultipleSendersOneReceiver(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modS1 := sys.NewSizedModule(sys.Context.Childf("modS1"), 2, wiop.PaddingDirectionNone)
+		modS2 := sys.NewSizedModule(sys.Context.Childf("modS2"), 2, wiop.PaddingDirectionNone)
+		modR := sys.NewSizedModule(sys.Context.Childf("modR"), 2, wiop.PaddingDirectionNone)
+		colS1 := modS1.NewColumn(sys.Context.Childf("S1"), wiop.VisibilityOracle, r0)
+		colS2 := modS2.NewColumn(sys.Context.Childf("S2"), wiop.VisibilityOracle, r0)
+		colR := modR.NewColumn(sys.Context.Childf("R"), wiop.VisibilityOracle, r0)
+		mulR := modR.NewColumn(sys.Context.Childf("mR"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-S1"),
+			"shard", "bus",
+			wiop.NewTable(colS1.View()),
+		)
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-S2"),
+			"shard", "bus",
+			wiop.NewTable(colS2.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-R"),
+			"shard", "bus",
+			wiop.NewTable(colR.View()),
+			mulR.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colS1, makeVec(10, 20))
+		rt.AssignColumn(colS2, makeVec(10, 20))
+		rt.AssignColumn(colR, makeVec(10, 20))
+		rt.AssignColumn(mulR, makeVec(2, 2))
+
+		drive(&rt)
+		require.NoError(t, checkAllVerifierActions(&rt))
+	})
+}
+
+// TestCompile_MultiColumnTuples covers width > 1 tables: senders push
+// (key, value) pairs; receivers consume them with matching multiplicity. The
+// compiler must allocate an α coin (in addition to β) and fold each tuple
+// via Horner before hashing.
+func TestCompile_MultiColumnTuples(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		keyA := modA.NewColumn(sys.Context.Childf("kA"), wiop.VisibilityOracle, r0)
+		valA := modA.NewColumn(sys.Context.Childf("vA"), wiop.VisibilityOracle, r0)
+		keyB := modB.NewColumn(sys.Context.Childf("kB"), wiop.VisibilityOracle, r0)
+		valB := modB.NewColumn(sys.Context.Childf("vB"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"),
+			"shard", "kv",
+			wiop.NewTable(keyA.View(), valA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"),
+			"shard", "kv",
+			wiop.NewTable(keyB.View(), valB.View()),
+			mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(keyA, makeVec(1, 2, 3, 4))
+		rt.AssignColumn(valA, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(keyB, makeVec(1, 2, 3, 4))
+		rt.AssignColumn(valB, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(mulB, makeVec(1, 1, 1, 1))
+
+		drive(&rt)
+		require.NoError(t, checkAllVerifierActions(&rt))
+	})
+}
+
+// TestCompile_FilteredSelectors covers Tables with a selector column on
+// either side: only rows where the selector is 1 contribute to the
+// accumulator.
+func TestCompile_FilteredSelectors(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		selA := modA.NewColumn(sys.Context.Childf("selA"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		selB := modB.NewColumn(sys.Context.Childf("selB"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"),
+			"shard", "filtered",
+			wiop.NewFilteredTable(selA.View(), colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"),
+			"shard", "filtered",
+			wiop.NewFilteredTable(selB.View(), colB.View()),
+			mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		// Active sends: A[0]=10, A[2]=20 (selA = [1,0,1,0]).
+		// Active receives at same values, multiplicities counted by selB-respecting
+		// filter (selB = [1,1,0,0], mulB = [1,1,0,0]) → receives 10 and 20 once each.
+		rt.AssignColumn(colA, makeVec(10, 99, 20, 99))
+		rt.AssignColumn(selA, makeVec(1, 0, 1, 0))
+		rt.AssignColumn(colB, makeVec(10, 20, 77, 77))
+		rt.AssignColumn(selB, makeVec(1, 1, 0, 0))
+		rt.AssignColumn(mulB, makeVec(1, 1, 0, 0))
+
+		drive(&rt)
+		require.NoError(t, checkAllVerifierActions(&rt))
+	})
+}
+
+// TestCompile_TwoHandlesIndependent verifies that two unrelated handles in
+// the same system are checked independently: they share the global (α, β)
+// coins but each handle still gets its own LogDerivativeSum cells and its
+// own verifier action, so tampering one handle cannot mask the other.
+func TestCompile_TwoHandlesIndependent(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 2, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 2, wiop.PaddingDirectionNone)
+		modC := sys.NewSizedModule(sys.Context.Childf("modC"), 2, wiop.PaddingDirectionNone)
+		modD := sys.NewSizedModule(sys.Context.Childf("modD"), 2, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+		colC := modC.NewColumn(sys.Context.Childf("C"), wiop.VisibilityOracle, r0)
+		colD := modD.NewColumn(sys.Context.Childf("D"), wiop.VisibilityOracle, r0)
+		mulD := modD.NewColumn(sys.Context.Childf("mD"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"), "shard", "alpha",
+			wiop.NewTable(colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"), "shard", "alpha",
+			wiop.NewTable(colB.View()), mulB.View(),
+		)
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-C"), "shard", "beta",
+			wiop.NewTable(colC.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-D"), "shard", "beta",
+			wiop.NewTable(colD.View()), mulD.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(7, 8))
+		rt.AssignColumn(colB, makeVec(7, 8))
+		rt.AssignColumn(mulB, makeVec(1, 1))
+		rt.AssignColumn(colC, makeVec(100, 200))
+		rt.AssignColumn(colD, makeVec(100, 200))
+		rt.AssignColumn(mulD, makeVec(1, 1))
+
+		drive(&rt)
+		require.NoError(t, checkAllVerifierActions(&rt))
+	})
+}
+
+// TestCompile_ReceiveWithoutMultiplicity covers the "implicit-1 multiplicity"
+// path on the Receive side. Pass nil and the compiler must treat it as the
+// constant 1.
+func TestCompile_ReceiveWithoutMultiplicity(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 2, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 2, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"), "shard", "impl-one",
+			wiop.NewTable(colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"), "shard", "impl-one",
+			wiop.NewTable(colB.View()),
+			nil, // explicit nil → constant-1 multiplicity
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(5, 6))
+		rt.AssignColumn(colB, makeVec(5, 6))
+
+		drive(&rt)
+		require.NoError(t, checkAllVerifierActions(&rt))
+	})
+}
+
+// TestCompile_NoMessageBusesIsNoOp asserts that running the compiler against
+// a system with no message-bus queries is a no-op: no rounds, coins, or
+// verifier actions are appended.
+func TestCompile_NoMessageBusesIsNoOp(t *testing.T) {
+	sys := wiop.NewSystemf("mb-empty")
+	r0 := sys.NewRound()
+	_ = r0
+
+	roundsBefore := len(sys.Rounds)
+	messagebus.Compile(sys)
+	assert.Len(t, sys.Rounds, roundsBefore,
+		"Compile must not append rounds when there are no MessageBus queries")
+}
+
+// TestCompile_DynamicModule_Balanced is the completeness counterpart of
+// [TestCompile_Balanced] for dynamic modules: the participating modules'
+// sizes are not declared statically but established at runtime by the first
+// column assignment. The same compiled System is then re-driven across two
+// different runtime sizes to confirm size-agnostic compilation.
+func TestCompile_DynamicModule_Balanced(t *testing.T) {
+	sys := wiop.NewSystemf("mb-dyn-balanced")
+	r0 := sys.NewRound()
+	setupMessageBusHook(sys)
+
+	modA := sys.NewDynamicModule(sys.Context.Childf("modA"), wiop.PaddingDirectionRight)
+	modB := sys.NewDynamicModule(sys.Context.Childf("modB"), wiop.PaddingDirectionRight)
+	colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+	mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-A"),
+		"shard", "ping",
+		wiop.NewTable(colA.View()),
+	)
+	sys.NewMessageBusReceive(
+		sys.Context.Childf("recv-B"),
+		"shard", "ping",
+		wiop.NewTable(colB.View()),
+		mulB.View(),
+	)
+
+	messagebus.Compile(sys)
+	logderivativesum.Compile(sys)
+
+	cases := []struct {
+		name string
+		vals []uint64
+	}{
+		{"size-4", []uint64{10, 20, 30, 40}},
+		{"size-8", []uint64{1, 2, 3, 4, 5, 6, 7, 8}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := wiop.NewRuntime(sys)
+			rt.AssignColumn(colA, makeVec(tc.vals...))
+			rt.AssignColumn(colB, makeVec(tc.vals...))
+			ones := make([]uint64, len(tc.vals))
+			for i := range ones {
+				ones[i] = 1
+			}
+			rt.AssignColumn(mulB, makeVec(ones...))
+
+			drive(&rt)
+			require.NoError(t, checkAllVerifierActions(&rt))
+		})
+	}
+}
+
+// TestCompile_DynamicModule_TamperedFails is the soundness counterpart on a
+// dynamic module: a multiplicity that miscounts the senders must be rejected
+// regardless of the runtime size.
+func TestCompile_DynamicModule_TamperedFails(t *testing.T) {
+
+	sys := wiop.NewSystemf("mb-dyn-tampered")
+	r0 := sys.NewRound()
+	setupMessageBusHook(sys)
+
+	modA := sys.NewDynamicModule(sys.Context.Childf("modA"), wiop.PaddingDirectionRight)
+	modB := sys.NewDynamicModule(sys.Context.Childf("modB"), wiop.PaddingDirectionRight)
+	colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+	mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-A"),
+		"shard", "ping",
+		wiop.NewTable(colA.View()),
+	)
+	sys.NewMessageBusReceive(
+		sys.Context.Childf("recv-B"),
+		"shard", "ping",
+		wiop.NewTable(colB.View()),
+		mulB.View(),
+	)
+
+	messagebus.Compile(sys)
+	logderivativesum.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(colB, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(mulB, makeVec(2, 1, 1, 1)) // wrong: row 0 counted twice
+
+	drive(&rt)
+	assert.Error(t, checkAllVerifierActions(&rt),
+		"verifier must reject a multiplicity that miscounts senders on a dynamic module")
+}
+
+// TestCompile_DynamicModule_TamperedValueFailsInShardCheck is the
+// dynamic-module counterpart of [TestCompile_TamperedValueFailsInShardCheck]:
+// the send and receive multisets disagree on a single row's value (colB has
+// 21 where colA has 20), so the per-handle sum lands at a non-zero element
+// of the extension field and the in-shard verifier action must reject —
+// regardless of the runtime-determined row count.
+func TestCompile_DynamicModule_TamperedValueFailsInShardCheck(t *testing.T) {
+	sys := wiop.NewSystemf("mb-dyn-tampered-value")
+	r0 := sys.NewRound()
+	setupMessageBusHook(sys)
+
+	modA := sys.NewDynamicModule(sys.Context.Childf("modA"), wiop.PaddingDirectionRight)
+	modB := sys.NewDynamicModule(sys.Context.Childf("modB"), wiop.PaddingDirectionRight)
+	colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+	mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-A"),
+		"shard", "ping",
+		wiop.NewTable(colA.View()),
+	)
+	sys.NewMessageBusReceive(
+		sys.Context.Childf("recv-B"),
+		"shard", "ping",
+		wiop.NewTable(colB.View()),
+		mulB.View(),
+	)
+
+	messagebus.Compile(sys)
+	logderivativesum.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(colB, makeVec(10, 21, 30, 40)) // wrong: row 1 holds 21, not 20
+	rt.AssignColumn(mulB, makeVec(1, 1, 1, 1))
+
+	drive(&rt)
+	assert.Error(t, checkAllVerifierActions(&rt),
+		"verifier must reject a tampered receive value on a dynamic-module bus")
+}
+
+// TestCompile_DynamicModule_TamperedFilterFailsInShardCheck is the
+// dynamic-module counterpart of [TestCompile_TamperedFilterFailsInShardCheck]:
+// the send side filters out a row the receive side still claims, so the
+// multisets have different cardinalities and the in-shard verifier action
+// must reject. Exercises the selector path through the dynamic-module fold.
+func TestCompile_DynamicModule_TamperedFilterFailsInShardCheck(t *testing.T) {
+	sys := wiop.NewSystemf("mb-dyn-tampered-filter")
+	r0 := sys.NewRound()
+	setupMessageBusHook(sys)
+
+	modA := sys.NewDynamicModule(sys.Context.Childf("modA"), wiop.PaddingDirectionRight)
+	modB := sys.NewDynamicModule(sys.Context.Childf("modB"), wiop.PaddingDirectionRight)
+	colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	selA := modA.NewColumn(sys.Context.Childf("selA"), wiop.VisibilityOracle, r0)
+	colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+	mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-A"),
+		"shard", "ping",
+		wiop.NewFilteredTable(selA.View(), colA.View()),
+	)
+	sys.NewMessageBusReceive(
+		sys.Context.Childf("recv-B"),
+		"shard", "ping",
+		wiop.NewTable(colB.View()),
+		mulB.View(),
+	)
+
+	messagebus.Compile(sys)
+	logderivativesum.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(selA, makeVec(1, 0, 1, 1)) // sender filters out row 1 (value 20)
+	rt.AssignColumn(colB, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(mulB, makeVec(1, 1, 1, 1)) // receiver still claims all four
+
+	drive(&rt)
+	assert.Error(t, checkAllVerifierActions(&rt),
+		"verifier must reject an asymmetric send-side selector on a dynamic-module bus")
+}
+
+// TestCompile_DynamicModule_MultiColumnTuples covers the width-2 α-fold over
+// dynamic modules: (key, value) tuples sent and received with matching
+// multiplicities. Exercises both the Horner fold and the runtime-determined
+// row count simultaneously.
+func TestCompile_DynamicModule_MultiColumnTuples(t *testing.T) {
+
+	sys := wiop.NewSystemf("mb-dyn-tuples")
+	r0 := sys.NewRound()
+	setupMessageBusHook(sys)
+
+	modA := sys.NewDynamicModule(sys.Context.Childf("modA"), wiop.PaddingDirectionRight)
+	modB := sys.NewDynamicModule(sys.Context.Childf("modB"), wiop.PaddingDirectionRight)
+	keyA := modA.NewColumn(sys.Context.Childf("kA"), wiop.VisibilityOracle, r0)
+	valA := modA.NewColumn(sys.Context.Childf("vA"), wiop.VisibilityOracle, r0)
+	keyB := modB.NewColumn(sys.Context.Childf("kB"), wiop.VisibilityOracle, r0)
+	valB := modB.NewColumn(sys.Context.Childf("vB"), wiop.VisibilityOracle, r0)
+	mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-A"),
+		"shard", "kv",
+		wiop.NewTable(keyA.View(), valA.View()),
+	)
+	sys.NewMessageBusReceive(
+		sys.Context.Childf("recv-B"),
+		"shard", "kv",
+		wiop.NewTable(keyB.View(), valB.View()),
+		mulB.View(),
+	)
+
+	messagebus.Compile(sys)
+	logderivativesum.Compile(sys)
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(keyA, makeVec(1, 2, 3, 4))
+	rt.AssignColumn(valA, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(keyB, makeVec(1, 2, 3, 4))
+	rt.AssignColumn(valB, makeVec(10, 20, 30, 40))
+	rt.AssignColumn(mulB, makeVec(1, 1, 1, 1))
+
+	drive(&rt)
+	require.NoError(t, checkAllVerifierActions(&rt))
+}
+
+// TestCompile_WidthMismatchPanics asserts that the compiler rejects two
+// participants on the same handle with different column widths — the
+// alpha-fold is only meaningful when every participant has the same width.
+func TestCompile_WidthMismatchPanics(t *testing.T) {
+	sys := wiop.NewSystemf("mb-width-mismatch")
+	r0 := sys.NewRound()
+
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 2, wiop.PaddingDirectionNone)
+	colA := mod.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colA2 := mod.NewColumn(sys.Context.Childf("A2"), wiop.VisibilityOracle, r0)
+	colB := mod.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-1col"), "shard", "h",
+		wiop.NewTable(colA.View()),
+	)
+	sys.NewMessageBusReceive(
+		sys.Context.Childf("recv-2col"), "shard", "h",
+		wiop.NewTable(colB.View(), colA2.View()),
+		nil,
+	)
+
+	assert.Panics(t, func() { messagebus.Compile(sys) })
+}
+
+// TestCompile_MixedOriginShardPanics asserts that Compile rejects a system
+// containing unreduced MessageBus entries from more than one shard.
+// [messagebus.Compile] is a per-shard operation; mixing OriginShard values
+// in a single invocation is a misuse the compiler catches at the top of
+// the pass so the error surfaces before any artefacts are emitted.
+func TestCompile_MixedOriginShardPanics(t *testing.T) {
+	sys := wiop.NewSystemf("mb-mixed-shards")
+	r0 := sys.NewRound()
+
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), 2, wiop.PaddingDirectionNone)
+	colA := mod.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+	colB := mod.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-shardA"), "shardA", "h",
+		wiop.NewTable(colA.View()),
+	)
+	sys.NewMessageBusSend(
+		sys.Context.Childf("send-shardB"), "shardB", "h",
+		wiop.NewTable(colB.View()),
+	)
+
+	assert.Panics(t, func() { messagebus.Compile(sys) },
+		"Compile must panic when MessageBus entries straddle different OriginShard values")
+}
+
+// TestCheckHandleSumInShard_ExpectedNonZero exercises the Expected field on
+// [messagebus.CheckHandleSumInShard]. The compile-time path always sets
+// Expected to zero (single-shard semantics); the non-zero branch is intended
+// for the cross-shard layer that constructs this action itself. This test
+// fills that coverage gap by:
+//
+//  1. Building a balanced single-handle pipeline so the LDS Result cell —
+//     this shard's residual on the handle — is guaranteed to be zero.
+//  2. Suppressing Compile's auto-registered action via
+//     [wiop.System.MessageBusSkipInShardCheck].
+//  3. Constructing CheckHandleSumInShard directly with two Expected values:
+//     zero (matches the actual residual) and one (does not), and asserting
+//     Check accepts/rejects accordingly.
+//
+// The error message is also spot-checked to confirm it mentions the handle
+// name and the "expected" framing, since the cross-shard caller will rely
+// on those for diagnostics.
+func TestCheckHandleSumInShard_ExpectedNonZero(t *testing.T) {
+	runWithAndWithoutHook(t, func(t *testing.T, sys *wiop.System, r0 *wiop.Round) {
+		t.Helper()
+		// Own the in-shard check ourselves so Compile doesn't pre-register one.
+		// This flag is orthogonal to the coin-source variation (hook vs natural
+		// FS) — both subtests exercise the manual CheckHandleSumInShard path.
+		sys.MessageBusSkipInShardCheck = true
+
+		modA := sys.NewSizedModule(sys.Context.Childf("modA"), 4, wiop.PaddingDirectionNone)
+		modB := sys.NewSizedModule(sys.Context.Childf("modB"), 4, wiop.PaddingDirectionNone)
+		colA := modA.NewColumn(sys.Context.Childf("A"), wiop.VisibilityOracle, r0)
+		colB := modB.NewColumn(sys.Context.Childf("B"), wiop.VisibilityOracle, r0)
+		mulB := modB.NewColumn(sys.Context.Childf("mB"), wiop.VisibilityOracle, r0)
+
+		sys.NewMessageBusSend(
+			sys.Context.Childf("send-A"), "shard", "ping",
+			wiop.NewTable(colA.View()),
+		)
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-B"), "shard", "ping",
+			wiop.NewTable(colB.View()), mulB.View(),
+		)
+
+		messagebus.Compile(sys)
+		logderivativesum.Compile(sys)
+
+		rt := wiop.NewRuntime(sys)
+		rt.AssignColumn(colA, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(colB, makeVec(10, 20, 30, 40))
+		rt.AssignColumn(mulB, makeVec(1, 1, 1, 1))
+
+		drive(&rt)
+
+		// The single LDS query is this shard's residual on the handle.
+		require.Len(t, sys.LogDerivativeSums, 1, "single-shard Compile must emit exactly one LDS per handle")
+		residual := sys.LogDerivativeSums[0].Result
+
+		// Happy path: Expected matches the actual residual (zero for a balanced bus).
+		happy := &messagebus.CheckHandleSumInShard{
+			Handle:   "ping",
+			Cell:     residual,
+			Path:     "test/ping/expected-zero",
+			Expected: field.ElemZero(),
+		}
+		require.NoError(t, happy.Check(rt),
+			"Check must accept when Expected matches the actual residual")
+
+		// Sad path: Expected differs from the actual residual, so Check must reject.
+		sad := &messagebus.CheckHandleSumInShard{
+			Handle:   "ping",
+			Cell:     residual,
+			Path:     "test/ping/expected-one",
+			Expected: field.ElemOne(),
+		}
+		err := sad.Check(rt)
+		require.Error(t, err,
+			"Check must reject when Expected differs from the actual residual")
+		assert.Contains(t, err.Error(), `handle "ping"`,
+			"error must name the handle for diagnostics")
+		assert.Contains(t, err.Error(), "expected",
+			"error must include the expected-value context for diagnostics")
+	})
+}
+
+// TestNewMessageBusReceive_WrongMultiplicityModulePanics asserts that the
+// constructor rejects a vector-valued multiplicity bound to a different
+// module than the receiving table.
+func TestNewMessageBusReceive_WrongMultiplicityModulePanics(t *testing.T) {
+	sys := wiop.NewSystemf("mb-bad-mul-mod")
+	r0 := sys.NewRound()
+	_ = r0
+	mod := sys.NewSizedModule(sys.Context.Childf("m"), 2, wiop.PaddingDirectionNone)
+	foreign := sys.NewSizedModule(sys.Context.Childf("foreign"), 2, wiop.PaddingDirectionNone)
+	col := mod.NewColumn(sys.Context.Childf("c"), wiop.VisibilityOracle, r0)
+
+	assert.Panics(t, func() {
+		sys.NewMessageBusReceive(
+			sys.Context.Childf("recv-bad-mod"), "shard", "h",
+			wiop.NewTable(col.View()),
+			wiop.NewConstantVector(foreign, field.NewFromString("1")),
+		)
+	})
+}

--- a/prover-ray/wiop/query_message_bus.go
+++ b/prover-ray/wiop/query_message_bus.go
@@ -1,0 +1,202 @@
+package wiop
+
+import "fmt"
+
+// BusDirection is the sign of a [MessageBus] entry's contribution to its
+// (OriginShard, Handle) accumulator.
+type BusDirection int
+
+const (
+	// BusSend marks an entry that ADDS its rows to the (OriginShard, Handle)
+	// accumulator. Built by [System.NewMessageBusSend].
+	BusSend BusDirection = iota
+	// BusReceive marks an entry that SUBTRACTS its rows (weighted by an optional
+	// multiplicity) from the (OriginShard, Handle) accumulator. Built by
+	// [System.NewMessageBusReceive].
+	BusReceive
+)
+
+// String returns a human-readable label for d, used in diagnostics.
+func (d BusDirection) String() string {
+	switch d {
+	case BusSend:
+		return "Send"
+	case BusReceive:
+		return "Receive"
+	default:
+		return fmt.Sprintf("BusDirection(%d)", int(d))
+	}
+}
+
+// MessageBus is a [Query] declaring that one [Table] participates in an
+// (OriginShard, Handle)-keyed log-up accumulator. Each instance is the unit of
+// participation: one Send entry adds its rows to the accumulator; one Receive
+// entry subtracts them.
+//
+// Semantics. Two coins α and β (extension field, shared across every
+// participant of every Handle reduced together by the [messagebus] compiler)
+// are drawn after every participant column is committed. For an entry with
+// column views (c_0, …, c_{w-1}), define the row-folding
+//
+//	d(row) = β + α^{w-1}·c_0(row) + … + α·c_{w-2}(row) + c_{w-1}(row)
+//
+// and a per-row filter equal to Tab.Selector when present and 1 otherwise.
+// The entry contributes
+//
+//	Send:    +Σ_row filter(row) · 1 / d(row)
+//	Receive: -Σ_row filter(row) · Multiplicity(row) / d(row)         (Multiplicity = 1 if nil)
+//
+// to the (OriginShard, Handle) accumulator. A single [messagebus.Compile]
+// invocation runs inside exactly one shard, so every entry it sees must agree
+// on OriginShard. The compiler enforces that invariant and lowers all entries
+// of a Handle into a single [LogDerivativeSum] holding this shard's running
+// sum (the shard's "residual" on that Handle), plus a verifier action that
+// asserts the residual equals an expected value (zero in the unsharded case).
+// The OriginShard tag is preserved on the query so a downstream cross-shard
+// layer can collect residuals from sibling shards and join them.
+//
+// MessageBus does not implement [GnarkCheckableQuery] nor [AssignableQuery]:
+// its semantics span multiple queries within a system and are discharged by
+// the dedicated compiler pass. [MessageBus.Check] is a no-op for that reason —
+// the in-shard residual identity is enforced after compilation by the
+// LogDerivativeSum and the verifier action.
+//
+// Use [System.NewMessageBusSend] and [System.NewMessageBusReceive] to
+// construct instances.
+type MessageBus struct {
+	baseQuery
+	// OriginShard names the shard whose [messagebus.Compile] call this entry
+	// belongs to. Within a single Compile invocation every entry must share
+	// the same OriginShard — the compiler panics on a mismatch. Across
+	// shards the field lets a downstream cross-shard layer identify which
+	// shard contributed which residual to the per-Handle accumulator.
+	// Always non-empty.
+	OriginShard string
+	// Handle is the bus name. Entries with the same Handle in the same
+	// Compile invocation are summed together into a single LogDerivativeSum
+	// representing this shard's residual on that Handle. Always non-empty.
+	Handle string
+	// Direction selects the sign of the contribution. See [BusDirection].
+	Direction BusDirection
+	// Tab is the column tuple (with an optional selector) being sent or
+	// received. The Selector field of Tab acts as a per-row filter and may be
+	// nil.
+	Tab Table
+	// Multiplicity is an optional row-weighting expression applied on the
+	// Receive side only. Always nil when Direction == BusSend; nil is also
+	// permitted on the Receive side and is treated as the constant 1.
+	//
+	// If non-nil and vector-valued, Multiplicity must share the same module as
+	// Tab. A scalar Multiplicity is allowed and applies uniformly to every row.
+	Multiplicity Expression
+}
+
+// Round implements [Query]. Returns the latest [Round] across every column in
+// Tab (including Tab.Selector) and, when present, Multiplicity. The bus's
+// semantic check cannot be performed before this round — both α/β need every
+// participant column to be committed before being sampled.
+func (mb *MessageBus) Round() *Round {
+	var best *Round
+	if r := mb.Tab.Round(); r != nil {
+		best = r
+	}
+	if mb.Multiplicity != nil {
+		if r := maxRoundInExpr(mb.Multiplicity); r != nil && (best == nil || r.ID > best.ID) {
+			best = r
+		}
+	}
+	return best
+}
+
+// Check implements [Query]. Always returns nil. The per-Handle residual
+// identity is inherently cross-query and is discharged by the [messagebus]
+// compiler pass together with the [logderivativesum] compiler that follows.
+func (mb *MessageBus) Check(_ Runtime) error { return nil }
+
+// NewMessageBusSend constructs and registers a Send entry on
+// (originShard, handle). The entry contributes +Σ_row filter(row) / d(row)
+// to the (OriginShard, Handle) accumulator. There is no multiplicity on the
+// Send side (per the message-bus spec).
+//
+// Invariants enforced at construction:
+//   - ctx is non-nil.
+//   - originShard and handle are non-empty.
+//   - tab has at least one column (already enforced by [NewTable]).
+//
+// Panics on any invariant violation.
+func (sys *System) NewMessageBusSend(ctx *ContextFrame, originShard, handle string, tab Table) *MessageBus {
+	return sys.newMessageBus(ctx, originShard, handle, BusSend, tab, nil)
+}
+
+// NewMessageBusReceive constructs and registers a Receive entry on
+// (originShard, handle). The entry contributes
+// -Σ_row filter(row) · multiplicity(row) / d(row) to the (OriginShard,
+// Handle) accumulator. multiplicity may be nil, in which case it is treated
+// as the constant 1.
+//
+// Invariants enforced at construction:
+//   - ctx is non-nil.
+//   - originShard and handle are non-empty.
+//   - tab has at least one column.
+//   - If multiplicity is non-nil and vector-valued, its module matches
+//     tab.Module().
+//
+// Panics on any invariant violation.
+func (sys *System) NewMessageBusReceive(
+	ctx *ContextFrame,
+	originShard, handle string,
+	tab Table,
+	multiplicity Expression,
+) *MessageBus {
+	return sys.newMessageBus(ctx, originShard, handle, BusReceive, tab, multiplicity)
+}
+
+// newMessageBus is the shared constructor for [System.NewMessageBusSend] and
+// [System.NewMessageBusReceive]. It validates the invariants and appends the
+// query to [System.MessageBuses].
+func (sys *System) newMessageBus(
+	ctx *ContextFrame,
+	originShard, handle string,
+	dir BusDirection,
+	tab Table,
+	multiplicity Expression,
+) *MessageBus {
+	if ctx == nil {
+		panic("wiop: System.NewMessageBus* requires a non-nil ContextFrame")
+	}
+	if originShard == "" {
+		panic("wiop: System.NewMessageBus*: originShard must be non-empty")
+	}
+	if handle == "" {
+		panic("wiop: System.NewMessageBus*: handle must be non-empty")
+	}
+	if len(tab.Columns) == 0 {
+		panic("wiop: System.NewMessageBus*: tab must have at least one column")
+	}
+	if dir == BusSend && multiplicity != nil {
+		panic("wiop: System.NewMessageBusSend: multiplicity must be nil on the Send side")
+	}
+	if multiplicity != nil {
+		if m := multiplicity.Module(); m != nil && m != tab.Module() {
+			panic(fmt.Sprintf(
+				"wiop: System.NewMessageBusReceive: multiplicity module %q differs from tab module %q; "+
+					"a vector-valued multiplicity must share the tab's module",
+				m.Context.Path(), tab.Module().Context.Path(),
+			))
+		}
+	}
+
+	mb := &MessageBus{
+		baseQuery: baseQuery{
+			context:     ctx,
+			Annotations: make(Annotations),
+		},
+		OriginShard:  originShard,
+		Handle:       handle,
+		Direction:    dir,
+		Tab:          tab,
+		Multiplicity: multiplicity,
+	}
+	sys.MessageBuses = append(sys.MessageBuses, mb)
+	return mb
+}

--- a/prover-ray/wiop/query_vanishing.go
+++ b/prover-ray/wiop/query_vanishing.go
@@ -194,6 +194,8 @@ func cancelledPositionsFromShifts(shifts map[int]struct{}) []int {
 				posSet[-i] = struct{}{}
 			}
 		} else if off < 0 {
+			// e.g. Shift(-1) in the LDS recurrence puts position 0 here, which is what makes Check
+			// vacuous on a dynamic module that turns out to have RuntimeSize == 1.
 			for i := 0; i < -off; i++ {
 				posSet[i] = struct{}{}
 			}

--- a/prover-ray/wiop/wiop_column.go
+++ b/prover-ray/wiop/wiop_column.go
@@ -373,12 +373,38 @@ func (cv *ColumnView) Visibility() Visibility { return cv.Column.Visibility }
 type ColumnPosition struct {
 	// Column is the parent column.
 	Column *Column
-	// Position is the zero-based row index into the column.
+	// Position is the row index into the column. Non-negative values index
+	// from the start of the domain; negative values index from the end, with
+	// −1 being the last row, −2 the second-to-last, etc. The end-indexed
+	// form is the only way to open the endpoint of a dynamic module, where
+	// the absolute row index is only known per-[Runtime]. The same
+	// convention is shared with [Vanishing.CancelledPositions].
 	Position int
 }
 
-// At constructs a [ColumnPosition] for this column at the given zero-based
-// row index. The result is a scalar [FieldPromise] evaluating to Column[pos].
+// resolvedRow returns the absolute row index of this position against a
+// runtime-known domain size n. Negative Position values are interpreted from
+// the end (−1 ⇒ n−1, −2 ⇒ n−2, …). Panics if the resolved index is out of
+// the [0, n) range.
+func (cp *ColumnPosition) resolvedRow(n int) int {
+	row := cp.Position
+	if row < 0 {
+		row += n
+	}
+	if row < 0 || row >= n {
+		panic(fmt.Sprintf(
+			"wiop: ColumnPosition: row %d (Position=%d, runtime size %d) out of bounds",
+			row, cp.Position, n,
+		))
+	}
+	return row
+}
+
+// At constructs a [ColumnPosition] for this column at the given row index.
+// Non-negative pos indexes from the start of the domain. Negative pos
+// indexes from the end and is the canonical way to address a dynamic
+// module's endpoint (pos = −1 ⇒ last row). The result is a scalar
+// [FieldPromise] evaluating to Column[pos].
 //
 // Panics if the receiver is nil.
 func (c *Column) At(pos int) *ColumnPosition {
@@ -434,10 +460,12 @@ func (cp *ColumnPosition) EvaluateVector(_ Runtime) ConcreteVector {
 }
 
 // EvaluateSingle implements [Expression]. Returns the value of the parent
-// column at Position in the given runtime.
+// column at Position in the given runtime. Negative Position values are
+// resolved from the end of the domain (see [ColumnPosition.Position]).
 func (cp *ColumnPosition) EvaluateSingle(rt Runtime) ConcreteField {
 	m := cp.Column.Module
-	elem := rt.GetColumnAssignment(cp.Column).ElementAtN(m.Padding, m.RuntimeSize(rt), cp.Position)
+	n := m.RuntimeSize(rt)
+	elem := rt.GetColumnAssignment(cp.Column).ElementAtN(m.Padding, n, cp.resolvedRow(n))
 	return ConcreteField{Value: elem, promise: cp}
 }
 
@@ -477,8 +505,11 @@ func (cp *ColumnPosition) Open(ctx *ContextFrame) *Cell {
 		col.IsExtension,
 		func(rt Runtime) field.Gen {
 			m := col.Module
-			return rt.GetColumnAssignment(col).
-				ElementAtN(m.Padding, m.RuntimeSize(rt), cp.Position)
+			n := m.RuntimeSize(rt)
+			// Negative Position values are resolved from the end at runtime;
+			// see [ColumnPosition.Position]. This is what allows callers to
+			// open the endpoint of a dynamic module via At(-1).
+			return rt.GetColumnAssignment(col).ElementAtN(m.Padding, n, cp.resolvedRow(n))
 		},
 	)
 

--- a/prover-ray/wiop/wiop_lagrange_selector.go
+++ b/prover-ray/wiop/wiop_lagrange_selector.go
@@ -18,7 +18,12 @@ import (
 type LagrangeSelector struct {
 	// Module is the module in which the selector is meant to be used as part
 	// of global constraints.
-	module   *Module
+	module *Module
+	// Position is the row at which the selector is 1. Non-negative values
+	// index from the start of the domain; negative values index from the end,
+	// with −1 being the last row, −2 the second-to-last, etc. Negative values
+	// are resolved against the runtime size, so they work on dynamic-size
+	// modules. See [LagrangeSelector.resolvedRow].
 	Position int
 }
 
@@ -29,21 +34,46 @@ var _ VectorPromise = (*LagrangeSelector)(nil)
 // NewLagrangeSelector returns a new LagrangeSelector that is 1 at the given
 // row position and 0 elsewhere.
 //
-// Panics if position is negative, or — when the module is statically sized — if
-// position is outside [0, module.Size()). For dynamic modules the upper bound
-// cannot be checked at construction time and is enforced lazily by
-// [LagrangeSelector.EvaluateVector] against the runtime size.
+// Position follows the same indexing convention as [ColumnPosition]:
+// non-negative values index from the start of the domain; negative values
+// index from the end, with −1 being the last row, −2 the second-to-last, etc.
+// Negative positions are resolved against the runtime size per-[Runtime] by
+// [LagrangeSelector.EvaluateVector] and [LagrangeSelector.EvaluateOutOfDomain].
+// This makes the selector usable on dynamic-size modules, whose final row is
+// only known at proving time — the localvanishing compiler relies on it to
+// lift end-relative openings (e.g. Z[−1]) into global constraints.
+//
+// Panics when the module is statically sized and position falls outside
+// [−module.Size(), module.Size()). For dynamic modules neither bound can be
+// checked at construction time; both are enforced lazily against the runtime
+// size by [LagrangeSelector.resolvedRow].
 func NewLagrangeSelector(module *Module, position int) *LagrangeSelector {
-	if position < 0 {
-		panic(fmt.Sprintf("wiop: NewLagrangeSelector: position must be non-negative, got %d", position))
-	}
-	if module.IsSized() && position >= module.Size() {
+	if module.IsSized() && (position >= module.Size() || position < -module.Size()) {
 		panic(fmt.Sprintf(
-			"wiop: NewLagrangeSelector: position %d out of range [0, %d) for module %q",
-			position, module.Size(), module.Context.Path(),
+			"wiop: NewLagrangeSelector: position %d out of range [-%d, %d) for module %q",
+			position, module.Size(), module.Size(), module.Context.Path(),
 		))
 	}
 	return &LagrangeSelector{module: module, Position: position}
+}
+
+// resolvedRow converts the (possibly negative) Position into an absolute row
+// index in [0, n), mirroring [ColumnPosition.resolvedRow]. Negative positions
+// index from the end: −1 → n−1, −2 → n−2, etc. Panics if the resolved row
+// falls outside [0, n), which on a dynamic module catches a runtime size too
+// small for the requested position.
+func (ls *LagrangeSelector) resolvedRow(n int) int {
+	row := ls.Position
+	if row < 0 {
+		row += n
+	}
+	if row < 0 || row >= n {
+		panic(fmt.Sprintf(
+			"wiop: LagrangeSelector: row %d (Position=%d, runtime size %d) out of bounds for module %q",
+			row, ls.Position, n, ls.module.Context.Path(),
+		))
+	}
+	return row
 }
 
 // IsExtension implements [VectorPromise]. Always returns false: a Lagrange
@@ -101,7 +131,7 @@ func (ls *LagrangeSelector) EvaluateVector(rt Runtime) ConcreteVector {
 		Padding: field.Zero(),
 	}
 
-	res.Plain.AsBase()[ls.Position] = field.One()
+	res.Plain.AsBase()[ls.resolvedRow(size)] = field.One()
 	return res
 }
 
@@ -123,10 +153,13 @@ func (ls *LagrangeSelector) EvaluateVector(rt Runtime) ConcreteVector {
 func (ls *LagrangeSelector) EvaluateOutOfDomain(rt Runtime, x field.Gen) field.Gen {
 
 	n := ls.module.RuntimeSize(rt)
+	// Resolve any end-relative (negative) Position against the runtime size
+	// before using it as a domain-point exponent; see [LagrangeSelector.Position].
+	pos := ls.resolvedRow(n)
 
-	// omegaPos = ω^Position, the domain point at which the selector is 1.
+	// omegaPos = ω^pos, the domain point at which the selector is 1.
 	var omegaPos field.Element
-	omegaPos.ExpInt64(field.RootOfUnityBy(n), int64(ls.Position))
+	omegaPos.ExpInt64(field.RootOfUnityBy(n), int64(pos))
 
 	// numerator = ω^Position · (x^n − 1). Since n is a power of two, x^n is
 	// computed by squaring log2(n) times.
@@ -145,7 +178,7 @@ func (ls *LagrangeSelector) EvaluateOutOfDomain(rt Runtime, x field.Gen) field.G
 	if xMinusOmega.IsZero() {
 		panic(fmt.Sprintf(
 			"wiop: LagrangeSelector.EvaluateOutOfDomain called at ω^%d, which is inside the domain",
-			ls.Position,
+			pos,
 		))
 	}
 	denominator := xMinusOmega.Mul(field.ElemFromBase(nElem))

--- a/prover-ray/wiop/wiop_lagrange_selector_test.go
+++ b/prover-ray/wiop/wiop_lagrange_selector_test.go
@@ -91,6 +91,98 @@ func TestLagrangeSelector_EvaluateOutOfDomain_PanicsOnOwnRow(t *testing.T) {
 	})
 }
 
+// TestLagrangeSelector_NegativePosition checks that a negative Position indexes
+// from the end of the domain: −1 is the last row, −2 the second-to-last, etc.
+// The materialised vector and the out-of-domain evaluation must both agree with
+// the equivalent non-negative position size+pos.
+func TestLagrangeSelector_NegativePosition(t *testing.T) {
+	const size = 8
+	baseX := field.ElemFromBase(field.NewFromString("7"))
+
+	for neg := -1; neg >= -size; neg-- {
+		absPos := size + neg // -1 -> 7, -8 -> 0
+
+		lsNeg, rtNeg := newLagrangeSelector(t, size, neg)
+		lsAbs, rtAbs := newLagrangeSelector(t, size, absPos)
+
+		// The materialised vectors must be identical.
+		vecNeg := lsNeg.EvaluateVector(rtNeg).Plain
+		vecAbs := lsAbs.EvaluateVector(rtAbs).Plain
+		require.Equalf(t, vecAbs.AsBase(), vecNeg.AsBase(),
+			"neg=%d: materialised vector must match position %d", neg, absPos)
+
+		// The single 1 must sit at the resolved row.
+		require.Truef(t, vecNeg.AsBase()[absPos].IsOne(),
+			"neg=%d: expected 1 at resolved row %d", neg, absPos)
+
+		// Out-of-domain evaluation must match the non-negative form.
+		gotNeg := lsNeg.EvaluateOutOfDomain(rtNeg, baseX)
+		gotAbs := lsAbs.EvaluateOutOfDomain(rtAbs, baseX)
+		diff := gotNeg.Sub(gotAbs)
+		require.Truef(t, diff.IsZero(),
+			"neg=%d: EvaluateOutOfDomain must match position %d", neg, absPos)
+	}
+}
+
+// TestLagrangeSelector_OutOfRangePosition checks construction-time bounds on a
+// statically sized module: positions in [−size, size) are accepted; anything
+// outside that range panics.
+func TestLagrangeSelector_OutOfRangePosition(t *testing.T) {
+	const size = 8
+	sys := wiop.NewSystemf("ls-bounds")
+	sys.NewRound()
+	mod := sys.NewSizedModule(sys.Context.Childf("mod"), size, wiop.PaddingDirectionNone)
+
+	// Boundaries inside the range must not panic.
+	require.NotPanics(t, func() { wiop.NewLagrangeSelector(mod, 0) })
+	require.NotPanics(t, func() { wiop.NewLagrangeSelector(mod, size-1) })
+	require.NotPanics(t, func() { wiop.NewLagrangeSelector(mod, -1) })
+	require.NotPanics(t, func() { wiop.NewLagrangeSelector(mod, -size) })
+
+	// Out-of-range on either side must panic.
+	require.Panics(t, func() { wiop.NewLagrangeSelector(mod, size) })
+	require.Panics(t, func() { wiop.NewLagrangeSelector(mod, -size-1) })
+}
+
+// TestLagrangeSelector_DynamicModule checks that a LagrangeSelector built on a
+// dynamic-size module with a negative (end-relative) Position resolves against
+// the per-Runtime size: the same selector is 1 at the last row whether the
+// runtime size is 4 or 8, and its out-of-domain evaluation tracks the size.
+func TestLagrangeSelector_DynamicModule(t *testing.T) {
+	baseX := field.ElemFromBase(field.NewFromString("7"))
+
+	sys := wiop.NewSystemf("ls-dyn")
+	r0 := sys.NewRound()
+	dyn := sys.NewDynamicModule(sys.Context.Childf("dyn"), wiop.PaddingDirectionRight)
+	col := dyn.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+
+	// Position −1: always the last row, regardless of runtime size.
+	ls := wiop.NewLagrangeSelector(dyn, -1)
+
+	for _, n := range []int{4, 8} {
+		rt := wiop.NewRuntime(sys)
+		// Assigning a column fixes the dynamic module's runtime size to n.
+		rt.AssignColumn(col, makeVec(n, 1))
+
+		vec := ls.EvaluateVector(rt).Plain
+		require.Equalf(t, n, vec.Len(), "n=%d: vector length", n)
+		for i := 0; i < n; i++ {
+			want := i == n-1
+			require.Equalf(t, want, vec.AsBase()[i].IsOne(),
+				"n=%d row=%d: selector value", n, i)
+		}
+
+		// The out-of-domain evaluation must match an equivalent static
+		// selector of size n at the last row (n−1).
+		lsStatic, rtStatic := newLagrangeSelector(t, n, n-1)
+		gotDyn := ls.EvaluateOutOfDomain(rt, baseX)
+		gotStatic := lsStatic.EvaluateOutOfDomain(rtStatic, baseX)
+		diff := gotDyn.Sub(gotStatic)
+		require.Truef(t, diff.IsZero(),
+			"n=%d: dynamic EvaluateOutOfDomain must match static size-%d selector", n, n)
+	}
+}
+
 // TestLagrangeSelector_InExpression checks that a LagrangeSelector composes as
 // an ordinary leaf inside an arithmetic expression and is evaluated correctly
 // by the expression compiler on the runtime (in-domain) path. The product

--- a/prover-ray/wiop/wiop_round.go
+++ b/prover-ray/wiop/wiop_round.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/sirupsen/logrus"
 )
 
 // Round represents a single interaction round between the prover and the
@@ -39,6 +40,19 @@ type Round struct {
 	// round, in declaration order. Each check is run by the verifier when the
 	// runtime enters this round, after coins have been derived.
 	VerifierActions []VerifierAction
+	// PreSamplingHooks holds prover-side actions registered to fire BEFORE
+	// any [CoinField] in this round is sampled. They run during
+	// [Runtime.AdvanceRound] *after* the previous round's columns and cells
+	// have been absorbed into the Fiat–Shamir state but *before* this
+	// round's coins are derived. Hooks run in declaration order.
+	//
+	// The canonical use is shared-randomness seeding in sharded protocols:
+	// a hook reads a precomputed seed from public columns and calls
+	// [Runtime.SetFSState] so this round's coins derive deterministically
+	// from that seed instead of from this shard's local transcript. For any
+	// non-seeding use case, prefer [ProverActions] — running before coin
+	// sampling is a sharp tool and easy to misuse.
+	PreSamplingHooks []ProverAction
 	// system is the owning System. Set once at registration time, never nil
 	// for a well-formed Round.
 	system *System
@@ -55,6 +69,34 @@ func (r *Round) RegisterAction(a ProverAction) {
 // round.
 func (r *Round) RegisterVerifierAction(a VerifierAction) {
 	r.VerifierActions = append(r.VerifierActions, a)
+}
+
+// RegisterPreSamplingHook appends a to the round's pre-sampling hook list.
+// Hooks fire in declaration order at the start of [Runtime.AdvanceRound]
+// into this round — after the previous round's commitments have been
+// absorbed into Fiat–Shamir but before this round's coins are sampled.
+//
+// Registering more than one hook on the same round is almost always a
+// bug: hooks typically end with [Runtime.SetFSState], so each one's effect
+// is wiped out by the next, and only the last-registered hook actually
+// influences the coins. This method emits a logrus warning when a second
+// (or later) hook is added so the misuse surfaces early; the behaviour
+// itself is still well-defined (last hook wins) for the rare legitimate
+// case where the stacking is intentional.
+//
+// See [Round.PreSamplingHooks] for when to use this versus
+// [Round.RegisterAction].
+func (r *Round) RegisterPreSamplingHook(a ProverAction) {
+	if len(r.PreSamplingHooks) > 0 {
+		logrus.Warnf(
+			"wiop: round %d already has %d PreSamplingHook(s); "+
+				"registering another is almost always a bug — hooks typically "+
+				"call Runtime.SetFSState and overwrite each other so only the "+
+				"last-registered hook affects the coins",
+			r.ID, len(r.PreSamplingHooks),
+		)
+	}
+	r.PreSamplingHooks = append(r.PreSamplingHooks, a)
 }
 
 // System returns the owning System. It is always non-nil for a well-formed

--- a/prover-ray/wiop/wiop_runtime.go
+++ b/prover-ray/wiop/wiop_runtime.go
@@ -102,7 +102,11 @@ func (run Runtime) CurrentRound() *Round { return run.currentRound }
 //  2. Every cell value assigned in the current round is fed into the
 //     Fiat-Shamir state. All cells are always public (see [Cell.Visibility]).
 //  3. The runtime advances to the next round.
-//  4. A fresh extension-field coin is derived via [fiatshamir.FiatShamir.RandomFext]
+//  4. Every [Round.PreSamplingHooks] entry on the new round runs, in
+//     declaration order. Hooks may mutate the Fiat-Shamir state via
+//     [Runtime.SetFSState] for shared-randomness seeding; any subsequent
+//     coin in this round is derived from the post-hook state.
+//  5. A fresh extension-field coin is derived via [fiatshamir.FiatShamir.RandomFext]
 //     for each [CoinField] declared in the new round.
 //
 // Panics if there is no next round, or if any oracle/public column in the
@@ -142,6 +146,14 @@ func (run *Runtime) AdvanceRound() {
 	}
 
 	run.currentRound = next
+
+	// Pre-sampling hooks: run before any coin is derived so they can seed
+	// the FS state (typically via [Runtime.SetFSState]). The Runtime value
+	// is shared with the hooks; FS-state mutations performed by them affect
+	// the coin loop below.
+	for _, h := range run.currentRound.PreSamplingHooks {
+		h.Run(*run)
+	}
 
 	// Derive a coin for every CoinField declared in the new round.
 	for _, coin := range run.currentRound.Coins {
@@ -352,6 +364,18 @@ func (run Runtime) GetCoinValue(coin *CoinField) field.Gen {
 		))
 	}
 	return v
+}
+
+// SetFSState replaces the runtime's Fiat–Shamir state with s. It is
+// intended for [Round.PreSamplingHooks] entries that seed the FS state
+// from a precomputed shared randomness (e.g. cross-shard handoff). Calling
+// it outside a pre-sampling hook can desynchronize the prover and verifier
+// transcripts and is almost always a bug.
+//
+// fiatshamir is a goroutine-unsafe singleton inside the runtime — like the
+// rest of the AdvanceRound pipeline this must not be called concurrently.
+func (run Runtime) SetFSState(s field.Octuplet) {
+	run.fs.SetState(s)
 }
 
 // GetState returns the value stored under key and whether it was present.

--- a/prover-ray/wiop/wiop_runtime_test.go
+++ b/prover-ray/wiop/wiop_runtime_test.go
@@ -1,10 +1,13 @@
 package wiop_test
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/consensys/linea-monorepo/prover-ray/crypto/koalabear/fiatshamir"
 	"github.com/consensys/linea-monorepo/prover-ray/maths/koalabear/field"
 	"github.com/consensys/linea-monorepo/prover-ray/wiop"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -288,6 +291,108 @@ func TestRuntime_AdvanceRound_WithCoinSampling(t *testing.T) {
 	v := rt.GetCoinValue(coin)
 	// just assert it's deterministic (call twice with same state → same coin)
 	assert.Equal(t, v, rt.GetCoinValue(coin))
+}
+
+// fixedSeedHook is a [wiop.ProverAction] that overrides the runtime's
+// Fiat–Shamir state with a precomputed seed before any coin on the
+// containing round is sampled. It is the test analogue of the original
+// prover's SetInitialFSHash, used to verify that PreSamplingHooks fire at
+// the right moment in AdvanceRound and that Runtime.SetFSState propagates
+// into the coin derivation.
+type fixedSeedHook struct {
+	seed field.Octuplet
+}
+
+func (h *fixedSeedHook) Run(rt wiop.Runtime) {
+	rt.SetFSState(h.seed)
+}
+
+// TestRound_PreSamplingHook_SeedsCoin verifies the wiring added for
+// shared-randomness seeding:
+//
+//  1. A PreSamplingHook registered on round N fires during AdvanceRound
+//     into N, *after* round (N-1)'s commitments have been absorbed and
+//     *before* round N's coins are sampled.
+//  2. Runtime.SetFSState invoked inside such a hook propagates into the
+//     subsequent coin derivation, so the sampled coin is uniquely determined
+//     by the seed (not by the natural FS transcript).
+//
+// The test reproduces the expected coin from an independent
+// fiatshamir.FiatShamir instance seeded with the same value; the natural
+// FS transcript would land on that exact extension-field element with
+// negligible probability, so a match proves the hook ran and SetFSState
+// took effect.
+func TestRound_PreSamplingHook_SeedsCoin(t *testing.T) {
+	sys, r0, r1, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	coin := r1.NewCoinField(sys.Context.Childf("coin"))
+
+	seed := field.NewOctupletFromStrings([8]string{
+		"1", "2", "3", "5", "8", "13", "21", "34",
+	})
+	r1.RegisterPreSamplingHook(&fixedSeedHook{seed: seed})
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, baseVec(4, 7)) // arbitrary, would influence natural FS
+	rt.AdvanceRound()
+
+	// Reproduce the post-seed coin from an independent FS instance.
+	fs := fiatshamir.NewFiatShamir()
+	fs.SetState(seed)
+	expected := field.ElemFromExt(fs.RandomFext())
+
+	assert.Equal(t, expected, rt.GetCoinValue(coin),
+		"PreSamplingHook must seed the FS state before the coin loop fires; "+
+			"sampled coin must equal the value produced by an independent FS instance with the same seed")
+}
+
+// TestRound_PreSamplingHook_RunsInOrder verifies two coupled contracts of
+// the multi-hook path:
+//
+//  1. Registering a second PreSamplingHook on a round emits a logrus
+//     warning. The wiring is informational, not blocking — see the
+//     RegisterPreSamplingHook docstring — but the warning must fire so the
+//     misuse is surfaced early.
+//  2. Despite being discouraged, the stacked-hooks behaviour is still
+//     well-defined: hooks run in registration order and the last hook's
+//     SetFSState is the state from which the coins are derived.
+func TestRound_PreSamplingHook_RunsInOrder(t *testing.T) {
+	sys, r0, r1, mod := newTestSystem(t)
+	col := mod.NewColumn(sys.Context.Childf("col"), wiop.VisibilityOracle, r0)
+	coin := r1.NewCoinField(sys.Context.Childf("coin"))
+
+	seedFirst := field.NewOctupletFromStrings([8]string{"1", "1", "1", "1", "1", "1", "1", "1"})
+	seedLast := field.NewOctupletFromStrings([8]string{"9", "9", "9", "9", "9", "9", "9", "9"})
+
+	// Capture logrus output so we can verify the multi-hook warning fires
+	// on the second registration. Restore the standard logger's output on
+	// exit so neighbouring tests are unaffected.
+	var buf bytes.Buffer
+	stdLogger := logrus.StandardLogger()
+	origOut := stdLogger.Out
+	stdLogger.SetOutput(&buf)
+	defer stdLogger.SetOutput(origOut)
+
+	r1.RegisterPreSamplingHook(&fixedSeedHook{seed: seedFirst})
+	assert.Empty(t, buf.String(),
+		"first PreSamplingHook registration must be silent")
+
+	r1.RegisterPreSamplingHook(&fixedSeedHook{seed: seedLast})
+	assert.Contains(t, buf.String(), "already has",
+		"second PreSamplingHook registration must emit a logrus warning")
+
+	rt := wiop.NewRuntime(sys)
+	rt.AssignColumn(col, baseVec(4, 0))
+	rt.AdvanceRound()
+
+	// Expected coin derives from seedLast, since it is registered second
+	// and overwrites the first hook's SetFSState.
+	fs := fiatshamir.NewFiatShamir()
+	fs.SetState(seedLast)
+	expected := field.ElemFromExt(fs.RandomFext())
+
+	assert.Equal(t, expected, rt.GetCoinValue(coin),
+		"PreSamplingHooks must fire in registration order; the last SetFSState wins")
 }
 
 func TestRuntime_GetCoinValue_NotSampledPanic(t *testing.T) {

--- a/prover-ray/wiop/wiop_system.go
+++ b/prover-ray/wiop/wiop_system.go
@@ -30,6 +30,22 @@ type System struct {
 	// LogDerivativeSums holds all [LogDerivativeSum] queries registered with
 	// this system via [System.NewLogDerivativeSum], in declaration order.
 	LogDerivativeSums []*LogDerivativeSum
+	// MessageBuses holds all [MessageBus] queries registered with this system
+	// via [System.NewMessageBusSend] and [System.NewMessageBusReceive], in
+	// declaration order.
+	MessageBuses []*MessageBus
+	// MessageBusSkipInShardCheck controls whether the messagebus compiler
+	// registers its per-handle in-shard verifier action — a
+	// [messagebus.CheckHandleSumInShard] — which asserts the per-segment LDS
+	// Results sum to that action's Expected value on this shard alone. When
+	// false (the default) the pass registers one such action per handle,
+	// preserving the single-shard "sum is zero" guarantee. Set to true in
+	// sharded protocols where a downstream cross-shard layer owns the
+	// consistency check and the in-shard residual must remain unasserted so
+	// it can be carried over to the cross-shard identity (typically the
+	// cross-shard layer registers its own CheckHandleSumInShard instances
+	// with appropriate non-zero Expected values).
+	MessageBusSkipInShardCheck bool
 	// scratchArena backs the [PlanningContext] used by [Materialize]. It is
 	// nil until Materialize is called.
 	scratchArena *arena.VectorArena


### PR DESCRIPTION
This PR implements issue(s) [#2927](https://github.com/LFDT-Lineth/lineth-monorepo/issues/2927)

It adds the `MessageBus` query and its per-shard compiler pass: each handle's
entries reduce to one `LogDerivativeSum` whose Result is this shard's residual
on the handle, asserted by `CheckHandleSumInShard{Cell, Expected}` `

Compile` is strictly per-shard — all unreduced entries
must share `OriginShard` or it panics — and a cross-shard layer will later be able to 
suppress the in-shard assertion via `System.MessageBusSkipInShardCheck` to plug its
own identity across shards.

Adds `Round.PreSamplingHooks` + `Runtime.SetFSState`: a sharded caller
pre-allocates the coin round and registers a hook that seeds the
Fiat–Shamir state from shared randomness; `AdvanceRound` fires the hook
between absorbing the previous round's commitments and sampling this
round's coins. `messagebus.Compile`'s `ensureRoundAfter` reuses any
pre-existing tail round, so α and β land on the same round the hook lives
on — every shard derives the same coins from the same seed.

Extends dynamic-module support through `LogDerivativeSum`:
`ColumnPosition.Position` now accepts negative end-indexed values (−1 =
last row), `LocalOpening` and `ColumnPosition.EvaluateSingle` resolve them
per-Runtime, and `buildZ` uses `zCol.At(-1)` for the endpoint opening
instead of a compile-time `m.Size()-1`. Recurrence Vanishing is emitted
unconditionally for dynamic modules; static n==1 still skips it.

Test coverage: every messagebus completeness/soundness test runs in both
`natural-fs` and `with-presampling-hook` subtests; dynamic-module
completeness + soundness suite at both messagebus and LDS layers
(including the n==1 corner case); mixed-shard and width-mismatch panic
tests pin down the new invariants. Full prover-ray suite green; gofmt +
golangci-lint clean on `./wiop/...`.
