### PR TITLE
chore(contracts): add stateless-safe-validator

### DIFF
--- a/contracts/deploy/24_deploy_SafeExecutionConditions.ts
+++ b/contracts/deploy/24_deploy_SafeExecutionConditions.ts
@@ -1,0 +1,25 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { LogContractDeployment, tryVerifyContract } from "../common/helpers";
+import { getUiSigner, withSignerUiSession } from "../scripts/hardhat/signer-ui-bridge";
+import { deployFromFactory } from "../scripts/hardhat/utils";
+
+const func: DeployFunction = withSignerUiSession(
+  "24_deploy_SafeExecutionConditions.ts",
+  async function (hre: HardhatRuntimeEnvironment) {
+    const contractName = "SafeExecutionConditions";
+    const signer = await getUiSigner(hre);
+
+    // No constructor args: the contract is stateless.
+    const contract = await deployFromFactory(contractName, signer);
+
+    await LogContractDeployment(contractName, contract);
+    const contractAddress = await contract.getAddress();
+
+    await tryVerifyContract(contractAddress, "src/operational/SafeExecutionConditions.sol:SafeExecutionConditions");
+  },
+);
+
+export default func;
+func.tags = ["SafeExecutionConditions"];

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -15,6 +15,7 @@ import { clearHandoffStore } from "./common/helpers/deploymentHandoff";
 import { SupportedChainIds } from "./common/supportedNetworks";
 import { overrides } from "./hardhat_overrides";
 import { resolveDeployerAccounts } from "./scripts/hardhat/deployer-accounts";
+import "./scripts/hardhat/solcWarningFilter";
 import "./scripts/operational/tasks/getCurrentFinalizedBlockNumberTask";
 import "./scripts/operational/tasks/grantContractRolesTask";
 import "./scripts/operational/tasks/renounceContractRolesTask";

--- a/contracts/scripts/hardhat/solcWarningFilter.ts
+++ b/contracts/scripts/hardhat/solcWarningFilter.ts
@@ -1,0 +1,55 @@
+import { TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS } from "hardhat/builtin-tasks/task-names";
+import { subtask } from "hardhat/config";
+
+/**
+ * Solc warnings that are intentionally suppressed, scoped to a specific source file and warning code.
+ *
+ * Add an entry only when a warning is a deliberate, documented design choice for a specific contract.
+ * The filter is intentionally narrow (file suffix + warning code) so unrelated warnings are never hidden.
+ *
+ * - 2018 ("Function state mutability can be restricted to view"): the `SafeExecutionConditions` guards are
+ *   intentionally non-`view` so multisig UIs (e.g. Safe{Wallet}) treat them as stageable batch transactions
+ *   rather than read-only calls.
+ *
+ * NB: `fileSuffix` is matched against the solc source path; update it if a contract is renamed or moved.
+ */
+const SUPPRESSED_SOLC_WARNINGS: { errorCode: string; fileSuffix: string }[] = [
+  { errorCode: "2018", fileSuffix: "operational/SafeExecutionConditions.sol" },
+];
+
+interface SolcCompilationError {
+  severity?: string;
+  errorCode?: string | number;
+  sourceLocation?: { file?: string };
+}
+
+interface SolcCompilationOutput {
+  errors?: SolcCompilationError[];
+}
+
+/**
+ * Overrides the Solidity compilation error logging subtask to drop the warnings listed in
+ * {@link SUPPRESSED_SOLC_WARNINGS}. Every other diagnostic (including warnings from other files) is forwarded
+ * unchanged, and errors are never filtered.
+ */
+subtask(
+  TASK_COMPILE_SOLIDITY_LOG_COMPILATION_ERRORS,
+  async (taskArgs: { output?: SolcCompilationOutput; quiet: boolean }, _hre, runSuper) => {
+    const { output } = taskArgs;
+    if (!output?.errors?.length) {
+      return runSuper(taskArgs);
+    }
+
+    const filteredErrors = output.errors.filter(
+      (error) =>
+        !SUPPRESSED_SOLC_WARNINGS.some(
+          (suppressed) =>
+            error.severity === "warning" &&
+            String(error.errorCode) === suppressed.errorCode &&
+            (error.sourceLocation?.file ?? "").endsWith(suppressed.fileSuffix),
+        ),
+    );
+
+    return runSuper({ ...taskArgs, output: { ...output, errors: filteredErrors } });
+  },
+);

