### PR TITLE
fix(prover): reserve a padding row in the state-manager modules

### DIFF
--- a/prover/zkevm/prover/statemanager/accumulator/settings.go
+++ b/prover/zkevm/prover/statemanager/accumulator/settings.go
@@ -20,7 +20,12 @@ type Settings struct {
 	Round int
 }
 
-// leaveSizes returns the column length for the
+// NumRows returns the column length for the accumulator module. The +1 keeps at
+// least one trailing padding row so the module is never fully packed: the
+// distributed prover pads columns to the segment size by repeating the last row,
+// which only yields the correct padding when that row is genuine padding. A fully
+// packed module otherwise breaks cross-row constraints (e.g. the counter
+// increment) on the padded rows.
 func (s Settings) NumRows() int {
-	return utils.NextPowerOfTwo(s.MaxNumProofs)
+	return utils.NextPowerOfTwo(s.MaxNumProofs + 1)
 }

--- a/prover/zkevm/prover/statemanager/state_manager.go
+++ b/prover/zkevm/prover/statemanager/state_manager.go
@@ -74,9 +74,10 @@ func (sm *StateManager) Assign(run *wizard.ProverRuntime, arith *arithmetization
 }
 
 // stateSummarySize returns the number of rows to give to the state-summary
-// module.
+// module. The +1 matches the accumulator and reserves a trailing padding row so
+// the module is never fully packed (see [accumulator.Settings.NumRows]).
 func (s *Settings) stateSummarySize() int {
-	return utils.NextPowerOfTwo(s.AccSettings.MaxNumProofs)
+	return utils.NextPowerOfTwo(s.AccSettings.MaxNumProofs + 1)
 }
 
 func removeSystemTransactions(shomeiTraces [][]statemanager.DecodedTrace) [][]statemanager.DecodedTrace {


### PR DESCRIPTION
## Problem

The limitless prover fails on conflation 30054884-30054999, which packs the accumulator to 100% of its rows (SHOMEI_MERKLE_PROOFS=8192). Debug mode reports:

```
GL module (debug) KECCAK: ACCUMULATOR_COUNTER_ADD_COL_TO_LIMBS_CONSTRAINT_LSB - the global constraint check failed at row 8191
```


(The accumulator is grouped into the KECCAK GL segment, so the label is the segment group, not keccak.) The monolithic full/partial prover passes the same conflation.

## Root cause

The limitless prover extends a module's columns to the GL segment size by repeat-last padding (`module_witness.go`), which only reproduces a column's natural padding when the module's last row is genuine padding. A 100%-full module has no padding row, so repeat-last extends active values into the padded rows. The accumulator counter (a +1 increment via `byte32cmp` `MultiLimbAdd`) then fails there: the repeated constant value cannot satisfy `counter[i]+1 == shift(counter)[i]`, and the mask `shift(IsActiveAccumulator)` stays 1. The monolithic prover never sees this (native domain, last-row bound cancellation, no padded interior).

## Fix

Size the accumulator and state-summary modules to `NextPowerOfTwo(MaxNumProofs + 1)` so the module is never fully packed. With a guaranteed trailing padding row, repeat-last reproduces the natural padding for every column (0 for flags/counter, `poseidon(0)` for hashes, etc.) and all constraints hold. Both modules are bumped because they are designed equal-sized and linked by the summary lookup, and the state-summary can also reach 100% fill.

## Cost / scope

This is a stopgap. When `MaxNumProofs` is a power of two (mainnet 8192) it doubles these two modules to 16384. The general fix (limitless prover pads full modules by natural value) is should be discussed separately and would let us revert this `+1`. Other modules use the same cross-row primitives (cyclic counter, `MultiLimbAdd`) and could hit this if filled (See below - General Fix).


## Testing

- Build and state-manager unit tests pass.
- Limitless prover rerun on 30054884-30054999 after asset regeneration: confirmed passing.


------------------
# General Fix (Limitless prover can't correctly pad a 100%-full module)

## Summary

When a module is packed to 100% of its rows, the limitless prover pads its columns to the GL segment size by repeating the last (active) row. That breaks any constraint the repeated last row does not satisfy. Confirmed on conflation 30054884-30054999, which fills the accumulator (SHOMEI_MERKLE_PROOFS=8192): the ACCUMULATOR_COUNTER increment fails at the last row in the GL segment. The full prover passes (native domain, last-row bound cancellation, no padded interior).

## Why repeat-last is wrong for a full module

Repeat-last reproduces a column's natural padding only when the last row is genuine padding. A full module has none, so repeat-last extends active values into the padded rows and breaks constraints there:

- Cross-row increment constraints (counters) fail: a constant repeated value cannot satisfy `x[i+1] = x[i] + 1`.
- Bound-cancelled shift constraints get checked at the module's real boundary, which the segment-level cancellation (only `S-1`) does not cover.
- Per-column natural padding is not uniform (0 for flags, `poseidon(0)` for hash columns), so a blanket zero-pad is also wrong.

## Potential fix

Have the limitless prover pad a full module by each column's natural padding rather than repeat-last. Cleanest approach: let each module/gadget synthesize one inactive (padding) row, and have segment compilation use it when a module's data fills its native size. This is one central change, it covers modules we have not hit yet, and it removes the 2x stopgap tax (lets us revert the `+1` sizing).

## Other modules that could have the same bug

Cyclic counter (`protocol/dedicated/counter.go`, also via `RepeatedPattern`): `plonk/alignment`, `keccak/keccakf/chi_iota`, `keccak/keccakf/io_keccakf`, `sha2/sha2_block`, `statemanager/accumulator`.

MultiLimbAdd (`byte32cmp`): `publicInput/block_data_fetcher`, `hash/importpad/padding_sha2`, `statemanager/accumulator`.

A module is vulnerable iff it can be packed 100% full AND the gadget's constraint is not satisfied by a repeated last row. Only the accumulator was full in this conflation; the others are latent (cf. the keccak cyclic-counter fix #2824, same family).


### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
