### PR TITLE
fix(coordinator): bound eth_getLogs in finalized-state lookup

### DIFF
--- a/coordinator/app/build.gradle
+++ b/coordinator/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   implementation project(':jvm-libs:generic:extensions:futures')
   implementation project(':jvm-libs:generic:persistence:db')
   implementation project(':jvm-libs:linea:web3j-extensions')
+  implementation project(':jvm-libs:linea:clients:eth-logs-searcher')
   implementation project(':jvm-libs:linea:core:metrics')
   implementation project(':jvm-libs:linea:metrics:micrometer')
   implementation project(':jvm-libs:linea:core:domain-models')

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
@@ -9,10 +9,12 @@ import linea.contract.l1.LineaSmartContractClient
 import linea.coordinator.config.v2.L1SubmissionConfig
 import linea.coordinator.config.v2.SignerConfig
 import linea.crypto.Web3SignerRestClient
+import linea.ethapi.EthLogsSearcherImpl
 import linea.kotlin.encodeHex
 import linea.web3j.ECKeypairSignerAdapter
 import linea.web3j.SmartContractErrors
 import linea.web3j.Web3SignerTxSignService
+import linea.web3j.ethapi.createEthApiClient
 import linea.web3j.transactionmanager.AsyncFriendlyTransactionManager
 import net.consensys.linea.contract.l1.Web3JLineaRollupSmartContractClient
 import net.consensys.linea.contract.l1.Web3JLineaValidiumSmartContractClient
@@ -121,6 +123,7 @@ fun createTransactionManager(
 }
 
 fun createLineaContractClient(
+  vertx: Vertx,
   dataAvailabilityType: L1SubmissionConfig.DataAvailability,
   contractAddress: String,
   transactionManager: AsyncFriendlyTransactionManager,
@@ -137,6 +140,7 @@ fun createLineaContractClient(
         transactionManager = transactionManager,
         contractGasProvider = contractGasProvider,
         smartContractErrors = smartContractErrors,
+        ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = createEthApiClient(web3jClient)),
         useEthEstimateGas = useEthEstimateGas,
       )
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
@@ -23,6 +23,7 @@ import linea.domain.BlockNumberAndHash
 import linea.domain.FinalizationSubmittedEvent
 import linea.domain.RetryConfig
 import linea.ethapi.EthApiClient
+import linea.ethapi.EthLogsSearcherImpl
 import linea.finalization.AggregationFinalizationCoordinator
 import linea.finalization.AggregationSubmitterImpl
 import linea.finalization.FinalizationHandler
