### PR TITLE
chore(misc): codeql update to v4.36.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
@@ -115,12 +115,12 @@ jobs:
 
       - name: Autobuild
         if: matrix.language != 'actions'
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN_RELEASE_ACCESS }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
         with:
           category: "/language:${{matrix.language}}"
           output: sarif-results

--- a/.github/workflows/dockerfile-security-scan.yml
+++ b/.github/workflows/dockerfile-security-scan.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Upload SARIF to GitHub Security
         if: ${{ !cancelled() && hashFiles('kics-results/results.sarif') != '' }}
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: kics-results/results.sarif
           category: kics-dockerfiles


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine CI dependency pin bumps only; no application or security-scan configuration changes beyond the action version.
> 
> **Overview**
> Bumps pinned **`github/codeql-action`** references to **v4.36.2** (`8aad20d150bbac5944a9f9d289da16a4b0d87c1e`) in CI workflows.
> 
> In **`codeql.yml`**, **`init`**, **`autobuild`**, and **`analyze`** move from v4.35.1 to v4.36.2. In **`dockerfile-security-scan.yml`**, **`upload-sarif`** moves from v4.35.4 to the same v4.36.2 pin. Step inputs and workflow behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d83cf20cc29843a3ffebb7ae3b05b56912a390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->