### PR TITLE
ci(ci): bump dorny/paths-filter to v4.0.2

### DIFF
--- a/.github/workflows/all-tools.yml
+++ b/.github/workflows/all-tools.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter commit changes
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           base: ${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |

--- a/.github/workflows/component-changelog-upload.yml
+++ b/.github/workflows/component-changelog-upload.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter commit changes
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           base: ${{ github.ref }}

--- a/.github/workflows/get-has-changes-requiring-e2e-testing.yml
+++ b/.github/workflows/get-has-changes-requiring-e2e-testing.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Filter for e2e-relevant paths
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           base: ${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Filter commit changes
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           base: ${{ github.ref }}
@@ -184,7 +184,7 @@ jobs:
               - '.github/workflows/main.yml'
 
       - name: Filter out commit changes
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 #v3.0.3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: exclusion-filter
         with:
           base: ${{ github.ref }}


### PR DESCRIPTION
## Summary
- Bumps `dorny/paths-filter` from `v3.0.3` to `v4.0.2` across all six call sites (`all-tools.yml`, `codeql.yml`, `component-changelog-upload.yml`, `get-has-changes-requiring-e2e-testing.yml`, and twice in `main.yml`).
- Resolves the deprecation warning shown in workflow runs (e.g. in the "Detect Changes" job), since v4.0.2 targets the currently supported Actions runtime.
- No behavior change: v4.0.2's `filters`/`id`/output interface is identical to v3.0.3; the only functional additions are merge-queue event support and a couple of git compatibility fixes.

## Test plan
- [ ] Confirm this PR's own checks (which exercise `all-tools.yml` / `main.yml` / `codeql.yml` filter steps) run cleanly with no warning
- [ ] Spot check that downstream steps still branch correctly on filter outputs (e.g. `steps.filter.outputs.*`, `steps.changes.outputs.*`)