### PR TITLE
fix(prover): bit-decompose limbs by absolute row, not compact position

### DIFF
--- a/prover/protocol/dedicated/bits/bitdecompose.go
+++ b/prover/protocol/dedicated/bits/bitdecompose.go
@@ -79,43 +79,26 @@ func BitDecompose(comp *wizard.CompiledIOP, packed []ifaces.Column, numBits int)
 // Run implements the [wizard.ProverAction] interface and assigns the bits
 // columns
 func (bd *BitDecomposed) Run(run *wizard.ProverRuntime) {
-	bits := make([][]field.Element, len(bd.Bits))
 
-	// Obtain packed elements from
-	elements := make([][]field.Element, 0, len(bd.Packed))
+	size := bd.Packed[0].Size()
+
+	// Limbs are compacted independently, so combine them by absolute row over a
+	// shared range rather than by per-limb compact position.
+	assignments := make([]smartvectors.SmartVector, len(bd.Packed))
 	for i, packed := range bd.Packed {
-		// ind mirrors the mapping in BitDecompose's constraint loop:
-		// packed[len-1] (LSB limb) → IsPackedLimbNotZero[0], etc.
-		ind := len(bd.Packed) - 1 - i
-
-		v := packed.GetColAssignment(run)
-		var packedElements []field.Element
-		var packedElementsIsZero []field.Element
-
-		for colElement := range v.IterateCompact() {
-			packedElements = append(packedElements, colElement)
-
-			isPackedLimbNotZero := field.One()
-			if colElement.IsZero() {
-				isPackedLimbNotZero = field.Zero()
-			}
-
-			packedElementsIsZero = append(packedElementsIsZero, isPackedLimbNotZero)
-		}
-
-		// Guard mirrors the `if ind*16 >= numBits { continue }` in BitDecompose:
-		// packed limbs beyond numBits have no corresponding IsPackedLimbNotZero entry.
-		if ind < len(bd.IsPackedLimbNotZero) {
-			run.AssignColumn(bd.IsPackedLimbNotZero[ind].GetColID(), smartvectors.RightZeroPadded(packedElementsIsZero, bd.Packed[0].Size()))
-		}
-
-		elements = append(elements, packedElements)
+		assignments[i] = packed.GetColAssignment(run)
 	}
 
-	for i := range elements[0] {
-		var el []field.Element
-		for j := range elements {
-			el = append(el, elements[j][i])
+	start, stop := smartvectors.CoCompactRange(assignments...)
+
+	bits := make([][]field.Element, len(bd.Bits))
+	notZero := make([][]field.Element, len(bd.IsPackedLimbNotZero))
+
+	el := make([]field.Element, len(assignments))
+	for row := start; row < stop; row++ {
+
+		for j := range assignments {
+			el[j] = assignments[j].Get(row)
 		}
 
 		x := combineElements(el)
@@ -125,17 +108,41 @@ func (bd *BitDecomposed) Run(run *wizard.ProverRuntime) {
 		}
 
 		xNum := x.Uint64()
-		for j := range len(bd.Bits) {
+		for j := range bd.Bits {
 			if xNum>>j&1 == 1 {
 				bits[j] = append(bits[j], field.One())
 			} else {
 				bits[j] = append(bits[j], field.Zero())
 			}
 		}
+
+		for i := range bd.Packed {
+			// LSB limb packed[len-1] maps to IsPackedLimbNotZero[0].
+			ind := len(bd.Packed) - 1 - i
+			if ind >= len(bd.IsPackedLimbNotZero) {
+				continue
+			}
+
+			if el[i].IsZero() {
+				notZero[ind] = append(notZero[ind], field.Zero())
+			} else {
+				notZero[ind] = append(notZero[ind], field.One())
+			}
+		}
 	}
 
-	for i, bitCol := range bd.Bits {
-		run.AssignColumn(bitCol.GetColID(), smartvectors.FromCompactWithShape(bd.Packed[0].GetColAssignment(run), bits[i]))
+	for i := range bd.IsPackedLimbNotZero {
+		run.AssignColumn(
+			bd.IsPackedLimbNotZero[i].GetColID(),
+			smartvectors.FromCompactWithRange(notZero[i], start, stop, size),
+		)
+	}
+
+	for j, bitCol := range bd.Bits {
+		run.AssignColumn(
+			bitCol.GetColID(),
+			smartvectors.FromCompactWithRange(bits[j], start, stop, size),
+		)
 	}
 }
 

--- a/prover/protocol/dedicated/bits/bitdecompose_test.go
+++ b/prover/protocol/dedicated/bits/bitdecompose_test.go
@@ -1,0 +1,86 @@
+package bits
+
+import (
+	"testing"
+
+	sv "github.com/consensys/linea-monorepo/prover/maths/common/smartvectors"
+	"github.com/consensys/linea-monorepo/prover/maths/field"
+	"github.com/consensys/linea-monorepo/prover/protocol/compiler/dummy"
+	"github.com/consensys/linea-monorepo/prover/protocol/ifaces"
+	"github.com/consensys/linea-monorepo/prover/protocol/wizard"
+	"github.com/consensys/linea-monorepo/prover/zkevm/prover/common"
+	"github.com/stretchr/testify/require"
+)
+
+// limbsOf splits a value into big-endian limbs, as [combineElements] reassembles them.
+func limbsOf(v uint64) []uint64 {
+	limbs := make([]uint64, common.NbElemForHasingU64)
+	mask := uint64(1)<<(8*common.LimbBytes) - 1
+	for i := common.NbElemForHasingU64 - 1; i >= 0; i-- {
+		limbs[i] = v & mask
+		v >>= 8 * common.LimbBytes
+	}
+	return limbs
+}
+
+// TestBitDecomposeHeterogeneousLimbs covers all-zero high-order limbs, which
+// compact to a Constant while the low limbs stay full. Decomposing on the first
+// limb's shape would freeze the bits to row 0 and break recombination.
+func TestBitDecomposeHeterogeneousLimbs(t *testing.T) {
+
+	const (
+		size    = 8
+		numBits = 32
+	)
+
+	// Positions from the failing trace; 70000 also exercises the second limb.
+	positions := []uint64{260, 29, 70000, 3, 45640, 95, 19228, 7}
+	require.Len(t, positions, size)
+
+	limbCols := make([][]field.Element, common.NbElemForHasingU64)
+	for i := range limbCols {
+		limbCols[i] = make([]field.Element, size)
+	}
+	for row, p := range positions {
+		ls := limbsOf(p)
+		for i := range ls {
+			limbCols[i][row] = field.NewElement(ls[i])
+		}
+	}
+
+	var bd *BitDecomposed
+
+	define := func(b *wizard.Builder) {
+		packed := make([]ifaces.Column, common.NbElemForHasingU64)
+		for i := range packed {
+			packed[i] = b.RegisterCommit(ifaces.ColIDf("POS_%v", i), size)
+		}
+		bd = BitDecompose(b.CompiledIOP, packed, numBits)
+	}
+
+	prove := func(run *wizard.ProverRuntime) {
+		for i := range limbCols {
+			run.AssignColumn(ifaces.ColIDf("POS_%v", i), sv.NewRegular(limbCols[i]))
+		}
+
+		bd.Run(run)
+
+		// Bits must track each row's position, not a frozen value.
+		for row, p := range positions {
+			var got uint64
+			for j := range bd.Bits {
+				bit := bd.Bits[j].GetColAssignment(run).Get(row)
+				if bit.IsOne() {
+					got |= uint64(1) << j
+				} else {
+					require.Truef(t, bit.IsZero(), "row %v bit %v is non-boolean", row, j)
+				}
+			}
+			require.Equalf(t, p, got, "row %v: recombined bits %v != position %v", row, got, p)
+		}
+	}
+
+	comp := wizard.Compile(define, dummy.Compile)
+	proof := wizard.Prove(comp, prove)
+	require.NoError(t, wizard.Verify(comp, proof), "recombination constraints must hold")
+}


### PR DESCRIPTION
## Problem

The position bit-decomposition in the state-manager accumulator produced wrong bits, failing `ACCUMULATOR_POSITIONS_*_BIT_RECOMBINATION` and `ACCUMULATOR_MERKLE_PROOFS_ROOT_*_MATCH`, and panicking in the limitless lookup ("entry not included in the table").

error msg:
```
panic: The prover did not pass: Several errors were encountered:
	failed ACCUMULATOR_POSITIONS_15_BIT_RECOMBINATION - the global constraint check failed at row 2
		res: -231
	failed ACCUMULATOR_POSITIONS_14_BIT_RECOMBINATION - the global constraint check failed at row 4
		res: 4
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_0_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_1_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_2_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_3_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_4_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_5_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_6_MATCH - the global constraint check failed at row 2
	failed ACCUMULATOR_MERKLE_PROOFS_ROOT_7_MATCH - the global constraint check failed at row 2
```

## Root cause

`BitDecomposed.Run` combined the packed limbs by walking `packed[0]`'s compact representation and indexing the other limbs at the same position, then shaped every bit column on `packed[0]`. This assumes all limbs share one compact shape. They don't: each limb is compacted independently at assignment time, and all-zero high-order limbs collapse to a `Constant`. Since the MSB position limb is always zero, its compact form has length 1, so the loop ran once and froze every bit column to row 0's value. The frozen bits then drove the wrong Merkle path, so the computed root did not match the claimed root.


## Fix

Combine limbs by absolute row index over a shared `CoCompactRange` and emit the bit / `IsPackedLimbNotZero` columns via `FromCompactWithRange`. This is independent of each limb's compact shape and handles full columns correctly.

## Testing

- New `TestBitDecomposeHeterogeneousLimbs` (zero MSB limb + varying low limb): fails on the old code with `recombined bits 260 != position 29`, passes with the fix.
- `bits`, `merkle`, `accumulator` suites pass.
- On the failing conflation, `BIT_RECOMBINATION` and `ROOT_*_MATCH` no longer fail. 

## Conflation with this error

`30054884-30054999` (mainnet backtest) fills `SHOMEI_MERKLE_PROOFS` (8192), making the state-manager full and triggering the bug. 



### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
