### PR TITLE
ci(ci): update dependency-maintenance skill and refresh GitHub Actions

### DIFF
--- a/.agents/skills/linea-dependency-maintenance/SKILL.md
+++ b/.agents/skills/linea-dependency-maintenance/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: linea-dependency-maintenance
 description:
-  Safely plan and execute JavaScript/TypeScript dependency maintenance across npm and pnpm repositories, including npm
-  lockfiles, pnpm workspaces, catalogs, overrides, release-age policies, audits, CI validation, Dependabot boundaries,
-  PRs, and GitHub tracking issues. Use whenever the user asks to update, bump, refresh, audit, clean, modernize, or
-  review dependencies, reduce vulnerabilities, clean overrides, or prepare dependency PRs/issues.
+  Safely plan and execute dependency maintenance for JavaScript/TypeScript (npm, pnpm) and GitHub Actions, including npm
+  lockfiles, pnpm workspaces, catalogs, overrides, SHA-pinned action versions, release-age policies, audits, CI
+  validation, Dependabot boundaries, PRs, and GitHub tracking issues. Use whenever the user asks to update, bump,
+  refresh, audit, clean, modernize, or review dependencies or GitHub Actions, reduce vulnerabilities, clean overrides, or
+  prepare dependency PRs/issues.
 metadata:
-  short-description: Safe npm/pnpm dependency maintenance
+  short-description: Safe npm/pnpm and GitHub Actions dependency maintenance
 ---
 
 # Dependency Maintenance
@@ -27,7 +28,8 @@ hiding remaining risk.
    - Do not introduce a different lockfile, workspace file, package-manager metadata, or install command.
 3. Check branch and worktree state with `git status --short --branch`. If unrelated changes are present, use an isolated
    worktree or avoid touching those files.
-4. Read `.nvmrc`, `.node-version`, `engines`, `.npmrc`, CI workflows, deploy config, and `dependabot.yml`.
+4. Read `.nvmrc`, `.node-version`, `engines`, `.npmrc`, deploy config, `dependabot.yml`, and the GitHub Actions pins in
+   `.github/workflows/*.yml` and `.github/actions/**/action.yml`.
 5. Capture the baseline: outdated report, audit report, lockfile state, and relevant validation commands.
 
 ## Policy
@@ -37,8 +39,16 @@ hiding remaining risk.
   list as read-only: respect the existing entries, but never add or widen it to push a fresher version through — the
   maturity window is a hard gate, not a hurdle to bypass.
 - Treat npm/pnpm dependency updates as owned by this skill. Do not re-enable Dependabot npm/pnpm package-ecosystem jobs
-  unless the user explicitly asks; GitHub Actions, Docker, and other non-JavaScript ecosystems may remain under
-  Dependabot.
+  unless the user explicitly asks.
+- GitHub Actions are in scope for manual/agent sweeps and for policy enforcement, but Dependabot keeps opening the
+  routine `github-actions` PRs: its cooldown in `dependabot.yml` (7 days) matches the action maturity window, so leave
+  that job enabled and let the two coexist. Docker and other non-JavaScript ecosystems also stay under Dependabot.
+- Pin GitHub Actions to a full 40-character commit SHA, never a tag or branch ref (`@v4`, `@main`). A movable ref lets
+  the upstream repo change what runs in CI without review. Append the human-readable version as an end-of-line comment
+  (`uses: actions/checkout@<sha> # v7.0.0`) and update that comment on every bump so the SHA stays auditable.
+- Gate GitHub Actions on release age: only adopt a SHA whose release (tag) is older than 7 days. Actions use a longer
+  7-day window than the JS/npm/pnpm gate because an action runs with repository scope in CI, so a fresh release is
+  higher-risk supply-chain surface. Treat the window as a hard gate, not a suggestion.
 - Pin exact versions (mandatory). Every npm/pnpm `dependencies`/`devDependencies` specifier must be an exact pin, never
   a `^` caret or `~` tilde range. Floating ranges silently pull unreviewed releases and widen the supply-chain attack
   surface, so a single exact version is the only safe and reproducible default. When a bump touches a manifest, also
@@ -149,6 +159,43 @@ See `references/pnpm.md` and `references/npm.md` for the per-manager commands (o
 overrides automatically; npm never writes `overrides`, so its flow relies on `npm audit fix` without `--force` plus
 manual targeted overrides).
 
+## GitHub Actions
+
+Workflow and composite-action files (`.github/workflows/*.yml`, `.github/actions/**/action.yml`) reference third-party
+actions. Maintain them on the same lifecycle as packages: inventory, triage by release age, bump, validate.
+
+Inventory the pins with a reproducible first pass:
+
+```bash
+node <skill-dir>/scripts/eligible-actions --days 7
+```
+
+The helper scans every external `uses:` pin and, for each action, reports the newest same-major release older than the
+cutoff plus its exact commit SHA. It needs an authenticated `gh` CLI. The action gate is 7 days; adjust
+`--days`/`--minutes` only if repo policy differs. When the same action is pinned to different SHAs across files, the
+report sets `conflictingPins` and lists each variant — reconcile those before bumping.
+
+Triage each pin:
+
+- Safe now: a newer same-major tag whose release is older than the cutoff. Bump both the SHA and the version comment.
+- Blocked (too fresh): the only newer tag is still inside the maturity window. Keep the current pin, note it, and
+  re-check after the release matures. Never bump to a release younger than the cutoff.
+- Pin drift: `conflictingPins` is true (different SHAs for the same action path). Align every workflow file to one SHA
+  and comment before applying any bump suggestion.
+- Comment drift: `commentDrift` is true (same SHA but different version comments). Align comments before bumping.
+- Major migration: a semver-major bump (for example a runner or Node baseline change). Track it in an issue instead of
+  bumping now, unless the user approves the major.
+
+Apply a bump by replacing the SHA and the trailing comment together, so they never drift:
+
+```
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
++ uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+```
+
+Local actions (`uses: ./.github/actions/...`) are first-party and need no pin. See `references/github-actions.md` for the
+exact `gh` commands to resolve a tag to its commit SHA and confirm its release age.
+
 ## Validation
 
 Run the narrowest meaningful checks first, then broaden by blast radius:
@@ -158,6 +205,8 @@ Run the narrowest meaningful checks first, then broaden by blast radius:
 - lint, typecheck, build, and tests
 - repo-specific checks such as Docusaurus prebuild/build, Turbo filters, Prisma generate, Playwright/Storybook browsers,
   Docker builds, Foundry/forge, subgraph codegen/tests, or generated-doc checks
+- for GitHub Actions changes: confirm every external `uses:` is a 40-character commit SHA with a matching version
+  comment, and that each bumped release cleared the age gate
 
 If a command cannot run, report why. If CI fails, inspect the actual logs and classify the failure as introduced by the
 update, exposed baseline debt, or external/non-actionable.
@@ -167,9 +216,13 @@ update, exposed baseline debt, or external/non-actionable.
 Open the PR only after local validation is green. Opening a PR is an outward-facing action, so commit the work on a
 dedicated branch, then pause and confirm with the user before pushing and creating the PR.
 
-- Branch from the repo's base branch, stage the manifest and lockfile changes together, and commit with the repository's
-  Conventional Commit format. Do not assume a universal type or scope; use the repo-approved prefix and set the
-  description to `refresh dependencies`.
+- Branch from the repo's base branch and commit with the repository's Conventional Commit format. Match the update set:
+  - npm/pnpm only: stage manifest and lockfile changes together. Use the repo-approved scope (for example
+    `deps(global): refresh dependencies`).
+  - GitHub Actions only: stage `.github/workflows/*.yml` and `.github/actions/**/action.yml` changes together. Use
+    `deps(actions): refresh GitHub Actions` to align with Dependabot's `github-actions` commit prefix.
+  - Mixed JS and Actions updates: prefer separate commits per ecosystem, or one commit whose message names both scopes
+    explicitly.
 - Open a PR.
 
 Open English follow-up issues for deferred major upgrades or blocked migration streams. Each issue should include
@@ -185,4 +238,6 @@ trees, or CI failures that suggest a cross-cutting regression.
 
 - For npm/package-lock repositories, read `references/npm.md`.
 - For pnpm workspace/catalog/override repositories, read `references/pnpm.md`.
-- For reproducible release-age inventory, run `scripts/eligible-updates`.
+- For GitHub Actions SHA pinning and release-age checks, read `references/github-actions.md`.
+- For reproducible release-age inventory, run `scripts/eligible-updates` (npm/pnpm) or `scripts/eligible-actions`
+  (GitHub Actions).

--- a/.agents/skills/linea-dependency-maintenance/agents/openai.yaml
+++ b/.agents/skills/linea-dependency-maintenance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Dependency Maintenance"
-  short_description: "Safe npm/pnpm upgrades, audits, PRs"
-  default_prompt: "Use this skill to refresh eligible dependencies safely, respect repo package-manager policy, document blocked work, and prepare a validated dependency PR."
+  display_name: 'Dependency Maintenance'
+  short_description: 'Safe npm/pnpm and GitHub Actions upgrades, audits, PRs'
+  default_prompt: 'Use this skill to refresh eligible dependencies and GitHub Actions safely, respect repo package-manager and SHA-pinning policy, document blocked work, and prepare a validated dependency PR.'

--- a/.agents/skills/linea-dependency-maintenance/evals/evals.json
+++ b/.agents/skills/linea-dependency-maintenance/evals/evals.json
@@ -30,6 +30,12 @@
       "prompt": "A dependency PR adds new packages and edits package.json with caret (^) and tilde (~) ranges. Bring it in line with the dependency-maintenance policy before it merges.",
       "expected_output": "Treats every ^/~ range in dependencies/devDependencies as a policy violation and rewrites it to an exact pin, keeps catalog:/workspace: references intact and pins the concrete version at the catalog definition, leaves intentional peerDependencies ranges and engines (>=) constraints untouched, and regenerates the lockfile.",
       "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Refresh the GitHub Actions used in .github/workflows and .github/actions. Some actions have newer releases, some released in the last few days, and some have a new semver-major.",
+      "expected_output": "Inventories every external uses: pin, bumps only releases older than the 7-day action maturity window (longer than the JS gate), updates both the commit SHA and its version comment together, pins to a full 40-character SHA (never a tag/branch ref), holds releases younger than the cutoff, tracks or applies semver-major action bumps per the user's instruction, leaves local (./) actions unpinned, and leaves Dependabot's github-actions job enabled.",
+      "files": []
     }
   ]
 }

--- a/.agents/skills/linea-dependency-maintenance/references/github-actions.md
+++ b/.agents/skills/linea-dependency-maintenance/references/github-actions.md
@@ -58,7 +58,7 @@ grep -rnE 'uses:\s+[^./]' .github/workflows .github/actions
   (` # vX.Y.Z` or ` # X.Y.Z`, space before `#`):
   ```bash
   grep -rnE 'uses:\s+[^./][^@]+@[^ ]+' .github/workflows .github/actions \
-    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\\.[0-9]+\\.[0-9]+'
+    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\.[0-9]+\.[0-9]+'
   ```
   The command should print nothing. Any line it prints is an unpinned action, a tag/branch ref, or a non-standard
   version comment (for example `#v7.2.0` without a leading space).

