### PR TITLE
chore(coordinator): update kotlin to v2.4

### DIFF
--- a/buildSrc/src/main/groovy/net.consensys.zkevm.kotlin-common-minimal-conventions.gradle
+++ b/buildSrc/src/main/groovy/net.consensys.zkevm.kotlin-common-minimal-conventions.gradle
@@ -15,7 +15,6 @@ java {
 
 kotlin {
   compilerOptions {
-    freeCompilerArgs.add("-Xannotation-default-target=param-property")
     sourceSets.configureEach {
       languageSettings.optIn("kotlin.time.ExperimentalTime")
     }

--- a/coordinator/clients/prover-client/file-based-client/src/main/kotlin/linea/coordinator/clients/prover/FileBasedProofAggregationClientV2.kt
+++ b/coordinator/clients/prover-client/file-based-client/src/main/kotlin/linea/coordinator/clients/prover/FileBasedProofAggregationClientV2.kt
@@ -170,7 +170,7 @@ class FileBasedProofAggregationClientV2(
     }
     return fileMonitor
       .awaitForAllFiles(responseNames)
-      .thenApply { null }
+      .thenApply { }
   }
 
   companion object {

--- a/coordinator/core/src/main/kotlin/linea/coordination/conflation/BlockToBatchSubmissionCoordinator.kt
+++ b/coordinator/core/src/main/kotlin/linea/coordination/conflation/BlockToBatchSubmissionCoordinator.kt
@@ -13,7 +13,7 @@ import linea.domain.Block
 import linea.domain.BlockCounters
 import linea.encoding.BlockEncoder
 import linea.error.ErrorResponse
-import net.consensys.linea.async.toSafeFuture
+import net.consensys.linea.async.toSafeFutureNonNull
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
@@ -77,6 +77,6 @@ class BlockToBatchSubmissionCoordinator(
         encoder.encode(block)
       },
     )
-      .toSafeFuture()
+      .toSafeFutureNonNull()
   }
 }

--- a/coordinator/ethereum/blob-submitter/src/main/kotlin/linea/finalization/AggregationFinalizationCoordinator.kt
+++ b/coordinator/ethereum/blob-submitter/src/main/kotlin/linea/finalization/AggregationFinalizationCoordinator.kt
@@ -165,7 +165,7 @@ class AggregationFinalizationCoordinator(
       parentShnarf = aggregationData.parentShnarf,
       parentL1RollingHash = aggregationData.parentL1RollingHash,
       parentL1RollingHashMessageNumber = aggregationData.parentL1RollingHashMessageNumber,
-    ).thenApply { Unit }
+    ).thenApply { }
   }
 
   override fun handleError(error: Throwable) {

--- a/coordinator/ethereum/message-anchoring/src/main/kotlin/linea/anchoring/MessageAnchoringApp.kt
+++ b/coordinator/ethereum/message-anchoring/src/main/kotlin/linea/anchoring/MessageAnchoringApp.kt
@@ -89,7 +89,6 @@ class MessageAnchoringApp(
       l1EventsPoller.stop(),
       messageAnchoringService.stop(),
     ).thenApply {
-      Unit
     }
   }
 }

--- a/coordinator/utilities/src/main/kotlin/linea/fileio/FileReader.kt
+++ b/coordinator/utilities/src/main/kotlin/linea/fileio/FileReader.kt
@@ -8,7 +8,7 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import io.vertx.core.Vertx
 import linea.error.ErrorResponse
-import net.consensys.linea.async.toSafeFuture
+import net.consensys.linea.async.toSafeFutureNonNull
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.nio.file.Path
 import java.util.concurrent.Callable
@@ -27,7 +27,7 @@ class FileReader<T>(
       .executeBlocking(
         Callable {
           try {
-            val value = mapper.readValue(filePath.toFile(), classOfT)
+            val value = mapper.readValue(filePath.toFile(), classOfT) as T
             Ok(value)
           } catch (e: Exception) {
             when (e) {
@@ -40,6 +40,6 @@ class FileReader<T>(
         },
         false,
       )
-      .toSafeFuture()
+      .toSafeFutureNonNull()
   }
 }

--- a/coordinator/utilities/src/main/kotlin/linea/fileio/FileWriter.kt
+++ b/coordinator/utilities/src/main/kotlin/linea/fileio/FileWriter.kt
@@ -2,7 +2,7 @@ package linea.fileio
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.vertx.core.Vertx
-import net.consensys.linea.async.toSafeFuture
+import net.consensys.linea.async.toSafeFutureNonNull
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.nio.file.Path
 import java.util.concurrent.Callable
@@ -26,7 +26,7 @@ class FileWriter(
           filePath
         },
         false,
-      ).toSafeFuture()
+      ).toSafeFutureNonNull()
   }
 
   fun writingDoneOrInProgress(filePath: Path, inProgressSuffix: String): SafeFuture<Boolean> {
@@ -35,7 +35,7 @@ class FileWriter(
         filePath.exists() || inProgressFilePath(filePath, inProgressSuffix).exists()
       },
       false,
-    ).toSafeFuture()
+    ).toSafeFutureNonNull()
   }
 
   private fun inProgressFilePath(filePath: Path, inProgressSuffix: String): Path {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ commonsIo = { group = "commons-io", name = "commons-io", version.ref = "commonsI
 
 [versions]
 # Build
-kotlin = "2.3.0"
+kotlin = "2.4.0"
 
 # Testing
 assertj = "3.27.3"

--- a/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/VertxFutureExtensions.kt
+++ b/jvm-libs/generic/extensions/futures/src/main/kotlin/net/consensys/linea/async/VertxFutureExtensions.kt
@@ -9,6 +9,12 @@ fun <T> Future<T>.get(): T = this.toCompletionStage().toCompletableFuture().get(
 
 fun <T> Future<T>.toSafeFuture(): SafeFuture<T> = SafeFuture.of(this.toCompletionStage())
 
+// Kotlin 2.4+ strictly propagates Vert.x's @Nullable annotation on executeBlocking's return type,
+// yielding Future<T?> even when the Callable never returns null. This overload re-asserts non-null.
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> Future<T?>.toSafeFutureNonNull(): SafeFuture<T> =
+  SafeFuture.of(this.toCompletionStage()) as SafeFuture<T>
+
 fun <T> SafeFuture<T>.toVertxFuture(): Future<T> {
   val result = Promise.promise<T>()
   this.thenAccept(result::complete)

--- a/jvm-libs/linea/besu-rlp-and-mappers/src/main/kotlin/linea/rlp/BesuRlpMainnetEncoder.kt
+++ b/jvm-libs/linea/besu-rlp-and-mappers/src/main/kotlin/linea/rlp/BesuRlpMainnetEncoder.kt
@@ -1,7 +1,7 @@
 package linea.rlp
 
 import io.vertx.core.Vertx
-import net.consensys.linea.async.toSafeFuture
+import net.consensys.linea.async.toSafeFutureNonNull
 import org.hyperledger.besu.ethereum.core.Block
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.concurrent.Callable
@@ -25,7 +25,7 @@ class BesuRlpMainnetEncoderAsyncVertxImpl(
       },
       false,
     )
-      .toSafeFuture()
+      .toSafeFutureNonNull()
   }
 }
 
@@ -55,6 +55,6 @@ class BesuRlpDecoderAsyncVertxImpl(
       },
       false,
     )
