### PR TITLE
fix(ci): pin changelog workflow checkouts to triggering commit SHA

### DIFF
--- a/.github/workflows/component-changelog-commit.yml
+++ b/.github/workflows/component-changelog-commit.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           # Use the App token so subsequent `git push` is authenticated as the App.
           token: ${{ steps.app-token.outputs.token }}
-          ref: ${{ github.head_ref || github.ref_name }}
+          # Pin to the immutable triggering commit rather than a mutable ref name (CodeQL actions/untrusted-checkout).
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
           submodules: false

--- a/.github/workflows/component-changelog-upload.yml
+++ b/.github/workflows/component-changelog-upload.yml
@@ -114,7 +114,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # git-cliff needs full history + tags to compute changelog/version
-          ref: ${{ github.head_ref || github.ref_name }}
+          # Pin to the immutable triggering commit rather than a mutable ref name (CodeQL actions/untrusted-checkout).
+          ref: ${{ github.sha }}
           fetch-depth: 0
           fetch-tags: true
           submodules: false


### PR DESCRIPTION
## Summary
- Fixes 2 open CodeQL Medium alerts (`actions/untrusted-checkout`, #21268 and #21239) by replacing `ref: ${{ github.head_ref || github.ref_name }}` with `ref: ${{ github.sha }}` in the `actions/checkout` steps of `component-changelog-commit.yml` and `component-changelog-upload.yml`.
- `github.head_ref` names a fork-controlled, mutable branch; combined with these reusable workflows' write permissions and privileged App token, that's what CodeQL flags. Both call sites only run on push to `main` (where `head_ref` is always empty anyway), so this is behavior-preserving.

## Test plan
- [x] Both files parse as valid YAML
- [x] Traced downstream steps in both workflows confirm no dependency on being checked out onto a named branch (rebase/push use `$GITHUB_REF_NAME`; changelog prepend does its own separate branch-based `git pull`)
- [ ] Confirm `component-changelog-upload` / `component-changelog-commit` jobs succeed on the next push to `main`
- [ ] Confirm alerts #21268 and #21239 close on the next CodeQL scan