### PR TITLE
fix(coordinator): bound eth_getLogs in deployment-block lookup

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/MessageAnchoringAppConfigurator.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/MessageAnchoringAppConfigurator.kt
@@ -6,6 +6,7 @@ import linea.anchoring.MessageAnchoringApp
 import linea.contract.l2.Web3JL2MessageServiceSmartContractClient
 import linea.coordinator.config.v2.CoordinatorConfig
 import linea.coordinator.config.v2.isDisabled
+import linea.ethapi.EthLogsSearcherImpl
 import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import org.apache.logging.log4j.LogManager
@@ -62,6 +63,7 @@ object MessageAnchoringAppConfigurator {
         Web3JL2MessageServiceSmartContractClient.create(
           web3jClient = l2Web3jClient,
           ethApiClient = l2EthApiClient,
+          ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l2EthApiClient),
           contractAddress = configs.protocol.l2.contractAddress,
           gasLimit = configs.messageAnchoring.gas.gasLimit,
           maxFeePerGasCap = configs.messageAnchoring.gas.maxFeePerGasCap,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
@@ -363,6 +363,7 @@ class ConflationApp(
         log = LogManager.getLogger("clients.l2.eth.conflation"),
       ),
       ethApiClient = l2EthClient,
+      ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l2EthClient),
       contractAddress = configs.protocol.l2.contractAddress,
       smartContractErrors = configs.smartContractErrors,
       smartContractDeploymentBlockNumber = configs.protocol.l2.contractDeploymentBlockNumber?.number,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingApp.kt
@@ -41,6 +41,7 @@ import linea.domain.BlockInterval
 import linea.domain.toBlockParameter
 import linea.encoding.BlockRLPEncoder
 import linea.ethapi.EthApiClient
+import linea.ethapi.EthLogsSearcherImpl
 import linea.kotlin.decodeHex
 import linea.persistence.DisabledForcedTransactionsDao
 import linea.timer.VertxTimerFactory
@@ -328,6 +329,7 @@ class ConflationBacktestingApp(
       log = log,
     ),
     ethApiClient = l2EthClient,
+    ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l2EthClient),
     contractAddress = backtestingCoordinatorConfig.protocol.l2.contractAddress,
     smartContractErrors = backtestingCoordinatorConfig.smartContractErrors,
     smartContractDeploymentBlockNumber = backtestingCoordinatorConfig.protocol.l2.contractDeploymentBlockNumber

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/ContractDeploymentBlockNumberProvider.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/ContractDeploymentBlockNumberProvider.kt
@@ -2,7 +2,9 @@ package linea.contract
 
 import linea.contract.events.Upgraded
 import linea.domain.BlockParameter
+import linea.domain.toBlockParameter
 import linea.ethapi.EthApiClient
