### PR TITLE
fix(coordinator): forced transactions concurrency update

### DIFF
--- a/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsExecutionStatusUpdater.kt
+++ b/coordinator/ethereum/forced-transactions/src/main/kotlin/linea/ftx/ForcedTransactionsExecutionStatusUpdater.kt
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.Queue
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Clock
 import kotlin.time.Duration
 
@@ -38,8 +39,7 @@ internal class ForcedTransactionsStatusUpdater(
   private val log: Logger = LogManager.getLogger(ForcedTransactionsStatusUpdater::class.java),
 ) : ForcedTransactionsProvider {
 
-  @Volatile
-  private var nextExpectedFtxNumber: ULong = lastProcessedFtxNumber + 1UL
+  private val nextExpectedFtxNumber: AtomicReference<ULong> = AtomicReference(lastProcessedFtxNumber + 1UL)
 
   override fun getUnprocessedForcedTransactions(): SafeFuture<List<ForcedTransactionAddedEvent>> {
     return filterOutAlreadyProcessed(ftxQueue.toList())
@@ -88,14 +88,14 @@ internal class ForcedTransactionsStatusUpdater(
       ftxs.map { it.event.forcedTransactionNumber },
     )
 
+    var currentExpected = nextExpectedFtxNumber.get()
     // Sort by ftxNumber and only consider transactions >= expectedNum
     val sortedFtxs = ftxs
-      .filter { it.event.forcedTransactionNumber >= nextExpectedFtxNumber }
+      .filter { it.event.forcedTransactionNumber >= currentExpected }
       .sortedBy { it.event.forcedTransactionNumber }
 
     // Find consecutive transactions starting from expectedNum (no gaps)
     val consecutiveFtxs = mutableListOf<ForcedTransactionWithTimestamp>()
-    var currentExpected = nextExpectedFtxNumber
     for (ftx in sortedFtxs) {
       if (ftx.event.forcedTransactionNumber == currentExpected) {
         consecutiveFtxs.add(ftx)
@@ -150,16 +150,16 @@ internal class ForcedTransactionsStatusUpdater(
         addFtxToConflation(dbRecord)
         // Remove from queue by matching the event's ftx number
         ftxQueue.removeIf { it.event.forcedTransactionNumber == ftx.forcedTransactionNumber }
-        nextExpectedFtxNumber = ftx.forcedTransactionNumber + 1uL
+        nextExpectedFtxNumber.set(ftx.forcedTransactionNumber + 1uL)
         log.debug(
-          "FTX #{} already processed, removed from queue. Next expected: {}",
+          "ftx={} already processed, removed from queue. Next expected: {}",
           ftx.forcedTransactionNumber,
           nextExpectedFtxNumber,
         )
         true
       } else {
         log.debug(
-          "FTX #{} not yet processed, stopping sequential check",
+          "ftx={} not yet processed, stopping sequential check",
           ftx.forcedTransactionNumber,
         )
         false


### PR DESCRIPTION
fixes an issue found in review #3243

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordinator FTX ordering and conflation gating; incorrect cursor behavior could skip or duplicate FTX processing, but the change is narrowly scoped to atomic cursor access.
> 
> **Overview**
> **Replaces `@Volatile` on `nextExpectedFtxNumber` with `AtomicReference<ULong>`** in `ForcedTransactionsStatusUpdater` so reads and updates of the sequential FTX cursor are atomic when `getUnprocessedForcedTransactions` runs concurrent `SafeFuture` work.
> 
> `filterOutAlreadyProcessed` now snapshots the expected number via `.get()` before filtering and gap detection; after a processed FTX is removed from the queue, the cursor advances with `.set()` instead of assignment. Debug log lines use `ftx={}` instead of `FTX #{}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6b23256b4f26fe8f24afcb1e62daf7b6ae49cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->