### PR TITLE
fix(prover): index-out-of-range panic in merkle proof verification

### DIFF
--- a/prover/maths/common/smartvectors/smartvectors.go
+++ b/prover/maths/common/smartvectors/smartvectors.go
@@ -639,12 +639,12 @@ func CoWindowRange(sv ...SmartVector) (start, stop int) {
 			if !foundAny {
 				start = s.Offset()
 				stop = s.Offset() + len(s.Window())
+				foundAny = true
 				continue
 			}
 
 			start = min(start, s.Offset())
 			stop = max(stop, s.Offset()+len(s.Window()))
-			foundAny = true
 		}
 	}
 

--- a/prover/maths/common/smartvectors/windowed_test.go
+++ b/prover/maths/common/smartvectors/windowed_test.go
@@ -64,3 +64,28 @@ func TestEdgeCases(t *testing.T) {
 	},
 		"NewConstant.Subvector should panic with 'zero length are not allowed' message")
 }
+
+// TestCoWindowRange checks that the range covers the union of every window,
+// independently of argument order, and that constants are skipped.
+func TestCoWindowRange(t *testing.T) {
+	const size = 16
+	a := NewPaddedCircularWindow(vector.Rand(3), field.Zero(), 2, size) // [2, 5)
+	b := NewPaddedCircularWindow(vector.Rand(4), field.Zero(), 8, size) // [8, 12)
+	c := NewConstant(field.Zero(), size)
+
+	start, stop := CoWindowRange(a, b)
+	require.Equal(t, 2, start)
+	require.Equal(t, 12, stop)
+
+	start, stop = CoWindowRange(b, a)
+	require.Equal(t, 2, start)
+	require.Equal(t, 12, stop)
+
+	start, stop = CoWindowRange(c, a, c)
+	require.Equal(t, 2, start)
+	require.Equal(t, 5, stop)
+
+	start, stop = CoWindowRange(NewRegular(vector.Rand(size)), a)
+	require.Equal(t, 0, start)
+	require.Equal(t, size, stop)
+}

--- a/prover/protocol/dedicated/ternary.go
+++ b/prover/protocol/dedicated/ternary.go
@@ -77,7 +77,7 @@ func (ctx *TernaryCtx) Run(run *wizard.ProverRuntime) {
 		res         = make([]field.Element, 0, stop-start)
 	)
 
