### PR TITLE
feat(coordinator): add config documentation annotations

### DIFF
--- a/coordinator/app/build.gradle
+++ b/coordinator/app/build.gradle
@@ -60,6 +60,8 @@ dependencies {
   implementation project(':coordinator:ethereum:gas-pricing:dynamic-cap')
   implementation project(':coordinator:ethereum:gas-pricing')
 
+  // Used by the config documentation generator to walk TOML schema classes via reflection.
+  implementation "org.jetbrains.kotlin:kotlin-reflect:${libs.versions.kotlin.get()}"
   implementation "info.picocli:picocli:${libs.versions.picoli.get()}"
   implementation "io.vertx:vertx-web-client"
   implementation "com.sksamuel.hoplite:hoplite-core:${libs.versions.hoplite.get()}"

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConfigDoc.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConfigDoc.kt
@@ -1,0 +1,56 @@
+package linea.coordinator.config.v2.toml
+
+/**
+ * Documents a leaf Coordinator config value that can appear directly in TOML.
+ *
+ * Use on scalar values, enums, lists, maps, durations, URLs, paths, and other leaf types,
+ * i.e. constructor parameters that are not themselves config data classes. Nested config
+ * data classes should be annotated with [ConfigSection] instead.
+ *
+ * Must be applied with the `@param:` use-site target so the annotation is retained on the
+ * constructor's value parameter and readable via Kotlin reflection
+ * (`KParameter.annotations`), e.g.:
+ *
+ * ```
+ * data class DatabaseToml(
+ *   @param:ConfigDoc("PostgreSQL hostname used by the coordinator persistence layer.", example = "postgres")
+ *   val hostname: String,
+ * )
+ * ```
+ *
+ * @property description Required human-readable explanation of what the key controls.
+ * @property example Optional example value rendered in the generated docs.
+ * @property deprecated Marks a config key as deprecated while keeping it documented.
+ * @property replacement Optional replacement key shown in the generated docs and changelog.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ConfigDoc(
+  val description: String,
+  val example: String = "",
+  val deprecated: Boolean = false,
+  val replacement: String = "",
+)
+
+/**
+ * Documents a nested Coordinator config TOML table.
+ *
+ * Use when a constructor parameter is itself another config data class rather than a direct
+ * value. Leaf values within that nested class should be annotated with [ConfigDoc].
+ *
+ * Must be applied with the `@param:` use-site target, e.g.:
+ *
+ * ```
+ * data class CoordinatorConfigFileToml(
+ *   @param:ConfigSection("Coordinator PostgreSQL persistence settings.")
+ *   val database: DatabaseToml,
+ * )
+ * ```
+ *
+ * @property description Required human-readable explanation of what the section configures.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ConfigSection(
+  val description: String,
+)

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/toml/ConfigDocTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/toml/ConfigDocTest.kt
@@ -1,0 +1,61 @@
+package linea.coordinator.config.v2.toml
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
+
+class ConfigDocTest {
+  private data class SampleToml(
+    @param:ConfigDoc(
+      description = "A documented leaf value.",
+      example = "example-value",
+    )
+    val leaf: String,
+
+    @param:ConfigDoc(
+      description = "A deprecated leaf value.",
+      deprecated = true,
+      replacement = "sample.new-leaf",
+    )
+    val deprecatedLeaf: String? = null,
+
+    @param:ConfigSection("A documented nested section.")
+    val section: SampleToml? = null,
+
+    val undocumented: String = "",
+  )
+
+  private val params = SampleToml::class.primaryConstructor!!.parameters.associateBy { it.name }
+
+  @Test
+  fun `ConfigDoc is retained at runtime and readable from the constructor value parameter`() {
+    val doc = params.getValue("leaf").findAnnotation<ConfigDoc>()
+    assertThat(doc).isNotNull
+    assertThat(doc!!.description).isEqualTo("A documented leaf value.")
+    assertThat(doc.example).isEqualTo("example-value")
+    assertThat(doc.deprecated).isFalse()
+    assertThat(doc.replacement).isEmpty()
+  }
+
+  @Test
+  fun `ConfigDoc carries deprecation metadata`() {
+    val doc = params.getValue("deprecatedLeaf").findAnnotation<ConfigDoc>()
+    assertThat(doc).isNotNull
+    assertThat(doc!!.deprecated).isTrue()
+    assertThat(doc.replacement).isEqualTo("sample.new-leaf")
+  }
+
+  @Test
+  fun `ConfigSection is retained at runtime and readable from the constructor value parameter`() {
+    val section = params.getValue("section").findAnnotation<ConfigSection>()
+    assertThat(section).isNotNull
+    assertThat(section!!.description).isEqualTo("A documented nested section.")
+  }
+
+  @Test
+  fun `parameters without an annotation report none`() {
+    assertThat(params.getValue("undocumented").findAnnotation<ConfigDoc>()).isNull()
+    assertThat(params.getValue("undocumented").findAnnotation<ConfigSection>()).isNull()
+  }
+}


### PR DESCRIPTION
#2978 

## Summary

First step toward generating Coordinator config documentation directly from the Hoplite TOML schema classes (Coordinator's config is not Picocli-based, so it can't reuse Besu's CLI-option metadata).

This change adds the documentation annotations that later phases will reflect over to validate and generate docs:

- **`ConfigDoc`** — documents a leaf config value (`description`, `example`, `deprecated`, `replacement`).
- **`ConfigSection`** — documents a nested TOML table.

Both are `@Retention(RUNTIME)` + `@Target(VALUE_PARAMETER)` so they are readable via Kotlin reflection from a data class's primary-constructor parameters (requires the `@param:` use-site target). A `kotlin-reflect` dependency is declared explicitly on `coordinator:app` for the upcoming schema walker/generator.

No existing config classes are annotated yet — that happens in a later phase once the generator and `check` task exist.

## Changes

- Add `ConfigDoc` / `ConfigSection` annotations under `linea.coordinator.config.v2.toml`.
- Declare explicit `kotlin-reflect` dependency in `coordinator/app/build.gradle`.
- Add `ConfigDocTest` verifying the annotations are runtime-readable (description, deprecation metadata, and the no-annotation case).

## Test plan

- `./gradlew :coordinator:app:test --tests "linea.coordinator.config.v2.toml.ConfigDocTest"` — passes (4 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only metadata and tests; no runtime config loading or behavior changes until later phases annotate schemas.
> 
> **Overview**
> Introduces **runtime-retained annotations** on Hoplite TOML schema constructor parameters so a later generator can walk `*Toml` data classes and produce Coordinator config docs (instead of reusing Besu-style CLI metadata).
> 
> **`ConfigDoc`** documents leaf keys (`description`, optional `example`, `deprecated`, `replacement`); **`ConfigSection`** documents nested TOML tables. Both target value parameters and are meant to be applied with `@param:` for `KParameter` reflection.
> 
> Adds an explicit **`kotlin-reflect`** dependency on `coordinator:app` for that upcoming walker, plus **`ConfigDocTest`** asserting annotations are readable and that undocumented parameters have none. No existing config classes are annotated in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf558f1d313daac7ab08ae176326567b8fb4e0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->