### PR TITLE
chore(misc): update actions/checkout to v6.0.3

### DIFF
--- a/.github/workflows/all-tools.yml
+++ b/.github/workflows/all-tools.yml
@@ -29,7 +29,7 @@ jobs:
       all-tools: ${{ steps.filter.outputs['all-tools'] }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Filter commit changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: filter
@@ -53,7 +53,7 @@ jobs:
     if: ${{ needs.changes.outputs['all-tools'] == 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check image tags exist
         uses: ./.github/actions/check-image-tags-exist
         with:
@@ -69,7 +69,7 @@ jobs:
       image_tagged: ${{ steps.image_tag_push.outputs.image_tagged }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Tag and push image
         id: image_tag_push
         uses: ./.github/actions/image-tag-and-push
@@ -96,7 +96,7 @@ jobs:
     name: All tools build and push
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
@@ -122,11 +122,11 @@ jobs:
             exit 1
           fi
           echo "We inject the commit tag in the docker image ${{ env.COMMIT_TAG }}"
-      
+
       - name: "Get Node.js version"
         id: get-node-version
         uses: ./.github/actions/get-node-version
-      
+
       - name: Build and push all tools image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 #v7.0.0
         with:

--- a/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
@@ -2,16 +2,16 @@ name: Arithmetization zkc interpreter benchmark (base vs optim)
 
 # Benchmark of guest programs executed by the zkc interpreter of
 # two branches, the base branch and the optim branch.
-# Guest programs are the Keccak and Blake programs in the arithmetization/src/test 
+# Guest programs are the Keccak and Blake programs in the arithmetization/src/test
 # directory.
 
-# Benchmark methodology : 
+# Benchmark methodology :
 # Designed to give a reliable paired comparison on a
 # single runner: one untimed warmup per branch, then N alternating (opt, base)
 # timed iterations with a per-iteration cache reset + brief cool-down to keep
 # the machine state similar across runs.
 
-# Benchmark data : 
+# Benchmark data :
 # -- For Keccak
 # In arithmetization/src/test/common_inputs/keccak.all
 # There are 20k test vectors you can select from to run the benchmark.
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           submodules: false

--- a/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
@@ -1,15 +1,15 @@
 name: Arithmetization native zkc benchmark - Keccak (base vs optim)
 
 # Benchmark of native zkc batched Keccak-f function against two
-# zkc versions: a "base" version and an "optim" version. 
+# zkc versions: a "base" version and an "optim" version.
 #
-# Benchmark methodology : 
+# Benchmark methodology :
 # one untimed warm-up (untimed) + N timed iterations for the base variant
 # one untimed warm-up (untimed) + N timed iterations for the optim variant
 # Per-iteration `cache_thrasher` + sleep attempts to keep CPU cache state comparable across timed runs.
 # Launched with zkc exec --field KOALABEAR_16 <input.json> <program.zkc>
 #
-# Benchmark data : 
+# Benchmark data :
 # In arithmetization/src/test/zkc/keccakf/keccakf_batched.accepts
 # There are 20k test vectors you can select from to run the benchmark.
 # Each test vector has a raw message of 16 * 32 bytes, ie fits in 4 blocks of 1088 bits.
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           submodules: false

--- a/.github/workflows/arithmetization-keccak-zkc-vs-reference-benchmark.yml
+++ b/.github/workflows/arithmetization-keccak-zkc-vs-reference-benchmark.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/arithmetization-riscv-act4-test.yml
+++ b/.github/workflows/arithmetization-riscv-act4-test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/arithmetization-sample-guest-programs-run.yml
+++ b/.github/workflows/arithmetization-sample-guest-programs-run.yml
@@ -40,7 +40,7 @@ jobs:
       ZKC_EXEC_FLAGS: "--fast -q"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/arithmetization-simple-zkc-binary-run-and-go-corset-check.yml
+++ b/.github/workflows/arithmetization-simple-zkc-binary-run-and-go-corset-check.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/arithmetization-zkc-riscv-check-compilation.yml
+++ b/.github/workflows/arithmetization-zkc-riscv-check-compilation.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/check-lib-versions-changes.yml
+++ b/.github/workflows/check-lib-versions-changes.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1

--- a/.github/workflows/component-changelog-commit.yml
+++ b/.github/workflows/component-changelog-commit.yml
@@ -21,7 +21,7 @@ jobs:
   push-component-changelog:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
-      # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes 
+      # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes
       # directly bypassin the branch-protection or for PR bot GitHub App to create PR with the changelog changes.
       - name: Generate release or PR bot App token
         id: app-token
@@ -43,7 +43,7 @@ jobs:
           echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/component-changelog-upload.yml
+++ b/.github/workflows/component-changelog-upload.yml
@@ -21,7 +21,7 @@ jobs:
       linea: ${{ steps.filter.outputs.linea }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Filter commit changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: filter
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Checkout
         if: needs.filter-commit-changes.outputs[matrix.component] == 'true'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # git-cliff needs full history + tags to compute changelog/version
           ref: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/coordinator-build-and-publish.yml
+++ b/.github/workflows/coordinator-build-and-publish.yml
@@ -50,7 +50,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -32,7 +32,7 @@ jobs:
     name: Coordinator tests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
       - name: Setup Java and Gradle

--- a/.github/workflows/dockerfile-security-scan.yml
+++ b/.github/workflows/dockerfile-security-scan.yml
@@ -24,7 +24,7 @@ jobs:
     if: false # Disabled — Checkmarx KICS supply chain compromise (2026-04-22)
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run KICS
         uses: checkmarx/kics-github-action@4063ea7186bec9fed1bf055e095a4658693f9998 # v2.1.19

--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -16,7 +16,7 @@ jobs:
       has_changes_requiring_e2e_testing: ${{ steps.evaluate.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Filter for e2e-relevant paths
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2

--- a/.github/workflows/github-release-besu-plugin.yml
+++ b/.github/workflows/github-release-besu-plugin.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/lido-governance-monitor-build-and-publish.yml
+++ b/.github/workflows/lido-governance-monitor-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/lido-governance-monitor-testing.yml
+++ b/.github/workflows/lido-governance-monitor-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Check besuCommit change
         uses: ./.github/actions/check-lib-version-change
         id: check_besu_commit

--- a/.github/workflows/linea-besu-package-build-and-upload.yml
+++ b/.github/workflows/linea-besu-package-build-and-upload.yml
@@ -37,7 +37,7 @@ jobs:
       dockerimage: ${{ steps.build-plugins-and-assemble.outputs.dockerimage }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build plugins and assemble
         id: build-plugins-and-assemble

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -30,13 +30,13 @@ jobs:
     name: Build docker images from source and upload (if needed) for e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Tracer Environment (for linea-besu-package build)
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
         uses: ./.github/actions/setup-tracer-environment
 
-      - name: Build linea-besu-package from source 
+      - name: Build linea-besu-package from source
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
         shell: bash
         run: cd linea-besu/package && make build
@@ -51,7 +51,7 @@ jobs:
           sudo apt update
           sudo apt-get install --no-install-recommends --assume-yes tree
           tree .
-      
+
       - name: Save linea-besu-package docker image as artifact
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
         run: |
@@ -74,7 +74,7 @@ jobs:
           go-version: '1.24.6'
           cache-dependency-path: "**/*.sum"
 
-      - name: Build prover from source 
+      - name: Build prover from source
         if: ${{ inputs.prover_image_tag == '' }}
         shell: bash
         run: cd linea-besu/package && make build-prover
@@ -95,7 +95,7 @@ jobs:
           name: linea-prover
           path: linea-prover-image.tar.gz
           retention-days: 1
-  
+
   run-e2e-tests-with-partial-prover:
     needs: [build-and-upload-images]
     uses: ./.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml

--- a/.github/workflows/linea-milestone-release-with-dry-run.yml
+++ b/.github/workflows/linea-milestone-release-with-dry-run.yml
@@ -61,7 +61,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout current branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref || github.ref_name }}
@@ -204,7 +204,7 @@ jobs:
           echo "Dispatched run terminal state: ${STATE}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout (full history + tags)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
@@ -268,7 +268,7 @@ jobs:
           else
             echo "Branch ${BRANCH} could not be deleted (already gone or protected)." >&2
           fi
-  
+
   milestone-release-on-main:
     needs: [manual-run-release-on-main]
     if: ${{ always() && !cancelled() && (!inputs.dry_run_release_on_branch || needs.manual-run-release-on-main.result == 'success') }}

--- a/.github/workflows/linea-sequencer-plugin-testing.yml
+++ b/.github/workflows/linea-sequencer-plugin-testing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Tracer Environment # configures Go, Java, and Gradle
         uses: ./.github/actions/setup-tracer-environment
@@ -51,7 +51,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Tracer Environment
         uses: ./.github/actions/setup-tracer-environment

--- a/.github/workflows/linea-tracer-plugin-release.yml
+++ b/.github/workflows/linea-tracer-plugin-release.yml
@@ -37,7 +37,7 @@ jobs:
           tag_name: ${{ inputs.release_tag }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Tracer Environment
         uses: ./.github/actions/setup-tracer-environment

--- a/.github/workflows/lint-commit-messages.yml
+++ b/.github/workflows/lint-commit-messages.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Need both PR head and base so we can list commits in the PR.
           fetch-depth: 0
           submodules: false
 
        # Check if PR title is in Conventional Commits format
-       # It's important, as in a squash merge, the PR title becomes 
+       # It's important, as in a squash merge, the PR title becomes
        # the single commit message on main.
       - name: Lint PR title
         if: github.event_name == 'pull_request'

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -34,7 +34,7 @@ jobs:
     name: Run Load Test
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   code-analysis:
     uses: ./.github/workflows/codeql.yml
-  
+
   lint-latest-commit-messages:
     uses: ./.github/workflows/lint-commit-messages.yml
     permissions:
@@ -27,7 +27,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [lint-latest-commit-messages]
     uses: ./.github/workflows/component-changelog-upload.yml
-  
+
   component-changelog-commit:
     if: github.ref == 'refs/heads/main'
     needs: [component-changelog-upload]
@@ -62,7 +62,7 @@ jobs:
       has-changes-requiring-linea-besu-package-build: ${{ steps.filter.outputs.linea-sequencer-plugin == 'true' || steps.filter.outputs.tracer == 'true' || steps.filter.outputs.tracer-constraints == 'true' ||  steps.filter.outputs.linea-besu == 'true' || steps.filter.outputs.linea-besu-package == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Filter commit changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: filter

--- a/.github/workflows/maru-build-and-publish.yml
+++ b/.github/workflows/maru-build-and-publish.yml
@@ -51,7 +51,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set image tag if not given
         if: ${{ inputs.image_tag == '' }}
         run: |

--- a/.github/workflows/maru-chaos-testing.yml
+++ b/.github/workflows/maru-chaos-testing.yml
@@ -60,7 +60,7 @@ jobs:
     #        iterations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/maru-e2e-tests.yml
+++ b/.github/workflows/maru-e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/maru-testing.yml
+++ b/.github/workflows/maru-testing.yml
@@ -35,7 +35,7 @@ jobs:
     #        iterations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
       - name: Setup Java and Gradle

--- a/.github/workflows/maven-release-all.yml
+++ b/.github/workflows/maven-release-all.yml
@@ -38,7 +38,7 @@ jobs:
           echo "VERSION: $VERSION"
 
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/native-yield-automation-service-build-and-publish.yml
+++ b/.github/workflows/native-yield-automation-service-build-and-publish.yml
@@ -67,7 +67,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/native-yield-automation-service-testing.yml
+++ b/.github/workflows/native-yield-automation-service-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -37,7 +37,7 @@ jobs:
     name: Run test:partial-prover:${{ matrix.test }} e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download local linea-besu-package docker image
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
@@ -133,7 +133,7 @@ jobs:
           if-no-files-found: error
           path: |
             docker_logs/**/*
-      
+
       - name: Archive shared folder
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/.github/workflows/postman-build-and-publish.yml
+++ b/.github/workflows/postman-build-and-publish.yml
@@ -50,7 +50,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/postman-testing.yml
+++ b/.github/workflows/postman-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/prover-build-and-publish.yml
+++ b/.github/workflows/prover-build-and-publish.yml
@@ -53,7 +53,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
 

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
@@ -78,7 +78,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-arm64-med
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
@@ -113,7 +113,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:

--- a/.github/workflows/prover-ray-testing.yml
+++ b/.github/workflows/prover-ray-testing.yml
@@ -19,7 +19,7 @@ jobs:
     name: Prover static check
     steps:
     - name: checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
     - name: install Go
@@ -68,7 +68,7 @@ jobs:
       - staticcheck
     steps:
     - name: checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: install Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -19,7 +19,7 @@ jobs:
     name: Prover static check
     steps:
     - name: checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
     - name: install Go
@@ -65,7 +65,7 @@ jobs:
       - staticcheck
     steps:
     - name: checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: install Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:

--- a/.github/workflows/reusable-component-docker-tag.yml
+++ b/.github/workflows/reusable-component-docker-tag.yml
@@ -29,7 +29,7 @@ jobs:
       docker_tag_with_suffix: ${{ steps.dockertag.outputs.dockertag_with_suffix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 2   # need at least 2 commits so HEAD~1 resolves later would not fail on compute-version-tags

--- a/.github/workflows/reusable-component-gh-release.yml
+++ b/.github/workflows/reusable-component-gh-release.yml
@@ -146,7 +146,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Append Changelog Action to release note
         id: append_change_log

--- a/.github/workflows/reusable-component-release-metadata.yml
+++ b/.github/workflows/reusable-component-release-metadata.yml
@@ -40,7 +40,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog_content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -53,7 +53,7 @@ jobs:
       release_version: ${{ steps.prepend-changelog.outputs.next_version }}
       changelog: ${{ steps.prepend-changelog.outputs.changelog_content }}
     steps:
-      # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes 
+      # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes
       # directly bypassin the branch-protection or for PR bot GitHub App to create PR with the changelog changes.
       - name: Generate release or PR bot App token
         id: app-token
@@ -77,7 +77,7 @@ jobs:
           echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ (!inputs.upload_changelog && steps.app-token.outputs.token) ||  github.token }}

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -72,7 +72,7 @@ jobs:
        commit_tag: ${{ steps.compute-version-tags.outputs.commit_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Compute version tags
         id: compute-version-tags
@@ -90,7 +90,7 @@ jobs:
     uses: ./.github/workflows/coordinator-testing.yml
     needs: [compute-commit-tag, compute-release-metadata]
     if: >
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
       inputs.component-name == 'coordinator' &&
       github.ref_name != 'main'
     with:
@@ -101,8 +101,8 @@ jobs:
     uses: ./.github/workflows/postman-testing.yml
     needs: [compute-commit-tag, compute-release-metadata]
     if: >
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
-      inputs.component-name == 'postman' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      inputs.component-name == 'postman' &&
       github.ref_name != 'main'
     with:
       commit_tag: ${{ needs.compute-commit-tag.outputs.commit_tag }}
@@ -112,8 +112,8 @@ jobs:
     uses: ./.github/workflows/prover-testing.yml
     needs: [compute-release-metadata]
     if: >
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
-      inputs.component-name == 'prover' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      inputs.component-name == 'prover' &&
       github.ref_name != 'main'
     secrets: inherit
 
@@ -132,8 +132,8 @@ jobs:
     uses: ./.github/workflows/transaction-exclusion-api-testing.yml
     needs: [compute-release-metadata]
     if: >
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
-      inputs.component-name == 'tx-exclusion-api' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
+      inputs.component-name == 'tx-exclusion-api' &&
       github.ref_name != 'main'
     secrets: inherit
 
@@ -141,7 +141,7 @@ jobs:
     needs: [compute-release-metadata, run-test-coordinator]
     if: >
       always() && !cancelled() &&
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
       inputs.component-name == 'coordinator' &&
       (github.ref_name == 'main' || needs.run-test-coordinator.result == 'success')
     uses: ./.github/workflows/coordinator-build-and-publish.yml
@@ -155,7 +155,7 @@ jobs:
     needs: [compute-release-metadata, run-test-postman]
     if: >
       always() && !cancelled() &&
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
       inputs.component-name == 'postman' &&
       (github.ref_name == 'main' || needs.run-test-postman.result == 'success')
     uses: ./.github/workflows/postman-build-and-publish.yml
@@ -169,7 +169,7 @@ jobs:
     needs: [compute-release-metadata, run-test-prover]
     if: >
       always() && !cancelled() &&
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
       inputs.component-name == 'prover' &&
       (github.ref_name == 'main' || needs.run-test-prover.result == 'success')
     uses: ./.github/workflows/prover-build-and-publish.yml
@@ -197,7 +197,7 @@ jobs:
     needs: [compute-release-metadata, run-test-transaction-exclusion-api]
     if: >
       always() && !cancelled() &&
-      needs.compute-release-metadata.outputs.tag_changed == 'true' && 
+      needs.compute-release-metadata.outputs.tag_changed == 'true' &&
       inputs.component-name == 'tx-exclusion-api' &&
       (github.ref_name == 'main' || needs.run-test-transaction-exclusion-api.result == 'success')
     uses: ./.github/workflows/transaction-exclusion-api-build-and-publish.yml

--- a/.github/workflows/reusable-compute-commit-tags.yml
+++ b/.github/workflows/reusable-compute-commit-tags.yml
@@ -32,7 +32,7 @@ jobs:
       develop_tag: ${{ steps.compute-version-tags.outputs.develop_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Compute version tags
         id: compute-version-tags

--- a/.github/workflows/reusable-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reusable-linea-besu-package-build-test-push.yml
@@ -106,7 +106,7 @@ jobs:
       docker_tag_with_suffix: ${{ steps.build-plugins-and-assemble.outputs.dockertag_with_suffix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 2   # need at least 2 commits so HEAD~1 resolves later would not fail on compute-version-tags
@@ -259,7 +259,7 @@ jobs:
               exit 1
             fi
           fi
-      
+
       - name: Append Changelog input to release note
         id: append_change_log_input
         if: ${{ inputs.changelog != '' }}

--- a/.github/workflows/reusable-linea-besu-package-run-e2e-tests.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-e2e-tests.yml
@@ -60,7 +60,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:

--- a/.github/workflows/reusable-linea-besu-package-run-test.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-test.yml
@@ -14,7 +14,7 @@ jobs:
       profile-files: ${{ steps.list-profiles.outputs.files }}
     steps:
       - name: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Split and list profiles
         id: list-profiles
@@ -38,7 +38,7 @@ jobs:
       DOCKER_IMAGE: ${{ inputs.dockerimage }}
     steps:
       - name: Check repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download local docker image artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
+++ b/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
@@ -34,7 +34,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0

--- a/.github/workflows/reusable-milestone-component-latest-docker-tags.yml
+++ b/.github/workflows/reusable-milestone-component-latest-docker-tags.yml
@@ -112,7 +112,7 @@ jobs:
       maru-release-version: ${{ steps.latest-release-version.outputs.maru-latest-release-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: fromJson(matrix.metadata).tag_changed != 'true'
         with:
           ref: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/reusable-milestone-component-release-metadata.yml
+++ b/.github/workflows/reusable-milestone-component-release-metadata.yml
@@ -63,7 +63,7 @@ jobs:
       linea-besu-package: ${{ steps.changelog-outputs.outputs.linea-besu-package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0

--- a/.github/workflows/reusable-milestone-gh-release.yml
+++ b/.github/workflows/reusable-milestone-gh-release.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Append Changelog Action to release note
         id: append_change_log

--- a/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
@@ -59,7 +59,7 @@ jobs:
       LINEA_TAG_PATTERN: 'releases/linea/v[0-9]+\.[0-9]+\.[0-9]+$'
       TMP_CHANGELOG: CHANGELOG.linea-milestone.tmp.md
     steps:
-      # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes 
+      # Mint a short-lived token either for the release bot GitHub App to commit the changelog changes
       # directly bypassin the branch-protection or for PR bot GitHub App to create PR with the changelog changes.
       - name: Generate release or PR bot App token
         id: app-token
@@ -81,7 +81,7 @@ jobs:
           echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ steps.app-token.outputs.token }}
@@ -272,7 +272,7 @@ jobs:
           add-paths: |
             CHANGELOG.md
             **/CHANGELOG.md
-      
+
       - name: Create and push Linea milestone release tag
         env:
           COMPONENT: "Linea Milestone"

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:

--- a/.github/workflows/reusable-store-image-name-and-tags.yml
+++ b/.github/workflows/reusable-store-image-name-and-tags.yml
@@ -30,7 +30,7 @@ jobs:
       develop_tag: ${{ steps.compute-version-tags.outputs.develop_tag}}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Compute version tags
         id: compute-version-tags
         uses: ./.github/actions/compute-version-tags

--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -48,7 +48,7 @@ jobs:
       disabled: ${{ steps.metrics.outputs.disabled }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Tracer Test Environment
         uses: ./.github/actions/setup-tracer-environment

--- a/.github/workflows/reusable-tracer-nightly-tests.yml
+++ b/.github/workflows/reusable-tracer-nightly-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/reusable-tracer-unit-tests.yml
+++ b/.github/workflows/reusable-tracer-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/reusable-tracer-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-prc-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/reusable-tracer-weekly-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/riscv-guests-host-tests.yml
+++ b/.github/workflows/riscv-guests-host-tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
@@ -58,7 +58,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/riscv-guests-zkc-interpreter-run.yml
+++ b/.github/workflows/riscv-guests-zkc-interpreter-run.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/rollup-spec-testing.yml
+++ b/.github/workflows/rollup-spec-testing.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run rollup spec tests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -95,7 +95,7 @@ jobs:
     name: Solidity format check
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/run-validium-e2e-tests.yml
+++ b/.github/workflows/run-validium-e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -46,7 +46,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.release_commit_sha }}
 
@@ -81,7 +81,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           pnpm-install-options: "--frozen-lockfile --prefer-offline --ignore-scripts"
-  
+
       - name: Build sdk-core
         run: pnpm -F @lfdt-lineth/sdk-core run build
 
@@ -202,7 +202,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.release_commit_sha }}
 
@@ -229,7 +229,7 @@ jobs:
             echo "::error::@consensys/linea-sdk-core@${CORE_VERSION} is not published on npm. Run this workflow for sdk-core with dual_publish_legacy enabled first."
             exit 1
           fi
-      
+
       - name: Build sdk-viem
         run: pnpm -F "@lfdt-lineth/sdk-viem..." run build
 

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -30,7 +30,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/slack-notify-e2e-runtime-report.yml
+++ b/.github/workflows/slack-notify-e2e-runtime-report.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
@@ -483,7 +483,7 @@ jobs:
                   type: plain_text
                   text: ":x: ${{ inputs.title }}"
                   emoji: true
-              
+
               - type: rich_text
                 elements:
                   - type: rich_text_section
@@ -494,7 +494,7 @@ jobs:
                           bold: true
                       - type: text
                         text: "${{ steps.ctx.outputs.repo }}"
-              
+
               - type: rich_text
                 elements:
                   - type: rich_text_section

--- a/.github/workflows/staterecovery-testing.yml
+++ b/.github/workflows/staterecovery-testing.yml
@@ -32,7 +32,7 @@ jobs:
     name: Staterecovery tests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Staterecovery - Build and Unit tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -163,7 +163,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/tracer-constraints-check-compilation.yml
+++ b/.github/workflows/tracer-constraints-check-compilation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/tracer-gradle-besu-node-tests.yml
+++ b/.github/workflows/tracer-gradle-besu-node-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/tracer-gradle-nightly-tests.yml
+++ b/.github/workflows/tracer-gradle-nightly-tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/tracer-gradle-tests.yml
+++ b/.github/workflows/tracer-gradle-tests.yml
@@ -35,7 +35,7 @@ jobs:
           echo "github.ref: ${{ github.ref }}"
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/tracer-gradle-weekly-tests.yml
+++ b/.github/workflows/tracer-gradle-weekly-tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 

--- a/.github/workflows/transaction-exclusion-api-build-and-publish.yml
+++ b/.github/workflows/transaction-exclusion-api-build-and-publish.yml
@@ -50,7 +50,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}

--- a/.github/workflows/transaction-exclusion-api-testing.yml
+++ b/.github/workflows/transaction-exclusion-api-testing.yml
@@ -33,7 +33,7 @@ jobs:
     name: Transaction exclusion api tests
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Run tests with coverage

--- a/.github/workflows/valid-audit-pr-has-tags.yml
+++ b/.github/workflows/valid-audit-pr-has-tags.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/verifier-ray.yml
+++ b/.github/workflows/verifier-ray.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: false
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine third-party action patch bump with no application or pipeline behavior changes; risk is limited to upstream checkout action regressions.
> 
> **Overview**
> **Bumps `actions/checkout`** from `de0fac2…` (v6.0.2) to `df4cb1c…` (v6.0.3) on every workflow checkout step under `.github/workflows/`, including reusable jobs for build, test, release, benchmarks, and Slack notifications.
> 
> A few workflows that were on unpinned or older checkout refs (e.g. `actions/checkout@v6`, v4.3.1) are aligned to the same v6.0.3 SHA. **No workflow logic, job graphs, or step inputs change** beyond trailing-whitespace and newline cleanup in some YAML comments and blank lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc374d28efae3ad8e31b47653bdff3398801726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->