### PR TITLE
fix(prover): fix the bitdecompose.go by removing IsPackedLimbNotZero

### DIFF
--- a/prover/protocol/dedicated/bits/bitdecompose.go
+++ b/prover/protocol/dedicated/bits/bitdecompose.go
@@ -17,8 +17,7 @@ type BitDecomposed struct {
 	Packed []ifaces.Column
 	// Bits lists the decomposed bits of the "packed" column in LSbit
 	// order.
-	Bits                []ifaces.Column
-	IsPackedLimbNotZero []ifaces.Column
+	Bits []ifaces.Column
 }
 
 // BitDecompose generates a bit decomposition of a column and returns
@@ -43,11 +42,10 @@ func BitDecompose(comp *wizard.CompiledIOP, packed []ifaces.Column, numBits int)
 	}
 
 	// This constraint ensures that the recombined bits are equal to the
-	// original column.
-	for i := 0; i*16 < numBits; i++ {
-		bd.IsPackedLimbNotZero = append(bd.IsPackedLimbNotZero, comp.InsertCommit(round, ifaces.ColIDf("IS_PACKED_NOT_ZERO_%v", i), packed[0].Size(), true))
-	}
-
+	// original column. It is enforced unconditionally on every limb that
+	// carries position bits: binding the committed packed limbs to the
+	// decomposed bits is what ties an accumulator position to the Merkle path
+	// actually walked, so it must not be gated by a prover-controlled column.
 	for i := len(packed) - 1; i >= 0; i-- {
 		ind := len(packed) - i - 1
 
@@ -63,12 +61,9 @@ func BitDecompose(comp *wizard.CompiledIOP, packed []ifaces.Column, numBits int)
 		comp.InsertGlobal(
 			round,
 			ifaces.QueryIDf("%v_BIT_RECOMBINATION", packed[i].GetColID()),
-			symbolic.Mul(
-				bd.IsPackedLimbNotZero[ind],
-				symbolic.Sub(
-					packed[i],
-					symbolic.NewPolyEval(symbolic.NewConstant(2), s),
-				),
+			symbolic.Sub(
+				packed[i],
+				symbolic.NewPolyEval(symbolic.NewConstant(2), s),
 			),
 		)
 	}
@@ -92,7 +87,6 @@ func (bd *BitDecomposed) Run(run *wizard.ProverRuntime) {
 	start, stop := smartvectors.CoCompactRange(assignments...)
 
 	bits := make([][]field.Element, len(bd.Bits))
-	notZero := make([][]field.Element, len(bd.IsPackedLimbNotZero))
 
 	el := make([]field.Element, len(assignments))
 	for row := start; row < stop; row++ {
@@ -115,27 +109,6 @@ func (bd *BitDecomposed) Run(run *wizard.ProverRuntime) {
 				bits[j] = append(bits[j], field.Zero())
 			}
 		}
-
-		for i := range bd.Packed {
-			// LSB limb packed[len-1] maps to IsPackedLimbNotZero[0].
-			ind := len(bd.Packed) - 1 - i
-			if ind >= len(bd.IsPackedLimbNotZero) {
-				continue
-			}
-
-			if el[i].IsZero() {
-				notZero[ind] = append(notZero[ind], field.Zero())
-			} else {
-				notZero[ind] = append(notZero[ind], field.One())
-			}
-		}
-	}
-
-	for i := range bd.IsPackedLimbNotZero {
-		run.AssignColumn(
-			bd.IsPackedLimbNotZero[i].GetColID(),
-			smartvectors.FromCompactWithRange(notZero[i], start, stop, size),
-		)
 	}
 
 	for j, bitCol := range bd.Bits {

--- a/prover/protocol/dedicated/bits/bitdecompose_test.go
+++ b/prover/protocol/dedicated/bits/bitdecompose_test.go
@@ -84,3 +84,75 @@ func TestBitDecomposeHeterogeneousLimbs(t *testing.T) {
 	proof := wizard.Prove(comp, prove)
 	require.NoError(t, wizard.Verify(comp, proof), "recombination constraints must hold")
 }
+
+// TestBitDecomposeRejectsMismatchedBits is the soundness counterpart to the
+// happy-path test: it asserts that the bit-recombination constraint binds the
+// committed packed limbs to the decomposed bits unconditionally.
+//
+// Previously the recombination was multiplied by a committed, otherwise
+// unconstrained IsPackedLimbNotZero gate; a prover could zero that gate to make
+// the identity vacuous and assign bits unrelated to the packed value. For the
+// Merkle gadget that decouples the committed accumulator position from the path
+// actually walked (false (non-)membership / state-root forgery). Here the
+// prover commits one position (committedPos) but assigns boolean bits that
+// decompose a different value (pathPos); verification must reject.
+func TestBitDecomposeRejectsMismatchedBits(t *testing.T) {
+
+	const (
+		size    = 8
+		numBits = 32
+	)
+
+	const (
+		committedPos = uint64(5) // value pinned in the packed limbs
+		pathPos      = uint64(2) // value the malicious bits decompose to
+	)
+	require.NotEqual(t, committedPos, pathPos)
+
+	limbCols := make([][]field.Element, common.NbElemForHasingU64)
+	for i := range limbCols {
+		limbCols[i] = make([]field.Element, size)
+	}
+	for row := 0; row < size; row++ {
+		ls := limbsOf(committedPos)
+		for i := range ls {
+			limbCols[i][row] = field.NewElement(ls[i])
+		}
+	}
+
+	var bd *BitDecomposed
+
+	define := func(b *wizard.Builder) {
+		packed := make([]ifaces.Column, common.NbElemForHasingU64)
+		for i := range packed {
+			packed[i] = b.RegisterCommit(ifaces.ColIDf("POS_%v", i), size)
+		}
+		bd = BitDecompose(b.CompiledIOP, packed, numBits)
+	}
+
+	prove := func(run *wizard.ProverRuntime) {
+		for i := range limbCols {
+			run.AssignColumn(ifaces.ColIDf("POS_%v", i), sv.NewRegular(limbCols[i]))
+		}
+
+		// Adversarial: assign boolean bits that decompose pathPos rather than
+		// the committed committedPos. This is exactly what the removed gate used
+		// to permit.
+		for j := range bd.Bits {
+			col := make([]field.Element, size)
+			for row := 0; row < size; row++ {
+				if pathPos>>j&1 == 1 {
+					col[row] = field.One()
+				} else {
+					col[row] = field.Zero()
+				}
+			}
+			run.AssignColumn(bd.Bits[j].GetColID(), sv.NewRegular(col))
+		}
+	}
+
+	comp := wizard.Compile(define, dummy.Compile)
+	proof := wizard.Prove(comp, prove)
+	require.Error(t, wizard.Verify(comp, proof),
+		"recombination must reject bits that do not match the committed packed position")
+}


### PR DESCRIPTION
This PR fixes a missing constraints following a broken (and unneeded constraint filter). This breaks the setup.

@gusiri Let's not include in the current version update, but to the next one to avoid disruption on your end.

There is some risks with this one as I have not fully grasped where this extra column was supposed to achieve.

### Checklist

* [x] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [x] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [x] I have informed the team of any breaking changes if there are any.
