### PR TITLE
chore(global): improve linea-dependency-maintenance skill

### DIFF
--- a/.agents/skills/linea-dependency-maintenance/SKILL.md
+++ b/.agents/skills/linea-dependency-maintenance/SKILL.md
@@ -33,12 +33,20 @@ hiding remaining risk.
 ## Policy
 
 - Treat release-age and cooldown rules as hard gates. Compute exact cutoff timestamps before selecting versions.
-- In pnpm repos, `minimumReleaseAge` is a maturity window in minutes; respect `minimumReleaseAgeExclude` exactly.
+- In pnpm repos, `minimumReleaseAge` is a maturity window in minutes. Treat the configured `minimumReleaseAgeExclude`
+  list as read-only: respect the existing entries, but never add or widen it to push a fresher version through — the
+  maturity window is a hard gate, not a hurdle to bypass.
 - Treat npm/pnpm dependency updates as owned by this skill. Do not re-enable Dependabot npm/pnpm package-ecosystem jobs
   unless the user explicitly asks; GitHub Actions, Docker, and other non-JavaScript ecosystems may remain under
   Dependabot.
-- Preserve version style: exact pins, ranges, `catalog:` references, `workspace:` references, and repo-specific package
-  placement.
+- Pin exact versions (mandatory). Every npm/pnpm `dependencies`/`devDependencies` specifier must be an exact pin, never
+  a `^` caret or `~` tilde range. Floating ranges silently pull unreviewed releases and widen the supply-chain attack
+  surface, so a single exact version is the only safe and reproducible default. When a bump touches a manifest, also
+  tighten any pre-existing `^`/`~` range on that package to an exact pin. The exception is `peerDependencies`: those
+  declare the version range a consumer must satisfy (the package never installs them itself), so pinning them exact
+  invents false incompatibilities — leave intentional peer ranges as ranges.
+- Preserve reference style otherwise: keep `catalog:` references, `workspace:` references, and repo-specific package
+  placement unchanged. Pin the concrete version at the catalog definition so consumers stay on `catalog:`.
 - Default PR scope is eligible patch and minor updates. Major upgrades, risky transitive fixes, and broad migrations get
   tracking issues unless the user explicitly approves doing them now.
 - Prefer official migration guides, changelogs, package registry metadata, and advisory pages for decisions that affect
@@ -107,6 +115,40 @@ Treat overrides as temporary exceptions:
 - Document every kept override with package path, advisory or compatibility reason, current resolution, target
   resolution, and remaining risk.
 
+Refresh overrides after the direct bumps land, so you only keep exceptions that are still required. Let natural
+resolution catch up first, then keep overrides only for advisories that remain. The flow is the same regardless of
+package manager, but the exact commands differ, so use the ones in the matching reference file:
+
+1. Remove the existing overrides block from the package manager's source config. For pnpm, inspect the repo first: the
+   live block can be top-level `overrides` in `pnpm-workspace.yaml`, `pnpm.overrides` in `package.json`, or `resolutions`.
+   For npm, use `overrides` in `package.json`. Do not edit generated lockfile override metadata by hand.
+2. Reinstall so resolution settles without the overrides.
+3. Apply the package manager's audit fix. For npm, run `npm audit fix` without `--force`, which stays non-major. For
+   pnpm, run `pnpm audit --fix`; on pnpm 10 this can write targeted overrides pinning the patched versions, while older
+   pnpm versions may require adding targeted exact overrides manually from the remaining audit output. If pnpm edits
+   `minimumReleaseAge`, `minimumReleaseAgeExclude`, or related maturity-gate settings, revert those edits immediately; do
+   not use audit fix to bypass the maturity gate.
+4. Reinstall again so the lockfile reflects the fixed tree.
+
+Then inspect the result — do not trust the audit fix blindly:
+
+- Any advisory still reported needs a deliberate, documented override pinned to an exact version (Policy); anything now
+  resolved should stay removed.
+- An audit fix can pin a transitive dependency to a new **major**. Before keeping such an override, confirm the
+  dependent package actually supports it; otherwise revert it and track the advisory as blocked (see the transitive-major
+  rule in `references/pnpm.md`).
+- In pnpm repos, `minimumReleaseAge` also gates overrides: pnpm refuses an exact-version override still inside the
+  maturity window and can silently fall back to an older in-range version that is still vulnerable. Confirm with
+  `pnpm why <pkg> -r` plus a re-audit that the intended patched version actually landed. If the only patched version is
+  still inside the maturity window, treat the advisory as blocked and track it until the version matures — never widen
+  `minimumReleaseAgeExclude` to force it in. If `pnpm audit --fix` adds such an exclusion, revert it; do not accept the
+  silent, still-vulnerable fallback or compensate for maturity failures with config changes.
+- Re-run validation, because dropping or changing overrides can shift transitive versions across the workspace.
+
+See `references/pnpm.md` and `references/npm.md` for the per-manager commands (on pnpm 10 `pnpm audit --fix` rewrites
+overrides automatically; npm never writes `overrides`, so its flow relies on `npm audit fix` without `--force` plus
+manual targeted overrides).
+
 ## Validation
 
 Run the narrowest meaningful checks first, then broaden by blast radius:
@@ -120,21 +162,19 @@ Run the narrowest meaningful checks first, then broaden by blast radius:
 If a command cannot run, report why. If CI fails, inspect the actual logs and classify the failure as introduced by the
 update, exposed baseline debt, or external/non-actionable.
 
-## Tracking
+## Open The PR
 
-Open one draft PR for safe updates unless the user asks otherwise. Include:
+Open the PR only after local validation is green. Opening a PR is an outward-facing action, so commit the work on a
+dedicated branch, then pause and confirm with the user before pushing and creating the PR.
 
-- updated packages and grouped stacks
-- release-age cutoff and skipped versions with publish timestamps
-- audit before/after summary
-- overrides removed, kept, added, or narrowed
-- blocked non-major updates and remaining advisories
-- major or blocked migration issue links
-- validation commands and caveats
+- Branch from the repo's base branch, stage the manifest and lockfile changes together, and commit with the repository's
+  Conventional Commit format. Do not assume a universal type or scope; use the repo-approved prefix and set the
+  description to `refresh dependencies`.
+- Open a PR.
 
-Open English `chore(deps): ...` issues for deferred major upgrades or blocked migration streams. Each issue should
-include official docs, current and target versions, expected code areas, migration plan, validation, rollout risk, and
-rollback notes.
+Open English follow-up issues for deferred major upgrades or blocked migration streams. Each issue should include
+official docs, current and target versions, expected code areas, migration plan, validation, rollout risk, and rollback
+notes.
 
 ## Stop And Ask
 

--- a/.agents/skills/linea-dependency-maintenance/evals/evals.json
+++ b/.agents/skills/linea-dependency-maintenance/evals/evals.json
@@ -10,7 +10,7 @@
     {
       "id": 2,
       "prompt": "In a pnpm monorepo with pnpm-workspace catalogs, minimumReleaseAge: 4320, and many pnpm overrides, bump safe patch/minor dependencies, clean stale overrides, and create issues for majors.",
-      "expected_output": "Updates catalog entries where appropriate, respects the 3-day maturity window and exclusions, regenerates pnpm-lock.yaml, minimizes overrides, validates affected workspaces, and tracks majors separately.",
+      "expected_output": "Updates catalog entries where appropriate, respects the 3-day maturity window and exclusions, regenerates pnpm-lock.yaml, pins every bumped version exactly (no ^/~), refreshes overrides by removing them then running pnpm i / pnpm audit --fix / pnpm i and reviewing what audit --fix generated, reverts any override forcing an incompatible transitive major, treats any fix still inside the maturity window as blocked rather than widening minimumReleaseAgeExclude, validates affected workspaces, and tracks majors separately.",
       "files": []
     },
     {
@@ -23,6 +23,12 @@
       "id": 4,
       "prompt": "A dependency PR fails CI after a safe update. Inspect logs, identify whether it is introduced or baseline debt, apply the smallest safe fix, and update the PR summary.",
       "expected_output": "Uses CI logs rather than guessing, reproduces narrowly when possible, classifies the failure, narrows or reverts the problematic update if needed, and keeps the PR description aligned with the actual update set.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "A dependency PR adds new packages and edits package.json with caret (^) and tilde (~) ranges. Bring it in line with the dependency-maintenance policy before it merges.",
+      "expected_output": "Treats every ^/~ range in dependencies/devDependencies as a policy violation and rewrites it to an exact pin, keeps catalog:/workspace: references intact and pins the concrete version at the catalog definition, leaves intentional peerDependencies ranges and engines (>=) constraints untouched, and regenerates the lockfile.",
       "files": []
     }
   ]