--- a/.agents/skills/linea-dependency-maintenance/references/github-actions.md
+++ b/.agents/skills/linea-dependency-maintenance/references/github-actions.md
@@ -1,0 +1,85 @@
+# GitHub Actions Dependency Maintenance
+
+<!-- markdownlint-disable -->
+<!-- vale off -->
+
+Use these notes for the GitHub Actions referenced by `.github/workflows/*.yml` and `.github/actions/**/action.yml`.
+
+## Rules
+
+- Pin every external action to a full 40-character commit SHA, never a tag or branch ref (`@v4`, `@main`). A tag is
+  movable: the upstream repo can repoint it at new code that then runs in CI without review.
+- Keep the human-readable version as an end-of-line comment (`uses: actions/checkout@<sha> # v6.0.3`) and update it in
+  the same edit as the SHA, so the pin stays auditable and the two never drift.
+- Release-age gate (mandatory): only adopt a SHA whose release (tag) is older than 7 days. Actions use a longer window
+  than the 3-day JS/npm/pnpm gate because an action runs with repository scope in CI, so a fresh release is higher-risk
+  supply-chain surface. This is a hard gate — hold the bump until the release matures.
+- Default scope is same-major (patch/minor) bumps. Track semver-major action bumps as issues; they can change runner or
+  Node baselines and need deliberate migration.
+- Local actions (`uses: ./.github/actions/...`) are first-party and are not pinned.
+- Dependabot keeps opening the routine `github-actions` PRs. Do not disable that job; its cooldown in `dependabot.yml`
+  (7 days) matches this maturity window. This skill covers manual/agent sweeps and enforcing the rules above on every PR.
+
+## Baseline
+
+```bash
+gh --version            # the checks below need an authenticated gh CLI
+# list every external action pin and its current version comment
+grep -rnE 'uses:\s+[^./]' .github/workflows .github/actions
+```
+
+## Update Flow
+
+1. Inventory the pins with a reproducible first pass:
+   ```bash
+   node <skill-dir>/scripts/eligible-actions --days 7
+   ```
+2. For a candidate `owner/repo`, list same-major releases and their publish dates:
+   ```bash
+   gh api "repos/<owner>/<repo>/releases?per_page=100" --jq '.[] | "\(.tag_name)\t\(.published_at)"'
+   ```
+3. Pick the newest same-major tag whose `published_at` is older than the cutoff. Resolve it to a commit SHA:
+   ```bash
+   gh api "repos/<owner>/<repo>/commits/<tag>" --jq '.sha'
+   ```
+   For an action that publishes tags without releases, fall back to the tag commit date:
+   ```bash
+   gh api "repos/<owner>/<repo>/commits/<tag>" --jq '.commit.committer.date'
+   ```
+4. Replace the SHA and the version comment together, on the same line, everywhere the action is used:
+   ```
+   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+   + uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+   ```
+
+## Validation
+
+- Confirm no mutable refs remain — every external `uses:` must be a 40-character SHA with a standard version comment
+  (` # vX.Y.Z` or ` # X.Y.Z`, space before `#`):
+  ```bash
+  grep -rnE 'uses:\s+[^./][^@]+@[^ ]+' .github/workflows .github/actions \
+    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\\.[0-9]+\\.[0-9]+'
+  ```
+  The command should print nothing. Any line it prints is an unpinned action, a tag/branch ref, or a non-standard
+  version comment (for example `#v7.2.0` without a leading space).
+- Re-run `scripts/eligible-actions` and confirm each bumped action now shows no eligible update, and that anything left
+  behind is either too fresh (blocked by the age gate) or a tracked major.
+
+## Inventory Script Limits
+
+`scripts/eligible-actions` scans each YAML line for `uses: owner/repo@ref` without surrounding quotes. It does not match
+refs wrapped in single or double quotes (for example `uses: 'actions/checkout@<sha>'`). This repo uses unquoted refs;
+if a workflow adopts quoted `uses:` lines, inventory that pin manually or extend the script before relying on the output.
+
+Inventory groups external actions by action path (the `uses` value before `@`), not just `owner/repo`. GitHub API
+lookups always use the first two path segments (`owner/repo`). When the same action appears on multiple lines, the
+script compares SHAs across files. If more than one SHA is pinned, the row
+includes `conflictingPins: true` and a `pinVariants` list — reconcile those pins before acting on bump suggestions for
+that action. When the same SHA carries different version comments, the row includes `commentDrift: true`.
+
+Release discovery merges GitHub releases with tag-only semver tags so newer tag-only versions are not missed when older
+formal releases still exist.
+
+Eligible bump suggestions include a commit SHA only when `gh api repos/<owner>/<repo>/commits/<tag>` resolves one. If
+SHA lookup fails for the newest mature same-major candidate, the script reports no eligible bump instead of falling back
+to an older tag.

