### PR TITLE
feat(misc): route Claude integrations through LiteLLM for cost tracking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,8 +59,14 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LITELLM_KEY_CLAUDE_PR_REVIEW }}
+          # The pinned action's inline-comment classifier calls api.anthropic.com
+          # directly, ignoring ANTHROPIC_BASE_URL. Disable it so review traffic
+          # stays on the LiteLLM-routed Claude Code path.
+          classify_inline_comments: "false"
           # use_sticky_comment: false
           direct_prompt: |
             You are a senior software engineer performing a thorough code review on PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.

--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -44,8 +44,10 @@ jobs:
       - name: Run Claude Coordinator Review
         id: review
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LITELLM_KEY_CLAUDE_COORDINATOR_REVIEW }}
           claude_args: --model claude-opus-4-7
           prompt: |
             Before starting your analysis, read the file `previous-findings.txt` in the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,8 +34,10 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LITELLM_KEY_CLAUDE_INTERACTIVE }}
           claude_args: '--allowed-tools Bash(gh pr:*) Bash(gh issue:*)'
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -340,4 +340,4 @@ jobs:
     secrets:
       channel_id: ${{ secrets.SLACK_ENGINEERING_ALERTS_CHANNEL_ID }}
       slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
-      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      anthropic_api_key: ${{ secrets.LITELLM_KEY_CI_FAILURE_ANALYSIS }}

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Run Claude AI analysis
         id: claude
         uses: anthropics/claude-code-base-action@3080e38742e9e6aab0ecf8713353dc072acca48c # main@2026-04-28 (sync from claude-code-action base-action@11a9dad)
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           settings: '{"permissions":{"allow":["Bash(*)","Read(*)","Edit(./e2e-failure-analysis.md)","Edit(./e2e-failure-summary.txt)"],"deny":[]}}'