--- a/.agents/skills/linea-dependency-maintenance/references/npm.md
+++ b/.agents/skills/linea-dependency-maintenance/references/npm.md
@@ -10,7 +10,10 @@ Use these notes only for npm repositories with `package-lock.json`, npm CI, or n
 - Keep npm as the only package manager unless the user explicitly asks for a migration.
 - Do not commit `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `yarn.lock`, or `packageManager` changes to an npm repo just to
   inspect dependencies.
-- Preserve existing version specifier style. Exact pins stay exact; intentional ranges stay ranges.
+- Pin exact versions (mandatory): in `dependencies`/`devDependencies` write a single exact version, never a `^` or `~`
+  range, and tighten any pre-existing range you touch to an exact pin. Floating ranges pull unreviewed releases and
+  widen the supply-chain attack surface. Leave intentional `peerDependencies` ranges as ranges — peers declare a
+  compatibility window, not an install target.
 - Do not rely on `npm audit fix --force` for dependency-refresh PRs because it can apply semver-major changes or obscure
   why the tree changed.
 
@@ -49,6 +52,21 @@ Inspect `engines.node`, `.nvmrc`, Vercel/Docusaurus config, GitHub Actions, and 
 - Confirm paths with `npm explain <package>` or `npm ls <package>`.
 - Prefer parent-scoped overrides when a broad override creates invalid peer/range errors.
 - If the tree becomes invalid, remove the override and document the advisory as blocked.
+- Refresh the overrides block after direct bumps so you only keep exceptions still required. Unlike pnpm, `npm audit fix`
+  does not write `overrides`, so re-adding them is a manual, deliberate step:
+  ```bash
+  # 1. Remove the existing overrides block from package.json.
+  # 2. Let resolution settle without the overrides.
+  npm install
+  # 3. Apply only non-major fixes (never --force, which can pull semver-major changes).
+  npm audit fix
+  # 4. Reinstall so the lockfile reflects the fixed tree.
+  npm install
+  # 5. Inspect what remains.
+  npm audit --json || true
+  ```
+  Re-add a targeted, exact-pinned override only for each advisory still reported, then validate with `npm ci` since
+  changing overrides can shift transitive versions.
 
 ## Common Validation
 

--- a/.agents/skills/linea-dependency-maintenance/references/pnpm.md
+++ b/.agents/skills/linea-dependency-maintenance/references/pnpm.md
@@ -12,9 +12,12 @@ pnpm-specific CI.
   `only-allow` guards.
 - `minimumReleaseAge` is a maturity window in minutes. For example, `4320` means 3 days.
 - Respect `minimumReleaseAgeExclude`; do not manually block an excluded package solely because it is inside the maturity
-  window.
+  window. Treat the list as read-only — never add or widen entries to push a fresher version through.
 - Preserve `catalog:` and `workspace:` dependency references. Update the catalog entry rather than each manifest when a
   catalog owns the version.
+- Pin exact versions (mandatory): no `^` or `~` ranges in `dependencies`/`devDependencies`, catalog entries, or
+  overrides. Pin the concrete version at the catalog definition so consumers can keep using `catalog:`. Leave
+  intentional `peerDependencies` ranges as ranges — peers declare a compatibility window, not an install target.
 
 ## Baseline
 
@@ -46,13 +49,37 @@ Inspect `pnpm-workspace.yaml`, package manifests, `pnpm.overrides`, `minimumRele
 - Test whether an override is stale by checking whether removing it changes resolution or audit output in a temporary
   copy/worktree.
 - Prefer targeted selectors such as `parent>child` when a global override changes unrelated tooling.
-- Do not force transitive major versions through overrides for Hardhat, Jest/Istanbul, Graph/Matchstick, Playwright, or
-  framework stacks unless compatibility is proven.
+- Do not force a transitive dependency to a new major through an override unless the dependent package is proven to
+  support that major. Deep toolchains are the usual victims: the parent targets an older major's API, so jamming a newer
+  one in to silence an audit breaks it at runtime. When unsure, leave the advisory blocked and track it instead.
 - Confirm override effects:
   ```bash
   pnpm why <package> -r
   pnpm audit --json || true
   ```
