### PR TITLE
test(prover):add in-circuit isAllowedCircuitID rejection test

### DIFF
--- a/prover/circuits/aggregation/circuit_test.go
+++ b/prover/circuits/aggregation/circuit_test.go
@@ -109,12 +109,31 @@ func TestAggregationFewDifferentInners(t *testing.T) {
 	testAggregation(t, 3, 2, 6, 10)
 }
 
+// A sub-proof whose circuit ID is not set in the mask must make the aggregation
+// circuit unsatisfiable. Claims use IDs {0,1}; mask 0b10 disallows ID 0.
+func TestAggregationAllowlistRejectsDisallowedCircuit(t *testing.T) {
+	runAggregation(t, 0b10, true, 2, 5)
+}
+
+// A non-all-ones mask that still permits every ID in use must solve. Claims use
+// IDs {0,1}; mask 0b011 permits them and clears unused bit 2.
+func TestAggregationAllowlistAcceptsWithRestrictiveMask(t *testing.T) {
+	runAggregation(t, 0b011, false, 3, 5)
+}
+
 // It generates subCircuits (exec/decomp/invalidity) and interconnection proofs to be aggregated.
 //
 //	nbVerifyingKey and maxNbProofs are parameters for the subCircuits (exec/decomp/invalidity).
 //
 // To generate the proofs based on the same SRS, replace the occurrence of circuits.MockCircuitID() with circuits.MockCircuitID(0).
 func testAggregation(t *testing.T, nbVerifyingKey int, maxNbProofs ...int) {
+	// Allow-all bitmask: every circuit ID used in the test is permitted.
+	runAggregation(t, (1<<nbVerifyingKey)-1, false, nbVerifyingKey, maxNbProofs...)
+}
+
+// runAggregation checks the aggregation circuit with the given IsAllowedCircuitID
+// mask. expectSolveErr asserts the allow-list gate rejects the witness.
+func runAggregation(t *testing.T, isAllowedMask int, expectSolveErr bool, nbVerifyingKey int, maxNbProofs ...int) {
 
 	// Mock circuits (exec, comp,invalidity) to aggregate
 	var innerSetups []circuits.Setup
@@ -208,9 +227,6 @@ func testAggregation(t *testing.T, nbVerifyingKey int, maxNbProofs ...int) {
 		decompPI := utils.RightPad(innerPiPartition[typeDecomp], len(piCircuit.DecompressionPublicInput))
 		invalPI := utils.RightPad(innerPiPartition[typeInval], len(piCircuit.InvalidityPublicInput))
 
-		// Set IsAllowedCircuitID bitmask to allow all circuit IDs used in the test.
-		isAllowedMask := (1 << nbVerifyingKey) - 1
-
 		piAssignment := pi_interconnection.DummyCircuit{
 			AggregationPublicInput:   [2]frontend.Variable{aggregationPIBytes[:16], aggregationPIBytes[16:]},
 			ExecutionPublicInput:     utils.ToVariableSlice(execPI),
@@ -248,7 +264,12 @@ func testAggregation(t *testing.T, nbVerifyingKey int, maxNbProofs ...int) {
 		aggrAssignment, err := aggregation.AssignAggregationCircuit(nc, innerProofClaims, piInfo, aggregationPI)
 		assert.NoError(t, err)
 
-		assert.NoError(t, test.IsSolved(aggrCircuit, aggrAssignment, ecc.BW6_761.ScalarField()))
+		solveErr := test.IsSolved(aggrCircuit, aggrAssignment, ecc.BW6_761.ScalarField())
+		if expectSolveErr {
+			assert.Error(t, solveErr, "allow-list gate should reject a disallowed circuit ID")
+		} else {
+			assert.NoError(t, solveErr)
+		}
 	}
 
 }

--- a/prover/circuits/registry.go
+++ b/prover/circuits/registry.go
@@ -70,21 +70,20 @@ const (
 //
 //	execution-dummy (ID 0, bit 0)                              = 0 → DISALLOWED
 //	data-availability-dummy (ID 1, bit 1)                      = 0 → DISALLOWED
-//	emulation-dummy (ID 2, bit 2)                              = 0 → DISALLOWED
-//	execution (ID 3, bit 3)                                    = 1 → ALLOWED
-//	execution-large (ID 4, bit 4)                              = 1 → ALLOWED
-//	execution-limitless (ID 5, bit 5)                          = 1 → ALLOWED
-//	data-availability-v2 (ID 6, bit 6)                         = 1 → ALLOWED
-//	invalidity-nonce-balance-dummy (ID 7, bit 7)               = 0 → DISALLOWED
-//	invalidity-precompile-logs-dummy (ID 8, bit 8)             = 0 → DISALLOWED
-//	invalidity-filtered-address-dummy (ID 9, bit 9)            = 0 → DISALLOWED
-//	invalidity-nonce-balance (ID 10, bit 10)                   = 1 → ALLOWED
-//	invalidity-precompile-logs (ID 11, bit 11)                 = 1 → ALLOWED
-//	invalidity-filtered-address (ID 12, bit 12)                = 1 → ALLOWED
-//	invalidity-precompile-logs-limitless (ID 13, bit 13)       = 1 → ALLOWED
-//	invalidity-precompile-logs-large (ID 14, bit 14)           = 1 → ALLOWED
-//	Binary: 0b111110001111000 = 31864 (decimal)
-//	is_allowed_circuit_id = 31864
+//	execution (ID 2, bit 2)                                    = 1 → ALLOWED
+//	execution-large (ID 3, bit 3)                              = 1 → ALLOWED
+//	execution-limitless (ID 4, bit 4)                          = 1 → ALLOWED
+//	data-availability-v2 (ID 5, bit 5)                         = 1 → ALLOWED
+//	invalidity-nonce-balance-dummy (ID 6, bit 6)               = 0 → DISALLOWED
+//	invalidity-precompile-logs-dummy (ID 7, bit 7)             = 0 → DISALLOWED
+//	invalidity-filtered-address-dummy (ID 8, bit 8)            = 0 → DISALLOWED
+//	invalidity-nonce-balance (ID 9, bit 9)                     = 1 → ALLOWED
+//	invalidity-precompile-logs (ID 10, bit 10)                 = 1 → ALLOWED
+//	invalidity-filtered-address (ID 11, bit 11)               = 1 → ALLOWED
+//	invalidity-precompile-logs-limitless (ID 12, bit 12)       = 1 → ALLOWED
+//	invalidity-precompile-logs-large (ID 13, bit 13)           = 1 → ALLOWED
+//	Binary: 0b11111000111100 = 15932 (decimal)
+//	is_allowed_circuit_id = 15932
 //
 // Use ComputeIsAllowedCircuitID() to calculate the bitmask from circuit names.
 var GlobalCircuitIDMapping = map[string]uint{


### PR DESCRIPTION
Add tests for the aggregation allow-list check
(AssertIsEqual(isCircuitAllowed[CircuitID], 1)): a negative test where a disallowed circuit ID makes the proof fail, and a positive test using a non-all-ones mask.

Also correct the GlobalCircuitIDMapping doc example to match the actual 14-circuit mapping (execution at bit 2, mainnet 15932) instead of a stale 15-circuit order (emulation-dummy at bit 2, mainnet 31864).

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