--- a/contracts/src/_testing/mocks/operational/TestSafe.sol
+++ b/contracts/src/_testing/mocks/operational/TestSafe.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity 0.8.33;
+
+import { ISafe } from "../../../operational/interfaces/ISafe.sol";
+
+/**
+ * @title Test double for a multisig Safe.
+ * @notice Implements the minimal {ISafe} surface and can forward an arbitrary call so tests can assert that
+ * downstream conditions rely on `tx.origin` (the EOA) rather than `msg.sender` (this contract).
+ * @author Consensys Software Inc.
+ * @custom:security-contact security-report@linea.build
+ */
+contract TestSafe is ISafe {
+  mapping(address owner => bool isRegistered) private _owners;
+
+  /**
+   * @notice Registers the initial set of Safe owners.
+   * @param _initialOwners The addresses to register as owners.
+   */
+  constructor(address[] memory _initialOwners) {
+    uint256 length = _initialOwners.length;
+    for (uint256 i; i < length; i++) {
+      _owners[_initialOwners[i]] = true;
+    }
+  }
+
+  /**
+   * @notice Sets the ownership flag for an address.
+   * @param _owner The address whose ownership flag is updated.
+   * @param _isOwner The ownership flag to assign.
+   */
+  function setOwner(address _owner, bool _isOwner) external {
+    _owners[_owner] = _isOwner;
+  }
+
+  /**
+   * @notice Forwards a call to `_target` so callees observe this contract as `msg.sender`.
+   * @param _target The contract to call.
+   * @param _data The calldata to forward.
+   */
+  function execute(address _target, bytes calldata _data) external {
+    (bool success, bytes memory returnData) = _target.call(_data);
+    if (!success) {
+      assembly {
+        revert(add(returnData, 0x20), mload(returnData))
+      }
+    }
+  }
+
+  /**
+   * @inheritdoc ISafe
+   */
+  function isOwner(address _owner) external view returns (bool isAnOwner) {
+    return _owners[_owner];
+  }
+}

--- a/contracts/src/operational/SafeExecutionConditions.sol
+++ b/contracts/src/operational/SafeExecutionConditions.sol
@@ -9,6 +9,8 @@ import { ISafeExecutionConditions } from "./interfaces/ISafeExecutionConditions.
  * @notice Intended to be invoked as the first call of a batched Safe transaction to gate execution on a condition.
  * @dev The contract holds no state. Each function reverts with a dedicated error when its condition is not met,
  * causing the enclosing Safe transaction to revert atomically.
+ * @dev The functions are intentionally non-`view`: multisig UIs exclude `view`/`pure` ABI entries when staging
+ * batched transactions, so non-`view` mutability is required for these guards to be selectable as a batch call.
  * @author Consensys Software Inc.
  * @custom:security-contact security-report@linea.build
  */
