### PR TITLE
fix(coordinator): drop insecure FileWriter temp-file fallback (CodeQL 21207)

### DIFF
--- a/coordinator/utilities/src/main/kotlin/linea/fileio/FileWriter.kt
+++ b/coordinator/utilities/src/main/kotlin/linea/fileio/FileWriter.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.vertx.core.Vertx
 import net.consensys.linea.async.toSafeFuture
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.io.File
 import java.nio.file.Path
 import java.util.concurrent.Callable
 import kotlin.io.path.exists
@@ -17,16 +16,11 @@ class FileWriter(
   private val vertx: Vertx,
   private val mapper: ObjectMapper,
 ) {
-  fun write(data: Any, filePath: Path, inProgressSuffix: String?): SafeFuture<Path> {
+  fun write(data: Any, filePath: Path, inProgressSuffix: String): SafeFuture<Path> {
     return vertx
       .executeBlocking(
         Callable {
-          val tmpFile =
-            if (inProgressSuffix != null) {
-              inProgressFilePath(filePath, inProgressSuffix).toFile()
-            } else {
-              File.createTempFile(filePath.fileName.toString(), null)
-            }
+          val tmpFile = inProgressFilePath(filePath, inProgressSuffix).toFile()
           mapper.writeValue(tmpFile, data)
           tmpFile.renameTo(filePath.toFile())
           filePath

--- a/coordinator/utilities/src/test/kotlin/linea/fileio/FileWriterTest.kt
+++ b/coordinator/utilities/src/test/kotlin/linea/fileio/FileWriterTest.kt
@@ -32,17 +32,4 @@ class FileWriterTest {
       text,
     )
   }
-
-  @Test
-  fun write_withoutInProgressSuffix(vertx: Vertx) {
-    val testFilePath = File.createTempFile("file-writer-test", null).toPath()
-    val data = "test-data"
-    val fileWriter = FileWriter(vertx, mapper)
-    val result = fileWriter.write(data, testFilePath, null).get()
-    val text = mapper.readValue(result.toFile(), String::class.java)
-    Assertions.assertEquals(
-      data,
-      text,
-    )
-  }
 }


### PR DESCRIPTION


This PR implements issue(s) [#Linea-Security-Reports/issues/31](https://github.com/Consensys/Linea-Security-Reports/issues/31)

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized API tightening with existing callers already supplying a suffix; no auth or data-model changes.
> 
> **Overview**
> Addresses CodeQL **21207** by removing the `FileWriter.write` path that used `File.createTempFile` when `inProgressSuffix` was null.
> 
> **`inProgressSuffix` is now required** on `write`, and every write goes through the existing adjacent `.<suffix>` staging file before rename to the final path. The nullable branch and `java.io.File` import are dropped, and the test that covered null-suffix behavior is removed. Production file-based prover clients already pass a configured in-progress suffix, so behavior there stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31c1feab1a2a90c9fe222ecd18b9ef747712f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->