### PR TITLE
fix(coordinator): l1FinalizationPriorityFeeCalculator feeLowerBound config

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
@@ -142,7 +142,7 @@ class L1DependentApp(
   private val l1FinalizationPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
     BoundableFeeCalculator.Config(
       feeUpperBound = configs.l1Submission!!.aggregation.gas.fallback.priorityFeePerGasUpperBound.toDouble(),
-      feeLowerBound = configs.l1Submission.aggregation.gas.fallback.priorityFeePerGasUpperBound.toDouble(),
+      feeLowerBound = configs.l1Submission.aggregation.gas.fallback.priorityFeePerGasLowerBound.toDouble(),
       feeMargin = 0.0,
     ),
     l1MinPriorityFeeCalculator,

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/DynamicGasPriceCap.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/DynamicGasPriceCap.kt
@@ -24,13 +24,6 @@ fun getTimeOfDayKey(dayOfWeek: DayOfWeek, hour: Int): String {
   return "${dayOfWeek}_$hour"
 }
 
-fun getAllTimeOfDayKeys(): Set<String> {
-  return DayOfWeek.values()
-    .flatMap { dayOfWeek ->
-      (0..23).map { hour -> getTimeOfDayKey(dayOfWeek, hour) }
-    }.toSet()
-}
-
 interface GasPriceCapFeeHistoryFetcher {
   fun getEthFeeHistoryData(startBlockNumberInclusive: Long, endBlockNumberInclusive: Long): SafeFuture<FeeHistory>
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -90,19 +90,20 @@ class GasPriceCapProviderImpl(
           val targetL2BlockTimestamp = Instant.fromEpochSeconds(it.toLong())
           val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(targetL2BlockTimestamp)
           val percentileGasFees = feeHistoriesRepository.getCachedPercentileGasFees()
+          val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers)
           val maxPriorityFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
             adjustmentConstant = config.adjustmentConstant,
             finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
             historicGasPriceCap = percentileGasFees.percentileAvgReward,
             elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
-            timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers),
+            timeOfDayMultiplier = timeOfDayMultiplier,
           )
           val maxBaseFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
             adjustmentConstant = config.adjustmentConstant,
             finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
             historicGasPriceCap = percentileGasFees.percentileBaseFeePerGas,
             elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
-            timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers),
+            timeOfDayMultiplier = timeOfDayMultiplier,
           )
           val maxFeePerBlobGasCap = gasPriceCapCalculator.calculateGasPriceCap(
             adjustmentConstant = config.blobAdjustmentConstant,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wrong fee bounds on L1 finalization transactions could have caused under- or over-paying priority fees until fixed; the fix directly affects aggregation submission gas pricing.
> 
> **Overview**
> Fixes a **copy-paste bug** in `l1FinalizationPriorityFeeCalculator`: `feeLowerBound` now reads `priorityFeePerGasLowerBound` instead of incorrectly using the **upper** bound, aligning L1 aggregation finalization fallback priority fees with blob submission and config intent.
> 
> In dynamic gas cap code, **`getAllTimeOfDayKeys()`** is removed (unused), and **`GasPriceCapProviderImpl`** computes the time-of-day multiplier once per cap calculation and reuses it for priority and base fee caps (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7837c301a6beff7f9873725a63592af745378235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->