--- a/docs/features/yield-management.md
+++ b/docs/features/yield-management.md
@@ -135,7 +135,7 @@ A standalone TypeScript service (`operations/native-yield/lido-governance-monito
 | ProposalFetcher | `lido-governance-monitor/src/services/` | Aggregates proposals from all sources |
 | ProposalProcessor | `lido-governance-monitor/src/services/` | AI analysis with retry logic |
 | NotificationService | `lido-governance-monitor/src/services/` | Slack alerting |
-| ClaudeAIClient | `lido-governance-monitor/src/clients/` | Anthropic Claude integration |
+| ClaudeAIClient | `lido-governance-monitor/src/clients/` | Claude integration, routed through the LiteLLM proxy (`ANTHROPIC_BASE_URL`) for cost tracking |
 | ProposalRepository | `lido-governance-monitor/src/clients/db/` | Prisma PostgreSQL persistence |
 
 ---

--- a/operations/native-yield/lido-governance-monitor/.env.sample
+++ b/operations/native-yield/lido-governance-monitor/.env.sample
@@ -7,8 +7,9 @@ MAX_TOPICS_PER_POLL="20"
 # Delay between Discourse proposal detail requests
 DISCOURSE_PROPOSAL_DETAILS_DELAY_MS="250"
 
-# Claude AI
-ANTHROPIC_API_KEY="sk-ant-xxx"
+# Claude AI via LiteLLM
+ANTHROPIC_API_KEY="sk-litellm-xxx"
+ANTHROPIC_BASE_URL="https://example.com"
 CLAUDE_MODEL="claude-sonnet-4-20250514"
 ANTHROPIC_MAX_OUTPUT_TOKENS="4096"
 ANTHROPIC_MAX_PROPOSAL_CHARS="700000"

--- a/operations/native-yield/lido-governance-monitor/README.md
+++ b/operations/native-yield/lido-governance-monitor/README.md
@@ -58,13 +58,20 @@ All environment variables, defaults, and validation rules are defined in the [co
 
 The Discourse fetcher waits 250ms between proposal detail requests by default. Override it with `DISCOURSE_PROPOSAL_DETAILS_DELAY_MS` when you need a different pacing.
 
+### LLM access via LiteLLM
+
+Claude calls are routed through the shared LiteLLM proxy. Two variables control this:
+
+- `ANTHROPIC_API_KEY` — the **LiteLLM virtual key** for this service
+- `ANTHROPIC_BASE_URL` — the LiteLLM proxy base URL
+
 ## Development
 
 ### Prerequisites
 
 - Node.js >= 24.18.0 (see repo root `.nvmrc`)
 - PostgreSQL database
-- Anthropic API key
+- A LiteLLM virtual key (`ANTHROPIC_API_KEY`), or a direct Anthropic key for local dev (see [LLM access via LiteLLM](#llm-access-via-litellm))
 - Slack incoming webhook
 
 ### Setup
@@ -107,7 +114,8 @@ Run the full pipeline locally against the test database and live APIs:
    INITIAL_LDO_VOTING_CONTRACT_VOTEID="150" \
    DISCOURSE_PROPOSALS_URL="https://research.lido.fi/c/proposals/9/l/latest.json" \
    DISCOURSE_PROPOSAL_DETAILS_DELAY_MS="250" \
-   ANTHROPIC_API_KEY="your-key" \
+   ANTHROPIC_API_KEY="your-litellm-or-anthropic-key" \
+   ANTHROPIC_BASE_URL="https://example.com" \
    SLACK_WEBHOOK_URL="https://hooks.slack.com/services/xxx" \
    ETHEREUM_RPC_URL="https://mainnet.infura.io/v3/xxx" \
    LDO_VOTING_CONTRACT_ADDRESS="0x2e59a20f205bb85a89c53f1936454680651e618e" \

--- a/operations/native-yield/lido-governance-monitor/docs/architecture.md
+++ b/operations/native-yield/lido-governance-monitor/docs/architecture.md
@@ -414,7 +414,7 @@ Forum and on-chain content is treated as untrusted input. Adversaries may craft 
 
 # Operational Considerations
 
-**LLM access** - Service account API key for Anthropic Claude.
+**LLM access** - Claude is reached through the shared LiteLLM proxy
 
 **Observability** - Structured logging via custom logger. Per-run metrics (items fetched, LLM calls, notifications sent).
 

--- a/operations/native-yield/lido-governance-monitor/docs/evals.md
+++ b/operations/native-yield/lido-governance-monitor/docs/evals.md
@@ -26,7 +26,8 @@ The script calls `ClaudeAIClient` directly - no DB, no state machine. Exits 0 re
 
 ### Prerequisites
 
-- `ANTHROPIC_API_KEY` set in env
+- `ANTHROPIC_API_KEY` set in env (a LiteLLM virtual key, or a direct Anthropic key for local runs)
+- `ANTHROPIC_BASE_URL` set to the LiteLLM proxy to route the eval through LiteLLM; leave unset to call Anthropic directly
 - Golden set labels reviewed and updated in `scripts/eval/golden-set.json` before running
 
 ### Run
@@ -39,7 +40,8 @@ ANTHROPIC_API_KEY=sk-ant-xxx pnpm exec tsx scripts/run-eval.ts
 With overrides:
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-xxx \
+ANTHROPIC_API_KEY=sk-litellm-xxx \
+ANTHROPIC_BASE_URL=https://example.com \
 RISK_THRESHOLD=50 \
 CLAUDE_MODEL=claude-sonnet-4-20250514 \
 pnpm exec tsx scripts/run-eval.ts

--- a/operations/native-yield/lido-governance-monitor/scripts/run-eval.ts
+++ b/operations/native-yield/lido-governance-monitor/scripts/run-eval.ts
@@ -197,7 +197,10 @@ async function main(): Promise<void> {
   console.log(`Threshold: ${threshold}, Model: ${model}`);
   console.log("");
 
-  const anthropicClient = new Anthropic({ apiKey });
+  const anthropicClient = new Anthropic({
+    apiKey,
+    ...(process.env.ANTHROPIC_BASE_URL ? { baseURL: process.env.ANTHROPIC_BASE_URL } : {}),
+  });
   const aiClient = new ClaudeAIClient(noopLogger, anthropicClient, model, systemPrompt, maxOutputTokens, maxProposalChars);
 
   const results: EvalResult[] = [];

--- a/operations/native-yield/lido-governance-monitor/scripts/test-proposal-processor.ts
+++ b/operations/native-yield/lido-governance-monitor/scripts/test-proposal-processor.ts
@@ -130,7 +130,10 @@ async function main() {
 
     // Create AI client
     console.log("\n=== Initializing AI client ===");
-    const anthropicClient = new Anthropic({ apiKey: anthropicApiKey });
+    const anthropicClient = new Anthropic({
+      apiKey: anthropicApiKey,
+      ...(process.env.ANTHROPIC_BASE_URL ? { baseURL: process.env.ANTHROPIC_BASE_URL } : {}),
+    });
     const aiClient = new ClaudeAIClient(
       logger,
       anthropicClient,

--- a/operations/native-yield/lido-governance-monitor/src/application/main/LidoGovernanceMonitorBootstrap.ts
+++ b/operations/native-yield/lido-governance-monitor/src/application/main/LidoGovernanceMonitorBootstrap.ts
@@ -50,7 +50,12 @@ export class LidoGovernanceMonitorBootstrap {
       config.http.timeoutMs,
     );
 
-    const anthropicClient = new Anthropic({ apiKey: config.anthropic.apiKey });
+    // Route Claude calls through the LiteLLM proxy when a base URL is configured
+    // otherwise the SDK targets Anthropic directly.
+    const anthropicClient = new Anthropic({
+      apiKey: config.anthropic.apiKey,
+      ...(config.anthropic.baseUrl ? { baseURL: config.anthropic.baseUrl } : {}),
+    });
     const aiClient = new ClaudeAIClient(
       createLidoGovernanceMonitorLogger("ClaudeAIClient"),
       anthropicClient,

--- a/operations/native-yield/lido-governance-monitor/src/application/main/__tests__/config.test.ts
+++ b/operations/native-yield/lido-governance-monitor/src/application/main/__tests__/config.test.ts
@@ -454,6 +454,43 @@ describe("loadConfigFromEnv", () => {
     expect(config.riskAssessment.maxNotifyAttempts).toBe(5);
   });
 
+  it("loads the LiteLLM base URL from ANTHROPIC_BASE_URL when set", () => {
+    // Arrange
+    const env = {
+      DATABASE_URL: "postgresql://localhost:5432/test",
+      DISCOURSE_PROPOSALS_URL: "https://research.lido.fi/c/proposals/9/l/latest.json",
+      ANTHROPIC_API_KEY: "sk-litellm-xxx",
+      ANTHROPIC_BASE_URL: "https://example.com",
+      SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/xxx",
+      ETHEREUM_RPC_URL: "https://mainnet.infura.io/v3/xxx",
+      LDO_VOTING_CONTRACT_ADDRESS: "0x2e59a20f205bb85a89c53f1936454680651e618e",
+    };
+
+    // Act
+    const config = loadConfigFromEnv(env);
+
+    // Assert
+    expect(config.anthropic.baseUrl).toBe("https://example.com");
+  });
+
+  it("leaves the base URL undefined when ANTHROPIC_BASE_URL is missing (direct Anthropic)", () => {
+    // Arrange
+    const env = {
+      DATABASE_URL: "postgresql://localhost:5432/test",
+      DISCOURSE_PROPOSALS_URL: "https://research.lido.fi/c/proposals/9/l/latest.json",
+      ANTHROPIC_API_KEY: "sk-ant-xxx",
+      SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/xxx",
+      ETHEREUM_RPC_URL: "https://mainnet.infura.io/v3/xxx",
+      LDO_VOTING_CONTRACT_ADDRESS: "0x2e59a20f205bb85a89c53f1936454680651e618e",
+    };
+
+    // Act
+    const config = loadConfigFromEnv(env);
+
+    // Assert
+    expect(config.anthropic.baseUrl).toBeUndefined();
+  });
+
   it("uses default values when optional env vars are missing", () => {
     // Arrange
     const env = {

--- a/operations/native-yield/lido-governance-monitor/src/application/main/config/index.ts
+++ b/operations/native-yield/lido-governance-monitor/src/application/main/config/index.ts
@@ -35,8 +35,10 @@ export const ConfigSchema = z.object({
     maxTopicsPerPoll: z.number().int().positive("Max topics per poll must be positive"),
   }),
   anthropic: z.object({
-    // Authentication key for the Anthropic Claude API
+    // LiteLLM virtual key used to authenticate against the LiteLLM proxy
     apiKey: NonEmptyString("Anthropic API key is required"),
+    // Optional LiteLLM proxy base URL
+    baseUrl: NonEmptyUrl("Invalid LiteLLM/Anthropic base URL").optional(),
     // Claude model ID used for proposal risk analysis
     model: NonEmptyString("Model name is required"),
     // Maximum tokens Claude can generate per analysis response
@@ -93,6 +95,7 @@ export function loadConfigFromEnv(env: Record<string, string | undefined>): Conf
     },
     anthropic: {
       apiKey: env.ANTHROPIC_API_KEY ?? "",
+      baseUrl: env.ANTHROPIC_BASE_URL,
       model: env.CLAUDE_MODEL ?? "claude-sonnet-4-20250514",
       maxOutputTokens: parseInt(env.ANTHROPIC_MAX_OUTPUT_TOKENS ?? "4096", 10),
       maxProposalChars: parseInt(env.ANTHROPIC_MAX_PROPOSAL_CHARS ?? "700000", 10),


### PR DESCRIPTION
## Summary
- Route all GitHub Actions Claude workloads through the LiteLLM proxy
- Add optional `ANTHROPIC_BASE_URL` support to lido-governance-monitor
- Disable `classify_inline_comments` on `@claude-review` so the action does not bypass LiteLLM

## Test plan
- [x] `pnpm -F @lfdt-lineth/lido-governance-monitor` config unit tests pass locally
- [ ] After merge: provision `LITELLM_BASE_URL` + four GitHub secrets before triggering Claude workflows

Made with [Cursor](https://cursor.com)