### PR TITLE
chore(contracts): add forced transactions audits

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -52,6 +52,14 @@
 - Linea Tokens Audit Report: [https://github.com/Cyfrin/cyfrin-audit-reports/blob/b9aace5911e3ff84488cb5199cfd28e7fe24d6aa/reports/2025-09-10-cyfrin-linea-tokens-v2.5.pdf](https://github.com/Cyfrin/cyfrin-audit-reports/blob/b9aace5911e3ff84488cb5199cfd28e7fe24d6aa/reports/2025-09-10-cyfrin-linea-tokens-v2.5.pdf)
 
 ---
+## Linea Rollup, L2MessageService and TokenBridge Smart Contract Audits
+### Eighth Audit Round
+#### Forced Transactions
+**Diligence**
+- Linea Forced Transactions - [https://diligence.security/audits/2026/02/linea-forced-transactions/](https://diligence.security/audits/2026/02/linea-forced-transactions/)
+
+**Cyfrin**
+- Linea Forced Transactions - [https://github.com/Cyfrin/cyfrin-audit-reports/blob/9397aab67a15854b08eb302722cdebf5ddb3ac3f/reports/2026-06-18-cyfrin-linea-forced-txns-v2.0.pdf](https://github.com/Cyfrin/cyfrin-audit-reports/blob/9397aab67a15854b08eb302722cdebf5ddb3ac3f/reports/2026-06-18-cyfrin-linea-forced-txns-v2.0.pdf)
 
 ## Linea Rollup, L2MessageService and TokenBridge Smart Contract Audits
 ### Seventh Audit Round


### PR DESCRIPTION
This PR implements issue(s) : add forced transactions audits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to audit index links; no runtime or contract code is modified.
> 
> **Overview**
> Adds an **Eighth Audit Round** subsection under rollup/message-service/bridge audits in `docs/audits.md`, scoped to **Forced Transactions**, with links to Consensys Diligence and Cyfrin reports.
> 
> The new block is inserted above the existing Seventh Audit Round so the rollup audit list stays ordered from newest round to older rounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8218d13d1be652c4924e85a1e97f18a01b05a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->