+- Refresh the whole overrides block after direct bumps. Remove the existing overrides from the repo's pnpm source config,
+  then let resolution settle, run `pnpm audit --fix`, and reinstall so the lockfile reflects the fixed tree. In workspace
+  repos the live source config is often top-level `overrides` in `pnpm-workspace.yaml`; otherwise check `package.json` for
+  `pnpm.overrides` or `resolutions`. Do not edit generated `pnpm-lock.yaml` override metadata by hand:
+  ```bash
+  # remove the live overrides block from pnpm-workspace.yaml or package.json first
+  pnpm i
+  pnpm audit --fix
+  pnpm i
+  ```
+  On pnpm 10, `pnpm audit --fix` writes the overrides for you, so the manual work is to review and prune what it
+  generated, not to re-add from scratch. Recent pnpm versions can also edit maturity-gate settings; revert any generated
+  changes to `minimumReleaseAge`, `minimumReleaseAgeExclude`, or related settings before keeping the override result. On
+  older pnpm versions, use the remaining audit output to add targeted exact overrides manually. In both cases, drop
+  overrides for advisories no longer reported, pin each kept one to an exact version, and revert any that force an
+  incompatible transitive major (see the transitive-major rule above).
+- `minimumReleaseAge` gates overrides too: pnpm refuses an exact-version override still inside the maturity window, and a
+  range override can silently resolve to an older, still-vulnerable in-range version. Confirm with `pnpm why <package> -r`
+  and a re-audit that the intended patched version actually landed. If the only patched version is still inside the
+  maturity window, treat the advisory as blocked and track it until it matures — never add it to
+  `minimumReleaseAgeExclude`. If `pnpm audit --fix` adds such an exclusion, revert it; do not accept the silent,
+  still-vulnerable fallback or compensate for maturity failures with config changes.
+- Re-run validation, since shifting overrides can move transitive versions across the workspace.
 
 ## Common Validation
 

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -37,6 +37,11 @@ Enforces backwards compatibility for public APIs and versioned assets (ABIs, con
 - Wildcard Solidity imports (`import "path/to/File.sol"`)
 - `console.log` or `console.error` with sensitive data (tokens, keys, connection strings)
 - New dependencies added without justification in the PR description
+- Unpinned dependency versions in `dependencies`/`devDependencies`, catalog entries, or overrides (`^` caret or `~`
+  tilde ranges). Treat these as **blocking**: floating ranges pull unreviewed releases and widen the supply-chain attack
+  surface. Require an exact pin (`workspace:` and `catalog:` references are allowed when the catalog itself pins an exact
+  version). Do not flag intentional `peerDependencies` ranges or `engines` (`>=`) constraints; those are compatibility
+  windows, not install targets.
 - Environment variable changes not reflected in `.env.template` or `.env.example`
 - Hardcoded addresses or chain IDs that should be configurable
 - Unchecked arithmetic in Solidity without a safety comment


### PR DESCRIPTION
## Description

Syncs `linea-dependency-maintenance` with Consensys/linea-hub#2238 and adds the Bugbot rule for unpinned dependencies.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec prettier --check .agents/skills/linea-dependency-maintenance/SKILL.md .agents/skills/linea-dependency-maintenance/evals/evals.json .agents/skills/linea-dependency-maintenance/references/npm.md .agents/skills/linea-dependency-maintenance/references/pnpm.md .cursor/BUGBOT.md`
- Policy scan: no `^`/`~` specifiers remain in dependency manifests, catalogs, or lockfile specifiers

Note: full `pnpm lint` currently fails on pre-existing `contracts/signer-ui/app/page.tsx` Prettier issues unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-guidance only; no application or contract runtime behavior changes.
> 
> **Overview**
> **Tightens** the `linea-dependency-maintenance` agent skill and npm/pnpm reference docs so dependency work follows stricter supply-chain rules and clearer override/PR workflows.
> 
> **Policy:** Mandates **exact pins** in `dependencies`/`devDependencies` (and catalogs/overrides for pnpm)—no `^`/`~`—while still allowing `catalog:`/`workspace:` references and intentional `peerDependencies`/`engines` ranges. Treats pnpm `minimumReleaseAgeExclude` as **read-only** (never widen to bypass the maturity window).
> 
> **Overrides:** Documents a repeatable refresh flow (strip overrides → install → audit fix → reinstall → review), including reverting pnpm audit-fix edits to maturity settings and blocking silent vulnerable fallbacks when overrides hit `minimumReleaseAge`.
> 
> **Process:** Renames/expands PR guidance (“Open The PR”) to require green local validation, user confirmation before push, and repo-specific Conventional Commits for `refresh dependencies`.
> 
> **Evals:** Updates pnpm eval expectations and adds eval **#5** for caret/tilde cleanup.
> 
> **Bugbot:** Adds a **blocking** red flag for unpinned `^`/`~` in manifests, catalogs, and overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919921017c4e13aad790775e888d0981ae36c487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->