--- a/.agents/skills/linea-dependency-maintenance/scripts/eligible-actions
+++ b/.agents/skills/linea-dependency-maintenance/scripts/eligible-actions
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+
+// Report GitHub Actions pins that have a newer same-major release older than a maturity window.
+// Requires an authenticated `gh` CLI (used for the GitHub API so auth and rate limits are handled).
+
+const { execFileSync } = require("node:child_process");
+const { readdirSync, readFileSync, statSync, existsSync } = require("node:fs");
+const { join, extname } = require("node:path");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const SHA_RE = /^[0-9a-f]{40}$/;
+const USES_RE = /uses:\s*([^\s'"#]+)(?:\s*#\s*(\S+))?/;
+
+function parseArgs(argv) {
+  // Actions use a 7-day maturity window (longer than the 3-day JS/npm/pnpm gate).
+  const args = { days: 7, minutes: null, dir: ".github" };
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--days" && next) {
+      args.days = Number(next);
+      index += 1;
+    } else if (arg === "--minutes" && next) {
+      args.minutes = Number(next);
+      index += 1;
+    } else if (arg === "--dir" && next) {
+      args.dir = next;
+      index += 1;
+    } else if (arg === "--help") {
+      console.error("Usage: eligible-actions [--days N | --minutes N] [--dir .github]");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function walk(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...walk(full));
+    } else if ([".yml", ".yaml"].includes(extname(full))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+// Collect every `uses:` pin, keyed by action path (uses value before @). Multiple files may reference the same action; flag SHA drift.
+function collectPins(dir) {
+  const occurrences = new Map();
+  for (const file of walk(dir)) {
+    for (const line of readFileSync(file, "utf8").split("\n")) {
+      const match = line.match(USES_RE);
+      if (!match) continue;
+      const ref = match[1];
+      const comment = String(match[2] ?? "").trim();
+      if (ref.startsWith("./") || ref.startsWith(".\\")) continue; // local action, not pinned
+      const [owner, repoName, at] = splitRef(ref);
+      if (!owner || !repoName) continue;
+      const key = actionPathFromRef(ref);
+      const sha = SHA_RE.test(at) ? at : "";
+      const list = occurrences.get(key) ?? [];
+      list.push({ file, sha, ref: at, comment });
+      occurrences.set(key, list);
+    }
+  }
+  return [...occurrences.entries()].map(([key, hits]) => finalizePin(key, hits));
+}
+
+function pickComment(comments) {
+  const unique = [...new Set(comments.filter(Boolean))].sort();
+  return unique[0] ?? "";
+}
+
+function hasCommentDrift(comments) {
+  const standard = [...new Set(comments.filter(isStandardVersion))];
+  if (standard.length <= 1) return false;
+  return new Set(standard.map((comment) => parseVersion(comment)?.raw)).size > 1;
+}
+
+function finalizePin(repo, hits) {
+  const files = [...new Set(hits.map((hit) => hit.file))].sort();
+  const hasMutableRef = hits.some((hit) => hit.sha === "" && hit.ref !== "");
+  const inventoryComment = pickComment(hits.map((hit) => hit.comment));
+  const bySha = new Map();
+  for (const hit of hits.filter((item) => item.sha !== "")) {
+    const bucket = bySha.get(hit.sha) ?? {
+      sha: hit.sha,
+      comments: new Set(),
+      files: new Set(),
+    };
+    if (hit.comment) bucket.comments.add(hit.comment);
+    bucket.files.add(hit.file);
+    bySha.set(hit.sha, bucket);
+  }
+
+  const pinVariants = [...bySha.values()]
+    .map((variant) => ({
+      sha: variant.sha,
+      comment: pickComment([...variant.comments]),
+      files: [...variant.files].sort(),
+    }))
+    .sort((a, b) => a.sha.localeCompare(b.sha));
+
+  const conflictingPins = pinVariants.length > 1;
+  const pinned = !hasMutableRef && pinVariants.length > 0;
+  const primary = pinVariants[0];
+  const primaryComments = primary ? [...bySha.get(primary.sha).comments] : [];
+  const canonicalComment = primary ? pickComment(primaryComments) : inventoryComment;
+  const commentDrift =
+    !conflictingPins && pinVariants.length === 1 && hasCommentDrift(primaryComments);
+
+  return {
+    repo,
+    pinned,
+    sha: !conflictingPins && primary ? primary.sha : "",
+    ref: hits.find((hit) => hit.sha === "")?.ref ?? primary?.sha ?? "",
+    comment: pinned && !conflictingPins ? canonicalComment : inventoryComment,
+    conflictingPins,
+    commentDrift,
+    pinVariants: conflictingPins ? pinVariants : [],
+    files,
+  };
+}
+
+function splitRef(ref) {
+  const [path, at] = ref.split("@");
+  const [owner, repo] = path.split("/");
+  return [owner, repo, at ?? ""];
+}
+
+// Inventory keys use the full `uses` path before `@`; GitHub API calls always use owner/repo only.
+function actionPathFromRef(ref) {
+  return ref.split("@")[0];
+}
+
+function apiRepo(actionPath) {
+  const parts = actionPath.split("/");
+  if (parts.length < 2 || !parts[0] || !parts[1]) return "";
+  return `${parts[0]}/${parts[1]}`;
+}
+
+function parseVersion(value) {
+  const match = String(value ?? "").match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    raw: `${match[1]}.${match[2]}.${match[3]}`,
+    major: +match[1],
+    minor: +match[2],
+    patch: +match[3],
+  };
+}
+
+// A comment we can compare against release tags: exactly `vX.Y.Z` or `X.Y.Z`. Anything else (e.g. `post-v2.0.6`,
+// an untagged commit) cannot be ranked reliably, so we flag it for manual review instead of suggesting a bump.
+function isStandardVersion(comment) {
+  return /^v?\d+\.\d+\.\d+$/.test(String(comment ?? "").trim());
+}
+
+function compareVersions(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+function classify(current, target) {
+  const c = parseVersion(current);
+  const t = parseVersion(target);
+  if (!c || !t) return "unknown";
+  if (t.major !== c.major) return "major";
+  if (t.minor !== c.minor) return "minor";
+  if (t.patch !== c.patch) return "patch";
+  return "same";
+}
+
+function gh(path) {
+  const raw = execFileSync("gh", ["api", path], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(raw);
+}
+
+function ghList(path, maxPages = 10) {
+  const items = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    try {
+      const batch = gh(`${path}?per_page=100&page=${page}`);
+      if (!Array.isArray(batch) || batch.length === 0) break;
+      items.push(...batch);
+      if (batch.length < 100) break;
+    } catch {
+      break;
+    }
+  }
+  return items;
+}
+
+function releaseCandidates(repo) {
+  let releases = [];
+  try {
+    releases = ghList(`repos/${repo}/releases`);
+  } catch {
+    releases = [];
+  }
+
+  const fromReleases = releases
+    .filter(
+      (release) =>
+        !release.draft && !release.prerelease && isStandardVersion(release.tag_name),
+    )
+    .map((release) => ({
+      tag: release.tag_name,
+      published: release.published_at,
+    }));
+
+  let tags = [];
+  try {
+    tags = ghList(`repos/${repo}/tags`);
+  } catch {
+    tags = [];
+  }
+  const fromTags = tags
+    .filter((tag) => isStandardVersion(tag.name))
+    .map((tag) => ({ tag: tag.name, published: null }));
+
+  const byTag = new Map();
+  for (const candidate of fromReleases) byTag.set(candidate.tag, candidate);
+  for (const candidate of fromTags) {
+    if (!byTag.has(candidate.tag)) byTag.set(candidate.tag, candidate);
+  }
+  return [...byTag.values()];
+}
+
+function sameMajorNewer(candidates, current) {
+  const currentMajor = parseVersion(current)?.major;
+  return candidates
+    .filter((item) => parseVersion(item.tag).major === currentMajor)
+    .filter((item) => compareVersions(item.tag, current) > 0)
+    .sort((a, b) => compareVersions(a.tag, b.tag))
+    .reverse();
+}
+
+// Newest same-major release strictly newer than `current` whose publish date is at/older than the cutoff.
+function selectEligible(repo, current, cutoff) {
+  const sameMajor = sameMajorNewer(releaseCandidates(repo), current);
+
+  for (const item of sameMajor) {
+    const published = item.published ?? commitDate(repo, item.tag);
+    if (!published || new Date(published) > cutoff) continue;
+    const sha = commitSha(repo, item.tag);
+    if (!sha) return null;
+    return { tag: item.tag, published, sha };
+  }
+  return null;
+}
+
+function selectBlockedTooFresh(repo, current, cutoff) {
+  const sameMajor = sameMajorNewer(releaseCandidates(repo), current);
+
+  for (const item of sameMajor) {
+    const published = item.published ?? commitDate(repo, item.tag);
+    if (published && new Date(published) > cutoff) {
+      const sha = commitSha(repo, item.tag);
+      if (!sha) return null;
+      return { tag: item.tag, published, sha };
+    }
+  }
+  return null;
+}
+
+function tagLookupCandidates(tag) {
+  const trimmed = String(tag ?? "").trim();
+  const parsed = parseVersion(trimmed);
+  if (!parsed) return [trimmed];
+  const bare = parsed.raw;
+  const withV = `v${bare}`;
+  return [...new Set([trimmed, bare, withV])];
+}
+
+function commitSha(repo, tag) {
+  for (const candidate of tagLookupCandidates(tag)) {
+    try {
+      return gh(`repos/${repo}/commits/${candidate}`).sha;
+    } catch {
+      // try next tag form
+    }
+  }
+  return "";
+}
+
+function commitDate(repo, tag) {
+  for (const candidate of tagLookupCandidates(tag)) {
+    try {
+      return gh(`repos/${repo}/commits/${candidate}`).commit.committer.date;
+    } catch {
+      // try next tag form
+    }
+  }
+  return null;
+}
+
+function releaseDate(repo, tag) {
+  for (const candidate of tagLookupCandidates(tag)) {
+    try {
+      return gh(`repos/${repo}/releases/tags/${candidate}`).published_at;
+    } catch {
+      // try next tag form
+    }
+  }
+  return null;
+}
+
+function currentPinState(repo, current, currentSha, cutoff) {
+  const currentPublished =
+    releaseDate(repo, current) ?? commitDate(repo, current);
+  const tagSha = commitSha(repo, current);
+  const tooFresh = currentPublished
+    ? new Date(currentPublished) > cutoff
+    : false;
+  return {
+    currentPublished: currentPublished ?? "",
+    currentMature: currentPublished ? !tooFresh : false,
+    currentShaMatchesTag: tagSha ? tagSha === currentSha : null,
+    note: tooFresh ? "current pin is younger than the maturity window" : "",
+  };
+}
+
+function newestOverall(repo) {
+  try {
+    const latest = gh(`repos/${repo}/releases/latest`).tag_name;
+    return parseVersion(latest) ? latest : "";
+  } catch {
+    return "";
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!existsSync(args.dir))
+    throw new Error(`Directory not found: ${args.dir}`);
+
+  const windowMs =
+    args.minutes != null ? args.minutes * MINUTE_MS : args.days * DAY_MS;
+  if (!Number.isFinite(windowMs) || windowMs < 0)
+    throw new Error("Release-age window must be a positive number");
+
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - windowMs);
+  const rows = [];
+
+  for (const pin of collectPins(args.dir)) {
+    if (pin.conflictingPins) {
+      rows.push({
+        repo: pin.repo,
+        pinned: pin.pinned,
+        conflictingPins: true,
+        pinVariants: pin.pinVariants,
+        ref: pin.ref,
+        note: pin.pinned
+          ? "multiple SHAs pinned for this action — reconcile before bumping"
+          : "multiple SHAs pinned for this action — remove mutable refs and reconcile before bumping",
+        files: pin.files,
+      });
+      continue;
+    }
+    if (pin.commentDrift) {
+      rows.push({
+        repo: pin.repo,
+        pinned: pin.pinned,
+        current: pin.comment,
+        currentSha: pin.sha,
+        commentDrift: true,
+        ref: pin.ref,
+        note: "same SHA with conflicting version comments — align comments before bumping",
+        files: pin.files,
+      });
+      continue;
+    }
+    if (!pin.pinned) {
+      rows.push({
+        repo: pin.repo,
+        pinned: false,
+        ref: pin.ref,
+        comment: pin.comment,
+        files: pin.files,
+      });
+      continue;
+    }
+    if (!isStandardVersion(pin.comment)) {
+      rows.push({
+        repo: pin.repo,
+        pinned: true,
+        current: pin.comment,
+        currentSha: pin.sha,
+        note: "non-standard version comment — resolve and verify manually",
+        files: pin.files,
+      });
+      continue;
+    }
+    const current = pin.comment;
+    const ghRepo = apiRepo(pin.repo);
+    const currentState = currentPinState(ghRepo, current, pin.sha, cutoff);
+    if (currentState.currentShaMatchesTag !== true) {
+      const shaNote =
+        currentState.currentShaMatchesTag === false
+          ? "pinned SHA does not match the version comment tag — reconcile before bumping"
+          : "unable to verify pinned SHA against version tag — reconcile before bumping";
+      rows.push({
+        repo: pin.repo,
+        pinned: true,
+        current,
+        currentSha: pin.sha,
+        currentPublished: currentState.currentPublished,
+        currentMature: currentState.currentMature,
+        currentShaMatchesTag: currentState.currentShaMatchesTag,
+        eligibleTag: "",
+        eligibleSha: "",
+        eligiblePublished: "",
+        blockedTooFreshTag: "",
+        blockedTooFreshSha: "",
+        blockedTooFreshPublished: "",
+        updateType: "",
+        latest: newestOverall(ghRepo),
+        majorAvailable: false,
+        note: [shaNote, currentState.note].filter(Boolean).join("; "),
+        files: pin.files,
+      });
+      continue;
+    }
+    const latest = newestOverall(ghRepo);
+    const eligible = selectEligible(ghRepo, current, cutoff);
+    const blockedTooFresh = eligible
+      ? null
+      : selectBlockedTooFresh(ghRepo, current, cutoff);
+    rows.push({
+      repo: pin.repo,
+      pinned: true,
+      current,
+      currentSha: pin.sha,
+      currentPublished: currentState.currentPublished,
+      currentMature: currentState.currentMature,
+      currentShaMatchesTag: currentState.currentShaMatchesTag,
+      eligibleTag: eligible?.tag ?? "",
+      eligibleSha: eligible?.sha ?? "",
+      eligiblePublished: eligible?.published ?? "",
+      blockedTooFreshTag: blockedTooFresh?.tag ?? "",
+      blockedTooFreshSha: blockedTooFresh?.sha ?? "",
+      blockedTooFreshPublished: blockedTooFresh?.published ?? "",
+      updateType: eligible ? classify(current, eligible.tag) : "",
+      latest,
+      majorAvailable: latest ? classify(current, latest) === "major" : false,
+      note:
+        currentState.note ||
+        (blockedTooFresh
+          ? "newer same-major release is younger than the maturity window"
+          : ""),
+      files: pin.files,
+    });
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        now: now.toISOString(),
+        cutoff: cutoff.toISOString(),
+        ...(args.minutes != null ? { minutes: args.minutes } : { days: args.days }),
+        rows,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/.github/actions/docker-build-publish/action.yml
+++ b/.github/actions/docker-build-publish/action.yml
@@ -106,12 +106,12 @@ runs:
 
     - name: Set up QEMU
       if: ${{ inputs.requires_qemu == 'true' }}
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       with:
         platforms: 'arm64,arm'
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Configure cache
       id: cache-config
@@ -135,7 +135,7 @@ runs:
 
     # Build for testing (when push_image is false)
     - name: Build for testing
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       if: ${{ inputs.push_image == 'false' }}
       with:
         context: ${{ inputs.docker_context }}
@@ -157,14 +157,14 @@ runs:
 
     - name: Upload Docker image artifact
       if: ${{ inputs.save_artifact == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.artifact_name }}-docker-image.tar.gz
 
     # Build & push
     - name: Build & push
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       if: ${{ inputs.push_image == 'true' }}
       with:
         context: ${{ inputs.docker_context }}
@@ -177,3 +177,4 @@ runs:
         build-args: ${{ inputs.build_args }}
         cache-from: ${{ steps.cache-config.outputs.cache_from_push }}
         cache-to: ${{ steps.cache-config.outputs.cache_to_push }}
+

--- a/.github/actions/download-and-update-changelog/action.yml
+++ b/.github/actions/download-and-update-changelog/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
       - name: Download CHANGELOG.md artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: ${{ inputs.artifact_prefix }}*
@@ -64,3 +64,4 @@ runs:
           else
             echo "Applied ${applied} CHANGELOG.md update(s)."
           fi
+

--- a/.github/actions/image-tag-and-push/action.yml
+++ b/.github/actions/image-tag-and-push/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Login to Docker Hub
       if: ${{ github.ref == 'refs/heads/main' && inputs.last_commit_tag_exists == '0' }}
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
       with:
         username: ${{ inputs.docker_username }}
         password: ${{ inputs.docker_password }}
@@ -67,7 +67,7 @@ runs:
         docker save ${{ inputs.image_name }}:${{ inputs.commit_tag }} | gzip > ${{ steps.split.outputs.image_name_suffix }}-docker-image.tar.gz
     - name: Upload Docker image artifact for later use in e2e test
       if: ${{ github.ref == 'refs/heads/main' && inputs.last_commit_tag_exists == '0' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.split.outputs.image_name_suffix }}
         path: ${{ steps.split.outputs.image_name_suffix }}-docker-image.tar.gz
@@ -77,3 +77,4 @@ runs:
       run: |
         echo "image_tagged=$IMAGE_TAGGED" >> $GITHUB_OUTPUT
         echo "image_name_suffix: ${{ steps.split.outputs.image_name_suffix }}"
+

--- a/.github/actions/linea-besu-package/assemble/action.yml
+++ b/.github/actions/linea-besu-package/assemble/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: generate token to fetch artifacts from private besu-fleet-plugin
       id: generate_token
       if: ${{ inputs.fetch_besu_fleet_plugin == 'true' }}
-      uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc #v3
+      uses: getsentry/action-github-app-token@5c1e90706fe007857338ac1bfbd7a4177db2f789 #v4.0.0
       with:
         private_key: ${{ inputs.fleet_github_app_private_key }}
         app_id: ${{ inputs.fleet_github_app_id }}
@@ -68,3 +68,4 @@ runs:
         sudo apt update
         sudo apt-get install --no-install-recommends --assume-yes tree
         tree .
+

--- a/.github/actions/linea-besu-package/compute-metadata/action.yml
+++ b/.github/actions/linea-besu-package/compute-metadata/action.yml
@@ -72,7 +72,7 @@ runs:
     
     - name: get versions via dotenv
       id: dotenv
-      uses: falti/dotenv-action@a33be0b8cf6a6e6f1b82cc9f3782061ab1022be5 #v1.1.4
+      uses: falti/dotenv-action@fff81fa3263fb96221c521b5e526e57c0c56d760 #v1.2.1
       with:
         path: linea-besu/package/versions.env
         mode: development
@@ -100,3 +100,4 @@ runs:
       shell: bash
       run: |
         echo "dockerimage=consensys/linea-besu-package:${{ steps.dockertag.outputs.dockertag }}" >> "$GITHUB_OUTPUT"
+

--- a/.github/actions/setup-arithmetization-riscv/action.yml
+++ b/.github/actions/setup-arithmetization-riscv/action.yml
@@ -14,7 +14,7 @@ runs:
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
 
       - name: Install Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.24.6'
           cache-dependency-path: "**/*.sum"
@@ -54,5 +54,6 @@ runs:
             | tar xz --directory="${XPACK_GCC_DIR}" --strip-components=1
           ln -sf "${XPACK_GCC_DIR}/bin/riscv-none-elf-gcc" "${XPACK_GCC_DIR}/bin/riscv64-unknown-elf-gcc"
           echo "${XPACK_GCC_DIR}/bin" >> "${GITHUB_PATH}"
+
 
 

--- a/.github/actions/setup-java-and-gradle/action.yml
+++ b/.github/actions/setup-java-and-gradle/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.distribution }}
@@ -22,6 +22,7 @@ runs:
       - name: Setup Gradle
         # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
         # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # 4.4.0
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+
 
 

--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -27,10 +27,10 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       name: setup-pnpm
 
-    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       name: setup-nodejs
       with:
         node-version-file: .nvmrc
@@ -51,3 +51,4 @@ runs:
       if: inputs.commands != ''
       shell: bash
       run: ${{ inputs.commands }}
+

--- a/.github/actions/setup-riscv-guests/action.yml
+++ b/.github/actions/setup-riscv-guests/action.yml
@@ -29,7 +29,7 @@ runs:
     # Bump the two SHAs here AND in the cache key together.
     - name: Cache blst + mcl builds
       id: crypto-cache
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.crypto-libs
         key: crypto-libs-blst-e7f90de551e8df682f3cc99067d204d8b90d27ad-mcl-0499298adcfad3bbcebf77f17700ebbe97166060
@@ -67,7 +67,7 @@ runs:
 
     # Zig package fetches (zesu, zesu-zkvm, EF zkevm fixtures) land in each guest's zig-pkg/.
     - name: Cache Zig package fetches
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: riscv-guests/*/zig-pkg
         key: riscv-guests-zig-pkg-${{ hashFiles('riscv-guests/**/build.zig.zon') }}
@@ -79,9 +79,10 @@ runs:
     # restore (restore-keys fallback) still reuses every unchanged object. Keys hash only tracked
     # build inputs — zig-pkg/ is populated at run time and must stay out of the key.
     - name: Cache Zig compile cache
-      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: riscv-guests/*/.zig-cache
         key: riscv-guests-zig-cache-${{ hashFiles('riscv-guests/.zigversion', 'riscv-guests/build_common/**', 'riscv-guests/*/build.zig', 'riscv-guests/*/build.zig.zon', 'riscv-guests/*/src/**') }}
         restore-keys: |
           riscv-guests-zig-cache-
+

--- a/.github/actions/setup-tracer-environment/action.yml
+++ b/.github/actions/setup-tracer-environment/action.yml
@@ -14,10 +14,11 @@ runs:
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
 
       - name: Install Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.24.6'
           cache-dependency-path: "**/*.sum"
 
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
+

--- a/.github/workflows/all-tools.yml
+++ b/.github/workflows/all-tools.yml
@@ -29,9 +29,9 @@ jobs:
       all-tools: ${{ steps.filter.outputs['all-tools'] }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter commit changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
         id: filter
         with:
           base: ${{ github.ref }}
@@ -53,7 +53,7 @@ jobs:
     if: ${{ needs.changes.outputs['all-tools'] == 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check image tags exist
         uses: ./.github/actions/check-image-tags-exist
         with:
@@ -69,7 +69,7 @@ jobs:
       image_tagged: ${{ steps.image_tag_push.outputs.image_tagged }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Tag and push image
         id: image_tag_push
         uses: ./.github/actions/image-tag-and-push
@@ -96,11 +96,11 @@ jobs:
     name: All tools build and push
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -110,11 +110,11 @@ jobs:
       # cases. We can later set up self-hosted arm64 github runners if we
       # want arm* based images back.
       # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+      #   uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 #v3.7.0
       #   with:
       #     platforms: 'arm64,arm'
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
       - name: Validate version tag
         run: |
           if [[ -z "${{ env.COMMIT_TAG }}" ]]; then
@@ -128,7 +128,7 @@ jobs:
         uses: ./.github/actions/get-node-version
 
       - name: Build and push all tools image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 #v7.0.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./operations/cli/Dockerfile
@@ -158,3 +158,4 @@ jobs:
     secrets:
       channel_id: ${{ secrets.SLACK_ENGINEERING_ALERTS_CHANNEL_ID }}
       slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
+

--- a/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
@@ -183,7 +183,7 @@ jobs:
           run_gogen_keccak() {  # $1=variant (opt|base)  $2=label (warmup|iter#)
             local zkc_bin="/tmp/zkc-${1}"
             local zkc_main="/tmp/wt-${1}/arithmetization/src/main/riscv/main.zkc"
-            "$zkc_bin" generate -v -q --field KOALABEAR_16 -o riscv.go "$zkc_main"
+            "$zkc_bin" generate --fast -v -q --field KOALABEAR_16 -o riscv.go "$zkc_main"
             go build -o riscv-gogen riscv.go
             /usr/bin/time -v ./riscv-gogen < "/tmp/keccak-${1}.json" \
               > "/tmp/bench/logs/keccak_${1}_${2}.log" 2>&1
@@ -192,7 +192,7 @@ jobs:
           run_gogen_blake() {   # $1=variant  $2=label. Runs all N vectors, one log file per vector.
             local zkc_bin="/tmp/zkc-${1}"
             local zkc_main="/tmp/wt-${1}/arithmetization/src/main/riscv/main.zkc"
-            "$zkc_bin" generate -v -q --field KOALABEAR_16 -o riscv.go "$zkc_main"
+            "$zkc_bin" generate --fast -v -q --field KOALABEAR_16 -o riscv.go "$zkc_main"
             go build -o riscv-gogen riscv.go
             for json in /tmp/bench/json/blake-"${1}"/*.json; do
               local n

--- a/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: false
@@ -254,3 +254,4 @@ jobs:
         with:
           name: zkc-bench-logs
           path: /tmp/bench/logs
+

--- a/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: false
@@ -202,3 +202,4 @@ jobs:
         with:
           name: zkc-native-keccak-bench-logs
           path: /tmp/bench/logs
+

--- a/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
@@ -140,7 +140,7 @@ jobs:
           # Run fast mode with gogen
           run_gogen_native_keccak() {  # $1=variant (base|opt)  $2=label (warmup|iter#)
             local variant="$1" label="$2" zkc_bin="/tmp/zkc-${1}"
-            "$zkc_bin" generate -v -q --field KOALABEAR_16 -o riscv.go "$zkc_prog"
+            "$zkc_bin" generate --fast -v -q --field KOALABEAR_16 -o riscv.go "$zkc_prog"
             go build -o riscv-gogen riscv.go
             /usr/bin/time -v ./riscv-gogen < /tmp/keccakf_input.json \
               > "/tmp/bench/logs/keccak_${variant}_${label}.log" 2>&1

--- a/.github/workflows/arithmetization-keccak-zkc-vs-reference-benchmark.yml
+++ b/.github/workflows/arithmetization-keccak-zkc-vs-reference-benchmark.yml
@@ -18,12 +18,12 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
       - name: Install Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.24.6'
           cache-dependency-path: "**/*.sum"
@@ -61,3 +61,4 @@ jobs:
           ZKC_REF= GO111MODULE=off go run ./arithmetization/src/test/scripts/keccak_zkc_vs_reference_speedup \
             --single-input-lengths 512,1024,2048,4096,8192,16384,32768 \
             | tee -a "$GITHUB_STEP_SUMMARY"
+

--- a/.github/workflows/arithmetization-riscv-act4-test.yml
+++ b/.github/workflows/arithmetization-riscv-act4-test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -46,3 +46,4 @@ jobs:
         working-directory: arithmetization/src/test
         env:
           ZKC_REF: ${{ inputs.zkc-ref || 'v1.2.20' }}
+

--- a/.github/workflows/arithmetization-sample-guest-programs-run.yml
+++ b/.github/workflows/arithmetization-sample-guest-programs-run.yml
@@ -40,7 +40,7 @@ jobs:
       ZKC_EXEC_FLAGS: "--fast -q"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -57,3 +57,4 @@ jobs:
         run: make blake-rust-exec
         working-directory: arithmetization/src/test
         timeout-minutes: 30
+

--- a/.github/workflows/arithmetization-simple-zkc-binary-run-and-go-corset-check.yml
+++ b/.github/workflows/arithmetization-simple-zkc-binary-run-and-go-corset-check.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -46,3 +46,4 @@ jobs:
           ZKC_MAIN: src/test/zkc/simple_add.zkc
           ZKC_FILES: src/test/zkc/simple_add.zkc
           ZKC_INPUT: src/test/zkc/simple_add.json
+

--- a/.github/workflows/arithmetization-zkc-riscv-check-compilation.yml
+++ b/.github/workflows/arithmetization-zkc-riscv-check-compilation.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -46,3 +46,4 @@ jobs:
 
       - name: Linting Check
         run: make -C arithmetization riscv-check-lint
+

--- a/.github/workflows/check-lib-versions-changes.yml
+++ b/.github/workflows/check-lib-versions-changes.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
 
@@ -33,3 +33,4 @@ jobs:
         with:
           target_lib: besuCommit
           target_file_path: gradle/libs.versions.toml
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,13 +52,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 #v1.0.158
         env:
           ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
@@ -85,3 +85,4 @@ jobs:
             - Incorrect or missing error handling
 
             Be specific, actionable, and constructive. Do NOT post a general top-level PR summary comment.
+

--- a/.github/workflows/claude-coordinator-review.yml
+++ b/.github/workflows/claude-coordinator-review.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run Claude Coordinator Review
         id: review
-        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 #v1.0.158
         env:
           ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
@@ -191,3 +191,4 @@ jobs:
         with:
           name: claude-execution-output
           path: ${{ steps.review.outputs.execution_file }}
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,13 +27,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 #v1.0.101
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0 #v1.0.158
         env:
           ANTHROPIC_BASE_URL: ${{ vars.LITELLM_BASE_URL }}
         with:
@@ -49,3 +49,4 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,11 +16,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
         id: changes
         with:
           filters: |
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e #v4.36.2
@@ -131,3 +131,4 @@ jobs:
           name: codeql-results-${{ matrix.language }}
           path: sarif-results
           retention-days: 1
+

--- a/.github/workflows/component-changelog-commit.yml
+++ b/.github/workflows/component-changelog-commit.yml
@@ -43,7 +43,7 @@ jobs:
           echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ steps.app-token.outputs.token }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Create pull request
         if: ${{ inputs.create_pull_request }}
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore(misc): update CHANGELOG.md unreleased section of each updated component and milestone [skip ci]"
@@ -112,3 +112,4 @@ jobs:
           add-paths: |
             CHANGELOG.md
             **/CHANGELOG.md
+

--- a/.github/workflows/component-changelog-upload.yml
+++ b/.github/workflows/component-changelog-upload.yml
@@ -21,9 +21,9 @@ jobs:
       linea: ${{ steps.filter.outputs.linea }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter commit changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
         id: filter
         with:
           base: ${{ github.ref }}
@@ -111,7 +111,7 @@ jobs:
     steps:
       - name: Checkout
         if: needs.filter-commit-changes.outputs[matrix.component] == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # git-cliff needs full history + tags to compute changelog/version
           ref: ${{ github.head_ref || github.ref_name }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install git-cliff
         if: needs.filter-commit-changes.outputs[matrix.component] == 'true'
-        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 #(v2.75.19)
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d #v2.82.5
         with:
           tool: git-cliff
 
@@ -137,7 +137,8 @@ jobs:
 
       - name: Upload CHANGELOG.md artifact
         if: github.ref == 'refs/heads/main' && needs.filter-commit-changes.outputs[matrix.component] == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unreleased-changelog-${{ matrix.artifact-name || matrix.folder-name }}
           path: ${{ matrix.folder-name }}/CHANGELOG.md
+

--- a/.github/workflows/coordinator-build-and-publish.yml
+++ b/.github/workflows/coordinator-build-and-publish.yml
@@ -50,11 +50,11 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -78,3 +78,4 @@ jobs:
           build_contexts: libs=./coordinator/app/build/install/coordinator/lib
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
           artifact_name: linea-coordinator
+

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -32,7 +32,7 @@ jobs:
     name: Coordinator tests
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
       - name: Setup Java and Gradle
@@ -48,12 +48,12 @@ jobs:
           ./gradlew -V coordinator:app:buildNeeded
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Pre-pull images for running integration tests
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -72,3 +72,4 @@ jobs:
           path: |
             **/build/jacoco/*.exec
           if-no-files-found: ignore
+

--- a/.github/workflows/dockerfile-security-scan.yml
+++ b/.github/workflows/dockerfile-security-scan.yml
@@ -24,7 +24,7 @@ jobs:
     if: false # Disabled — Checkmarx KICS supply chain compromise (2026-04-22)
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run KICS
         uses: checkmarx/kics-github-action@4063ea7186bec9fed1bf055e095a4658693f9998 # v2.1.19
@@ -42,3 +42,4 @@ jobs:
         with:
           sarif_file: kics-results/results.sarif
           category: kics-dockerfiles
+

--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -16,10 +16,10 @@ jobs:
       has_changes_requiring_e2e_testing: ${{ steps.evaluate.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Filter for e2e-relevant paths
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
         id: filter
         with:
           base: ${{ github.ref }}
@@ -105,3 +105,4 @@ jobs:
 
           echo "Only excluded e2e paths, test files, or doc files changed"
           echo "result=false" >> $GITHUB_OUTPUT
+

--- a/.github/workflows/github-release-besu-plugin.yml
+++ b/.github/workflows/github-release-besu-plugin.yml
@@ -62,7 +62,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
@@ -105,3 +105,4 @@ jobs:
           path: |
             build/jreleaser/trace.log
             build/jreleaser/output.properties
+

--- a/.github/workflows/lido-governance-monitor-build-and-publish.yml
+++ b/.github/workflows/lido-governance-monitor-build-and-publish.yml
@@ -67,11 +67,11 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -93,3 +93,4 @@ jobs:
           build_args: NODE_VERSION=${{ steps.get-node-version.outputs.node-version }}
           artifact_name: linea-lido-governance-monitor
           requires_qemu: ${{ env.PUSH_IMAGE }}
+

--- a/.github/workflows/lido-governance-monitor-testing.yml
+++ b/.github/workflows/lido-governance-monitor-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -76,3 +76,4 @@ jobs:
           name: codecov-lido-governance-monitor
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/linea-besu-build-and-publish.yml
+++ b/.github/workflows/linea-besu-build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check besuCommit change
         uses: ./.github/actions/check-lib-version-change
@@ -95,3 +95,4 @@ jobs:
             git commit -m "chore: refresh linea-besu/besu/.besu-resolved after besuCommit bump"
             git push origin "$BRANCH"
           fi
+

--- a/.github/workflows/linea-besu-package-build-and-upload.yml
+++ b/.github/workflows/linea-besu-package-build-and-upload.yml
@@ -37,7 +37,7 @@ jobs:
       dockerimage: ${{ steps.build-plugins-and-assemble.outputs.dockerimage }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build plugins and assemble
         id: build-plugins-and-assemble
@@ -49,7 +49,7 @@ jobs:
           fleet_github_app_private_key: ${{ secrets.FLEET_GITHUB_APP_PRIVATE_KEY }}
 
       - name: set up docker buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
 
       - name: set docker build args
         run: |
@@ -76,7 +76,7 @@ jobs:
           NEWLINE: "\n"
 
       - name: build the combined manifest
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 #v7.0.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -98,8 +98,9 @@ jobs:
         shell: bash
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linea-besu-package
           path: linea-besu-package-images.tar.gz
           retention-days: 1
+

--- a/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
+++ b/.github/workflows/linea-besu-package-e2e-tests-with-partial-prover.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build docker images from source and upload (if needed) for e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Tracer Environment (for linea-besu-package build)
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload linea-besu-package docker image artifact
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linea-besu-package
           path: linea-besu-package-image.tar.gz
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Go (for prover build)
         if: ${{ inputs.linea_besu_package_image_tag != '' &&  inputs.prover_image_tag == '' }}
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.24.6'
           cache-dependency-path: "**/*.sum"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload prover docker image artifact
         if: ${{ inputs.prover_image_tag == '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linea-prover
           path: linea-prover-image.tar.gz
@@ -103,4 +103,5 @@ jobs:
       linea_besu_package_image_tag: ${{ inputs.linea_besu_package_image_tag }}
       prover_image_tag: ${{ inputs.prover_image_tag }}
       shomei_image_tag: ${{ inputs.shomei_image_tag }}
+
 

--- a/.github/workflows/linea-milestone-release-with-dry-run.yml
+++ b/.github/workflows/linea-milestone-release-with-dry-run.yml
@@ -61,7 +61,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout current branch
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref || github.ref_name }}
@@ -204,7 +204,7 @@ jobs:
           echo "Dispatched run terminal state: ${STATE}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout (full history + tags)
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: main
@@ -282,3 +282,4 @@ jobs:
     with:
       pre_release: ${{ inputs.pre_release }}
     secrets: inherit
+

--- a/.github/workflows/linea-sequencer-plugin-testing.yml
+++ b/.github/workflows/linea-sequencer-plugin-testing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Tracer Environment # configures Go, Java, and Gradle
         uses: ./.github/actions/setup-tracer-environment
@@ -51,7 +51,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Tracer Environment
         uses: ./.github/actions/setup-tracer-environment
@@ -75,3 +75,4 @@ jobs:
           path: |
             **/build/jacoco/*.exec
           if-no-files-found: ignore
+

--- a/.github/workflows/linea-tracer-plugin-release.yml
+++ b/.github/workflows/linea-tracer-plugin-release.yml
@@ -37,7 +37,7 @@ jobs:
           tag_name: ${{ inputs.release_tag }}
 
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Tracer Environment
         uses: ./.github/actions/setup-tracer-environment
@@ -133,3 +133,4 @@ jobs:
         env:
           CLOUDSMITH_USER: ${{ secrets.CLOUDSMITH_USER }}
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+

--- a/.github/workflows/lint-commit-messages.yml
+++ b/.github/workflows/lint-commit-messages.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Need both PR head and base so we can list commits in the PR.
           fetch-depth: 0
@@ -93,3 +93,4 @@ jobs:
             exit 1
           fi
           echo "✓ All commit messages OK."
+

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -34,13 +34,13 @@ jobs:
     name: Run Load Test
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
 
       - name: Hide sensitive inputs
-        uses: levibostian/action-hide-sensitive-inputs@80877460a95aa5e56cba23314096ef0e0a3c10c1 #v1.1.1
+        uses: levibostian/action-hide-sensitive-inputs@15951963797b16aa43fa0b093b45cd2db0319fdd #v1.2.0
         with:
           exclude_inputs: network, file
 
@@ -84,3 +84,4 @@ jobs:
         run: |
           echo "Network to execute load test on: ${INPUT_NETWORK}"
           ./gradlew :testing-tools:traffic-generator:run --args="-request ${INPUT_NETWORK}/${INPUT_FILE} -pk ${PRIVATE_KEY}"
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,9 @@ jobs:
       has-changes-requiring-linea-besu-package-build: ${{ steps.filter.outputs.linea-sequencer-plugin == 'true' || steps.filter.outputs.tracer == 'true' || steps.filter.outputs.tracer-constraints == 'true' ||  steps.filter.outputs.linea-besu == 'true' || steps.filter.outputs.linea-besu-package == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter commit changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
         id: filter
         with:
           base: ${{ github.ref }}
@@ -184,7 +184,7 @@ jobs:
               - '.github/workflows/main.yml'
 
       - name: Filter out commit changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
         id: exclusion-filter
         with:
           base: ${{ github.ref }}
@@ -306,7 +306,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: strumwolf/delete-deployment-environment@a4825dd9648c57da8437a4885c3fcad58beac69c #v3.0.0
+      - uses: strumwolf/delete-deployment-environment@035f6d27c8b8951729f4d71b2d3d6a7975139476 #v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: docker-build-and-e2e
@@ -341,3 +341,4 @@ jobs:
       channel_id: ${{ secrets.SLACK_ENGINEERING_ALERTS_CHANNEL_ID }}
       slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
       anthropic_api_key: ${{ secrets.LITELLM_KEY_CI_FAILURE_ANALYSIS }}
+

--- a/.github/workflows/maru-build-and-publish.yml
+++ b/.github/workflows/maru-build-and-publish.yml
@@ -51,7 +51,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set image tag if not given
         if: ${{ inputs.image_tag == '' }}
         run: |
@@ -65,7 +65,7 @@ jobs:
           echo "IMAGE_TAG=$IMAGE_TAG"
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -89,3 +89,4 @@ jobs:
             maru=./maru/app/build/libs/
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
           artifact_name: maru
+

--- a/.github/workflows/maru-chaos-testing.yml
+++ b/.github/workflows/maru-chaos-testing.yml
@@ -60,17 +60,17 @@ jobs:
     #        iterations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Install helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: 'v3.18.3'
         id: install
@@ -136,7 +136,7 @@ jobs:
 
       - name: Store reports and pod logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: chaos-test-reports-and-logs
           path: |
@@ -152,3 +152,4 @@ jobs:
         with:
           ## If no one connects shut down ssh server after timeout.
           wait-timeout-minutes: 20
+

--- a/.github/workflows/maru-e2e-tests.yml
+++ b/.github/workflows/maru-e2e-tests.yml
@@ -61,10 +61,10 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -86,10 +86,11 @@ jobs:
           echo "E2E_TESTS_RESULT: ${{ steps.run_e2e_tests.outcome }}"
 
       - name: Archive debug logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() && inputs.e2e-tests-logs-dump }}
         with:
           name: end-2-end-debug-logs
           if-no-files-found: error
           path: |
             maru/e2e/docker_logs/**/*
+

--- a/.github/workflows/maru-testing.yml
+++ b/.github/workflows/maru-testing.yml
@@ -35,7 +35,7 @@ jobs:
     #        iterations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
       - name: Setup Java and Gradle
@@ -68,3 +68,4 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/maven-release-all.yml
+++ b/.github/workflows/maven-release-all.yml
@@ -38,7 +38,7 @@ jobs:
           echo "VERSION: $VERSION"
 
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
@@ -82,3 +82,4 @@ jobs:
           path: |
             build/jreleaser/trace.log
             build/jreleaser/output.properties
+

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
@@ -91,3 +91,4 @@ jobs:
           path: |
             build/jreleaser/trace.log
             build/jreleaser/output.properties
+

--- a/.github/workflows/native-yield-automation-service-build-and-publish.yml
+++ b/.github/workflows/native-yield-automation-service-build-and-publish.yml
@@ -67,11 +67,11 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -94,3 +94,4 @@ jobs:
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
           artifact_name: linea-native-yield-automation-service
           requires_qemu: ${{ env.PUSH_IMAGE }}
+

--- a/.github/workflows/native-yield-automation-service-testing.yml
+++ b/.github/workflows/native-yield-automation-service-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -75,3 +75,4 @@ jobs:
           name: codecov-native-yield-automation-service
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
+++ b/.github/workflows/partial-prover-run-e2e-tests-in-parallel.yml
@@ -37,11 +37,11 @@ jobs:
     name: Run test:partial-prover:${{ matrix.test }} e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download local linea-besu-package docker image
         if: ${{ inputs.linea_besu_package_image_tag == '' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: linea-besu-package
           path: ${{ github.workspace }}/tmp/artifacts
@@ -55,7 +55,7 @@ jobs:
 
       - name: Download local prover docker image
         if: ${{ inputs.prover_image_tag == '' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: linea-prover
           path: ${{ github.workspace }}/tmp/artifacts
@@ -80,7 +80,7 @@ jobs:
           chmod -R a+rw tmp/local/
 
       - name: Spin up fresh environment with besu tracing with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -141,3 +141,4 @@ jobs:
           name: end-2-end-shared-folder-${{ matrix.archive-name }}
           path: |
             tmp/local/**/*
+

--- a/.github/workflows/postman-build-and-publish.yml
+++ b/.github/workflows/postman-build-and-publish.yml
@@ -50,11 +50,11 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -77,3 +77,4 @@ jobs:
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
           artifact_name: linea-postman
           requires_qemu: ${{ env.PUSH_IMAGE }}
+

--- a/.github/workflows/postman-testing.yml
+++ b/.github/workflows/postman-testing.yml
@@ -24,7 +24,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -89,3 +89,4 @@ jobs:
           name: codecov-sdk-viem
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/prover-build-and-publish.yml
+++ b/.github/workflows/prover-build-and-publish.yml
@@ -53,13 +53,13 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -77,3 +77,4 @@ jobs:
           push_platforms: linux/amd64
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
           artifact_name: linea-prover
+

--- a/.github/workflows/prover-native-lib-blob-compressor-release.yml
+++ b/.github/workflows/prover-native-lib-blob-compressor-release.yml
@@ -43,9 +43,9 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.22.x
 
@@ -78,9 +78,9 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-arm64-med
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.22.x
           architecture: arm64
@@ -113,9 +113,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: 1.22.x
       - name: Build the MacOS artefacts
@@ -153,7 +153,7 @@ jobs:
       VERSION: ${{ github.event.inputs.version }}
     steps:
       - name: Load cached binaries
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
       - name: List artifacts
@@ -189,3 +189,4 @@ jobs:
           asset_path: ./linea-blob-libs-${{ env.VERSION }}.zip
           asset_name: linea-blob-libs-${{ env.VERSION }}.zip
           asset_content_type: application/zip
+

--- a/.github/workflows/prover-ray-testing.yml
+++ b/.github/workflows/prover-ray-testing.yml
@@ -19,16 +19,16 @@ jobs:
     name: Prover static check
     steps:
     - name: checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
     - name: install Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: 1.25.7
         cache-dependency-path: |
               prover-ray/go.sum
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build
@@ -41,7 +41,7 @@ jobs:
       working-directory: prover-ray
       run: if [[ -n $(gofmt -l .) ]]; then echo "please run gofmt"; exit 1; fi
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee #v9.2.1
       with:
           version: v2.11.3
           working-directory: prover-ray
@@ -68,14 +68,14 @@ jobs:
       - staticcheck
     steps:
     - name: checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: install Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: |
               prover-ray/go.sum
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build
@@ -94,3 +94,4 @@ jobs:
     #   if: matrix.go-version == '1.25.7'
     #   run: |
     #       go test -p=1 -tags=nocorset,fuzzlight -timeout=120m -short -race  ./...
+

--- a/.github/workflows/prover-testing.yml
+++ b/.github/workflows/prover-testing.yml
@@ -19,16 +19,16 @@ jobs:
     name: Prover static check
     steps:
     - name: checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
     - name: install Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: 1.25.7
         cache-dependency-path: |
               prover/go.sum
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build
@@ -41,7 +41,7 @@ jobs:
       working-directory: prover
       run: if [[ -n $(gofmt -l .) ]]; then echo "please run gofmt"; exit 1; fi
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8
+      uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee #v9.2.1
       with:
           version: v2.11.3
           working-directory: prover
@@ -65,14 +65,14 @@ jobs:
       - staticcheck
     steps:
     - name: checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: install Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: |
               prover/go.sum
-    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cache/go-build
@@ -95,3 +95,4 @@ jobs:
     #   if: matrix.go-version == '1.25.7'
     #   run: |
     #       go test -p=1 -tags=nocorset,fuzzlight -timeout=120m -short -race  ./...
+

--- a/.github/workflows/reusable-component-docker-tag.yml
+++ b/.github/workflows/reusable-component-docker-tag.yml
@@ -29,7 +29,7 @@ jobs:
       docker_tag_with_suffix: ${{ steps.dockertag.outputs.dockertag_with_suffix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 2   # need at least 2 commits so HEAD~1 resolves later would not fail on compute-version-tags
@@ -45,4 +45,5 @@ jobs:
           version_prefix: ${{ inputs.version-prefix }}
           image_tag_suffix: ${{ inputs.image-tag-suffix }}
           commit_tag: ${{ steps.compute_version_tags.outputs.commit_tag }}
+
 

--- a/.github/workflows/reusable-component-gh-release.yml
+++ b/.github/workflows/reusable-component-gh-release.yml
@@ -146,7 +146,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Append Changelog Action to release note
         id: append_change_log
@@ -191,7 +191,7 @@ jobs:
           echo "COMPONENT_CAP=${COMPONENT_NAME^}" >> $GITHUB_ENV
 
       - name: gh-release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 #v2.6.2
         with:
           name: ${{ env.COMPONENT_CAP }} v${{ needs.release-push-tag-changelog.outputs.release_version }}
           tag_name: ${{ needs.release-push-tag-changelog.outputs.release_tag }}
@@ -201,3 +201,4 @@ jobs:
           generate_release_notes: false
           target_commitish: ${{ github.sha }}
           fail_on_unmatched_files: true
+

--- a/.github/workflows/reusable-component-release-metadata.yml
+++ b/.github/workflows/reusable-component-release-metadata.yml
@@ -40,14 +40,14 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog_content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
           submodules: false
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 #(v2.75.19)
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d #v2.82.5
         with:
           tool: git-cliff
 
@@ -59,3 +59,4 @@ jobs:
           include-path: ${{ inputs.include-path }}
           release_tag_suffix: ${{ inputs.release_tag_suffix }}
           generate-changelog-with-next-tag-version: 'true'
+

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -77,7 +77,7 @@ jobs:
           echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ (!inputs.upload_changelog && steps.app-token.outputs.token) ||  github.token }}
@@ -102,7 +102,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 #(v2.75.19)
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d #v2.82.5
         with:
           tool: git-cliff
 
@@ -152,7 +152,7 @@ jobs:
           exit 1
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         if: ${{ !inputs.upload_changelog && inputs.create_pull_request }}
         id: create-pull-request
         with:
@@ -164,7 +164,7 @@ jobs:
           add-paths: ${{ inputs.folder-name }}/CHANGELOG.md
 
       - name: Upload CHANGELOG.md artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ inputs.upload_changelog }}
         with:
           name: prepended-changelog-${{ inputs.component-name }}
@@ -187,3 +187,4 @@ jobs:
           git tag -a "${TAG}" -m "${COMPONENT^} release ${TAG}"
           git push origin "${TAG}"
           echo "Pushed ${TAG} pointing at $(git rev-parse HEAD)"
+

--- a/.github/workflows/reusable-component-release.yml
+++ b/.github/workflows/reusable-component-release.yml
@@ -72,7 +72,7 @@ jobs:
        commit_tag: ${{ steps.compute-version-tags.outputs.commit_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Compute version tags
         id: compute-version-tags
@@ -238,3 +238,4 @@ jobs:
       draft_release: ${{ inputs.draft_release }}
       pre_release: ${{ inputs.pre_release }}
     secrets: inherit
+

--- a/.github/workflows/reusable-compute-commit-tags.yml
+++ b/.github/workflows/reusable-compute-commit-tags.yml
@@ -32,7 +32,7 @@ jobs:
       develop_tag: ${{ steps.compute-version-tags.outputs.develop_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Compute version tags
         id: compute-version-tags
@@ -44,4 +44,5 @@ jobs:
           echo "LAST_COMMIT_TAG: ${{ steps.compute-version-tags.outputs.last_commit_tag }}"
           echo "DEVELOP_TAG: ${{ steps.compute-version-tags.outputs.develop_tag }}"
           echo "github.ref: ${{ github.ref }}"
+
 

--- a/.github/workflows/reusable-linea-besu-package-build-test-push.yml
+++ b/.github/workflows/reusable-linea-besu-package-build-test-push.yml
@@ -106,7 +106,7 @@ jobs:
       docker_tag_with_suffix: ${{ steps.build-plugins-and-assemble.outputs.dockertag_with_suffix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 2   # need at least 2 commits so HEAD~1 resolves later would not fail on compute-version-tags
@@ -123,15 +123,15 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ !inputs.skip_docker_image_build_and_push }}
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 #v3.7.0
 
       - name: set up docker buildx
         if: ${{ !inputs.skip_docker_image_build_and_push }}
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
 
       - name: Login to Docker Hub
         if: ${{ !inputs.skip_docker_image_build_and_push && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -146,7 +146,7 @@ jobs:
 
       - name: build and push the combined manifest (if Besu fleet plugin is included)
         if: ${{ !inputs.skip_docker_image_build_and_push && inputs.with_besu_fleet_plugin }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 #v7.0.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -179,7 +179,7 @@ jobs:
 
       - name: build and push the combined manifest (without Besu fleet plugin)
         if: ${{ !inputs.skip_docker_image_build_and_push }}
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 #v7.0.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           DOCKER_BUILD_SUMMARY: false
         with:
@@ -276,7 +276,7 @@ jobs:
 
       - name: release - publish artifacts and release notes
         id: release_publish
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 #v2.6.2
         with:
           name: Linea Besu ${{ inputs.release_version && format('v{0}', inputs.release_version) }}
           tag_name: ${{ inputs.release_tag }}
@@ -288,3 +288,4 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             release/linea-besu-package-${{ steps.build-plugins-and-assemble.outputs.dockertag }}.tar.gz
+

--- a/.github/workflows/reusable-linea-besu-package-run-e2e-tests.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-e2e-tests.yml
@@ -60,7 +60,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
@@ -69,7 +69,7 @@ jobs:
             pnpm run -F "e2e^..." build
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -78,7 +78,7 @@ jobs:
           mkdir -p tmp/local/traces/v2/conflated
           chmod -R a+rw tmp/local/
       - name: Download local docker image artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: linea-besu-package
           path: ${{ github.workspace }}/tmp/artifacts
@@ -90,7 +90,7 @@ jobs:
         shell: bash
       - name: Spin up fresh environment with besu tracing with retry
         if: ${{ !inputs.e2e-tests-with-besu-fleet }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -102,7 +102,7 @@ jobs:
             make clean-environment
       - name: Spin up fresh environment with besu tracing and fleet nodes with retry
         if: ${{ inputs.e2e-tests-with-besu-fleet }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -160,3 +160,4 @@ jobs:
           if-no-files-found: error
           path: |
             docker_logs/**/*
+

--- a/.github/workflows/reusable-linea-besu-package-run-test.yml
+++ b/.github/workflows/reusable-linea-besu-package-run-test.yml
@@ -14,7 +14,7 @@ jobs:
       profile-files: ${{ steps.list-profiles.outputs.files }}
     steps:
       - name: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Split and list profiles
         id: list-profiles
@@ -38,10 +38,10 @@ jobs:
       DOCKER_IMAGE: ${{ inputs.dockerimage }}
     steps:
       - name: Check repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download local docker image artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: linea-besu-package
           path: ${{ github.workspace }}/tmp/artifacts
@@ -67,3 +67,4 @@ jobs:
 
       - name: Stop container
         run: docker stop ${{ env.CONTAINER_NAME }}
+

--- a/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
+++ b/.github/workflows/reusable-milestone-check-branch-and-compute-tag.yml
@@ -34,7 +34,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
@@ -42,7 +42,7 @@ jobs:
           submodules: false
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 #(v2.75.19)
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d #v2.82.5
         with:
           tool: git-cliff
 
@@ -78,3 +78,4 @@ jobs:
             echo "Tag ${TAG} already exists; exit now."
             exit 1
           fi
+

--- a/.github/workflows/reusable-milestone-component-latest-docker-tags.yml
+++ b/.github/workflows/reusable-milestone-component-latest-docker-tags.yml
@@ -112,7 +112,7 @@ jobs:
       maru-release-version: ${{ steps.latest-release-version.outputs.maru-latest-release-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: fromJson(matrix.metadata).tag_changed != 'true'
         with:
           ref: ${{ github.head_ref || github.ref_name }}
@@ -137,3 +137,4 @@ jobs:
         if: fromJson(matrix.metadata).tag_changed != 'true'
         run: |
           echo "${{ matrix.component }}-latest-release-version=${{ steps.get-latest-docker-tag.outputs.release_version }}" >> $GITHUB_OUTPUT
+

--- a/.github/workflows/reusable-milestone-component-release-metadata.yml
+++ b/.github/workflows/reusable-milestone-component-release-metadata.yml
@@ -63,7 +63,7 @@ jobs:
       linea-besu-package: ${{ steps.changelog-outputs.outputs.linea-besu-package }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
@@ -71,7 +71,7 @@ jobs:
           submodules: false
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 #(v2.75.19)
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d #v2.82.5
         with:
           tool: git-cliff
 
@@ -105,3 +105,4 @@ jobs:
             printf '%s\n' "$JSON_OUTPUTS"
             echo "__JSON_EOF__"
           } >> "$GITHUB_OUTPUT"
+

--- a/.github/workflows/reusable-milestone-gh-release.yml
+++ b/.github/workflows/reusable-milestone-gh-release.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Append Changelog Action to release note
         id: append_change_log
@@ -157,7 +157,7 @@ jobs:
           fi
 
       - name: gh-release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 #v2.6.2
         with:
           name: Linea Milestone v${{ inputs.release_version }}
           tag_name: ${{ inputs.release_tag }}
@@ -167,3 +167,4 @@ jobs:
           generate_release_notes: false
           target_commitish: ${{ github.sha }}
           fail_on_unmatched_files: true
+

--- a/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
@@ -81,7 +81,7 @@ jobs:
           echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ steps.app-token.outputs.token }}
@@ -99,7 +99,7 @@ jobs:
           git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 #(v2.75.19)
+        uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d #v2.82.5
         with:
           tool: git-cliff
 
@@ -250,7 +250,7 @@ jobs:
 
       - name: Create pull request
         if: ${{ inputs.create_pull_request }}
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
         with:
@@ -290,3 +290,4 @@ jobs:
           git tag -a "${TAG}" -m "${COMPONENT^} release ${TAG}"
           git push origin "${TAG}"
           echo "Pushed ${TAG} pointing at $(git rev-parse HEAD)"
+

--- a/.github/workflows/reusable-milestone-retag-latest-docker-tags.yml
+++ b/.github/workflows/reusable-milestone-retag-latest-docker-tags.yml
@@ -88,13 +88,13 @@ jobs:
             latest-docker-tag: ${{ inputs.linea_besu_package_latest_docker_tag }}
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Retag latest docker tag
         id: retag-latest-docker-tag
@@ -109,3 +109,4 @@ jobs:
           TARGET_IMAGE="consensys/${IMAGE_NAME}:${IMAGE_TAG}-${IMAGE_TAG_SUFFIX}"
 
           docker buildx imagetools create --tag "${TARGET_IMAGE}" "${SOURCE_IMAGE}"
+

--- a/.github/workflows/reusable-run-e2e-tests.yml
+++ b/.github/workflows/reusable-run-e2e-tests.yml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ inputs.e2e-tests-with-ssh }}
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
         with:
@@ -113,7 +113,7 @@ jobs:
             pnpm run -F "e2e^..." build
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -122,7 +122,7 @@ jobs:
           mkdir -p tmp/local/traces/v2/conflated
           chmod -R a+rw tmp/local/
       - name: Pull all external-to-monorepo images with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         if: ${{ inputs.linea_besu_package_tag == '' }}
         with:
           max_attempts: 10
@@ -133,7 +133,7 @@ jobs:
             make docker-pull-images-external-to-monorepo
 
       - name: Download local docker image artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: linea-*
@@ -141,14 +141,14 @@ jobs:
           merge-multiple: true
 
       - name: Download Maru docker image artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: maru
           path: ${{ github.workspace }}/tmp/artifacts
 
       - name: Load Docker images from artifacts or pull develop for unchanged services
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -205,7 +205,7 @@ jobs:
             echo "No artifact at ${artifact_path}; skipping docker load."
           fi
       - name: Spin up fresh environment with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -256,3 +256,4 @@ jobs:
           if-no-files-found: error
           path: |
             docker_logs/**/*
+

--- a/.github/workflows/reusable-store-image-name-and-tags.yml
+++ b/.github/workflows/reusable-store-image-name-and-tags.yml
@@ -30,7 +30,7 @@ jobs:
       develop_tag: ${{ steps.compute-version-tags.outputs.develop_tag}}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Compute version tags
         id: compute-version-tags
         uses: ./.github/actions/compute-version-tags
@@ -40,3 +40,4 @@ jobs:
           echo "LAST_COMMIT_TAG: ${{ steps.compute-version-tags.outputs.last_commit_tag }}"
           echo "DEVELOP_TAG: ${{ steps.compute-version-tags.outputs.develop_tag }}"
           echo "github.ref: ${{ github.ref }}"
+

--- a/.github/workflows/reusable-tracer-blockchain-tests.yml
+++ b/.github/workflows/reusable-tracer-blockchain-tests.yml
@@ -48,7 +48,7 @@ jobs:
       disabled: ${{ steps.metrics.outputs.disabled }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Tracer Test Environment
         uses: ./.github/actions/setup-tracer-environment
@@ -129,3 +129,4 @@ jobs:
           echo "disabled=$DISABLED_COUNTER" >> $GITHUB_OUTPUT
         env:
           JSON_REPORT: ${{ github.workspace }}/tmp/${{ github.head_ref || github.ref_name }}/BlockchainReferenceTestOutcome.json
+

--- a/.github/workflows/reusable-tracer-nightly-tests.yml
+++ b/.github/workflows/reusable-tracer-nightly-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -84,3 +84,4 @@ jobs:
         with:
           name: nightly-modexp-tests-report-${{ inputs.zkevm_fork }}
           path: tracer/arithmetization/build/reports/tests/**/*
+

--- a/.github/workflows/reusable-tracer-unit-tests.yml
+++ b/.github/workflows/reusable-tracer-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -73,3 +73,4 @@ jobs:
           name: codecov-tracer-unit-${{ inputs.zkevm_fork }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/reusable-tracer-weekly-prc-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-prc-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -53,3 +53,4 @@ jobs:
         with:
           name: jacoco-prc-call-tests-exec-file-${{ inputs.zkevm_fork }}
           path: tracer/arithmetization/build/jacoco/prcCallTests.exec
+

--- a/.github/workflows/reusable-tracer-weekly-tests.yml
+++ b/.github/workflows/reusable-tracer-weekly-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -52,3 +52,4 @@ jobs:
         with:
           name: jacoco-weekly-tests-exec-file-${{ inputs.zkevm_fork }}
           path: tracer/arithmetization/build/jacoco/weeklyTests.exec
+

--- a/.github/workflows/riscv-guests-host-tests.yml
+++ b/.github/workflows/riscv-guests-host-tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -58,7 +58,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -69,3 +69,4 @@ jobs:
         run: make spec-test
         working-directory: riscv-guests/l2-execution
         timeout-minutes: 30
+

--- a/.github/workflows/riscv-guests-zkc-interpreter-run.yml
+++ b/.github/workflows/riscv-guests-zkc-interpreter-run.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -79,11 +79,11 @@ jobs:
         uses: ./.github/actions/setup-riscv-guests
 
       # exec needs Go twice: zkc's `go install` and elf_to_json_gen's `go run`. The Zig setup above
-      # installs no Go. Pin chosen to match the repo's other Go pins (keep in sync). setup-go@v5 puts
+      # installs no Go. Pin chosen to match the repo's other Go pins (keep in sync). setup-go@v6 sets
       # $(go env GOPATH)/bin on PATH, so `zkc` is found in later steps without adding ~/go/bin
       # manually — the same precedent the repo's existing zkc workflows rely on.
       - name: Install Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.24.6'
           cache-dependency-path: "**/*.sum"
@@ -107,3 +107,4 @@ jobs:
       # TODO: gogen is disabled until it start supporting native arithmetic
       - name: Run l2-execution guest under zkc (gogen, fast, accel keccak)
         run: make -C riscv-guests/l2-execution exec KECCAK_ACCEL=true ZKC_EXEC_FLAGS="--quiet --fast"
+

--- a/.github/workflows/rollup-spec-testing.yml
+++ b/.github/workflows/rollup-spec-testing.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run rollup spec tests
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -35,3 +35,4 @@ jobs:
         working-directory: rollup_spec
         run: |
           python -m pytest
+

--- a/.github/workflows/run-smc-tests.yml
+++ b/.github/workflows/run-smc-tests.yml
@@ -24,16 +24,16 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: 1.23.x
+          go-version: 1.25.7
           cache-dependency-path: |
                 prover/go.sum
 
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Cache Hardhat compiler
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/hardhat-nodejs
           key: ${{ runner.os }}-hardhat-compilers-${{ hashFiles('contracts/hardhat.config.ts', 'contracts/hardhat_overrides.ts') }}
@@ -59,7 +59,7 @@ jobs:
 
       # Required for hardhat commands due to @nomicfoundation/hardhat-foundry package
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 #v1.7.0
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d #v1.8.0
 
       - name: Compile kzg.node
         run: pnpm -F contracts exec node-gyp --directory=node_modules/c-kzg rebuild # explicitly running rebuild to get the .node file
@@ -95,7 +95,7 @@ jobs:
     name: Solidity format check
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -104,3 +104,4 @@ jobs:
         run: |
           pnpm -F contracts run lint:sol
           pnpm -F contracts run prettier:sol
+

--- a/.github/workflows/run-validium-e2e-tests.yml
+++ b/.github/workflows/run-validium-e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 #v1
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
@@ -49,7 +49,7 @@ jobs:
           chmod -R a+rw tmp/local/
 
       - name: Pull all external-to-monorepo images with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -59,7 +59,7 @@ jobs:
             make docker-pull-images-external-to-monorepo
 
       - name: Spin up fresh environment with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
         with:
           max_attempts: 10
           retry_on: error
@@ -109,3 +109,4 @@ jobs:
           if-no-files-found: error
           path: |
             docker_logs/**/*
+

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -46,7 +46,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.release_commit_sha }}
 
@@ -182,7 +182,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 #v2.6.2
         with:
           tag_name: "@lfdt-lineth/sdk-core@${{ steps.release_notes.outputs.version }}"
           name: "@lfdt-lineth/sdk-core@${{ steps.release_notes.outputs.version }}"
@@ -202,7 +202,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.release_commit_sha }}
 
@@ -335,7 +335,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2.5.0
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 #v2.6.2
         with:
           tag_name: "@lfdt-lineth/sdk-viem@${{ steps.release_notes.outputs.version }}"
           name: "@lfdt-lineth/sdk-viem@${{ steps.release_notes.outputs.version }}"
@@ -355,3 +355,4 @@ jobs:
     secrets:
       channel_id: ${{ secrets.SLACK_ENGINEERING_ALERTS_CHANNEL_ID }}
       slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
+

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -195,7 +195,7 @@ jobs:
           } > "$BODY_FILE"
           echo "path=${BODY_FILE}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
           app-id: ${{ secrets.CREATE_GITHUB_PR_APP_ID }}
@@ -203,7 +203,7 @@ jobs:
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app_token.outputs.token }}
           commit-message: "release(${{ inputs.package }}): v${{ steps.version.outputs.next }}"
@@ -212,3 +212,4 @@ jobs:
           title: "chore(${{ inputs.package }}): release v${{ steps.version.outputs.next }}"
           body-path: ${{ steps.pr_body.outputs.path }}
           signoff: true
+

--- a/.github/workflows/sdk-testing.yml
+++ b/.github/workflows/sdk-testing.yml
@@ -30,7 +30,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -125,3 +125,4 @@ jobs:
           name: codecov-sdk-ethers
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/security-report-to-csv.yml
+++ b/.github/workflows/security-report-to-csv.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: CSV export
-        uses: advanced-security/ghas-to-csv@8c2ad35efb234e8e1bd12efaced0f0609ad8afbb # v3
+        uses: advanced-security/ghas-to-csv@ab2f3f6b7cf5f464602edc46cc6ef9d424097a49 # v3.0.6
       - name: Upload CSV
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ghas-data
           path: ${{ github.workspace }}/*.csv
           if-no-files-found: error
+

--- a/.github/workflows/slack-notify-e2e-runtime-report.yml
+++ b/.github/workflows/slack-notify-e2e-runtime-report.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup nodejs environment
         uses: ./.github/actions/setup-nodejs
@@ -43,14 +43,14 @@ jobs:
 
       - name: Upload HTML report
         if: ${{ fromJSON(steps.summary.outputs.json).totalRuns > 0 }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-runtime-report
           path: e2e/e2e-runtime-report.html
 
       - name: Post to Slack
         if: ${{ fromJSON(steps.summary.outputs.json).totalRuns > 0 }}
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a #v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c #v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
@@ -123,3 +123,4 @@ jobs:
                       - type: link
                         url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                         text: "View workflow run artifacts"
+

--- a/.github/workflows/slack-notify-failed-jobs.yml
+++ b/.github/workflows/slack-notify-failed-jobs.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
 
@@ -85,7 +85,7 @@ jobs:
           tail -c 500000 /tmp/failed-job-logs-raw.txt > /tmp/failed-job-logs.txt
 
       - name: Download Docker logs artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: ${{ inputs.docker_logs_artifact_name }}
@@ -215,7 +215,7 @@ jobs:
       - name: Upload analysis artifact
         id: upload_artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
           name: ai-failure-analysis
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload Claude execution log
         if: ${{ always() && steps.claude.outputs.execution_file != '' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
           name: ai-execution-log
@@ -472,7 +472,7 @@ jobs:
 
       - name: Send Slack Notification
         if: ${{ steps.extract_jobs.outputs.has_results == 'true' }}
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 #v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c #v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.slack_bot_token }}
@@ -526,3 +526,4 @@ jobs:
               ${{ steps.ai_block.outputs.divider_block }}
               ${{ steps.ai_block.outputs.analysis_block }}
               ${{ steps.ai_block.outputs.link_block }}
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           # Issues
           days-before-issue-stale: -1 # Deactivate stale issues
@@ -25,3 +25,4 @@ jobs:
           stale-pr-message: 'PR has had no activity for 30 days. What is blocking it? Is there anything you can do to help move it forward? Without action it will be closed in 7 days.'
           close-pr-message: 'Closing stale PR as no activity for 7 days'
           delete-branch: true
+

--- a/.github/workflows/staterecovery-testing.yml
+++ b/.github/workflows/staterecovery-testing.yml
@@ -32,7 +32,7 @@ jobs:
     name: Staterecovery tests
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Staterecovery - Build and Unit tests
@@ -49,7 +49,7 @@ jobs:
           ./gradlew linea-besu:plugins:state-recovery:besu-plugin:shadowJar
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -88,7 +88,7 @@ jobs:
 #            ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
 #      - name: Upload coverage to Codecov Staterecovery
 #        if: ${{ env.CODECOV_TOKEN != '' }}
-#        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 #v5.4.3
+#        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac #v5.5.5
 #        with:
 #          fail_ci_if_error: true
 #          files: ${{ github.workspace }}/build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
@@ -97,3 +97,4 @@ jobs:
 #          name: codecov-staterecovery
 #          verbose: true
 #          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -163,7 +163,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -172,31 +172,31 @@ jobs:
 
       - name: Download Jacoco execution data from coordinator
         if: needs.coordinator.result != 'skipped'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-coordinator-exec
           path: .
       - name: Download Jacoco execution data from linea-sequencer unit tests
         if: needs.linea-sequencer.result != 'skipped'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-linea-sequencer-unit-exec
           path: .
       - name: Download Jacoco execution data from linea-sequencer acceptance tests
         if: needs.linea-sequencer.result != 'skipped'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-linea-sequencer-acceptance-exec
           path: .
       - name: Download Jacoco execution data from staterecovery
         if: needs.staterecovery.result != 'skipped'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-staterecovery-exec
           path: .
       - name: Download Jacoco execution data from transaction-exclusion-api
         if: needs.transaction-exclusion-api.result != 'skipped'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: jacoco-transaction-exclusion-api-exec
           path: .
@@ -244,3 +244,4 @@ jobs:
     steps:
       - name: Ensure Workflow Success
         run: echo "All jobs were skipped, but workflow succeeds."
+

--- a/.github/workflows/tracer-constraints-check-compilation.yml
+++ b/.github/workflows/tracer-constraints-check-compilation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-med
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -21,3 +21,4 @@ jobs:
 
       - name: Run Tracer buildZkevmBins
         run: ./gradlew :tracer:arithmetization:buildZkevmBins
+

--- a/.github/workflows/tracer-gradle-besu-node-tests.yml
+++ b/.github/workflows/tracer-gradle-besu-node-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -46,3 +46,4 @@ jobs:
           path: tracer/arithmetization/build/besu/traces/**/*
           compression-level: 9
           if-no-files-found: 'error'
+

--- a/.github/workflows/tracer-gradle-nightly-tests.yml
+++ b/.github/workflows/tracer-gradle-nightly-tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -58,3 +58,4 @@ jobs:
     secrets:
       channel_id: ${{ secrets.SLACK_ARITHMETIZATION_ALERTS_CHANNEL_ID }}
       slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
+

--- a/.github/workflows/tracer-gradle-tests.yml
+++ b/.github/workflows/tracer-gradle-tests.yml
@@ -35,7 +35,7 @@ jobs:
           echo "github.ref: ${{ github.ref }}"
 
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -116,3 +116,4 @@ jobs:
         with:
           name: jacoco-fast-replay-tests-exec-file
           path: tracer/arithmetization/build/jacoco/fastReplayTests.exec
+

--- a/.github/workflows/tracer-gradle-weekly-tests.yml
+++ b/.github/workflows/tracer-gradle-weekly-tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-xxl
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
@@ -59,3 +59,4 @@ jobs:
     secrets:
       channel_id: ${{ secrets.SLACK_ARITHMETIZATION_ALERTS_CHANNEL_ID }}
       slack_bot_token: ${{ secrets.SLACK_GITHUB_ACTIONS_ALERTS_BOT_TOKEN }}
+

--- a/.github/workflows/transaction-exclusion-api-build-and-publish.yml
+++ b/.github/workflows/transaction-exclusion-api-build-and-publish.yml
@@ -50,11 +50,11 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -77,3 +77,4 @@ jobs:
           save_artifact: ${{ env.PUSH_IMAGE == 'false' }}
           artifact_name: linea-transaction-exclusion-api
           requires_qemu: ${{ env.PUSH_IMAGE }}
+

--- a/.github/workflows/transaction-exclusion-api-testing.yml
+++ b/.github/workflows/transaction-exclusion-api-testing.yml
@@ -33,7 +33,7 @@ jobs:
     name: Transaction exclusion api tests
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-and-gradle
       - name: Run tests with coverage
@@ -46,7 +46,7 @@ jobs:
           ./gradlew transaction-exclusion-api:app:buildNeeded
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -61,3 +61,4 @@ jobs:
           path: |
             **/build/jacoco/*.exec
           if-no-files-found: ignore
+

--- a/.github/workflows/valid-audit-pr-has-tags.yml
+++ b/.github/workflows/valid-audit-pr-has-tags.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
 
@@ -58,3 +58,4 @@ jobs:
           exit 1
         fi
         echo "Audit tag check passed: ${TAG_NAME}"
+

--- a/.github/workflows/verifier-ray.yml
+++ b/.github/workflows/verifier-ray.yml
@@ -49,14 +49,14 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: false
 
       # Keep this aligned with .github/actions/setup-arithmetization-riscv, but use
       # newer Go because verifier-ray/prover-ray modules declare go 1.25.7.
       - name: Install Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
@@ -107,3 +107,4 @@ jobs:
       - name: ZKC verifier failing smoke test
         working-directory: verifier-ray
         run: make zkc-verify-failing-expected
+


### PR DESCRIPTION
## Summary
- Update the `linea-dependency-maintenance` skill (GitHub Actions support)
- Refresh GitHub Actions pins to full commit SHAs with version comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CI supply-chain updates (including major bumps for checkout, setup-node/go, upload/download-artifact, and docker/build-push-action) can change runner behavior or break workflows; benchmark workflows still mix one unpinned `@v4` artifact action with the new SHA policy.
> 
> **Overview**
> **Extends `linea-dependency-maintenance`** so agents treat GitHub Actions like npm/pnpm: preflight includes workflow pins, policy mandates **40-character SHAs** with matching version comments and a **7-day release-age gate**, plus a **GitHub Actions** section (inventory via `scripts/eligible-actions`, triage for pin/comment drift, validation, and `deps(actions)` commit guidance). Adds **`references/github-actions.md`**, **`scripts/eligible-actions`**, skill metadata/eval case **#6**, and points agents at the new tooling.
> 
> **Refreshes CI pins repo-wide** in `.github/workflows/*.yml` and `.github/actions/**`—notably `actions/checkout` **v7**, `actions/upload-artifact` **v7**, `actions/download-artifact` **v8**, `actions/setup-go` **v6**, `actions/setup-node` **v6**, Docker build/login/setup actions, `dorny/paths-filter`, `nick-fields/retry` **v4**, release/PR helpers (`peter-evans/create-pull-request` **v8**, `softprops/action-gh-release` **v2.6**), and **`anthropics/claude-code-action` v1.0.158**.
> 
> **Smaller workflow tweaks:** arithmetization benchmark jobs pass **`--fast`** to `zkc generate`; `run-smc-tests` aligns **Go 1.25.7** with other prover workflows. Two benchmark upload steps still use **`actions/upload-artifact@v4`** (tag refs), unlike the rest of the refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce2baa7fc17fc020de3b4f799ab642a01acbfc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->