@@ -17,7 +19,7 @@ contract SafeExecutionConditions is ISafeExecutionConditions {
    * @notice Reverts when the current block timestamp is earlier than `_timestamp`.
    * @param _timestamp The earliest timestamp at which execution is allowed.
    */
-  function onlyAfterTimestamp(uint256 _timestamp) external view {
+  function onlyAfterTimestamp(uint256 _timestamp) external {
     require(block.timestamp >= _timestamp, OnlyOnOrAfter(_timestamp));
   }
 
@@ -27,7 +29,7 @@ contract SafeExecutionConditions is ISafeExecutionConditions {
    * transaction, rather than the Safe contract itself which would be `msg.sender`.
    * @param _executors The list of addresses allowed to originate the transaction.
    */
-  function onlyExecutedBy(address[] calldata _executors) external view {
+  function onlyExecutedBy(address[] calldata _executors) external {
     // solhint-disable-next-line avoid-tx-origin
     require(_contains(_executors, tx.origin), OnlyAllowedExecutor());
   }
@@ -40,7 +42,7 @@ contract SafeExecutionConditions is ISafeExecutionConditions {
    * transaction, rather than the Safe contract itself which would be `msg.sender`.
    * @param _safe The Safe whose ownership is checked against the transaction origin. Must equal `msg.sender`.
    */
-  function onlyExecutedBySafeOwner(address _safe) external view {
+  function onlyExecutedBySafeOwner(address _safe) external {
     require(_safe == msg.sender, OnlyExecutingSafe());
     // solhint-disable-next-line avoid-tx-origin
     require(ISafe(_safe).isOwner(tx.origin), OnlySafeOwner());

--- a/contracts/src/operational/SafeExecutionConditions.sol
+++ b/contracts/src/operational/SafeExecutionConditions.sol
@@ -16,18 +16,16 @@ import { ISafeExecutionConditions } from "./interfaces/ISafeExecutionConditions.
  */
 contract SafeExecutionConditions is ISafeExecutionConditions {
   /**
-   * @notice Reverts when the current block timestamp is earlier than `_timestamp`.
-   * @param _timestamp The earliest timestamp at which execution is allowed.
+   * @inheritdoc ISafeExecutionConditions
    */
-  function onlyAfterTimestamp(uint256 _timestamp) external {
+  function onlyOnOrAfterTimestamp(uint256 _timestamp) external {
     require(block.timestamp >= _timestamp, OnlyOnOrAfter(_timestamp));
   }
 
   /**
-   * @notice Reverts when the transaction origin is not contained in `_executors`.
+   * @inheritdoc ISafeExecutionConditions
    * @dev `tx.origin` is used deliberately to authorise the externally owned account that submitted the Safe
    * transaction, rather than the Safe contract itself which would be `msg.sender`.
-   * @param _executors The list of addresses allowed to originate the transaction.
    */
   function onlyExecutedBy(address[] calldata _executors) external {
     // solhint-disable-next-line avoid-tx-origin
@@ -35,12 +33,12 @@ contract SafeExecutionConditions is ISafeExecutionConditions {
   }
 
   /**
-   * @notice Reverts when the transaction origin is not an owner of `_safe`.
+   * @inheritdoc ISafeExecutionConditions
    * @dev `_safe` must equal `msg.sender`, i.e. the Safe executing the call. Binding to the caller prevents a
    * submitter from passing the check against a Safe they control rather than the executing Safe.
    * @dev `tx.origin` is used deliberately to authorise the externally owned account that submitted the Safe
-   * transaction, rather than the Safe contract itself which would be `msg.sender`.
-   * @param _safe The Safe whose ownership is checked against the transaction origin. Must equal `msg.sender`.
+   * transaction, rather than the Safe contract itself which would be `msg.sender`. Consequently, if `_safe` has
+   * another contract (e.g. a sub-Safe) registered as an owner, that owner can never satisfy this check.
    */
   function onlyExecutedBySafeOwner(address _safe) external {
     require(_safe == msg.sender, OnlyExecutingSafe());

--- a/contracts/src/operational/SafeExecutionConditions.sol
+++ b/contracts/src/operational/SafeExecutionConditions.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity 0.8.33;
+
+import { ISafe } from "./interfaces/ISafe.sol";
+import { ISafeExecutionConditions } from "./interfaces/ISafeExecutionConditions.sol";
+
+/**
+ * @title Stateless precondition checks for multisig Safe transaction execution.
+ * @notice Intended to be invoked as the first call of a batched Safe transaction to gate execution on a condition.
+ * @dev The contract holds no state. Each function reverts with a dedicated error when its condition is not met,
+ * causing the enclosing Safe transaction to revert atomically.
+ * @author Consensys Software Inc.
+ * @custom:security-contact security-report@linea.build
+ */
+contract SafeExecutionConditions is ISafeExecutionConditions {
+  /**
+   * @notice Reverts when the current block timestamp is earlier than `_timestamp`.
+   * @param _timestamp The earliest timestamp at which execution is allowed.
+   */
+  function onlyAfterTimestamp(uint256 _timestamp) external view {
+    require(block.timestamp >= _timestamp, OnlyOnOrAfter(_timestamp));
+  }
+
+  /**
+   * @notice Reverts when the transaction origin is not contained in `_executors`.
+   * @dev `tx.origin` is used deliberately to authorise the externally owned account that submitted the Safe
+   * transaction, rather than the Safe contract itself which would be `msg.sender`.
+   * @param _executors The list of addresses allowed to originate the transaction.
+   */
+  function onlyExecutedBy(address[] calldata _executors) external view {
+    // solhint-disable-next-line avoid-tx-origin
+    require(_contains(_executors, tx.origin), OnlyAllowedExecutor());
+  }
+
+  /**
+   * @notice Reverts when the transaction origin is not an owner of `_safe`.
+   * @dev `_safe` must equal `msg.sender`, i.e. the Safe executing the call. Binding to the caller prevents a
+   * submitter from passing the check against a Safe they control rather than the executing Safe.
+   * @dev `tx.origin` is used deliberately to authorise the externally owned account that submitted the Safe
+   * transaction, rather than the Safe contract itself which would be `msg.sender`.
+   * @param _safe The Safe whose ownership is checked against the transaction origin. Must equal `msg.sender`.
+   */
+  function onlyExecutedBySafeOwner(address _safe) external view {
+    require(_safe == msg.sender, OnlyExecutingSafe());
+    // solhint-disable-next-line avoid-tx-origin
+    require(ISafe(_safe).isOwner(tx.origin), OnlySafeOwner());
+  }
+
+  /**
+   * @notice Returns whether `_target` is present in `_addresses`.
+   * @param _addresses The list of addresses to search.
+   * @param _target The address to look for.
+   * @return found True when `_target` is contained in `_addresses`.
+   */
+  function _contains(address[] calldata _addresses, address _target) private pure returns (bool found) {
+    for (uint256 i; i < _addresses.length; i++) {
+      if (_addresses[i] == _target) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/contracts/src/operational/interfaces/ISafe.sol
+++ b/contracts/src/operational/interfaces/ISafe.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.33;
+
+/**
+ * @title Minimal interface for a multisig Safe.
+ * @notice Exposes only the subset of the Safe API consumed by operational helpers.
+ * @author Consensys Software Inc.
+ * @custom:security-contact security-report@linea.build
+ */
+interface ISafe {
+  /**
+   * @notice Returns whether an address is an owner of the Safe.
+   * @param _owner The address to check ownership for.
+   * @return isAnOwner True when `_owner` is registered as a Safe owner.
+   */
+  function isOwner(address _owner) external view returns (bool isAnOwner);
+}

--- a/contracts/src/operational/interfaces/ISafeExecutionConditions.sol
+++ b/contracts/src/operational/interfaces/ISafeExecutionConditions.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.33;
 /**
  * @title Interface for the stateless Safe execution conditions helper.
  * @notice Declares the precondition checks intended to be invoked as the first call of a multisig Safe transaction.
+ * @dev The functions are intentionally non-`view` even though they do not mutate state. Multisig UIs (e.g.
+ * Safe{Wallet} Transaction Builder) classify `view`/`pure` ABI entries as read-only calls and exclude them when
+ * staging batched transactions, so a non-`view` mutability is required for these guards to be usable as a batch call.
  * @author Consensys Software Inc.
  * @custom:security-contact security-report@linea.build
  */
@@ -33,13 +36,13 @@ interface ISafeExecutionConditions {
    * @notice Reverts when the current block timestamp is earlier than `_timestamp`.
    * @param _timestamp The earliest timestamp at which execution is allowed.
    */
-  function onlyAfterTimestamp(uint256 _timestamp) external view;
+  function onlyAfterTimestamp(uint256 _timestamp) external;
 
   /**
    * @notice Reverts when the transaction origin is not contained in `_executors`.
    * @param _executors The list of addresses allowed to originate the transaction.
    */
-  function onlyExecutedBy(address[] calldata _executors) external view;
+  function onlyExecutedBy(address[] calldata _executors) external;
 
   /**
    * @notice Reverts when the transaction origin is not an owner of `_safe`.
@@ -47,5 +50,5 @@ interface ISafeExecutionConditions {
    * prevents a submitter from satisfying the check against a Safe they control instead of the executing Safe.
    * @param _safe The Safe whose ownership is checked against the transaction origin. Must equal `msg.sender`.
    */
-  function onlyExecutedBySafeOwner(address _safe) external view;
+  function onlyExecutedBySafeOwner(address _safe) external;
 }

--- a/contracts/src/operational/interfaces/ISafeExecutionConditions.sol
+++ b/contracts/src/operational/interfaces/ISafeExecutionConditions.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.33;
+
+/**
+ * @title Interface for the stateless Safe execution conditions helper.
+ * @notice Declares the precondition checks intended to be invoked as the first call of a multisig Safe transaction.
+ * @author Consensys Software Inc.
+ * @custom:security-contact security-report@linea.build
+ */
+interface ISafeExecutionConditions {
+  /**
+   * @notice Thrown when the call is executed before the required timestamp.
+   * @param timestamp The earliest timestamp at which execution is allowed.
+   */
+  error OnlyOnOrAfter(uint256 timestamp);
+
+  /**
+   * @notice Thrown when the transaction origin is not part of the allowed executors.
+   */
+  error OnlyAllowedExecutor();
+
+  /**
+   * @notice Thrown when the transaction origin is not an owner of the provided Safe.
+   */
+  error OnlySafeOwner();
+
+  /**
+   * @notice Thrown when the provided Safe is not the Safe executing the call.
+   */
+  error OnlyExecutingSafe();
+
+  /**
+   * @notice Reverts when the current block timestamp is earlier than `_timestamp`.
+   * @param _timestamp The earliest timestamp at which execution is allowed.
+   */
+  function onlyAfterTimestamp(uint256 _timestamp) external view;
+
+  /**
+   * @notice Reverts when the transaction origin is not contained in `_executors`.
+   * @param _executors The list of addresses allowed to originate the transaction.
+   */
+  function onlyExecutedBy(address[] calldata _executors) external view;
+
+  /**
+   * @notice Reverts when the transaction origin is not an owner of `_safe`.
+   * @dev `_safe` must be the Safe executing the call (`msg.sender`); supplying any other address reverts. This
+   * prevents a submitter from satisfying the check against a Safe they control instead of the executing Safe.
+   * @param _safe The Safe whose ownership is checked against the transaction origin. Must equal `msg.sender`.
+   */
+  function onlyExecutedBySafeOwner(address _safe) external view;
+}

--- a/contracts/src/operational/interfaces/ISafeExecutionConditions.sol
+++ b/contracts/src/operational/interfaces/ISafeExecutionConditions.sol
@@ -36,7 +36,7 @@ interface ISafeExecutionConditions {
    * @notice Reverts when the current block timestamp is earlier than `_timestamp`.
    * @param _timestamp The earliest timestamp at which execution is allowed.
    */
-  function onlyAfterTimestamp(uint256 _timestamp) external;
+  function onlyOnOrAfterTimestamp(uint256 _timestamp) external;
 
   /**
    * @notice Reverts when the transaction origin is not contained in `_executors`.
@@ -48,6 +48,9 @@ interface ISafeExecutionConditions {
    * @notice Reverts when the transaction origin is not an owner of `_safe`.
    * @dev `_safe` must be the Safe executing the call (`msg.sender`); supplying any other address reverts. This
    * prevents a submitter from satisfying the check against a Safe they control instead of the executing Safe.
+   * @dev Ownership is checked against `tx.origin`, which is always an EOA. If `_safe` has another contract (e.g. a
+   * sub-Safe) registered as an owner, that owner can never satisfy this check, since it cannot originate a
+   * transaction itself.
    * @param _safe The Safe whose ownership is checked against the transaction origin. Must equal `msg.sender`.
    */
   function onlyExecutedBySafeOwner(address _safe) external;

--- a/contracts/test/hardhat/operational/SafeExecutionConditions.ts
+++ b/contracts/test/hardhat/operational/SafeExecutionConditions.ts
@@ -1,0 +1,117 @@
+import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers, network } from "hardhat";
+
+import { SafeExecutionConditions, TestSafe } from "../../../typechain-types";
+import { deployFromFactory } from "../common/deployment";
+import { expectRevertWithCustomError } from "../common/helpers";
+
+describe("SafeExecutionConditions", () => {
+  let conditions: SafeExecutionConditions;
+  let safe: TestSafe;
+  let executor: SignerWithAddress;
+  let owner: SignerWithAddress;
+  let stranger: SignerWithAddress;
+
+  async function deploySafeExecutionConditionsFixture() {
+    const [executor, owner, stranger] = await ethers.getSigners();
+
+    const conditions = (await deployFromFactory("SafeExecutionConditions")) as unknown as SafeExecutionConditions;
+    const safe = (await deployFromFactory("TestSafe", [owner.address])) as unknown as TestSafe;
+
+    return { conditions, safe, executor, owner, stranger };
+  }
+
+  before(async () => {
+    await network.provider.send("hardhat_reset");
+  });
+
+  beforeEach(async () => {
+    ({ conditions, safe, executor, owner, stranger } = await loadFixture(deploySafeExecutionConditionsFixture));
+  });
+
+  describe("onlyAfterTimestamp", () => {
+    it("Should not revert when the current timestamp equals the threshold", async () => {
+      const currentTimestamp = await time.latest();
+      await expect(conditions.onlyAfterTimestamp(currentTimestamp)).to.not.be.reverted;
+    });
+
+    it("Should not revert when the current timestamp is after the threshold", async () => {
+      const pastTimestamp = (await time.latest()) - 1;
+      await expect(conditions.onlyAfterTimestamp(pastTimestamp)).to.not.be.reverted;
+    });
+
+    it("Should revert with OnlyOnOrAfter when the current timestamp is before the threshold", async () => {
+      const futureTimestamp = (await time.latest()) + 3600;
+      await expectRevertWithCustomError(conditions, conditions.onlyAfterTimestamp(futureTimestamp), "OnlyOnOrAfter", [
+        futureTimestamp,
+      ]);
+    });
+  });
+
+  describe("onlyExecutedBy", () => {
+    it("Should not revert when the transaction origin is in the executors list", async () => {
+      await expect(conditions.connect(executor).onlyExecutedBy([stranger.address, executor.address])).to.not.be
+        .reverted;
+    });
+
+    it("Should revert with OnlyAllowedExecutor when the transaction origin is not in the executors list", async () => {
+      await expectRevertWithCustomError(
+        conditions,
+        conditions.connect(stranger).onlyExecutedBy([executor.address, owner.address]),
+        "OnlyAllowedExecutor",
+      );
+    });
+
+    it("Should revert with OnlyAllowedExecutor when the executors list is empty", async () => {
+      await expectRevertWithCustomError(
+        conditions,
+        conditions.connect(executor).onlyExecutedBy([]),
+        "OnlyAllowedExecutor",
+      );
+    });
+
+    it("Should authorise the EOA via tx.origin even when called through a contract", async () => {
+      const calldata = conditions.interface.encodeFunctionData("onlyExecutedBy", [[owner.address]]);
+      await expect(safe.connect(owner).execute(await conditions.getAddress(), calldata)).to.not.be.reverted;
+    });
+  });
+
+  describe("onlyExecutedBySafeOwner", () => {
+    it("Should not revert when executed through the Safe by one of its owners", async () => {
+      const calldata = conditions.interface.encodeFunctionData("onlyExecutedBySafeOwner", [await safe.getAddress()]);
+      await expect(safe.connect(owner).execute(await conditions.getAddress(), calldata)).to.not.be.reverted;
+    });
+
+    it("Should revert with OnlySafeOwner when the transaction origin is not a Safe owner", async () => {
+      const calldata = conditions.interface.encodeFunctionData("onlyExecutedBySafeOwner", [await safe.getAddress()]);
+      await expectRevertWithCustomError(
+        conditions,
+        safe.connect(stranger).execute(await conditions.getAddress(), calldata),
+        "OnlySafeOwner",
+      );
+    });
+
+    it("Should revert with OnlyExecutingSafe when called directly rather than through the Safe", async () => {
+      // Direct EOA call: msg.sender is the owner EOA, not the Safe referenced by _safe.
+      await expectRevertWithCustomError(
+        conditions,
+        conditions.connect(owner).onlyExecutedBySafeOwner(await safe.getAddress()),
+        "OnlyExecutingSafe",
+      );
+    });
+
+    it("Should revert with OnlyExecutingSafe when the executing Safe references a different Safe", async () => {
+      const otherSafe = (await deployFromFactory("TestSafe", [owner.address])) as unknown as TestSafe;
+      const calldata = conditions.interface.encodeFunctionData("onlyExecutedBySafeOwner", [
+        await otherSafe.getAddress(),
+      ]);
+      await expectRevertWithCustomError(
+        conditions,
+        safe.connect(owner).execute(await conditions.getAddress(), calldata),
+        "OnlyExecutingSafe",
+      );
+    });
+  });
+});

--- a/contracts/test/hardhat/operational/SafeExecutionConditions.ts
+++ b/contracts/test/hardhat/operational/SafeExecutionConditions.ts
@@ -31,22 +31,25 @@ describe("SafeExecutionConditions", () => {
     ({ conditions, safe, executor, owner, stranger } = await loadFixture(deploySafeExecutionConditionsFixture));
   });
 
-  describe("onlyAfterTimestamp", () => {
+  describe("onlyOnOrAfterTimestamp", () => {
     it("Should not revert when the current timestamp equals the threshold", async () => {
       const currentTimestamp = await time.latest();
-      await expect(conditions.onlyAfterTimestamp(currentTimestamp)).to.not.be.reverted;
+      await expect(conditions.onlyOnOrAfterTimestamp(currentTimestamp)).to.not.be.reverted;
     });
 
     it("Should not revert when the current timestamp is after the threshold", async () => {
       const pastTimestamp = (await time.latest()) - 1;
-      await expect(conditions.onlyAfterTimestamp(pastTimestamp)).to.not.be.reverted;
+      await expect(conditions.onlyOnOrAfterTimestamp(pastTimestamp)).to.not.be.reverted;
     });
 
     it("Should revert with OnlyOnOrAfter when the current timestamp is before the threshold", async () => {
       const futureTimestamp = (await time.latest()) + 3600;
-      await expectRevertWithCustomError(conditions, conditions.onlyAfterTimestamp(futureTimestamp), "OnlyOnOrAfter", [
-        futureTimestamp,
-      ]);
+      await expectRevertWithCustomError(
+        conditions,
+        conditions.onlyOnOrAfterTimestamp(futureTimestamp),
+        "OnlyOnOrAfter",
+        [futureTimestamp],
+      );
     });
   });
 


### PR DESCRIPTION
This PR adds a stateless safe validator that works for certain pre-conditions only as configured in the safe TX

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [x] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Operational multisig gating relies on deliberate `tx.origin` checks and Safe caller binding; behavior is tested and documented but worth careful review for Safe/sub-Safe owner edge cases.
> 
> **Overview**
> Adds a **stateless** `SafeExecutionConditions` contract meant as the **first call** in a batched Safe transaction so the whole batch reverts if a precondition fails.
> 
> Guards include **time** (`onlyOnOrAfterTimestamp`), **allowed submitters** via `tx.origin` (`onlyExecutedBy`), and **Safe owner + executing Safe** binding (`onlyExecutedBySafeOwner` requires `_safe == msg.sender` and `isOwner(tx.origin)`). Functions are intentionally **non-`view`** so Safe Transaction Builder can stage them as batch calls; a narrow Hardhat **solc warning filter** hides the related mutability warning for that file only.
> 
> Also adds minimal `ISafe`, a `TestSafe` mock for forwarded calls, Hardhat **deploy** (`24_deploy_SafeExecutionConditions`) with verification, and Hardhat tests covering success and custom-error revert paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd586855dc937dc38fd2ce617fd8b365847c6c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->