### PR TITLE
fix(prover): populate isAllowedCircuitID in aggregation response

### DIFF
--- a/prover/backend/aggregation/craft.go
+++ b/prover/backend/aggregation/craft.go
@@ -274,6 +274,7 @@ func CraftResponse(cfg *config.Config, cf *CollectedFields) (resp *Response, err
 		BaseFee:              uint64(cfg.Layer2.BaseFee),
 		CoinBase:             types.EthAddress(cfg.Layer2.CoinBase),
 		L2MessageServiceAddr: types.EthAddress(cfg.Layer2.MsgSvcContract),
+		IsAllowedCircuitID:   uint64(cfg.Aggregation.IsAllowedCircuitID),
 
 		FilteredAddresses: filteredAddrs,
 	}


### PR DESCRIPTION
Commit 8f2a5f5b wired IsAllowedCircuitID into the aggregation public-input hash (pubInputParts) but never assigned it to the Response struct that is serialized to the proof JSON. As a result the response always reported "isAllowedCircuitID": 0 regardless of the configured value, even though the value was correctly folded into the public input.

Assign IsAllowedCircuitID from cfg.Aggregation in the resp literal so the serialized response matches the configured bitmask. Placing it in the resp literal also covers proofless jobs, which return before pubInputParts is built.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
