### PR TITLE
refactor(contracts): centralize deploy helpers and validate nonce env vars

### DIFF
--- a/contracts/common/helpers/deployments.test.ts
+++ b/contracts/common/helpers/deployments.test.ts
@@ -1,0 +1,123 @@
+import { AbstractSigner } from "ethers";
+import fs from "fs";
+import * as assert from "node:assert/strict";
+import os from "os";
+import path from "path";
+
+import { getDeployNonceFromEnv, loadArtifactFromDirectory } from "./deployments";
+
+type TestCase = {
+  name: string;
+  run: () => Promise<void> | void;
+};
+
+const ENV_NAME = "LINETH_DEPLOY_NONCE_TEST_NONCE";
+
+function withEnv(value: string | undefined, run: () => Promise<void> | void): Promise<void> | void {
+  const previous = process.env[ENV_NAME];
+  if (value === undefined) {
+    delete process.env[ENV_NAME];
+  } else {
+    process.env[ENV_NAME] = value;
+  }
+  const restore = () => {
+    if (previous === undefined) {
+      delete process.env[ENV_NAME];
+    } else {
+      process.env[ENV_NAME] = previous;
+    }
+  };
+  try {
+    const result = run();
+    if (result instanceof Promise) {
+      return result.finally(restore);
+    }
+    restore();
+    return result;
+  } catch (error) {
+    restore();
+    throw error;
+  }
+}
+
+function mockWallet(liveNonce: number): AbstractSigner {
+  return {
+    getNonce: async () => liveNonce,
+  } as unknown as AbstractSigner;
+}
+
+const tests: TestCase[] = [
+  {
+    name: "getDeployNonceFromEnv uses the env value plus offset when set",
+    run: async () => {
+      await withEnv("10", async () => {
+        assert.equal(await getDeployNonceFromEnv(mockWallet(999), ENV_NAME), 10);
+        assert.equal(await getDeployNonceFromEnv(mockWallet(999), ENV_NAME, 5), 15);
+      });
+    },
+  },
+  {
+    name: "getDeployNonceFromEnv falls back to the live wallet nonce plus offset when unset or empty",
+    run: async () => {
+      await withEnv(undefined, async () => {
+        assert.equal(await getDeployNonceFromEnv(mockWallet(42), ENV_NAME), 42);
+        assert.equal(await getDeployNonceFromEnv(mockWallet(42), ENV_NAME, 3), 45);
+      });
+      await withEnv("", async () => {
+        assert.equal(await getDeployNonceFromEnv(mockWallet(7), ENV_NAME, 1), 8);
+      });
+    },
+  },
+  {
+    name: "getDeployNonceFromEnv throws on non-integer env values",
+    run: async () => {
+      for (const value of ["abc", "5x", "-1", "1e3", "1.5"]) {
+        await withEnv(value, async () => {
+          await assert.rejects(() => getDeployNonceFromEnv(mockWallet(0), ENV_NAME), /must be a non-negative integer/);
+        });
+      }
+    },
+  },
+  {
+    name: "loadArtifactFromDirectory reads a JSON artifact from disk",
+    run: () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lineth-artifact-test-"));
+      try {
+        const artifact = { abi: [{ type: "function", name: "foo" }], bytecode: "0x1234" };
+        fs.writeFileSync(path.join(dir, "Foo.json"), JSON.stringify(artifact));
+        assert.deepEqual(loadArtifactFromDirectory(dir, "Foo"), artifact);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+  {
+    name: "loadArtifactFromDirectory throws with folder and contract name when the file is missing",
+    run: () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lineth-artifact-test-"));
+      try {
+        assert.throws(
+          () => loadArtifactFromDirectory(dir, "Missing"),
+          (error: unknown) => {
+            const message = error instanceof Error ? error.message : String(error);
+            return message.includes("Missing") && message.includes(dir);
+          },
+        );
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  },
+];
+
+async function main() {
+  for (const test of tests) {
+    await test.run();
+    console.log(`ok - ${test.name}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/contracts/common/helpers/deployments.test.ts
+++ b/contracts/common/helpers/deployments.test.ts
@@ -57,14 +57,14 @@ const tests: TestCase[] = [
     },
   },
   {
-    name: "getDeployNonceFromEnv falls back to the live wallet nonce plus offset when unset or empty",
+    name: "getDeployNonceFromEnv falls back to the live wallet nonce when unset or empty (offset ignored)",
     run: async () => {
       await withEnv(undefined, async () => {
         assert.equal(await getDeployNonceFromEnv(mockWallet(42), ENV_NAME), 42);
-        assert.equal(await getDeployNonceFromEnv(mockWallet(42), ENV_NAME, 3), 45);
+        assert.equal(await getDeployNonceFromEnv(mockWallet(42), ENV_NAME, 3), 42);
       });
       await withEnv("", async () => {
-        assert.equal(await getDeployNonceFromEnv(mockWallet(7), ENV_NAME, 1), 8);
+        assert.equal(await getDeployNonceFromEnv(mockWallet(7), ENV_NAME, 1), 7);
       });
     },
   },

--- a/contracts/common/helpers/deployments.ts
+++ b/contracts/common/helpers/deployments.ts
@@ -1,4 +1,6 @@
 import { ethers, AbstractSigner, Interface, InterfaceAbi, BaseContract } from "ethers";
+import fs from "fs";
+import path from "path";
 
 import { normalizeAddressArgs } from "./normalize-address-args";
 import { clearSignerUiWorkflowStatus, setSignerUiWorkflowStatus } from "./signerUiWorkflowStatus";
@@ -12,6 +14,41 @@ import {
   abi as TransparentUpgradeableProxyAbi,
   bytecode as TransparentUpgradeableProxyBytecode,
 } from "../../deployments/bytecode/mainnet-proxy/TransparentUpgradeableProxy.json";
+
+/**
+ * Loads a compiled contract artifact ("<contractName>.json") from a directory.
+ * Replaces the per-script `findContractArtifacts` copies in local-deployments-artifacts.
+ */
+export function loadArtifactFromDirectory(
+  folderPath: string,
+  contractName: string,
+): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
+  const fileName = `${contractName}.json`;
+  const filePath = path.join(folderPath, fileName);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
+  }
+  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
+  return JSON.parse(fileContent);
+}
+
+/**
+ * Resolves a deploy nonce from an env var (e.g. "L1_NONCE"/"L2_NONCE"), validated as a
+ * non-negative integer. When the var is unset/empty, falls back to the wallet's live nonce.
+ * `offset` is added on top for scripts that deploy in a fixed order from a base nonce.
+ *
+ * Replaces the unvalidated `parseInt(process.env.L1_NONCE)` pattern across deploy scripts.
+ */
+export async function getDeployNonceFromEnv(wallet: AbstractSigner, envVarName: string, offset = 0): Promise<number> {
+  const raw = process.env[envVarName];
+  if (raw === undefined || raw === "") {
+    return (await wallet.getNonce()) + offset;
+  }
+  if (!/^[0-9]+$/.test(raw)) {
+    throw new Error(`${envVarName} must be a non-negative integer, got: ${raw}`);
+  }
+  return Number(raw) + offset;
+}
 
 export function getInitializerData(contractAbi: InterfaceAbi, initializerFunctionName: string, args: unknown[]) {
   const contractInterface = new Interface(contractAbi);

--- a/contracts/common/helpers/deployments.ts
+++ b/contracts/common/helpers/deployments.ts
@@ -35,14 +35,14 @@ export function loadArtifactFromDirectory(
 /**
  * Resolves a deploy nonce from an env var (e.g. "L1_NONCE"/"L2_NONCE"), validated as a
  * non-negative integer. When the var is unset/empty, falls back to the wallet's live nonce.
- * `offset` is added on top for scripts that deploy in a fixed order from a base nonce.
+ * `offset` is added only when the env var is set, for scripts that deploy in a fixed order from a base nonce.
  *
  * Replaces the unvalidated `parseInt(process.env.L1_NONCE)` pattern across deploy scripts.
  */
 export async function getDeployNonceFromEnv(wallet: AbstractSigner, envVarName: string, offset = 0): Promise<number> {
   const raw = process.env[envVarName];
   if (raw === undefined || raw === "") {
-    return (await wallet.getNonce()) + offset;
+    return await wallet.getNonce();
   }
   if (!/^[0-9]+$/.test(raw)) {
     throw new Error(`${envVarName} must be a non-negative integer, got: ${raw}`);

--- a/contracts/common/helpers/environment.test.ts
+++ b/contracts/common/helpers/environment.test.ts
@@ -1,0 +1,88 @@
+import * as assert from "node:assert/strict";
+
+import { getBooleanEnvVar, getBooleanEnvVarOrDefault } from "./environment";
+
+type TestCase = {
+  name: string;
+  run: () => Promise<void> | void;
+};
+
+const ENV_NAME = "LINETH_BOOLEAN_ENV_VAR_TEST_FLAG";
+
+function withEnv(value: string | undefined, run: () => void): void {
+  const previous = process.env[ENV_NAME];
+  if (value === undefined) {
+    delete process.env[ENV_NAME];
+  } else {
+    process.env[ENV_NAME] = value;
+  }
+  try {
+    run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[ENV_NAME];
+    } else {
+      process.env[ENV_NAME] = previous;
+    }
+  }
+}
+
+const tests: TestCase[] = [
+  {
+    name: 'getBooleanEnvVarOrDefault parses "true" and "false"',
+    run: () => {
+      withEnv("true", () => assert.equal(getBooleanEnvVarOrDefault(ENV_NAME, false), true));
+      withEnv("false", () => assert.equal(getBooleanEnvVarOrDefault(ENV_NAME, true), false));
+    },
+  },
+  {
+    name: "getBooleanEnvVarOrDefault returns the default when unset or empty",
+    run: () => {
+      withEnv(undefined, () => assert.equal(getBooleanEnvVarOrDefault(ENV_NAME, true), true));
+      withEnv(undefined, () => assert.equal(getBooleanEnvVarOrDefault(ENV_NAME, false), false));
+      withEnv("", () => assert.equal(getBooleanEnvVarOrDefault(ENV_NAME, true), true));
+      withEnv("", () => assert.equal(getBooleanEnvVarOrDefault(ENV_NAME, false), false));
+    },
+  },
+  {
+    name: "getBooleanEnvVarOrDefault throws on any other value",
+    run: () => {
+      withEnv("1", () =>
+        assert.throws(() => getBooleanEnvVarOrDefault(ENV_NAME, false), /must be either "true" or "false"/),
+      );
+      withEnv("yes", () =>
+        assert.throws(() => getBooleanEnvVarOrDefault(ENV_NAME, false), /must be either "true" or "false"/),
+      );
+      withEnv("TRUE", () =>
+        assert.throws(() => getBooleanEnvVarOrDefault(ENV_NAME, false), /must be either "true" or "false"/),
+      );
+    },
+  },
+  {
+    name: "getBooleanEnvVar throws when unset or empty",
+    run: () => {
+      withEnv(undefined, () => assert.throws(() => getBooleanEnvVar(ENV_NAME), /missing or empty/));
+      withEnv("", () => assert.throws(() => getBooleanEnvVar(ENV_NAME), /missing or empty/));
+    },
+  },
+  {
+    name: "getBooleanEnvVar parses a set boolean value",
+    run: () => {
+      withEnv("true", () => assert.equal(getBooleanEnvVar(ENV_NAME), true));
+      withEnv("false", () => assert.equal(getBooleanEnvVar(ENV_NAME), false));
+      withEnv("nope", () => assert.throws(() => getBooleanEnvVar(ENV_NAME), /must be either "true" or "false"/));
+    },
+  },
+];
+
+async function main() {
+  for (const test of tests) {
+    await test.run();
+    console.log(`ok - ${test.name}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/contracts/common/helpers/environment.ts
+++ b/contracts/common/helpers/environment.ts
@@ -43,6 +43,30 @@ export function getEnvVarOrDefault(envVar: string, defaultValue: unknown) {
   return envValue;
 }
 
+/**
+ * Parses a strict boolean env var ("true"/"false"). Returns `defaultValue` when unset/empty.
+ * Throws on any other value so a typo never silently becomes `false`.
+ * Do NOT route booleans through getEnvVarOrDefault — it returns the string "false" (truthy).
+ */
+export function getBooleanEnvVarOrDefault(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return defaultValue;
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  throw new Error(`${name} must be either "true" or "false", got: ${raw}`);
+}
+
+/** Strict required boolean — throws when unset/empty. Use for required flags. */
+export function getBooleanEnvVar(name: string): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    throw new Error(`Required boolean environment variable "${name}" is missing or empty.`);
+  }
+  return getBooleanEnvVarOrDefault(name, false);
+}
+
 export function getOptionalEnvVar(name: string): string | undefined {
   const envValue = process.env[name];
   if (envValue === undefined) {

--- a/contracts/common/helpers/feeOverrides.ts
+++ b/contracts/common/helpers/feeOverrides.ts
@@ -42,6 +42,14 @@ export function assertSingleFeeModel(fees: FeeOverrides): FeeOverrides {
   return fees;
 }
 
+// Fixed local-devnet L2 deploy fees (gwei-scale wei). Centralizes the value copied
+// across local L2 deploy scripts. These are deterministic local-only fees, not a policy
+// for real networks. Validated as a single complete EIP-1559 model.
+export const LOCAL_L2_DEPLOY_FEE_OVERRIDES: FeeOverrides = assertSingleFeeModel({
+  maxFeePerGas: 7_200_000_000_000n,
+  maxPriorityFeePerGas: 7_000_000_000_000n,
+});
+
 // Effective per-gas price used to size a value+gas budget: the legacy gasPrice
 // when legacy fees are selected, otherwise the EIP-1559 ceiling maxFeePerGas.
 export function feeBudgetPricePerGas(fees: FeeOverrides): bigint {

--- a/contracts/common/helpers/index.ts
+++ b/contracts/common/helpers/index.ts
@@ -5,6 +5,7 @@ export * from "./environment";
 export * from "./envVarLogging";
 export * from "./auditedDeployVerifier";
 export * from "./deployments";
+export * from "./feeOverrides";
 export * from "./deploymentHandoff";
 export * from "./environmentHelper";
 export * from "./addressRegistry";

--- a/contracts/deploy/03_deploy_ImplementationForProxy.ts
+++ b/contracts/deploy/03_deploy_ImplementationForProxy.ts
@@ -2,7 +2,12 @@ import { ethers, upgrades } from "hardhat";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 
-import { getRequiredEnvVar, requireAddressFromRegistryOrEnv, tryVerifyContract } from "../common/helpers";
+import {
+  getBooleanEnvVarOrDefault,
+  getRequiredEnvVar,
+  requireAddressFromRegistryOrEnv,
+  tryVerifyContract,
+} from "../common/helpers";
 import { getUiSigner, withSignerUiSession } from "../scripts/hardhat/signer-ui-bridge";
 
 /**
@@ -28,7 +33,7 @@ const CONTRACT_PROXY_MAP: Record<string, { registryKey: string; envVar: string }
   Validium: { registryKey: "Validium", envVar: "PROXY_ADDRESS" },
   L2MessageService: { registryKey: "L2MessageService", envVar: "L2_MESSAGE_SERVICE_ADDRESS" },
   TokenBridge: {
-    registryKey: process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true" ? "TokenBridge_L1" : "TokenBridge_L2",
+    registryKey: getBooleanEnvVarOrDefault("DEPLOY_TOKEN_BRIDGE_ON_L1", false) ? "TokenBridge_L1" : "TokenBridge_L2",
     envVar: "TOKEN_BRIDGE_ADDRESS",
   },
   CallForwardingProxy: { registryKey: "CallForwardingProxy", envVar: "PROXY_ADDRESS" },

--- a/contracts/deploy/05_deploy_BridgedToken.ts
+++ b/contracts/deploy/05_deploy_BridgedToken.ts
@@ -2,7 +2,7 @@ import { ethers, upgrades } from "hardhat";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 
-import { tryVerifyContract, setHandoffAddress } from "../common/helpers";
+import { getBooleanEnvVarOrDefault, tryVerifyContract, setHandoffAddress } from "../common/helpers";
 import {
   clearUiWorkflowStatus,
   getUiSigner,
@@ -44,7 +44,7 @@ const func: DeployFunction = withSignerUiSession(
       throw "Contract deployment transaction receipt not found.";
     }
 
-    if (process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true") {
+    if (getBooleanEnvVarOrDefault("DEPLOY_TOKEN_BRIDGE_ON_L1", false)) {
       console.log(`L1 BridgedToken beacon deployed on ${hre.network.name}, at address:`, bridgedTokenAddress);
     } else {
       console.log(`L2 BridgedToken beacon deployed on ${hre.network.name}, at address:`, bridgedTokenAddress);

--- a/contracts/deploy/06_deploy_TokenBridge.ts
+++ b/contracts/deploy/06_deploy_TokenBridge.ts
@@ -10,6 +10,7 @@ import {
 import {
   generateRoleAssignments,
   getAddressesFromRegistryOrEnv,
+  getBooleanEnvVarOrDefault,
   getEnvVarOrDefault,
   requireAddressFromRegistryOrEnv,
   tryVerifyContract,
@@ -29,6 +30,7 @@ const func: DeployFunction = withSignerUiSession(
   async function (hre: HardhatRuntimeEnvironment) {
     const signer = await getUiSigner(hre);
     const contractName = "TokenBridge";
+    const deployTokenBridgeOnL1 = getBooleanEnvVarOrDefault("DEPLOY_TOKEN_BRIDGE_ON_L1", false);
 
     const l2MessageServiceAddress = requireAddressFromRegistryOrEnv(
       network.name,
@@ -54,7 +56,7 @@ const func: DeployFunction = withSignerUiSession(
     let deployingChainMessageService = l2MessageServiceAddress;
     let reservedAddresses: string[];
 
-    if (process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true") {
+    if (deployTokenBridgeOnL1) {
       securityCouncilAddress = requireAddressFromRegistryOrEnv(
         network.name,
         "L1_SECURITY_COUNCIL",
@@ -128,7 +130,7 @@ const func: DeployFunction = withSignerUiSession(
 
     const tokenBridgeAddress = await tokenBridge.getAddress();
 
-    if (process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true") {
+    if (deployTokenBridgeOnL1) {
       console.log(`L1 TokenBridge deployed on ${network.name}, at address: ${tokenBridgeAddress}`);
     } else {
       console.log(`L2 TokenBridge deployed on ${network.name}, at address: ${tokenBridgeAddress}`);

--- a/contracts/deploy/06_deploy_TokenBridgeWithReinitialization.ts
+++ b/contracts/deploy/06_deploy_TokenBridgeWithReinitialization.ts
@@ -3,7 +3,7 @@ import { ethers, upgrades } from "hardhat";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 
-import { tryVerifyContract, requireAddressFromRegistryOrEnv } from "../common/helpers";
+import { getBooleanEnvVarOrDefault, tryVerifyContract, requireAddressFromRegistryOrEnv } from "../common/helpers";
 import { getUiSigner, withSignerUiSession } from "../scripts/hardhat/signer-ui-bridge";
 
 const func: DeployFunction = withSignerUiSession(
@@ -12,7 +12,9 @@ const func: DeployFunction = withSignerUiSession(
     const signer = await getUiSigner(hre);
     const contractName = "TokenBridge";
 
-    const tokenBridgeKey = process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true" ? "TokenBridge_L1" : "TokenBridge_L2";
+    const tokenBridgeKey = getBooleanEnvVarOrDefault("DEPLOY_TOKEN_BRIDGE_ON_L1", false)
+      ? "TokenBridge_L1"
+      : "TokenBridge_L2";
     const proxyAddress = requireAddressFromRegistryOrEnv(hre.network.name, tokenBridgeKey, "TOKEN_BRIDGE_ADDRESS");
 
     const factory = await ethers.getContractFactory(contractName, signer);

--- a/contracts/local-deployments-artifacts/deployBridgedTokenAndTokenBridgeV1_1.ts
+++ b/contracts/local-deployments-artifacts/deployBridgedTokenAndTokenBridgeV1_1.ts
@@ -29,8 +29,9 @@ import {
   abi as UpgradeableBeaconAbi,
   bytecode as UpgradeableBeaconBytecode,
 } from "./static-artifacts/UpgradeableBeacon.json";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
-import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
+import { deployContractFromArtifacts, getDeployNonceFromEnv, getInitializerData } from "../common/helpers/deployments";
+import { getBooleanEnvVarOrDefault, getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
+import { LOCAL_L2_DEPLOY_FEE_OVERRIDES } from "../common/helpers/feeOverrides";
 import {
   getAddressesFromRegistryOrEnv,
   getDeploymentNetworkName,
@@ -42,10 +43,11 @@ async function main() {
   const ORDERED_NONCE_POST_L2MESSAGESERVICE = 3;
   const ORDERED_NONCE_POST_LINEAROLLUP = 7;
   const networkName = getDeploymentNetworkName();
+  const deployTokenBridgeOnL1 = getBooleanEnvVarOrDefault("DEPLOY_TOKEN_BRIDGE_ON_L1", false);
 
   let securityCouncilAddress: string;
 
-  if (process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true") {
+  if (deployTokenBridgeOnL1) {
     securityCouncilAddress = requireAddressFromRegistryOrEnv(networkName, "L1_SECURITY_COUNCIL", "L1_SECURITY_COUNCIL");
   } else {
     securityCouncilAddress = requireAddressFromRegistryOrEnv(networkName, "L2_SECURITY_COUNCIL", "L2_SECURITY_COUNCIL");
@@ -71,32 +73,13 @@ async function main() {
   let remoteDeployerNonce;
   let fees = {};
 
-  if (process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true") {
-    walletNonce = await getL1DeployerNonce();
-    remoteDeployerNonce = await getL2DeployerNonce();
+  if (deployTokenBridgeOnL1) {
+    walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE", ORDERED_NONCE_POST_LINEAROLLUP);
+    remoteDeployerNonce = await getDeployNonceFromEnv(wallet, "L2_NONCE", ORDERED_NONCE_POST_L2MESSAGESERVICE);
   } else {
-    walletNonce = await getL2DeployerNonce();
-    remoteDeployerNonce = await getL1DeployerNonce();
-    fees = {
-      maxFeePerGas: 7_200_000_000_000n,
-      maxPriorityFeePerGas: 7_000_000_000_000n,
-    };
-  }
-
-  async function getL1DeployerNonce(): Promise<number> {
-    if (!process.env.L1_NONCE) {
-      return await wallet.getNonce();
-    } else {
-      return parseInt(process.env.L1_NONCE) + ORDERED_NONCE_POST_LINEAROLLUP;
-    }
-  }
-
-  async function getL2DeployerNonce(): Promise<number> {
-    if (!process.env.L2_NONCE) {
-      return await wallet.getNonce();
-    } else {
-      return parseInt(process.env.L2_NONCE) + ORDERED_NONCE_POST_L2MESSAGESERVICE;
-    }
+    walletNonce = await getDeployNonceFromEnv(wallet, "L2_NONCE", ORDERED_NONCE_POST_L2MESSAGESERVICE);
+    remoteDeployerNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE", ORDERED_NONCE_POST_LINEAROLLUP);
+    fees = { ...LOCAL_L2_DEPLOY_FEE_OVERRIDES };
   }
 
   const tokenBridgeContractImplementationName = "tokenBridgeContractImplementation";
@@ -142,7 +125,7 @@ async function main() {
     nonce: remoteDeployerNonce + 4,
   });
 
-  if (process.env.DEPLOY_TOKEN_BRIDGE_ON_L1 === "true") {
+  if (deployTokenBridgeOnL1) {
     console.log(
       `DEPLOY_TOKEN_BRIDGE_ON_L1=${process.env.DEPLOY_TOKEN_BRIDGE_ON_L1}. Deploying TokenBridge on L1, using L1_RESERVED_TOKEN_ADDRESSES from registry or env and remoteSender=${remoteSender}`,
     );

--- a/contracts/local-deployments-artifacts/deployEIPSystemContracts.ts
+++ b/contracts/local-deployments-artifacts/deployEIPSystemContracts.ts
@@ -1,6 +1,8 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
 
+import { getDeployNonceFromEnv } from "../common/helpers/deployments";
+
 dotenv.config();
 
 interface EIPContractConfig {
@@ -150,12 +152,7 @@ async function main() {
 
   const contractNames = ["EIP2935", "EIP4788"] as const;
 
-  let walletNonce: number;
-  if (!process.env.L2_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L2_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L2_NONCE");
 
   for (const [index, contractName] of contractNames.entries()) {
     const config = EIP_CONTRACTS[contractName];

--- a/contracts/local-deployments-artifacts/deployL2MessageServiceV1.ts
+++ b/contracts/local-deployments-artifacts/deployL2MessageServiceV1.ts
@@ -21,8 +21,9 @@ import {
   L2_MESSAGE_SERVICE_ROLES,
   L2_MESSAGE_SERVICE_UNPAUSE_TYPES_ROLES,
 } from "../common/constants";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import { deployContractFromArtifacts, getDeployNonceFromEnv, getInitializerData } from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
+import { LOCAL_L2_DEPLOY_FEE_OVERRIDES } from "../common/helpers/feeOverrides";
 import { getDeploymentNetworkName, requireAddressFromRegistryOrEnv } from "../common/helpers/readAddress";
 import { generateRoleAssignments } from "../common/helpers/roles";
 
@@ -38,13 +39,7 @@ async function main() {
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
   const wallet = new ethers.Wallet(process.env.DEPLOYER_PRIVATE_KEY!, provider);
-  let walletNonce;
-
-  if (!process.env.L2_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L2_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L2_NONCE");
 
   const l2MessageServiceContractImplementationName = "L2MessageServiceImplementation";
 
@@ -56,14 +51,12 @@ async function main() {
       wallet,
       {
         nonce: walletNonce,
-        maxFeePerGas: 7_200_000_000_000n,
-        maxPriorityFeePerGas: 7_000_000_000_000n,
+        ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
       },
     ),
     deployContractFromArtifacts(ProxyAdminContractName, ProxyAdminAbi, ProxyAdminBytecode, wallet, {
       nonce: walletNonce + 1,
-      maxFeePerGas: 7_200_000_000_000n,
-      maxPriorityFeePerGas: 7_000_000_000_000n,
+      ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
     }),
   ]);
 
@@ -114,8 +107,7 @@ async function main() {
     proxyAdminAddress,
     initializer,
     {
-      maxFeePerGas: 7_200_000_000_000n,
-      maxPriorityFeePerGas: 7_000_000_000_000n,
+      ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
     },
   );
 }

--- a/contracts/local-deployments-artifacts/deployOpcodeTestingFramework.ts
+++ b/contracts/local-deployments-artifacts/deployOpcodeTestingFramework.ts
@@ -12,6 +12,7 @@ import {
   bytecode as yulBasedOpcodeTestingBytecode,
 } from "./static-artifacts/YulBasedOpcodeTesting.json";
 import { deployContractFromArtifacts } from "../common/helpers/deployments";
+import { LOCAL_L2_DEPLOY_FEE_OVERRIDES } from "../common/helpers/feeOverrides";
 
 async function main() {
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
@@ -34,8 +35,7 @@ async function deployyulBasedOpcodeTesting(wallet: ethers.Wallet): Promise<strin
     wallet,
     {
       nonce: walletNonce,
-      maxFeePerGas: 7_200_000_000_000n,
-      maxPriorityFeePerGas: 7_000_000_000_000n,
+      ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
     },
   );
 
@@ -55,8 +55,7 @@ async function deployOpcodeTester(wallet: ethers.Wallet, yulBasedOpcodeTestingAd
     yulBasedOpcodeTestingAddress,
     {
       nonce: walletNonce,
-      maxFeePerGas: 7_200_000_000_000n,
-      maxPriorityFeePerGas: 7_000_000_000_000n,
+      ...LOCAL_L2_DEPLOY_FEE_OVERRIDES,
     },
   );
 }

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV6.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV6.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
-import fs from "fs";
 import path from "path";
 
 import { abi as LineaRollupV6Abi, bytecode as LineaRollupV6Bytecode } from "./dynamic-artifacts/LineaRollupV6.json";
@@ -19,7 +18,12 @@ import {
   LINEA_ROLLUP_V6_ROLES,
   OPERATOR_ROLE,
 } from "../common/constants";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+  loadArtifactFromDirectory,
+} from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
 import {
   getDeploymentNetworkName,
@@ -30,28 +34,6 @@ import { generateRoleAssignments } from "../common/helpers/roles";
 import { get1559Fees } from "../scripts/utils";
 
 dotenv.config();
-
-function findContractArtifacts(
-  folderPath: string,
-  contractName: string,
-): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
-  const files = fs.readdirSync(folderPath);
-
-  const foundFile = files.find((file) => file === `${contractName}.json`);
-
-  if (!foundFile) {
-    // Throw an error if the file is not found
-    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
-  }
-
-  // Construct the full file path
-  const filePath = path.join(folderPath, foundFile);
-
-  // Read the file content
-  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
-  const parsedContent = JSON.parse(fileContent);
-  return parsedContent;
-}
 
 async function main() {
   const networkName = getDeploymentNetworkName();
@@ -82,7 +64,7 @@ async function main() {
   ]);
   const roleAddresses = getEnvVarOrDefault("LINEA_ROLLUP_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = findContractArtifacts(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
@@ -90,13 +72,7 @@ async function main() {
 
   const { gasPrice } = await get1559Fees(provider);
 
-  let walletNonce;
-
-  if (!process.env.L1_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L1_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   const [verifier, lineaRollupImplementation, proxyAdmin] = await Promise.all([
     deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV7.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV7.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
-import fs from "fs";
 import path from "path";
 
 import { abi as LineaRollupV7Abi, bytecode as LineaRollupV7Bytecode } from "./dynamic-artifacts/LineaRollupV7.json";
@@ -20,7 +19,12 @@ import {
   OPERATOR_ROLE,
   YIELD_PROVIDER_STAKING_ROLE,
 } from "../common/constants";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+  loadArtifactFromDirectory,
+} from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
 import {
   getDeploymentNetworkName,
@@ -31,28 +35,6 @@ import { generateRoleAssignments } from "../common/helpers/roles";
 import { get1559Fees } from "../scripts/utils";
 
 dotenv.config();
-
-function findContractArtifacts(
-  folderPath: string,
-  contractName: string,
-): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
-  const files = fs.readdirSync(folderPath);
-
-  const foundFile = files.find((file) => file === `${contractName}.json`);
-
-  if (!foundFile) {
-    // Throw an error if the file is not found
-    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
-  }
-
-  // Construct the full file path
-  const filePath = path.join(folderPath, foundFile);
-
-  // Read the file content
-  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
-  const parsedContent = JSON.parse(fileContent);
-  return parsedContent;
-}
 
 async function main() {
   const networkName = getDeploymentNetworkName();
@@ -88,7 +70,7 @@ async function main() {
   ];
   const roleAddresses = getEnvVarOrDefault("LINEA_ROLLUP_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = findContractArtifacts(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
@@ -96,13 +78,7 @@ async function main() {
 
   const { gasPrice } = await get1559Fees(provider);
 
-  let walletNonce;
-
-  if (!process.env.L1_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L1_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   const [verifier, lineaRollupImplementation, proxyAdmin] = await Promise.all([
     deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV7_1.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV7_1.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
-import fs from "fs";
 import path from "path";
 
 import {
@@ -23,7 +22,12 @@ import {
   OPERATOR_ROLE,
   ADDRESS_ZERO,
 } from "../common/constants";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+  loadArtifactFromDirectory,
+} from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
 import {
   getDeploymentNetworkName,
@@ -34,28 +38,6 @@ import { generateRoleAssignments } from "../common/helpers/roles";
 import { get1559Fees } from "../scripts/utils";
 
 dotenv.config();
-
-function findContractArtifacts(
-  folderPath: string,
-  contractName: string,
-): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
-  const files = fs.readdirSync(folderPath);
-
-  const foundFile = files.find((file) => file === `${contractName}.json`);
-
-  if (!foundFile) {
-    // Throw an error if the file is not found
-    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
-  }
-
-  // Construct the full file path
-  const filePath = path.join(folderPath, foundFile);
-
-  // Read the file content
-  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
-  const parsedContent = JSON.parse(fileContent);
-  return parsedContent;
-}
 
 async function main() {
   const networkName = getDeploymentNetworkName();
@@ -87,7 +69,7 @@ async function main() {
   ]);
   const roleAddresses = getEnvVarOrDefault("LINEA_ROLLUP_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = findContractArtifacts(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
@@ -95,13 +77,7 @@ async function main() {
 
   const { gasPrice } = await get1559Fees(provider);
 
-  let walletNonce;
-
-  if (!process.env.L1_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L1_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   const [verifier, lineaRollupImplementation, proxyAdmin] = await Promise.all([
     deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV8.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndLineaRollupV8.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
-import fs from "fs";
 import path from "path";
 
 import { abi as LineaRollupV8Abi, bytecode as LineaRollupV8Bytecode } from "./dynamic-artifacts/LineaRollupV8.json";
@@ -37,8 +36,13 @@ import {
   PRECOMPILES_ADDRESSES,
   FORCED_TRANSACTION_SENDER_ROLE,
 } from "../common/constants";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
-import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+  loadArtifactFromDirectory,
+} from "../common/helpers/deployments";
+import { getBooleanEnvVarOrDefault, getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
 import { resolveOneModelFeeOverrides } from "../common/helpers/feeOverrides";
 import {
   getDeploymentNetworkName,
@@ -48,55 +52,6 @@ import {
 import { generateRoleAssignments } from "../common/helpers/roles";
 
 dotenv.config();
-
-function findContractArtifacts(
-  folderPath: string,
-  contractName: string,
-): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
-  const files = fs.readdirSync(folderPath);
-
-  const foundFile = files.find((file) => file === `${contractName}.json`);
-
-  if (!foundFile) {
-    // Throw an error if the file is not found
-    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
-  }
-
-  // Construct the full file path
-  const filePath = path.join(folderPath, foundFile);
-
-  // Read the file content
-  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
-  const parsedContent = JSON.parse(fileContent);
-  return parsedContent;
-}
-
-function getBooleanEnvVarOrDefault(name: string, defaultValue: boolean): boolean {
-  const rawValue = process.env[name];
-  if (rawValue === undefined || rawValue === "") {
-    return defaultValue;
-  }
-  if (rawValue === "true") {
-    return true;
-  }
-  if (rawValue === "false") {
-    return false;
-  }
-  throw new Error(`${name} must be either "true" or "false"`);
-}
-
-async function getDeployNonce(wallet: ethers.Wallet): Promise<number> {
-  const l1Nonce = process.env.L1_NONCE;
-  if (l1Nonce === undefined || l1Nonce === "") {
-    return wallet.getNonce();
-  }
-
-  if (!/^[0-9]+$/.test(l1Nonce)) {
-    throw new Error(`L1_NONCE must be a non-negative integer, got: ${l1Nonce}`);
-  }
-
-  return Number(l1Nonce);
-}
 
 async function main() {
   const networkName = getDeploymentNetworkName();
@@ -138,7 +93,7 @@ async function main() {
   ];
   const roleAddresses = getEnvVarOrDefault("LINEA_ROLLUP_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = findContractArtifacts(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
@@ -149,7 +104,7 @@ async function main() {
   // used. resolveOneModelFeeOverrides guarantees a single, complete fee model.
   const feeOverrides = await resolveOneModelFeeOverrides(provider, "L1_DEPLOY_GAS_PRICE_WEI");
 
-  const walletNonce = await getDeployNonce(wallet);
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   const [verifier, lineaRollupImplementation, proxyAdmin, addressFilter] = await Promise.all([
     deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndValidiumV1.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndValidiumV1.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
-import fs from "fs";
 import path from "path";
 
 import { abi as ValidiumV1Abi, bytecode as ValidiumV1Bytecode } from "./dynamic-artifacts/ValidiumV1.json";
@@ -20,35 +19,18 @@ import {
   OPERATOR_ROLE,
 } from "../common/constants";
 import { ADDRESS_ZERO } from "../common/constants/general";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+  loadArtifactFromDirectory,
+} from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
 import { getDeploymentNetworkName, requireAddressFromRegistryOrEnv } from "../common/helpers/readAddress";
 import { generateRoleAssignments } from "../common/helpers/roles";
 import { get1559Fees } from "../scripts/utils";
 
 dotenv.config();
-
-function findContractArtifacts(
-  folderPath: string,
-  contractName: string,
-): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
-  const files = fs.readdirSync(folderPath);
-
-  const foundFile = files.find((file) => file === `${contractName}.json`);
-
-  if (!foundFile) {
-    // Throw an error if the file is not found
-    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
-  }
-
-  // Construct the full file path
-  const filePath = path.join(folderPath, foundFile);
-
-  // Read the file content
-  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
-  const parsedContent = JSON.parse(fileContent);
-  return parsedContent;
-}
 
 async function main() {
   const networkName = getDeploymentNetworkName();
@@ -74,7 +56,7 @@ async function main() {
   ]);
   const roleAddresses = getEnvVarOrDefault("VALIDIUM_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = findContractArtifacts(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
@@ -82,13 +64,7 @@ async function main() {
 
   const { gasPrice } = await get1559Fees(provider);
 
-  let walletNonce;
-
-  if (!process.env.L1_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L1_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   const [verifier, validiumImplementation, proxyAdmin] = await Promise.all([
     deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {

--- a/contracts/local-deployments-artifacts/deployPlonkVerifierAndValidiumV2.ts
+++ b/contracts/local-deployments-artifacts/deployPlonkVerifierAndValidiumV2.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
-import fs from "fs";
 import path from "path";
 
 import { abi as ValidiumV2Abi, bytecode as ValidiumV2Bytecode } from "./dynamic-artifacts/ValidiumV2.json";
@@ -27,35 +26,18 @@ import {
   ADDRESS_ZERO,
   PRECOMPILES_ADDRESSES,
 } from "../common/constants";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import {
+  deployContractFromArtifacts,
+  getDeployNonceFromEnv,
+  getInitializerData,
+  loadArtifactFromDirectory,
+} from "../common/helpers/deployments";
 import { getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
 import { getDeploymentNetworkName, requireAddressFromRegistryOrEnv } from "../common/helpers/readAddress";
 import { generateRoleAssignments } from "../common/helpers/roles";
 import { get1559Fees } from "../scripts/utils";
 
 dotenv.config();
-
-function findContractArtifacts(
-  folderPath: string,
-  contractName: string,
-): { abi: ethers.InterfaceAbi; bytecode: ethers.BytesLike } {
-  const files = fs.readdirSync(folderPath);
-
-  const foundFile = files.find((file) => file === `${contractName}.json`);
-
-  if (!foundFile) {
-    // Throw an error if the file is not found
-    throw new Error(`Contract "${contractName}" not found in folder "${folderPath}"`);
-  }
-
-  // Construct the full file path
-  const filePath = path.join(folderPath, foundFile);
-
-  // Read the file content
-  const fileContent = fs.readFileSync(filePath, "utf-8").trim();
-  const parsedContent = JSON.parse(fileContent);
-  return parsedContent;
-}
 
 async function main() {
   const networkName = getDeploymentNetworkName();
@@ -88,7 +70,7 @@ async function main() {
   ];
   const roleAddresses = getEnvVarOrDefault("VALIDIUM_ROLE_ADDRESSES", defaultRoleAddresses);
 
-  const verifierArtifacts = findContractArtifacts(path.join(__dirname, "./dynamic-artifacts"), verifierName);
+  const verifierArtifacts = loadArtifactFromDirectory(path.join(__dirname, "./dynamic-artifacts"), verifierName);
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
 
@@ -96,13 +78,7 @@ async function main() {
 
   const { gasPrice } = await get1559Fees(provider);
 
-  let walletNonce;
-
-  if (!process.env.L1_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L1_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
 
   const [verifier, validiumImplementation, proxyAdmin, addressFilter] = await Promise.all([
     deployContractFromArtifacts(verifierName, verifierArtifacts.abi, verifierArtifacts.bytecode, wallet, {

--- a/contracts/local-deployments-artifacts/deployPredeployContractsV1.ts
+++ b/contracts/local-deployments-artifacts/deployPredeployContractsV1.ts
@@ -25,7 +25,7 @@ import {
   abi as TransparentUpgradeableProxyAbi,
   bytecode as TransparentUpgradeableProxyBytecode,
 } from "./static-artifacts/TransparentUpgradeableProxy.json";
-import { deployContractFromArtifacts, getInitializerData } from "../common/helpers/deployments";
+import { deployContractFromArtifacts, getDeployNonceFromEnv, getInitializerData } from "../common/helpers/deployments";
 
 dotenv.config();
 
@@ -34,13 +34,7 @@ async function main() {
 
   const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
   const wallet = new ethers.Wallet(process.env.DEPLOYER_PRIVATE_KEY!, provider);
-  let walletNonce;
-
-  if (!process.env.L2_NONCE) {
-    walletNonce = await wallet.getNonce();
-  } else {
-    walletNonce = parseInt(process.env.L2_NONCE);
-  }
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L2_NONCE");
   console.log("walletNonce:", walletNonce);
 
   // Contract implementation names

--- a/contracts/local-deployments-artifacts/deployTestERC20.ts
+++ b/contracts/local-deployments-artifacts/deployTestERC20.ts
@@ -5,8 +5,9 @@ import {
   abi as TestERC20Abi,
   bytecode as TestERC20Bytecode,
 } from "./static-artifacts/TestERC20.json";
-import { deployContractFromArtifacts } from "../common/helpers/deployments";
-import { getRequiredEnvVar } from "../common/helpers/environment";
+import { deployContractFromArtifacts, getDeployNonceFromEnv } from "../common/helpers/deployments";
+import { getBooleanEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
+import { LOCAL_L2_DEPLOY_FEE_OVERRIDES } from "../common/helpers/feeOverrides";
 import { get1559Fees } from "../scripts/utils";
 
 async function main() {
@@ -24,24 +25,20 @@ async function main() {
   let walletNonce;
   let fees = {};
 
-  if (process.env.TEST_ERC20_L1 === "true") {
-    if (!process.env.L1_NONCE) {
-      walletNonce = await wallet.getNonce();
-    } else {
-      walletNonce = parseInt(process.env.L1_NONCE) + ORDERED_NONCE_POST_LINEAROLLUP + ORDERED_NONCE_POST_TOKENBRIDGE;
-    }
+  if (getBooleanEnvVarOrDefault("TEST_ERC20_L1", false)) {
+    walletNonce = await getDeployNonceFromEnv(
+      wallet,
+      "L1_NONCE",
+      ORDERED_NONCE_POST_LINEAROLLUP + ORDERED_NONCE_POST_TOKENBRIDGE,
+    );
     fees = { gasPrice: (await get1559Fees(provider)).gasPrice };
   } else {
-    if (!process.env.L2_NONCE) {
-      walletNonce = await wallet.getNonce();
-    } else {
-      walletNonce =
-        parseInt(process.env.L2_NONCE) + ORDERED_NONCE_POST_L2MESSAGESERVICE + ORDERED_NONCE_POST_TOKENBRIDGE;
-    }
-    fees = {
-      maxFeePerGas: 7_200_000_000_000n,
-      maxPriorityFeePerGas: 7_000_000_000_000n,
-    };
+    walletNonce = await getDeployNonceFromEnv(
+      wallet,
+      "L2_NONCE",
+      ORDERED_NONCE_POST_L2MESSAGESERVICE + ORDERED_NONCE_POST_TOKENBRIDGE,
+    );
+    fees = { ...LOCAL_L2_DEPLOY_FEE_OVERRIDES };
   }
 
   await deployContractFromArtifacts(


### PR DESCRIPTION
## Summary

This PR is the first of three small refactors suggested after review of the Linea stack quickstart work (#3325). It moves repeated deploy-script utilities into `contracts/common/helpers/` and updates local deploy scripts to use them.

**What moved into shared helpers**

- **`loadArtifactFromDirectory`** — loads a compiled contract JSON from a folder (replaces many copy-pasted `findContractArtifacts` functions).
- **`getDeployNonceFromEnv`** — reads `L1_NONCE` / `L2_NONCE` with strict validation (must be a non-negative integer string). Replaces `parseInt(process.env.*_NONCE)`, which could silently accept bad values like `"5x"` or `"1e3"`.
- **`getBooleanEnvVar` / `getBooleanEnvVarOrDefault`** — strict `"true"` / `"false"` parsing for deploy flags.
- **`LOCAL_L2_DEPLOY_FEE_OVERRIDES`** — shared constant for local L2 deploy fee settings (exported from the helpers barrel).

**What changed in deploy scripts**

All scripts under `contracts/local-deployments-artifacts/` (and a few Hardhat deploy tasks) now import these helpers instead of keeping local copies. Script-specific logic (which nonce offset to use, deployment order, etc.) stays at the call site.

**Nonce fallback fix (included in this PR)**

During review we found that the new helper briefly applied the `offset` argument even when the env var was **unset** and the code fell back to the wallet’s live nonce. That would skip a nonce compared to the old behaviour. The fix keeps offsets **only when the env var is explicitly set** — unset/empty still returns the wallet nonce unchanged.

## Why

- Less duplication across deploy scripts (easier to maintain, fewer drift bugs).
- Safer env parsing for nonces and booleans during local/quickstart deploys.
- Addresses feedback to refactor generic deploy mechanics out of individual scripts and reuse them elsewhere.

## Test plan

- [x] `ts-node contracts/common/helpers/deployments.test.ts`
- [x] `ts-node contracts/common/helpers/environment.test.ts`
- [x] `ts-node contracts/common/helpers/feeOverrides.test.ts`
- [ ] `pnpm -F contracts run lint:ts`
- [ ] `pnpm -F contracts run build`
- [ ] Optional: run a local deploy script that uses `L1_NONCE` / `L2_NONCE` overrides

## Related

- Follow-up to quickstart review context in #3325
- Companion PRs (separate branches): quickstart TS lib consolidation and shell helper consolidation


Made with [Cursor](https://cursor.com)