### PR TITLE
ci(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-interpreter.yml
@@ -249,7 +249,7 @@ jobs:
             | tee /tmp/bench/logs/summary.md
 
       - name: Upload benchmark logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: zkc-bench-logs

--- a/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
+++ b/.github/workflows/arithmetization-benchmark-zkc-native-keccak.yml
@@ -197,7 +197,7 @@ jobs:
             | tee /tmp/bench/logs/summary.md
 
       - name: Upload benchmark logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: zkc-native-keccak-bench-logs

--- a/.github/workflows/component-changelog-commit.yml
+++ b/.github/workflows/component-changelog-commit.yml
@@ -25,7 +25,7 @@ jobs:
       # directly bypassin the branch-protection or for PR bot GitHub App to create PR with the changelog changes.
       - name: Generate release or PR bot App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ !inputs.create_pull_request && secrets.RELEASE_BOT_APP_ID || secrets.CREATE_GITHUB_PR_APP_ID }}
           private-key: ${{ !inputs.create_pull_request && secrets.RELEASE_BOT_PRIVATE_KEY || secrets.CREATE_GITHUB_PR_PRIVATE_KEY }}

--- a/.github/workflows/linea-milestone-release-with-dry-run.yml
+++ b/.github/workflows/linea-milestone-release-with-dry-run.yml
@@ -55,7 +55,7 @@ jobs:
       # so we mint an App token that has actions:write + contents:write.
       - name: Mint App token (actions:write + contents:write)
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
@@ -162,7 +162,7 @@ jobs:
     steps:
       - name: Mint App token (actions:read + contents:write)
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/reusable-component-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-component-release-push-tag-changelog.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Generate release or PR bot App token
         id: app-token
         if: ${{ !inputs.upload_changelog }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ !inputs.create_pull_request && secrets.RELEASE_BOT_APP_ID || secrets.CREATE_GITHUB_PR_APP_ID }}
           private-key: ${{ !inputs.create_pull_request && secrets.RELEASE_BOT_PRIVATE_KEY || secrets.CREATE_GITHUB_PR_PRIVATE_KEY }}

--- a/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
+++ b/.github/workflows/reusable-milestone-release-push-tag-changelog.yml
@@ -63,7 +63,7 @@ jobs:
       # directly bypassin the branch-protection or for PR bot GitHub App to create PR with the changelog changes.
       - name: Generate release or PR bot App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ !inputs.create_pull_request && secrets.RELEASE_BOT_APP_ID || secrets.CREATE_GITHUB_PR_APP_ID }}
           private-key: ${{ !inputs.create_pull_request && secrets.RELEASE_BOT_PRIVATE_KEY || secrets.CREATE_GITHUB_PR_PRIVATE_KEY }}


### PR DESCRIPTION
### What
Pin the last unpinned GitHub Actions references to full commit SHAs, matching the
convention already used for the vast majority of `uses:` steps in this repo. Two
of the seven pins also bump to the latest stable release, since nothing about how
they're used here hits a breaking change:

- `actions/upload-artifact` v4 → v7.0.1 (2 call sites) — only uses `name`/`path`,
  unchanged; SHA now matches the one already used elsewhere in the repo.
- `actions/create-github-app-token` v2 → v3.2.0 (5 call sites) — only uses
  `app-id`/`private-key`, both still supported (`app-id` is soft-deprecated in
  favor of `client-id` but not removed); no proxy env vars in use here, so the
  v3 proxy-handling change doesn't apply.

One more unpinned reference (`upload-artifact@v7` in `staterecovery-testing.yml`)
is left as-is — it's inside an already-disabled block of steps, out of scope here.

### Why
A floating version tag can be repointed to different code — accidentally or via
a compromised maintainer account — without anything changing on our side.
Pinning to a commit SHA removes that risk. This closes out the last few gaps so
every active third-party Action in the repo is SHA-pinned.

### Note for reviewers
Both bumps move to Node 24-based runtimes (need Actions Runner ≥2.327.1). Our
self-hosted runners already run other Node 24-era actions successfully
elsewhere in this repo, so this shouldn't be an issue — flagging for a final
sanity check.

### Checklist
- [x] No new tests needed — this repins/rebumps existing Action references only,
      no application code or behavior changes.
- [x] Validated via this PR's own CI run (one of the two upload-artifact call
      sites triggers on this PR's `pull_request` event).
- [ ] N/A — no deploy/E2E-relevant behavior changed.
- [x] No breaking changes for consumers of this repo.