### PR TITLE
fix: make smart contract skill commit step conditional on explicit user request

### DIFF
--- a/.agents/skills/developing-smart-contracts/SKILL.md
+++ b/.agents/skills/developing-smart-contracts/SKILL.md
@@ -149,11 +149,11 @@ Follow this sequence when writing or modifying Solidity contracts:
    ```
 5. **Verify NatSpec coverage**: confirm all public/external functions, events, and errors have complete docstrings with `@notice`, `@param` (in signature order), and `@return`.
 6. **Review gas patterns**: check for unnecessary `memory` copies, repeated storage reads, and missing batch limits.
-7. **Commit** after passing the checklist below.
+7. **Commit** only if the user explicitly requested a commit: review the staged diff and confirm every item in the checklist below passes before committing.
 
-## Commit Checklist
+## Pre-Commit Checklist
 
-Before making a commit, please verify:
+Run through this before committing (skip if the user only asked for a code change or review):
 
 - [ ] Rules on licenses and Solidity pragma have been applied
 - [ ] All public items have NatSpec docstrings (`@notice`, `@param`, `@return`)


### PR DESCRIPTION
This PR implements issue(s) #

## Summary

- Makes the Development Workflow commit step conditional on an explicit user request
- Renames "Commit Checklist" to "Pre-Commit Checklist" to avoid implying commits are mandatory
- Clarifies that the checklist can be skipped when the user only asked for a code change or review

## Problem

The smart contract skill's Development Workflow ended with an imperative **Commit** step ("Commit after passing the checklist below"). That wording caused agents to treat committing as mandatory even when the user only asked for a code change or review.

## Solution

Update step 7 in `.agents/skills/developing-smart-contracts/SKILL.md` to gate commits behind explicit user request and staged-diff review. Rename the checklist section and add guidance to skip it for non-commit tasks.

## Related

None

## Scope

- `.agents/skills/developing-smart-contracts/SKILL.md`

## Test Plan

- [x] Verified wording change in SKILL.md
- [x] Doc drift check: no other documentation references the old "Commit Checklist" heading

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR.
* [ ] I have informed the team of any breaking changes if there are any.


Made with [Cursor](https://cursor.com)