### PR TITLE
ci(ci): bump actions/setup-java and gradle/actions/setup-gradle for Node.js 24

### DIFF
--- a/.github/actions/setup-java-and-gradle/action.yml
+++ b/.github/actions/setup-java-and-gradle/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.distribution }}
@@ -22,7 +22,7 @@ runs:
       - name: Setup Gradle
         # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
         # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
 
 

--- a/.github/actions/setup-java-and-gradle/action.yml
+++ b/.github/actions/setup-java-and-gradle/action.yml
@@ -20,7 +20,7 @@ runs:
           distribution: ${{ inputs.distribution }}
 
       - name: Setup Gradle
-        # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+        # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
         # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-java` (v4.8.0 → v5.4.0) and `gradle/actions/setup-gradle` (v4.4.4 → v5.0.2) in the single composite action that provides them, `.github/actions/setup-java-and-gradle`. Every workflow needing Java/Gradle consumes this wrapper, so no other files change.
- Resolves the "Node.js 20 is deprecated" warning shown on jobs like `code-analysis / Analyze (java-kotlin)`, since both target versions declare the currently supported Actions runtime.
- No behavior change: for `actions/setup-java`, the only breaking change across the entire v5 line is the runtime bump itself — inputs/outputs are untouched. For `setup-gradle`, v5.0.2 is intentionally used instead of the latest v6.x, since v6 extracts Gradle's caching into a separately-licensed component with different terms; v5.0.2 avoids that while still fixing the warning.

## Test plan
- [ ] Confirm this PR's own checks (which exercise the wrapper via `code-analysis`, `coordinator-testing`, `maru-testing`, etc.) run cleanly with no Node 20 warning
- [ ] Spot check that Java/Gradle setup still succeeds across the jobs that use the wrapper