### PR TITLE
fix(prover): bump BLOCKHASH module limit from 2048 to 4096

### DIFF
--- a/prover/config/config-devnet-full.toml
+++ b/prover/config/config-devnet-full.toml
@@ -69,7 +69,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/config-devnet-limitless.toml
+++ b/prover/config/config-devnet-limitless.toml
@@ -71,7 +71,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/config-integration-benchmark.toml
+++ b/prover/config/config-integration-benchmark.toml
@@ -54,7 +54,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/config-integration-development.toml
+++ b/prover/config/config-integration-development.toml
@@ -58,7 +58,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/config-integration-full.toml
+++ b/prover/config/config-integration-full.toml
@@ -55,7 +55,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/config-mainnet-limitless.toml
+++ b/prover/config/config-mainnet-limitless.toml
@@ -73,7 +73,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/config-sepolia-limitless.toml
+++ b/prover/config/config-sepolia-limitless.toml
@@ -71,7 +71,7 @@ modules = [
     {module = "BIN", limit = 262144, limit_large = 524288},
     {module = "BLAKE2FMODEXPDATA", limit = 16384, limit_large = 32768},
     {module = "BLOCKDATA", limit = 4096, limit_large = 8192},
-    {module = "BLOCKHASH", limit = 2048, limit_large = 4096},
+    {module = "BLOCKHASH", limit = 4096, limit_large = 8192},
     {module = "ECDATA", limit = 65536, limit_large = 131072},
     {module = "EUC", limit = 65536, limit_large = 131072},
     {module = "EXP", limit = 65536, limit_large = 131072},

--- a/prover/config/traces_limit.go
+++ b/prover/config/traces_limit.go
@@ -427,7 +427,7 @@ func GetTestTracesLimits() *TracesLimits {
 			{Module: "bin", Limit: 262144, LimitLarge: 524288},
 			{Module: "blake2fmodexpdata", Limit: 16384, LimitLarge: 32768},
 			{Module: "blockdata", Limit: 4096, LimitLarge: 8192},
-			{Module: "blockhash", Limit: 2048, LimitLarge: 4096},
+			{Module: "blockhash", Limit: 4096, LimitLarge: 8192},
 			{Module: "ecdata", Limit: 65536, LimitLarge: 131072},
 			{Module: "euc", Limit: 65536, LimitLarge: 131072},
 			{Module: "exp", Limit: 65536, LimitLarge: 131072},


### PR DESCRIPTION
This PR bumps prover BLOCKHASH module limit from 2048 to 4096

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