@@ -173,10 +174,13 @@ class L1DependentApp(
     Web3JLineaRollupSmartContractClientReadOnly(
       contractAddress = configs.protocol.l1.contractAddress,
       web3j = web3j,
-      ethLogsClient = createEthApiClient(
-        web3jClient = web3j,
-        requestRetryConfig = configs.l1FinalizationMonitor.l1RequestRetries,
+      ethLogsSearcher = EthLogsSearcherImpl(
         vertx = vertx,
+        ethApiClient = createEthApiClient(
+          web3jClient = web3j,
+          requestRetryConfig = configs.l1FinalizationMonitor.l1RequestRetries,
+          vertx = vertx,
+        ),
       ),
     )
   }
@@ -325,6 +329,7 @@ class L1DependentApp(
       client = l1Web3jClient,
     )
     createLineaContractClient(
+      vertx = vertx,
       dataAvailabilityType = configs.l1Submission.dataAvailability,
       contractAddress = configs.protocol.l1.contractAddress,
       transactionManager = transactionManager,
@@ -422,6 +427,7 @@ class L1DependentApp(
         ),
       )
       val lineaSmartContractClientForFinalization = createLineaContractClient(
+        vertx = vertx,
         dataAvailabilityType = configs.l1Submission.dataAvailability,
         contractAddress = configs.protocol.l1.contractAddress,
         transactionManager = finalizationTransactionManager,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
@@ -46,6 +46,7 @@ import linea.domain.BlobRecord
 import linea.domain.BlocksConflation
 import linea.encoding.BlockRLPEncoder
 import linea.ethapi.EthApiClient
+import linea.ethapi.EthLogsSearcherImpl
 import linea.ftx.ForcedTransactionsApp
 import linea.metrics.LineaMetricsCategory
 import linea.persistence.AggregationsRepository
@@ -149,10 +150,13 @@ class ConflationApp(
       val contractClient = Web3JLineaRollupSmartContractClientReadOnly(
         contractAddress = configs.protocol.l1.contractAddress,
         web3j = l1Web3jClient,
-        ethLogsClient = createEthApiClient(
-          web3jClient = l1Web3jClient,
-          requestRetryConfig = ftxConfig.l1RequestRetries,
+        ethLogsSearcher = EthLogsSearcherImpl(
           vertx = vertx,
+          ethApiClient = createEthApiClient(
+            web3jClient = l1Web3jClient,
+            requestRetryConfig = ftxConfig.l1RequestRetries,
+            vertx = vertx,
+          ),
         ),
       )
       ForcedTransactionsApp.create(

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -1,5 +1,6 @@
 package net.consensys.linea.contract.l1
 
+import linea.EthLogsSearcher
 import linea.contract.LineaRollupV6
 import linea.contract.l1.BlockAndNonce
 import linea.contract.l1.LineaRollupSmartContractClient
@@ -8,10 +9,8 @@ import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize
 import linea.domain.gas.GasPriceCaps
 import linea.domain.toBlockParameter
-import linea.ethapi.EthLogsClient
 import linea.kotlin.toULong
 import linea.web3j.SmartContractErrors
-import linea.web3j.ethapi.createEthApiClient
 import linea.web3j.transactionmanager.AsyncFriendlyTransactionManager
 import net.consensys.linea.contract.Web3JContractAsyncHelper
 import org.apache.logging.log4j.LogManager
@@ -29,12 +28,14 @@ class Web3JLineaRollupSmartContractClient internal constructor(
   private val transactionManager: AsyncFriendlyTransactionManager,
   private val web3jContractHelper: Web3JContractAsyncHelper,
   private val web3jLineaClient: LineaRollupV6,
-  ethLogsClient: EthLogsClient = createEthApiClient(web3j),
+  ethLogsSearcher: EthLogsSearcher,
+  l1EventSearchMaxBlockRange: UInt = 10_000u,
   private val log: Logger = LogManager.getLogger(Web3JLineaRollupSmartContractClient::class.java),
 ) : Web3JLineaRollupSmartContractClientReadOnly(
   contractAddress = contractAddress,
   web3j = web3j,
-  ethLogsClient = ethLogsClient,
+  ethLogsSearcher = ethLogsSearcher,
+  l1EventSearchMaxBlockRange = l1EventSearchMaxBlockRange,
   log = log,
 ),
   LineaRollupSmartContractClient {
@@ -45,6 +46,7 @@ class Web3JLineaRollupSmartContractClient internal constructor(
       transactionManager: AsyncFriendlyTransactionManager,
       contractGasProvider: ContractGasProvider,
       smartContractErrors: SmartContractErrors,
+      ethLogsSearcher: EthLogsSearcher,
       useEthEstimateGas: Boolean = false,
     ): Web3JLineaRollupSmartContractClient {
       val web3JContractAsyncHelper =
@@ -70,6 +72,7 @@ class Web3JLineaRollupSmartContractClient internal constructor(
         transactionManager = transactionManager,
         web3jContractHelper = web3JContractAsyncHelper,
         web3jLineaClient = lineaRollupEnhancedWrapper,
+        ethLogsSearcher = ethLogsSearcher,
       )
     }
 
@@ -79,6 +82,7 @@ class Web3JLineaRollupSmartContractClient internal constructor(
       credentials: Credentials,
       contractGasProvider: ContractGasProvider,
       smartContractErrors: SmartContractErrors,
+      ethLogsSearcher: EthLogsSearcher,
       useEthEstimateGas: Boolean,
     ): Web3JLineaRollupSmartContractClient {
       return load(
@@ -88,6 +92,7 @@ class Web3JLineaRollupSmartContractClient internal constructor(
         AsyncFriendlyTransactionManager(web3j, credentials),
         contractGasProvider,
         smartContractErrors,
+        ethLogsSearcher,
         useEthEstimateGas,
       )
     }

--- a/coordinator/ethereum/test-utils/build.gradle
+++ b/coordinator/ethereum/test-utils/build.gradle
@@ -8,6 +8,7 @@ plugins {
 dependencies {
   implementation(project(":coordinator:core"))
   implementation(project(":coordinator:clients:smart-contract-client"))
+  implementation(project(":jvm-libs:linea:clients:eth-logs-searcher"))
   implementation(project(":jvm-libs:linea:web3j-extensions"))
   implementation(testFixtures(project(":jvm-libs:linea:web3j-extensions")))
   implementation(project(":jvm-libs:linea:testing:file-system"))

--- a/coordinator/ethereum/test-utils/src/main/kotlin/linea/ContractsManager.kt
+++ b/coordinator/ethereum/test-utils/src/main/kotlin/linea/ContractsManager.kt
@@ -3,8 +3,10 @@ package linea
 import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.ExperimentalHoplite
 import com.sksamuel.hoplite.addFileSource
+import io.vertx.core.Vertx
 import linea.contract.l1.LineaRollupContractVersion
 import linea.contract.l1.LineaRollupSmartContractClient
+import linea.ethapi.EthLogsSearcherImpl
 import linea.kotlin.gwei
 import linea.web3j.SmartContractErrors
 import linea.web3j.gas.StaticGasProvider
@@ -75,6 +77,7 @@ interface ContractsManager {
 
 object MakeFileDelegatedContractsManager : ContractsManager {
   private val log = LoggerFactory.getLogger(MakeFileDelegatedContractsManager::class.java)
+  private val vertx: Vertx = Vertx.vertx()
 
   @OptIn(ExperimentalHoplite::class)
   val lineaRollupContractErrors = findPathTo("config")!!
@@ -175,11 +178,12 @@ object MakeFileDelegatedContractsManager : ContractsManager {
     smartContractErrors: SmartContractErrors?,
   ): LineaRollupSmartContractClient {
     return Web3JLineaRollupSmartContractClient.load(
-      contractAddress,
-      Web3jClientManager.l1Client,
-      transactionManager,
-      gasProvider,
-      smartContractErrors ?: lineaRollupContractErrors,
+      contractAddress = contractAddress,
+      web3j = Web3jClientManager.l1Client,
+      transactionManager = transactionManager,
+      contractGasProvider = gasProvider,
+      smartContractErrors = smartContractErrors ?: lineaRollupContractErrors,
+      ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = EthApiClientManager.l1Client),
     )
   }
 }

--- a/jvm-libs/linea/clients/linea-contract-clients/build.gradle
+++ b/jvm-libs/linea/clients/linea-contract-clients/build.gradle
@@ -23,4 +23,6 @@ dependencies {
 
   testImplementation "io.vertx:vertx-junit5"
   testImplementation "org.wiremock:wiremock:${libs.versions.wiremock.get()}"
+  testImplementation project(':jvm-libs:linea:clients:eth-logs-searcher')
+  testImplementation testFixtures(project(':jvm-libs:linea:clients:interfaces'))
 }

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -1,13 +1,15 @@
 package linea.contract.l1
 
+import linea.EthLogsSearcher
+import linea.SearchDirection
 import linea.contract.FAKE_READ_ONLY_CREDENTIALS
 import linea.contract.LineaRollupV6
 import linea.contract.LineaRollupV8
 import linea.contract.events.FinalizedStateUpdatedEvent
 import linea.domain.BlockParameter
-import linea.ethapi.EthLogsClient
+import linea.domain.EthLogEvent
+import linea.domain.toBlockParameter
 import linea.kotlin.toBigInteger
-import linea.kotlin.toHexStringUInt256
 import linea.kotlin.toULong
 import linea.web3j.domain.toWeb3j
 import net.consensys.linea.async.toSafeFuture
@@ -23,7 +25,8 @@ import java.util.concurrent.atomic.AtomicReference
 open class Web3JLineaRollupSmartContractClientReadOnly(
   val web3j: Web3j,
   val contractAddress: String,
-  private val ethLogsClient: EthLogsClient,
+  private val ethLogsSearcher: EthLogsSearcher,
+  private val l1EventSearchMaxBlockRange: UInt = 10_000u,
   private val log: Logger = LogManager.getLogger(Web3JLineaRollupSmartContractClientReadOnly::class.java),
 ) : LineaRollupSmartContractClientReadOnly,
   LineaRollupSmartContractClientReadOnlyFinalizedStateProvider,
@@ -210,23 +213,65 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
       }
   }
 
-  private fun findFinalizedStateEvent(
+  // The finalized L2 block number increases monotonically, so each FinalizedStateUpdated event is at
+  // an L1 block >= the previous one. We remember the last found L1 block and start the next search
+  // there, turning the repeated finalization-monitor lookups (polled every ~500ms) into a small
+  // forward search instead of a full-chain binary search. A full-range fallback covers the rare case
+  // where the cached window overshoots (e.g. an L1 reorg moved the event earlier, or a caller queries
+  // a historical block).
+  private val finalizedStateSearchFromBlock = AtomicReference<BlockParameter>(BlockParameter.Tag.EARLIEST)
+
+  internal fun findFinalizedStateEvent(
     upToBlock: BlockParameter,
     finalisedBlockNumber: ULong,
   ): SafeFuture<FinalizedStateUpdatedEvent?> {
-    return ethLogsClient.getLogs(
-      fromBlock = BlockParameter.Tag.EARLIEST,
-      toBlock = upToBlock,
-      address = contractAddress,
-      topics = listOf(
-        FinalizedStateUpdatedEvent.topic,
-        finalisedBlockNumber.toHexStringUInt256(),
-      ),
-    ).thenApply { logs ->
-      // only one log expected because we use indexed finalized block number
-      logs.firstOrNull()
-        ?.let(FinalizedStateUpdatedEvent::fromEthLog)
+    val fromBlock = finalizedStateSearchFromBlock.get()
+    val search =
+      if (fromBlock == BlockParameter.Tag.EARLIEST) {
+        searchFinalizedStateEvent(BlockParameter.Tag.EARLIEST, upToBlock, finalisedBlockNumber)
+      } else {
+        searchFinalizedStateEvent(fromBlock, upToBlock, finalisedBlockNumber)
+          // The cached forward window is only an optimization: on a miss OR any failure (e.g. it sits
+          // after a historical upToBlock, which EthLogsSearcher rejects as an invalid range) fall back
+          // to the authoritative full-range search, which re-surfaces any genuine (e.g. RPC) error.
+          .exceptionally { null }
+          .thenCompose { event ->
+            if (event != null) {
+              SafeFuture.completedFuture(event)
+            } else {
+              searchFinalizedStateEvent(BlockParameter.Tag.EARLIEST, upToBlock, finalisedBlockNumber)
+            }
+          }
+      }
+    return search.thenApply { event ->
+      event?.also { finalizedStateSearchFromBlock.set(it.log.blockNumber.toBlockParameter()) }
         ?.event
+    }
+  }
+
+  private fun searchFinalizedStateEvent(
+    fromBlock: BlockParameter,
+    upToBlock: BlockParameter,
+    finalisedBlockNumber: ULong,
+  ): SafeFuture<EthLogEvent<FinalizedStateUpdatedEvent>?> {
+    // FinalizedStateUpdated has a unique, monotonically-increasing indexed blockNumber, so we binary
+    // search for it in bounded chunks instead of an unbounded getLogs(EARLIEST..upToBlock) query,
+    // which rate-limited providers (e.g. Infura) reject for spans > 10_000 blocks.
+    return ethLogsSearcher.findLog(
+      fromBlock = fromBlock,
+      toBlock = upToBlock,
+      chunkSize = l1EventSearchMaxBlockRange.toInt(),
+      address = contractAddress,
+      topics = listOf(FinalizedStateUpdatedEvent.topic),
+    ) { ethLog ->
+      val foundBlockNumber = FinalizedStateUpdatedEvent.fromEthLog(ethLog).event.blockNumber
+      when {
+        foundBlockNumber < finalisedBlockNumber -> SearchDirection.FORWARD
+        foundBlockNumber > finalisedBlockNumber -> SearchDirection.BACKWARD
+        else -> null
+      }
+    }.thenApply { ethLog ->
+      ethLog?.let(FinalizedStateUpdatedEvent::fromEthLog)
     }
   }
 

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
@@ -1,0 +1,138 @@
+package linea.contract.l1
+
+import io.vertx.core.Vertx
+import linea.contract.events.FactoryFinalizedStateUpdatedEvent
+import linea.domain.BlockParameter
+import linea.domain.toBlockParameter
+import linea.ethapi.EthLogsSearcherImpl
+import linea.ethapi.FakeEthApiClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.web3j.protocol.Web3j
+
+class Web3JLineaRollupSmartContractClientReadOnlyTest {
+  private val contractAddress = "0x" + "aa".repeat(20)
+  private lateinit var vertx: Vertx
+  private lateinit var l1Client: FakeEthApiClient
+  private lateinit var client: Web3JLineaRollupSmartContractClientReadOnly
+
+  @BeforeEach
+  fun setUp() {
+    vertx = Vertx.vertx()
+    l1Client = FakeEthApiClient()
+    client = Web3JLineaRollupSmartContractClientReadOnly(
+      web3j = mock<Web3j>(), // not used by findFinalizedStateEvent
+      contractAddress = contractAddress,
+      ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1Client),
+      // deliberately small so the search spans multiple bounded chunks instead of one query
+      l1EventSearchMaxBlockRange = 100u,
+    )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    vertx.close()
+  }
+
+  @Test
+  fun `findFinalizedStateEvent locates the event by finalized block number across bounded chunks`() {
+    // FinalizedStateUpdated events are sparse across the L1 range; the indexed L2 block number is
+    // monotonic with the L1 block, so the binary search must converge on the matching one.
+    l1Client.setLogs(
+      listOf(
+        event(l1Block = 1_000UL, l2FinalizedBlockNumber = 100UL, forcedTransactionNumber = 5UL),
+        event(l1Block = 3_000UL, l2FinalizedBlockNumber = 200UL, forcedTransactionNumber = 9UL),
+        event(l1Block = 5_000UL, l2FinalizedBlockNumber = 300UL, forcedTransactionNumber = 14UL),
+      ),
+    )
+    l1Client.setLatestBlockTag(6_000UL)
+
+    val result = client.findFinalizedStateEvent(
+      upToBlock = BlockParameter.Tag.LATEST,
+      finalisedBlockNumber = 200UL,
+    ).get()
+
+    assertThat(result).isNotNull
+    assertThat(result!!.blockNumber).isEqualTo(200UL)
+    assertThat(result.forcedTransactionNumber).isEqualTo(9UL)
+  }
+
+  @Test
+  fun `findFinalizedStateEvent returns null when no event matches the finalized block number`() {
+    l1Client.setLogs(
+      listOf(
+        event(l1Block = 1_000UL, l2FinalizedBlockNumber = 100UL, forcedTransactionNumber = 5UL),
+      ),
+    )
+    l1Client.setLatestBlockTag(6_000UL)
+
+    val result = client.findFinalizedStateEvent(
+      upToBlock = BlockParameter.Tag.LATEST,
+      finalisedBlockNumber = 999UL,
+    ).get()
+
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `findFinalizedStateEvent falls back to a full-range search when the cached window overshoots`() {
+    l1Client.setLogs(
+      listOf(
+        event(l1Block = 1_000UL, l2FinalizedBlockNumber = 100UL, forcedTransactionNumber = 5UL),
+        event(l1Block = 3_000UL, l2FinalizedBlockNumber = 200UL, forcedTransactionNumber = 9UL),
+        event(l1Block = 5_000UL, l2FinalizedBlockNumber = 300UL, forcedTransactionNumber = 14UL),
+      ),
+    )
+    l1Client.setLatestBlockTag(6_000UL)
+
+    // Advance the high-water-mark to the latest finalization (L1 block 5_000).
+    assertThat(client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalisedBlockNumber = 300UL).get())
+      .isNotNull
+
+    // A subsequent query for an earlier finalization sits before the cached window, so the bounded
+    // search misses and the full-range fallback must still resolve it.
+    val result = client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalisedBlockNumber = 200UL).get()
+
+    assertThat(result).isNotNull
+    assertThat(result!!.blockNumber).isEqualTo(200UL)
+    assertThat(result.forcedTransactionNumber).isEqualTo(9UL)
+  }
+
+  @Test
+  fun `findFinalizedStateEvent recovers when the cached window sits after a historical upToBlock`() {
+    l1Client.setLogs(
+      listOf(
+        event(l1Block = 1_000UL, l2FinalizedBlockNumber = 100UL, forcedTransactionNumber = 5UL),
+        event(l1Block = 3_000UL, l2FinalizedBlockNumber = 200UL, forcedTransactionNumber = 9UL),
+        event(l1Block = 5_000UL, l2FinalizedBlockNumber = 300UL, forcedTransactionNumber = 14UL),
+      ),
+    )
+    l1Client.setLatestBlockTag(6_000UL)
+
+    // Advance the high-water-mark to L1 block 5_000.
+    assertThat(client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalisedBlockNumber = 300UL).get())
+      .isNotNull
+
+    // Query a historical upToBlock (2_000) that is before the cached window, so the bounded search
+    // would be an invalid range; it must recover via the full-range fallback.
+    val result = client.findFinalizedStateEvent(
+      upToBlock = 2_000UL.toBlockParameter(),
+      finalisedBlockNumber = 100UL,
+    ).get()
+
+    assertThat(result).isNotNull
+    assertThat(result!!.blockNumber).isEqualTo(100UL)
+    assertThat(result.forcedTransactionNumber).isEqualTo(5UL)
+  }
+
+  private fun event(l1Block: ULong, l2FinalizedBlockNumber: ULong, forcedTransactionNumber: ULong) =
+    FactoryFinalizedStateUpdatedEvent.createEthLog(
+      blockNumber = l1Block,
+      contractAddress = contractAddress,
+      l2FinalizedBlockNumber = l2FinalizedBlockNumber,
+      forcedTransactionNumber = forcedTransactionNumber,
+    )
+}

--- a/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/AppConfigurator.kt
+++ b/linea-besu/plugins/state-recovery/besu-plugin/src/main/kotlin/linea/staterecovery/plugin/AppConfigurator.kt
@@ -125,7 +125,7 @@ fun createAppClients(
         rpcUrl = l1RpcEndpoint.toString(),
         log = LogManager.getLogger("linea.plugin.staterecovery.clients.l1.smart-contract"),
       ),
-      ethLogsClient = ethLogsSearcher,
+      ethLogsSearcher = ethLogsSearcher,
     )
   val blobScanClient =
     BlobScanClient.create(

--- a/maru/app/build.gradle
+++ b/maru/app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   implementation(project(':jvm-libs:linea:web3j-extensions')) {
     exclude group: "build.linea", module: "besu-libs"
   }
+  implementation project(':jvm-libs:linea:clients:eth-logs-searcher')
   implementation project(':jvm-libs:generic:extensions:kotlin')
   implementation project(':jvm-libs:generic:extensions:futures')
   implementation project(':jvm-libs:linea:core:long-running-service')

--- a/maru/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/maru/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -16,6 +16,7 @@ import io.vertx.micrometer.MicrometerMetricsOptions
 import io.vertx.micrometer.backends.BackendRegistries
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
+import linea.ethapi.EthLogsSearcherImpl
 import linea.kotlin.encodeHex
 import linea.timer.JvmTimerFactory
 import linea.timer.TimerFactory
@@ -375,9 +376,12 @@ class MaruAppFactory : MaruAppFactoryCreator {
               ?: Web3JLineaRollupSmartContractClientReadOnly(
                 web3j = web3jClient,
                 contractAddress = lineaConfig.contractAddress.encodeHex(),
-                ethLogsClient = createEthApiClient(
-                  web3jClient = web3jClient,
+                ethLogsSearcher = EthLogsSearcherImpl(
                   vertx = vertx,
+                  ethApiClient = createEthApiClient(
+                    web3jClient = web3jClient,
+                    vertx = vertx,
+                  ),
                 ),
                 log = LogManager.getLogger("maru.clients.l1.linea"),
               )


### PR DESCRIPTION
## Description

Follow-up to #3435 / PR #3473.

`Web3JLineaRollupSmartContractClientReadOnly.findFinalizedStateEvent` issued an unbounded `getLogs(EARLIEST..upToBlock)` query for the indexed `FinalizedStateUpdated` event. Rate-limited providers (e.g. Infura) reject `eth_getLogs` once the range exceeds 10,000 blocks — **including indexed single-result queries** — which was breaking the finalization monitor:

```
{"error":{"code":-32602,"message":"range 11217608 exceeds limit of 10000"}}  logger=finalization-monitor
```

The finalization monitor polls this every ~500 ms (via `getFinalizedStateData`), and `getLatestFinalizedState` (FTX resume) hits the same method.

## Changes

- **Bounded search**: `findFinalizedStateEvent` now uses `EthLogsSearcher.findLog` binary search instead of the unbounded `getLogs`. It drops the indexed `blockNumber` topic and compares the decoded L2 block number in the predicate — valid because it is monotonic with L1 block height. Added a configurable `l1EventSearchMaxBlockRange` (default `10_000`).
- **High-water-mark optimization**: the finalized L2 block number increases monotonically, so the last found L1 block is cached and the next search starts there. Steady-state polling becomes a single forward chunk instead of a full-chain binary search. On any failure of the cached window (a miss, or an invalid range when a caller queries a historical block) it falls back to the authoritative full-range search, which re-surfaces genuine (e.g. RPC) errors rather than masking them.
- **Wiring**: the shared read-only client and its subclass now take an `EthLogsSearcher` (interface) instead of a plain `EthLogsClient`. All construction sites are updated to build/forward one: coordinator (`L1DependentApp`, `ConflationApp`, `BlockchainClientHelper`, `Web3JLineaRollupSmartContractClient.load`), maru (`MaruAppFactory`), the besu state-recovery plugin (`AppConfigurator`, already had a searcher), and `test-utils` (`ContractsManager`).

## Testing

New `Web3JLineaRollupSmartContractClientReadOnlyTest` (made `findFinalizedStateEvent` `internal`) covering:
1. bounded multi-chunk search hit,
2. not-found,
3. high-water-mark overshoot → full-range fallback,
4. historical `upToBlock` (invalid cached range) → recovery.

All modules compile (coordinator, maru, besu state-recovery, contract clients); the new suite and the full `linea-contract-clients` suite pass; spotless clean on all touched modules.

## Out of scope

One remaining unbounded `eth_getLogs` — `EventBasedContractDeploymentBlockNumberProvider` (a cached, conditional L2 fallback with a different first-occurrence search shape) — is tracked separately in #3518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path finalization monitoring and L1 event resolution; incorrect search or fallback behavior could miss or mis-resolve finalized state, though behavior is covered by new tests and preserves full-range fallback on cache failures.
> 
> **Overview**
> Fixes finalization-monitor failures on rate-limited L1 RPCs by replacing unbounded `eth_getLogs` with **bounded** log search (default **10,000** block chunks).
> 
> **`findFinalizedStateEvent`** now uses `EthLogsSearcher.findLog` with a predicate on decoded L2 finalized block number (instead of an indexed topic + one huge range). It keeps a **forward high-water L1 block** for steady ~500ms polling, with **full-range fallback** when the cached window misses or is invalid (historical `upToBlock`, reorgs).
> 
> **`EventBasedContractDeploymentBlockNumberProvider`** scans forward in the same chunk size to find the earliest `Upgraded` event instead of `EARLIEST..LATEST` in one call.
> 
> Linea rollup read/write clients take an injected **`EthLogsSearcher`** (not plain `EthLogsClient`); coordinator, maru, besu state-recovery, and test-utils are wired to `EthLogsSearcherImpl`. New unit tests cover multi-chunk search, cache overshoot, and historical queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049a0281f908969aa83abdebea04e3bdc17ebba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->