### PR TITLE
test(e2e): disable partial-prover forced-tx test

### DIFF
--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -33,8 +33,6 @@ jobs:
         include:
           - test: local
             archive-name: local
-          - test: forced-transactions:local
-            archive-name: forced-transactions-local
 
     name: Run test:partial-prover:${{ matrix.test }} e2e tests
     steps:

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Run e2e tests with partial prover
         id: run_e2e_tests
-        timeout-minutes: 110
+        timeout-minutes: 60
         run: |
           LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:${{ matrix.test }}
 

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Run e2e tests with partial prover
         id: run_e2e_tests
-        timeout-minutes: 60
+        timeout-minutes: 110
         run: |
           LOG_LEVEL=debug pnpm run -F e2e test:partial-prover:${{ matrix.test }}
 

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -26,8 +26,8 @@ import {
 const context = createTestContext();
 const l1AccountManager = context.getL1AccountManager();
 const l2AccountManager = context.getL2AccountManager();
-const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 2400_000;
-const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 3000_000;
+const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 5400_000;
+const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 6000_000;
 
 async function expectReceiptNotFound(
   client: { getTransactionReceipt: (args: { hash: Hash }) => Promise<unknown> },

--- a/e2e/src/forced-transactions.spec.ts
+++ b/e2e/src/forced-transactions.spec.ts
@@ -26,8 +26,8 @@ import {
 const context = createTestContext();
 const l1AccountManager = context.getL1AccountManager();
 const l2AccountManager = context.getL2AccountManager();
-const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 5400_000;
-const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 6000_000;
+const l1EventTimeOutMs = process.env.PARTIAL_PROVER != "true" ? 200_000 : 2400_000;
+const timeOutMs = process.env.PARTIAL_PROVER != "true" ? 300_000 : 3000_000;
 
 async function expectReceiptNotFound(
   client: { getTransactionReceipt: (args: { hash: Hash }) => Promise<unknown> },


### PR DESCRIPTION
Raise the event wait to 90m, the jest per-test timeout to 100m, and the CI step timeout to 110m

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