-      .toSafeFuture()
+      .toSafeFutureNonNull()
   }
 }

--- a/jvm-libs/linea/core/long-running-service/src/main/kotlin/linea/LongRunningService.kt
+++ b/jvm-libs/linea/core/long-running-service/src/main/kotlin/linea/LongRunningService.kt
@@ -23,11 +23,11 @@ interface LongRunningService {
 
 internal class ServiceAggregator<T : LongRunningService>(private val services: List<T>) : LongRunningService {
   override fun start(): CompletableFuture<Unit> {
-    return CompletableFuture.allOf(*services.map { it.start() }.toTypedArray()).thenApply { Unit }
+    return CompletableFuture.allOf(*services.map { it.start() }.toTypedArray()).thenApply { }
   }
 
   override fun stop(): CompletableFuture<Unit> {
-    return CompletableFuture.allOf(*services.reversed().map { it.stop() }.toTypedArray()).thenApply { Unit }
+    return CompletableFuture.allOf(*services.reversed().map { it.stop() }.toTypedArray()).thenApply { }
   }
 }
 

--- a/linea-besu/plugins/state-recovery/appcore/logic/src/main/kotlin/linea/staterecovery/BlobDecompressorAndDeserializer.kt
+++ b/linea-besu/plugins/state-recovery/appcore/logic/src/main/kotlin/linea/staterecovery/BlobDecompressorAndDeserializer.kt
@@ -7,7 +7,7 @@ import linea.kotlin.decodeHex
 import linea.kotlin.encodeHex
 import linea.rlp.BesuRlpBlobDecoder
 import linea.rlp.RLP
-import net.consensys.linea.async.toSafeFuture
+import net.consensys.linea.async.toSafeFutureNonNull
 import net.consensys.linea.blob.BlobDecompressor
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -133,6 +133,6 @@ class BlobDecompressorToDomainV1(
       false,
     )
       .onFailure(logger::error)
-      .toSafeFuture()
+      .toSafeFutureNonNull()
   }
 }

--- a/maru/consensus/src/main/kotlin/maru/consensus/qbft/QbftGossiper.kt
+++ b/maru/consensus/src/main/kotlin/maru/consensus/qbft/QbftGossiper.kt
@@ -27,6 +27,5 @@ class QbftGossiper : QbftGossiper {
     message: QbftMessage,
     replayed: Boolean,
   ) {
-    Unit
   }
 }

--- a/maru/core/src/test/kotlin/maru/subscription/InOrderFanoutSubscriptionManagerTest.kt
+++ b/maru/core/src/test/kotlin/maru/subscription/InOrderFanoutSubscriptionManagerTest.kt
@@ -189,7 +189,6 @@ class InOrderFanoutSubscriptionManagerTest {
           notifications.add("handler$i called with: $data")
           SafeFuture.runAsync({
             Thread.sleep(5) // Simulate async processing delay
-            "handler2 called with: $data"
           })
         })
       }


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide but mechanical Kotlin/typing changes across coordinator and async I/O paths; behavior should be unchanged aside from compile-time null assertions on Vert.x blocking work.
> 
> **Overview**
> **Bumps Kotlin from 2.3.0 to 2.4.0** and drops the `-Xannotation-default-target=param-property` compiler flag from shared Gradle conventions.
> 
> Kotlin 2.4 treats Vert.x `executeBlocking` as returning **`Future<T?>`** because of `@Nullable`, which broke typing for `SafeFuture` chains. The PR adds **`toSafeFutureNonNull()`** in `VertxFutureExtensions` and switches coordinator, file I/O, RLP, and state-recovery call sites from `toSafeFuture()` to that helper. **`FileReader`** also adds an explicit `as T` on Jackson `readValue`.
> 
> Several **`thenApply { Unit }`** usages become empty lambdas **`thenApply { }`** (e.g. aggregation finalization, long-running service compose, message anchoring stop). Minor cleanups: no-op **`QbftGossiper.send`** uses an empty body instead of `Unit`, and a maru subscription test removes an unused string expression inside `SafeFuture.runAsync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e8b897694fc825a02296da1d71ad4ccb23a41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->