-	for i := start; i <= stop; i++ {
+	for i := start; i < stop; i++ {
 
 		c := condition.Get(i)
 

--- a/prover/protocol/dedicated/ternary_test.go
+++ b/prover/protocol/dedicated/ternary_test.go
@@ -1,0 +1,85 @@
+package dedicated
+
+import (
+	"fmt"
+	"testing"
+
+	sv "github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+	"github.com/consensys/linea-monorepo/prover/maths/common/vector"
+	"github.com/consensys/linea-monorepo/prover/maths/field"
+	"github.com/consensys/linea-monorepo/prover/protocol/compiler/dummy"
+	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTernary checks [Ternary] over constant, full and padded-window inputs.
+// Full vectors and end-anchored windows cover the case where the active range
+// reaches the last row, which previously read past the end of the column.
+func TestTernary(t *testing.T) {
+
+	const size = 8
+
+	boolShapes := []sv.SmartVector{
+		sv.NewConstant(field.Zero(), size),
+		sv.NewConstant(field.One(), size),
+		sv.ForTest(0, 1, 0, 1, 0, 1, 0, 1),
+		sv.ForTest(1, 1, 1, 1, 1, 1, 1, 1),
+		sv.NewPaddedCircularWindow(vector.ForTest(1, 0, 1, 0), field.Zero(), 0, size),
+		sv.NewPaddedCircularWindow(vector.ForTest(1, 0, 1, 0), field.Zero(), 2, size),
+		sv.NewPaddedCircularWindow(vector.ForTest(1, 0, 1, 0), field.Zero(), 4, size),
+	}
+
+	valShapes := []sv.SmartVector{
+		sv.NewConstant(field.NewElement(7), size),
+		sv.ForTest(10, 11, 12, 13, 14, 15, 16, 17),
+		sv.NewPaddedCircularWindow(vector.ForTest(1, 2, 3, 4), field.NewElement(42), 0, size),
+		sv.NewPaddedCircularWindow(vector.ForTest(1, 2, 3, 4), field.NewElement(42), 4, size),
+	}
+
+	runCase := func(t *testing.T, cond, ifTrue, ifFalse sv.SmartVector) {
+
+		var ctx *TernaryCtx
+
+		define := func(b *wizard.Builder) {
+			c := b.RegisterCommit("COND", size)
+			tCol := b.RegisterCommit("IF_TRUE", size)
+			fCol := b.RegisterCommit("IF_FALSE", size)
+			ctx = Ternary(b.CompiledIOP, c, tCol, fCol)
+		}
+
+		prover := func(run *wizard.ProverRuntime) {
+			run.AssignColumn("COND", cond)
+			run.AssignColumn("IF_TRUE", ifTrue)
+			run.AssignColumn("IF_FALSE", ifFalse)
+
+			ctx.Run(run)
+
+			res := ctx.Result.GetColAssignment(run)
+			for k := 0; k < size; k++ {
+				want := ifFalse.Get(k)
+				c := cond.Get(k)
+				if !c.IsZero() {
+					want = ifTrue.Get(k)
+				}
+				got := res.Get(k)
+				require.Truef(t, want.Equal(&got), "row #%v: want %v got %v", k, want.String(), got.String())
+			}
+		}
+
+		comp := wizard.Compile(define, dummy.Compile)
+		proof := wizard.Prove(comp, prover)
+		if err := wizard.Verify(comp, proof); err != nil {
+			t.Fatalf("verifier did not accept: %v", err.Error())
+		}
+	}
+
+	for ci, cond := range boolShapes {
+		for ti, ifTrue := range valShapes {
+			for fi, ifFalse := range valShapes {
+				t.Run(fmt.Sprintf("cond-%v-true-%v-false-%v", ci, ti, fi), func(t *testing.T) {
+					runCase(t, cond, ifTrue, ifFalse)
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION

### Problem
The prover panics with `index out of range [N] with length N` during state-manager Merkle proof verification (`FlatMerkleProofVerification.Run` in `prover/protocol/dedicated/merkle/flat_proof_verification.go` → `TernaryCtx.Run` in `prover/protocol/dedicated/ternary.go`) on near-full batches.

The Merkle proof has `MerkleTreeDepth = 40` levels — set in `prover/zkevm/full.go` and passed as the proof depth in `prover/zkevm/prover/statemanager/accumulator/define.go` — and each level extends the active range by one row. So the panic triggers when the number of active Merkle-proof rows comes within 40 of the column size, i.e. when there are fewer than 40 padding rows left:

```
column size − active rows ≤ 40
```


For an 8192-row column that means active rows in [8152, 8192] (8192 − 40 = 8152).  With more padding than that, the out-of-bounds read lands on a padding row and is harmless, which is why it only surfaces on near-full batches.

### Root cause
Two related bugs in the compact-range handling that backs `Ternary`:

1. **`TernaryCtx.Run`** (`prover/protocol/dedicated/ternary.go`) iterates `for i := start; i <= stop; i++` over the **half-open** range `[start, stop)` returned by `CoCompactRange`. The `<=` reads index `stop`, one element past the end. For non-full inputs the extra read lands on a padding row and is harmless, which is why it only surfaces when the active range reaches the last row.

2. **`CoWindowRange`** (`prover/maths/common/smartvectors/smartvectors.go`) sets `foundAny = true` only *after* an early `continue`, so it is never set. Each padded window overwrites `start`/`stop` instead of being merged, and the `min`/`max` union becomes dead code — combining two distinct windows returns only the last window's range.


### Fix
- `prover/protocol/dedicated/ternary.go`: iterate `i < stop`.
- `prover/maths/common/smartvectors/smartvectors.go`: set `foundAny` in the first branch so the range spans every window.

### Testing
- `TestTernary` (`prover/protocol/dedicated/ternary_test.go`, new): exercises constant / full / padded-window inputs, including the end-reaching case that read past the column.
- `TestCoWindowRange` (`prover/maths/common/smartvectors/windowed_test.go`, new): asserts the range is the union of all windows, order-independent, constants skipped.
- Both new tests fail on the previous code and pass with the fix; the `dedicated`, `smartvectors`, `merkle`, and `accumulator` packages all pass.

### Conflation with this panic
- 30040499-30040593 (mainnet backtesting conflation)


### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