+import linea.ethapi.extensions.getAbsoluteBlockNumbers
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
@@ -21,6 +23,7 @@ class StaticContractDeploymentBlockNumberProvider(
 class EventBasedContractDeploymentBlockNumberProvider(
   private val ethApiClient: EthApiClient,
   private val contractAddress: String,
+  private val ethLogsSearchMaxBlockRange: UInt = 10_000u,
   private val log: Logger = LogManager.getLogger(EventBasedContractDeploymentBlockNumberProvider::class.java),
 ) : ContractDeploymentBlockNumberProvider {
   private val deploymentBlockNumberCache = AtomicReference<ULong>(0UL)
@@ -28,29 +31,46 @@ class EventBasedContractDeploymentBlockNumberProvider(
   fun getDeploymentBlock(): SafeFuture<ULong> {
     if (deploymentBlockNumberCache.get() != 0UL) {
       return SafeFuture.completedFuture(deploymentBlockNumberCache.get())
-    } else {
-      return ethApiClient
-        .getLogs(
-          fromBlock = BlockParameter.Tag.EARLIEST,
-          toBlock = BlockParameter.Tag.LATEST,
-          address = contractAddress,
-          topics = listOf(Upgraded.topic),
-        ).thenApply { logs ->
-          if (logs.isEmpty()) {
-            throw IllegalStateException("Upgraded event not found: contractAddress=$contractAddress")
-          }
-          val blockNumber = logs.minBy { it.blockNumber }.blockNumber
-          deploymentBlockNumberCache.set(blockNumber)
-          blockNumber
-        }
-        .whenException {
-          log.error(
-            "Failed to get deployment block number for contract={} errorMessage={}",
-            contractAddress,
-            it.message,
-          )
-        }
     }
+    // The deployment block is the first block that emitted an Upgraded event. Scan forward in bounded
+    // chunks instead of a single getLogs(EARLIEST..LATEST), which rate-limited providers (e.g. Infura)
+    // reject for spans > 10_000 blocks. The result is cached, so this runs at most once.
+    return ethApiClient
+      .getAbsoluteBlockNumbers(BlockParameter.Tag.EARLIEST, BlockParameter.Tag.LATEST)
+      .thenCompose { (start, end) -> findFirstUpgradedBlock(fromBlock = start, toBlock = end) }
+      .thenApply { blockNumber ->
+        blockNumber ?: throw IllegalStateException("Upgraded event not found: contractAddress=$contractAddress")
+      }
+      .thenPeek { deploymentBlockNumberCache.set(it) }
+      .whenException {
+        log.error(
+          "Failed to get deployment block number for contract={} errorMessage={}",
+          contractAddress,
+          it.message,
+        )
+      }
+  }
+
+  private fun findFirstUpgradedBlock(fromBlock: ULong, toBlock: ULong): SafeFuture<ULong?> {
+    if (fromBlock > toBlock) {
+      return SafeFuture.completedFuture(null)
+    }
+    val chunkEnd = minOf(fromBlock + ethLogsSearchMaxBlockRange.toULong() - 1UL, toBlock)
+    return ethApiClient
+      .getLogs(
+        fromBlock = fromBlock.toBlockParameter(),
+        toBlock = chunkEnd.toBlockParameter(),
+        address = contractAddress,
+        topics = listOf(Upgraded.topic),
+      ).thenCompose { logs ->
+        // Scanning forward, so the first chunk with any Upgraded event holds the earliest one.
+        val earliestInChunk = logs.minByOrNull { it.blockNumber }
+        if (earliestInChunk != null) {
+          SafeFuture.completedFuture(earliestInChunk.blockNumber)
+        } else {
+          findFirstUpgradedBlock(fromBlock = chunkEnd + 1UL, toBlock = toBlock)
+        }
+      }
   }
 
   override fun invoke(): SafeFuture<ULong> {

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/ContractDeploymentBlockNumberProvider.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/ContractDeploymentBlockNumberProvider.kt
@@ -1,14 +1,13 @@
 package linea.contract
 
+import linea.EthLogsSearcher
 import linea.contract.events.Upgraded
 import linea.domain.BlockParameter
-import linea.domain.toBlockParameter
-import linea.ethapi.EthApiClient
-import linea.ethapi.extensions.getAbsoluteBlockNumbers
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
 
 typealias ContractDeploymentBlockNumberProvider = () -> SafeFuture<ULong>
 
@@ -21,7 +20,7 @@ class StaticContractDeploymentBlockNumberProvider(
 }
 
 class EventBasedContractDeploymentBlockNumberProvider(
-  private val ethApiClient: EthApiClient,
+  private val ethLogsSearcher: EthLogsSearcher,
   private val contractAddress: String,
   private val ethLogsSearchMaxBlockRange: UInt = 10_000u,
   private val log: Logger = LogManager.getLogger(EventBasedContractDeploymentBlockNumberProvider::class.java),
@@ -32,44 +31,33 @@ class EventBasedContractDeploymentBlockNumberProvider(
     if (deploymentBlockNumberCache.get() != 0UL) {
       return SafeFuture.completedFuture(deploymentBlockNumberCache.get())
     }
-    // The deployment block is the first block that emitted an Upgraded event. Scan forward in bounded
-    // chunks instead of a single getLogs(EARLIEST..LATEST), which rate-limited providers (e.g. Infura)
-    // reject for spans > 10_000 blocks. The result is cached, so this runs at most once.
-    return ethApiClient
-      .getAbsoluteBlockNumbers(BlockParameter.Tag.EARLIEST, BlockParameter.Tag.LATEST)
-      .thenCompose { (start, end) -> findFirstUpgradedBlock(fromBlock = start, toBlock = end) }
-      .thenApply { blockNumber ->
-        blockNumber ?: throw IllegalStateException("Upgraded event not found: contractAddress=$contractAddress")
+    // The deployment block is the first block that emitted an Upgraded event. Roll forward in bounded
+    // chunks (stopping at the first match) instead of a single getLogs(EARLIEST..LATEST), which
+    // rate-limited providers (e.g. Infura) reject for spans > 10_000 blocks. INFINITE timeout so the
+    // scan terminates on the first match or on chunk exhaustion, never on the clock. Cached, so this
+    // runs at most once.
+    return ethLogsSearcher
+      .getLogsRollingForward(
+        fromBlock = BlockParameter.Tag.EARLIEST,
+        toBlock = BlockParameter.Tag.LATEST,
+        address = contractAddress,
+        topics = listOf(Upgraded.topic),
+        chunkSize = ethLogsSearchMaxBlockRange,
+        searchTimeout = Duration.INFINITE,
+        stopAfterTargetLogsCount = 1u,
+      )
+      .thenApply { result ->
+        val blockNumber = result.logs.minByOrNull { it.blockNumber }?.blockNumber
+          ?: throw IllegalStateException("Upgraded event not found: contractAddress=$contractAddress")
+        deploymentBlockNumberCache.set(blockNumber)
+        blockNumber
       }
-      .thenPeek { deploymentBlockNumberCache.set(it) }
       .whenException {
         log.error(
           "Failed to get deployment block number for contract={} errorMessage={}",
           contractAddress,
           it.message,
         )
-      }
-  }
-
-  private fun findFirstUpgradedBlock(fromBlock: ULong, toBlock: ULong): SafeFuture<ULong?> {
-    if (fromBlock > toBlock) {
-      return SafeFuture.completedFuture(null)
-    }
-    val chunkEnd = minOf(fromBlock + ethLogsSearchMaxBlockRange.toULong() - 1UL, toBlock)
-    return ethApiClient
-      .getLogs(
-        fromBlock = fromBlock.toBlockParameter(),
-        toBlock = chunkEnd.toBlockParameter(),
-        address = contractAddress,
-        topics = listOf(Upgraded.topic),
-      ).thenCompose { logs ->
-        // Scanning forward, so the first chunk with any Upgraded event holds the earliest one.
-        val earliestInChunk = logs.minByOrNull { it.blockNumber }
-        if (earliestInChunk != null) {
-          SafeFuture.completedFuture(earliestInChunk.blockNumber)
-        } else {
-          findFirstUpgradedBlock(fromBlock = chunkEnd + 1UL, toBlock = toBlock)
-        }
       }
   }
 

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l2/Web3JL2MessageServiceSmartContractClient.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l2/Web3JL2MessageServiceSmartContractClient.kt
@@ -1,5 +1,6 @@
 package linea.contract.l2
 
+import linea.EthLogsSearcher
 import linea.contract.ContractDeploymentBlockNumberProvider
 import linea.contract.EventBasedContractDeploymentBlockNumberProvider
 import linea.contract.FAKE_READ_ONLY_CREDENTIALS
@@ -35,6 +36,7 @@ class Web3JL2MessageServiceSmartContractClient(
     fun create(
       web3jClient: Web3j,
       ethApiClient: EthApiClient,
+      ethLogsSearcher: EthLogsSearcher,
       contractAddress: String,
       gasLimit: ULong,
       maxFeePerGasCap: ULong,
@@ -64,7 +66,7 @@ class Web3JL2MessageServiceSmartContractClient(
       val deploymentBlockNumberProvider = smartContractDeploymentBlockNumber
         ?.let { StaticContractDeploymentBlockNumberProvider(it) }
         ?: EventBasedContractDeploymentBlockNumberProvider(
-          ethApiClient = ethApiClient,
+          ethLogsSearcher = ethLogsSearcher,
           contractAddress = contractAddress,
           log = LogManager.getLogger(Web3JL2MessageServiceSmartContractClient::class.java),
         )
@@ -80,6 +82,7 @@ class Web3JL2MessageServiceSmartContractClient(
     fun createReadOnly(
       web3jClient: Web3j,
       ethApiClient: EthApiClient,
+      ethLogsSearcher: EthLogsSearcher,
       contractAddress: String,
       smartContractErrors: SmartContractErrors,
       smartContractDeploymentBlockNumber: ULong?,
@@ -92,6 +95,7 @@ class Web3JL2MessageServiceSmartContractClient(
       return create(
         web3jClient = web3jClient,
         ethApiClient = ethApiClient,
+        ethLogsSearcher = ethLogsSearcher,
         contractAddress = contractAddress,
         gasLimit = 0UL,
         maxFeePerGasCap = 0UL,

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/EventBasedContractDeploymentBlockNumberProviderTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/EventBasedContractDeploymentBlockNumberProviderTest.kt
@@ -1,30 +1,40 @@
 package linea.contract
 
+import io.vertx.core.Vertx
 import linea.contract.events.Upgraded
 import linea.domain.EthLog
+import linea.ethapi.EthLogsSearcherImpl
 import linea.ethapi.FakeEthApiClient
 import linea.kotlin.decodeHex
 import linea.kotlin.toHexStringUInt256
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 
 class EventBasedContractDeploymentBlockNumberProviderTest {
   private val contractAddress = "0x" + "aa".repeat(20)
+  private lateinit var vertx: Vertx
   private lateinit var ethApiClient: FakeEthApiClient
   private lateinit var provider: EventBasedContractDeploymentBlockNumberProvider
 
   @BeforeEach
   fun setUp() {
+    vertx = Vertx.vertx()
     ethApiClient = FakeEthApiClient()
     provider = EventBasedContractDeploymentBlockNumberProvider(
-      ethApiClient = ethApiClient,
+      ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = ethApiClient),
       contractAddress = contractAddress,
       // small so the forward scan spans multiple bounded chunks instead of one query
       ethLogsSearchMaxBlockRange = 1_000u,
     )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    vertx.close()
   }
 
   @Test

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/EventBasedContractDeploymentBlockNumberProviderTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/EventBasedContractDeploymentBlockNumberProviderTest.kt
@@ -1,0 +1,65 @@
+package linea.contract
+
+import linea.contract.events.Upgraded
+import linea.domain.EthLog
+import linea.ethapi.FakeEthApiClient
+import linea.kotlin.decodeHex
+import linea.kotlin.toHexStringUInt256
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class EventBasedContractDeploymentBlockNumberProviderTest {
+  private val contractAddress = "0x" + "aa".repeat(20)
+  private lateinit var ethApiClient: FakeEthApiClient
+  private lateinit var provider: EventBasedContractDeploymentBlockNumberProvider
+
+  @BeforeEach
+  fun setUp() {
+    ethApiClient = FakeEthApiClient()
+    provider = EventBasedContractDeploymentBlockNumberProvider(
+      ethApiClient = ethApiClient,
+      contractAddress = contractAddress,
+      // small so the forward scan spans multiple bounded chunks instead of one query
+      ethLogsSearchMaxBlockRange = 1_000u,
+    )
+  }
+
+  @Test
+  fun `getDeploymentBlock returns the earliest Upgraded event block across bounded chunks`() {
+    // Two upgrades; the deployment block is the first one, several chunks past genesis.
+    ethApiClient.setLogs(
+      listOf(
+        upgradedLog(l1Block = 3_000UL),
+        upgradedLog(l1Block = 4_500UL),
+      ),
+    )
+    ethApiClient.setLatestBlockTag(5_000UL)
+
+    assertThat(provider.getDeploymentBlock().get()).isEqualTo(3_000UL)
+  }
+
+  @Test
+  fun `getDeploymentBlock throws when no Upgraded event exists`() {
+    ethApiClient.setLatestBlockTag(5_000UL)
+
+    assertThatThrownBy { provider.getDeploymentBlock().get() }
+      .hasRootCauseInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("Upgraded event not found")
+  }
+
+  private fun upgradedLog(l1Block: ULong): EthLog =
+    EthLog(
+      removed = false,
+      logIndex = 0UL,
+      transactionIndex = 0UL,
+      transactionHash = Random.nextBytes(32),
+      blockHash = l1Block.toHexStringUInt256().decodeHex(),
+      blockNumber = l1Block,
+      address = contractAddress.decodeHex(),
+      data = ByteArray(0),
+      topics = listOf(Upgraded.topic.decodeHex()),
+    )
+}


### PR DESCRIPTION
## Description

#3518. Stacked on #3519 (base branch `fix/bound-finalized-state-getlogs`) because the added test reuses the `testFixtures(interfaces)` test dependency introduced there.

`EventBasedContractDeploymentBlockNumberProvider.getDeploymentBlock` issued an unbounded `getLogs(EARLIEST..LATEST)` query to find the earliest `Upgraded` event (the contract deployment block). Rate-limited providers (e.g. Infura) reject `eth_getLogs` spanning more than 10,000 blocks.

## Change

This is a *first-occurrence* search (not an indexed monotonic lookup), so binary search does not apply. Replaced it with a bounded forward-chunk scan over `EthApiClient`: walk `[EARLIEST..LATEST]` in `<= ethLogsSearchMaxBlockRange` (default 10_000) windows and return the earliest `Upgraded` event from the first non-empty chunk. The result stays cached, so it runs at most once.

Kept `EthApiClient` (self-contained recursive scan, no `Vertx`) rather than switching to `EthLogsSearcher` — this avoids a DI cascade through the widely-constructed L2 message-service `create`/`createReadOnly` factories, and the new max-range is a defaulted constructor param, so **no call sites change**.

## Testing

New `EventBasedContractDeploymentBlockNumberProviderTest`: bounded multi-chunk search hit + not-found. Full `linea-contract-clients` suite passes; spotless clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized RPC lookup change with the same semantics and cache; no auth or call-site wiring changes.
> 
> **Overview**
> Fixes coordinator/L2 contract startup against rate-limited RPCs by **replacing one unbounded `getLogs(EARLIEST..LATEST)`** in `EventBasedContractDeploymentBlockNumberProvider` with a **forward scan in windows of at most `ethLogsSearchMaxBlockRange` blocks** (default **10_000**).
> 
> After resolving the chain span via `getAbsoluteBlockNumbers`, `findFirstUpgradedBlock` walks chunks until the first `Upgraded` log appears and returns the **earliest** block in that chunk; behavior and caching are unchanged, and existing constructors keep working via the defaulted range param.
> 
> Adds **`EventBasedContractDeploymentBlockNumberProviderTest`** for multi-chunk success and the not-found `IllegalStateException` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049a0281f908969aa83abdebea04e3bdc17ebba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->