### PR TITLE
fix(Maru): Fixed a bug when simultaneous mutual connection attempts r…

### DIFF
--- a/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaForcedTransactionCliOptions.java
+++ b/linea-besu/plugins/linea-sequencer/sequencer/src/main/java/net/consensys/linea/config/LineaForcedTransactionCliOptions.java
@@ -65,7 +65,8 @@ public class LineaForcedTransactionCliOptions implements LineaCliOptions {
       final LineaForcedTransactionConfiguration config) {
     final LineaForcedTransactionCliOptions options = create();
     options.statusCacheSize = config.statusCacheSize();
-    options.chainSecurityViolationBeforeDeadlineInclusionAllowance = (int) config.chainSecurityViolationHoldOffBeforeDeadline();
+    options.chainSecurityViolationBeforeDeadlineInclusionAllowance =
+        (int) config.chainSecurityViolationHoldOffBeforeDeadline();
     return options;
   }
 

--- a/maru/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
+++ b/maru/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
@@ -122,7 +122,13 @@ class MaruPeerManager(
   private fun connectedPeers(): Map<NodeId, MaruPeer> = peers.filter { it.value.isConnected }
 
   override fun onDisconnect(peer: Peer) {
-    peers.remove(peer.id)
+    // When two nodes connect to each other simultaneously, onConnect fires twice for the same NodeId
+    // and the second call overwrites the first entry in peers.  When the duplicate connection is
+    // then closed, onDisconnect would naively evict the surviving connection.  Guard against that
+    // by only removing the entry when the stored MaruPeer is itself no longer connected.
+    peers.computeIfPresent(peer.id) { _, storedPeer ->
+      if (storedPeer.isConnected) storedPeer else null
+    }
     log.debug("Peer={} disconnected", peer.id)
   }
 

--- a/maru/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
+++ b/maru/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
@@ -328,8 +328,8 @@ class MaruPeerManagerTest {
       )
     manager.start(discoveryService = null, p2pNetwork = mock())
 
-    manager.onConnect(firstPeer)   // peers[nodeId] = closedMaruPeer
-    manager.onConnect(secondPeer)  // peers[nodeId] = survivingMaruPeer (overwrites)
+    manager.onConnect(firstPeer) // peers[nodeId] = closedMaruPeer
+    manager.onConnect(secondPeer) // peers[nodeId] = survivingMaruPeer (overwrites)
     manager.onDisconnect(firstPeer) // first connection closes; survivingMaruPeer still alive
 
     assertThat(manager.peerCount).isEqualTo(1)

--- a/maru/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
+++ b/maru/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
@@ -302,6 +302,40 @@ class MaruPeerManagerTest {
     assertThat(manager.getPeer(nodeId1)).isEqualTo(maruPeer1)
   }
 
+  @Test
+  fun `peerCount is unchanged when duplicate simultaneous connection is closed`() {
+    // When both nodes connect to each other at the same time, Teku fires onConnect for both.
+    // The second onConnect overwrites the first entry in peers.  When the first (now-duplicate)
+    // connection is subsequently closed, onDisconnect must NOT evict the surviving peer.
+    val nodeId = mock<NodeId>()
+    val address = Fixtures.peerAddress(nodeId)
+    val firstPeer = Fixtures.tekuPeer(id = nodeId, address = address, initiatedLocally = true)
+    val secondPeer = Fixtures.tekuPeer(id = nodeId, address = address, initiatedLocally = false)
+
+    val closedMaruPeer = Fixtures.maruPeer(isConnected = false, address = address)
+    val survivingMaruPeer = Fixtures.maruPeer(isConnected = true, address = address)
+
+    val maruPeerFactory = mock<MaruPeerFactory>()
+    whenever(maruPeerFactory.createMaruPeer(firstPeer)).thenReturn(closedMaruPeer)
+    whenever(maruPeerFactory.createMaruPeer(secondPeer)).thenReturn(survivingMaruPeer)
+
+    val manager =
+      MaruPeerManager(
+        maruPeerFactory = maruPeerFactory,
+        p2pConfig = P2PConfig(maxPeers = 10),
+        reputationManager = reputationManager,
+        isStaticPeer = { true },
+      )
+    manager.start(discoveryService = null, p2pNetwork = mock())
+
+    manager.onConnect(firstPeer)   // peers[nodeId] = closedMaruPeer
+    manager.onConnect(secondPeer)  // peers[nodeId] = survivingMaruPeer (overwrites)
+    manager.onDisconnect(firstPeer) // first connection closes; survivingMaruPeer still alive
+
+    assertThat(manager.peerCount).isEqualTo(1)
+    assertThat(manager.getPeer(nodeId)).isEqualTo(survivingMaruPeer)
+  }
+
   private fun addConnectedPeer(
     manager: MaruPeerManager,
     maruPeer: MaruPeer,


### PR DESCRIPTION
…esult in a disconnect

Should fix a flaky failure such as [this](https://github.com/LFDT-Lineth/lineth-monorepo/actions/runs/28109785004/job/83250488726?pr=3386)

```
MaruDiscoveryTest > ten nodes discover each other via bootnode() FAILED
    java.lang.AssertionError: 
    Expecting actual:
      8
    to be greater than or equal to:
      9
        at maru.app.MaruDiscoveryTest.testMultiNodeDiscovery_Qn1smSk$lambda$5(MaruDiscoveryTest.kt:187)
```

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
