### PR TITLE
fix(sequencer-interfaces): pin Java toolchain to JVM 25

### DIFF
--- a/linea-besu/plugins/sequencer-interfaces/build.gradle
+++ b/linea-besu/plugins/sequencer-interfaces/build.gradle
@@ -16,6 +16,12 @@ repositories {
   }
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(25)
+  }
+}
+
 group = 'build.linea'
 description = 'Linea chain security interfaces'
 // publishing.gradle uses project.artifactId when set (or else falling back to project.name)


### PR DESCRIPTION
## Problem

`sequencer-interfaces` had no `java { toolchain {} }` declaration. Gradle compiled it using whatever JDK the daemon ran with — JDK 26 when invoked from IntelliJ — producing JVM 26 bytecode.

`linea-sequencer:acceptance-tests` applies `net.consensys.zkevm.kotlin-library-minimal-conventions` which requests a JVM 25 toolchain, then tries to consume `sequencer-interfaces` as a compile dependency. Gradle's JVM compatibility check rejects the JVM 26 artifact:

```
Dependency resolution is looking for a library compatible with JVM runtime version 25,
but 'project :lineth-monorepo:linea-besu:plugins:sequencer-interfaces' is only compatible
with JVM runtime version 26 or newer.
```

## Fix

Add an explicit `java { toolchain { languageVersion = JavaLanguageVersion.of(25) } }` block, consistent with every other module in this repo that uses `net.consensys.zkevm.kotlin-common-minimal-conventions`.

## Test plan

- [ ] `./gradlew :linea-besu:plugins:sequencer-interfaces:compileJava` passes with JDK 26 daemon
- [ ] `./gradlew :linea-besu:plugins:linea-sequencer:acceptance-tests:compileTestKotlin` resolves without JVM compatibility error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Gradle toolchain alignment; no runtime logic, API, or security behavior changes.
> 
> **Overview**
> **Pins `sequencer-interfaces` to JVM 25** so its bytecode matches the rest of the Linea Besu Gradle modules and downstream consumers that require a Java 25 runtime.
> 
> The module previously had no `java { toolchain {} }` block, so builds could emit **JVM 26** bytecode when the Gradle daemon ran on JDK 26 (e.g. from IntelliJ). That broke **`linea-sequencer:acceptance-tests`**, which uses conventions that target JVM 25 and failed dependency resolution when compiling against `sequencer-interfaces`.
> 
> The change adds `languageVersion = JavaLanguageVersion.of(25)` in `sequencer-interfaces/build.gradle`, aligned with other modules using the shared Kotlin/JVM conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be204c07a36a2589a110a54a84c1e7c95464b10b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->