### PR TITLE
fix(misc): pin quickstart coordinator past Infura eth_getLogs limits and improve boot logs

### DIFF
--- a/docs/getting-started/lineth-stack/README.md
+++ b/docs/getting-started/lineth-stack/README.md
@@ -357,12 +357,14 @@ Latest verified dev-proof fresh boot (2026-05-31, clean local state):
 | Rollup finalized L2 block | 8 |
 
 Largest remaining bottleneck in simple terms: after `./scripts/reset.sh`, the
-Docker-side Node dependency cache is gone. The next boot must download and
-rebuild the npm packages used by the TypeScript account/deploy tooling before
-it can generate artifacts or deploy contracts. That is the cold Docker-side
-`pnpm install` cost. A prebuilt tooling image would ship those dependencies
-already installed; a better cache strategy would avoid deleting or rebuilding
-them unnecessarily.
+Docker-side `node_modules` volumes are gone and the next boot must reinstall
+the npm packages used by the TypeScript account/deploy tooling before it can
+generate artifacts or deploy contracts. The pnpm download cache
+(`lineth-stack-contracts-pnpm-store`) survives resets, so that reinstall
+resolves package tarballs locally (`pnpm install --prefer-offline`) instead of
+re-downloading them from the npm registry; use `./scripts/reset.sh
+--purge-deps` if you intentionally want a cold cache. A prebuilt tooling image
+would remove even the reinstall cost.
 
 Runtime funding is already batched in TypeScript. The previous serial funding
 path measured about 77s; the batched path measured about 22s in the verified

--- a/docs/getting-started/lineth-stack/docker-compose.yml
+++ b/docs/getting-started/lineth-stack/docker-compose.yml
@@ -50,6 +50,13 @@ volumes:
   blockscout-l2-pg-data:
   lineth-contracts-pnpm-store:
     name: "lineth-stack-contracts-pnpm-store"
+    # External so `docker compose down -v` (used by reset.sh) never deletes the
+    # content-addressed pnpm download cache: fresh boots reinstall node_modules
+    # from the lockfile but resolve tarballs locally (`pnpm install
+    # --prefer-offline`), instead of re-downloading ~1,500 packages from the
+    # npm registry on every reset. Created idempotently by
+    # scripts/bootstrap-artifacts.sh; purge with ./scripts/reset.sh --purge-deps.
+    external: true
   lineth-contracts-root-node-modules:
     name: "lineth-stack-contracts-root-node-modules"
   lineth-contracts-package-node-modules:

--- a/docs/getting-started/lineth-stack/scripts/bootstrap-artifacts.sh
+++ b/docs/getting-started/lineth-stack/scripts/bootstrap-artifacts.sh
@@ -163,6 +163,9 @@ lineth_ok "generated files ready"
 
 lineth_section "Generate runtime wallets and keystores"
 lineth_info "generating/reusing runtime wallets, encrypted keystores, and Web3Signer key files"
+# The pnpm download cache is an external volume (see docker-compose.yml) so
+# resets keep it; compose requires external volumes to exist before use.
+docker volume create lineth-stack-contracts-pnpm-store >/dev/null
 # shellcheck disable=SC2086
 COMPOSE_PROGRESS=plain $COMPOSE run --rm --no-deps account-setup
 

--- a/docs/getting-started/lineth-stack/scripts/lib/logging.sh
+++ b/docs/getting-started/lineth-stack/scripts/lib/logging.sh
@@ -105,7 +105,9 @@ lineth_clean_prefixes() {
 }
 
 lineth_child_output() {
-  lineth_clean_prefixes | lineth_indent
+  # Single sed (strip [context] prefixes, then indent) so live-streamed child
+  # output stays line-buffered; chaining seds adds a pipe with block buffering.
+  sed -E 's/^\[[^]]+\][[:space:]]*(ERROR:[[:space:]]*)?//; s/^/  /'
 }
 
 lineth_run_stream() {

--- a/docs/getting-started/lineth-stack/scripts/phases/01-generate-accounts.sh
+++ b/docs/getting-started/lineth-stack/scripts/phases/01-generate-accounts.sh
@@ -25,11 +25,20 @@ corepack prepare pnpm@11.9.0 --activate >/dev/null 2>&1 || true
 if [ ! -x "$WORKSPACE_DIR/node_modules/.bin/ts-node" ] \
   || [ ! -d "$WORKSPACE_DIR/node_modules/.pnpm" ] \
   || [ ! -e "$CONTRACTS_DIR/node_modules/ethers" ]; then
-  log "Installing minimal workspace dependencies for TypeScript account setup"
-  (
+  log "Installing minimal workspace dependencies for TypeScript account setup (seconds from a warm cache; ~2 minutes on a cold one)"
+  # Full pnpm output goes to a container-local log; it is only interesting on
+  # failure, where the tail is dumped below.
+  install_log="/tmp/pnpm-install.log"
+  if (
     cd "$WORKSPACE_DIR"
     HUSKY=0 CI=true pnpm install --filter linea-monorepo --filter contracts... --no-frozen-lockfile --prefer-offline
-  )
+  ) > "$install_log" 2>&1; then
+    log "Workspace dependencies ready"
+  else
+    printf '[account-setup] ----- last 40 lines of pnpm install output -----\n' >&2
+    tail -40 "$install_log" >&2
+    die "pnpm install failed inside account-setup container"
+  fi
 fi
 
 cd "$CONTRACTS_DIR"

--- a/docs/getting-started/lineth-stack/scripts/reset.sh
+++ b/docs/getting-started/lineth-stack/scripts/reset.sh
@@ -13,13 +13,16 @@ LINETH_LOG_CONTEXT="reset"
 COMPOSE="docker compose --env-file versions.env --env-file .env --profile stack-partial-prover"
 RESET_LOCAL_L1=false
 FORGET_DEPLOYER=false
+PURGE_DEPS=false
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/reset.sh [--local-l1] [--forget-deployer]
+Usage: ./scripts/reset.sh [--local-l1] [--forget-deployer] [--purge-deps]
 
   --local-l1          also remove the quickstart local L1 data volume
   --forget-deployer  remove the generated Sepolia deployer keystore
+  --purge-deps        also remove the preserved pnpm download-cache volume, so
+                      the next boot re-downloads all Node dependencies
 EOF
 }
 
@@ -30,6 +33,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     --forget-deployer)
       FORGET_DEPLOYER=true
+      ;;
+    --purge-deps)
+      PURGE_DEPS=true
       ;;
     -h|--help)
       usage
@@ -63,6 +69,14 @@ docker volume rm \
   lineth-stack-postman-runtime-config >/dev/null 2>&1 || true
 if [ "$RESET_LOCAL_L1" = "true" ]; then
   docker volume rm lineth-stack-local-l1-data >/dev/null 2>&1 || true
+fi
+# lineth-stack-contracts-pnpm-store is external in docker-compose.yml, so the
+# `down -v` above leaves it alone: fresh boots reinstall node_modules from the
+# lockfile but resolve package tarballs from this local cache instead of the
+# npm registry. Only --purge-deps removes it.
+if [ "$PURGE_DEPS" = "true" ]; then
+  docker volume rm lineth-stack-contracts-pnpm-store >/dev/null 2>&1 || true
+  lineth_info "removed pnpm download-cache volume; next boot re-downloads Node dependencies"
 fi
 if docker network inspect lineth-stack_linea >/dev/null 2>&1; then
   lineth_warn "lineth-stack_linea network still in use by an external container"

--- a/docs/getting-started/lineth-stack/scripts/start.sh
+++ b/docs/getting-started/lineth-stack/scripts/start.sh
@@ -13,6 +13,7 @@ LINETH_LOG_CONTEXT="start"
 
 TAIL=false
 PULL=true
+FORCE_PULL=false
 LINETH_VERBOSE="${LINETH_VERBOSE:-false}"
 WIZARD=false
 WIZARD_THEN_START=false
@@ -34,6 +35,7 @@ Usage: ./scripts/start.sh [--tail] [--no-pull] [--verbose]
 
   --tail              start the stack, then show guided deployment/finality progress
   --no-pull           skip docker compose pull
+  --pull              force docker compose pull even when all pinned images are local
   --verbose           show raw preparation/pull details in the default terminal output
   --wizard, --init    configure .env with the guided setup wizard
   --then-start        after --wizard succeeds, start with ./scripts/start.sh --tail
@@ -89,6 +91,9 @@ while [ "$#" -gt 0 ]; do
       ;;
     --no-pull)
       PULL=false
+      ;;
+    --pull)
+      FORCE_PULL=true
       ;;
     --verbose)
       LINETH_VERBOSE=true
@@ -190,15 +195,18 @@ if [ "$WIZARD" = "true" ]; then
     exit 0
   fi
 
-  if [ "$PULL" = "false" ] && [ "$LINETH_VERBOSE" = "true" ]; then
-    exec "$SCRIPT_DIR/start.sh" --tail --no-pull --verbose
-  elif [ "$PULL" = "false" ]; then
-    exec "$SCRIPT_DIR/start.sh" --tail --no-pull
-  elif [ "$LINETH_VERBOSE" = "true" ]; then
-    exec "$SCRIPT_DIR/start.sh" --tail --verbose
-  else
-    exec "$SCRIPT_DIR/start.sh" --tail
+  wizard_start_args=""
+  if [ "$PULL" = "false" ]; then
+    wizard_start_args="$wizard_start_args --no-pull"
   fi
+  if [ "$FORCE_PULL" = "true" ]; then
+    wizard_start_args="$wizard_start_args --pull"
+  fi
+  if [ "$LINETH_VERBOSE" = "true" ]; then
+    wizard_start_args="$wizard_start_args --verbose"
+  fi
+  # shellcheck disable=SC2086
+  exec "$SCRIPT_DIR/start.sh" --tail $wizard_start_args
 fi
 
 COMPOSE="docker compose --env-file versions.env --env-file .env --profile stack-partial-prover"
@@ -399,45 +407,82 @@ run_ts_preflight
 
 lineth_section "Generate accounts and configs"
 bootstrap_log="/tmp/lineth-bootstrap.$$.$(date '+%Y%m%d%H%M%S').log"
-if [ "${LINETH_VERBOSE:-false}" = "true" ]; then
-  lineth_run_stream env LINETH_EMBEDDED=true LINETH_SKIP_BANNER=true "$SCRIPT_DIR/bootstrap-artifacts.sh"
-else
-  if env LINETH_EMBEDDED=true LINETH_SKIP_BANNER=true "$SCRIPT_DIR/bootstrap-artifacts.sh" > "$bootstrap_log" 2>&1; then
-    lineth_kv "accounts" "runtime wallets and encrypted keystores ready"
-    lineth_kv "web3signer" "runtime key files ready"
-    lineth_kv "configs" "Postman Web3Signer config ready"
-    lineth_info "raw generation output: $bootstrap_log"
-  else
-    lineth_error "account/config generation failed; raw output: $bootstrap_log"
-    tail -80 "$bootstrap_log" | lineth_indent
-    exit 1
-  fi
+# Stream bootstrap progress live instead of buffering it into a temp file; the
+# noisy dependency install is already reduced to single progress lines inside
+# phases/01-generate-accounts.sh. A status file carries the child exit code
+# across the pipe because POSIX sh has no pipefail.
+bootstrap_status_file="$bootstrap_log.status"
+{
+  env LINETH_EMBEDDED=true LINETH_SKIP_BANNER=true "$SCRIPT_DIR/bootstrap-artifacts.sh" 2>&1 \
+    || printf '%s\n' "$?" > "$bootstrap_status_file"
+} | tee "$bootstrap_log" | lineth_child_output
+if [ -s "$bootstrap_status_file" ]; then
+  rm -f "$bootstrap_status_file"
+  lineth_error "account/config generation failed; raw output: $bootstrap_log"
+  exit 1
 fi
+rm -f "$bootstrap_status_file"
+lineth_info "raw generation output: $bootstrap_log"
+
+# Print image references required by the compose profile that are not in the
+# local Docker image store. Prints a sentinel line when the list itself cannot
+# be resolved, so callers treat "unknown" as "missing".
+missing_required_images() {
+  required_images="$($COMPOSE config --images 2>/dev/null | sort -u)"
+  if [ -z "$required_images" ]; then
+    printf '%s' "(could not list required images via docker compose config --images)"
+    return
+  fi
+  missing=""
+  for required_image in $required_images; do
+    docker image inspect "$required_image" >/dev/null 2>&1 \
+      || missing="$missing $required_image"
+  done
+  printf '%s' "$missing"
+}
 
 if [ "$PULL" = "true" ]; then
   lineth_section "Pull Docker images"
-  lineth_info "checking/pulling Docker images; this can take a while on a slow connection"
-  pull_log="/tmp/lineth-docker-pull.$$.$(date '+%Y%m%d%H%M%S').log"
-  # shellcheck disable=SC2086
-  if [ "${LINETH_VERBOSE:-false}" = "true" ]; then
-    set +e
-    COMPOSE_PROGRESS=plain $COMPOSE pull
-    pull_status=$?
-    set -e
-  elif COMPOSE_PROGRESS=plain $COMPOSE pull > "$pull_log" 2>&1; then
-    pull_status=0
+  missing_images="$(missing_required_images)"
+  if [ -z "$missing_images" ] && [ "${FORCE_PULL:-false}" != "true" ]; then
+    # All images in versions.env are pinned, so a registry round-trip adds
+    # nothing when every required image is already local — and it makes boot
+    # time hostage to registry latency/outages.
+    lineth_ok "all pinned images already local; skipping registry pull"
+    lineth_info "force a registry refresh with ./scripts/start.sh --pull"
   else
-    pull_status=$?
-  fi
-  if [ "$pull_status" -ne 0 ]; then
-    lineth_error "Docker image pull failed. This is usually a Docker Hub/network issue."
-    [ "${LINETH_VERBOSE:-false}" = "true" ] || tail -60 "$pull_log" | lineth_indent
-    lineth_info "retry the same command, or use ./scripts/start.sh --tail --no-pull if the images are already local"
-    exit 1
-  fi
-  if [ "${LINETH_VERBOSE:-false}" != "true" ]; then
-    lineth_ok "Docker images are available"
-    lineth_info "raw Docker pull output: $pull_log"
+    lineth_info "checking/pulling Docker images; this can take a while on a slow connection"
+    pull_log="/tmp/lineth-docker-pull.$$.$(date '+%Y%m%d%H%M%S').log"
+    # shellcheck disable=SC2086
+    if [ "${LINETH_VERBOSE:-false}" = "true" ]; then
+      set +e
+      COMPOSE_PROGRESS=plain $COMPOSE pull
+      pull_status=$?
+      set -e
+    elif COMPOSE_PROGRESS=plain $COMPOSE pull > "$pull_log" 2>&1; then
+      pull_status=0
+    else
+      pull_status=$?
+    fi
+    if [ "$pull_status" -ne 0 ]; then
+      # Registry hiccups (e.g. transient Docker Hub 5xx on the auth token
+      # endpoint) must not abort a boot that can run entirely from local
+      # images. Only fail hard when a required image is actually missing.
+      missing_images="$(missing_required_images)"
+      if [ -z "$missing_images" ]; then
+        lineth_warn "image pull/refresh failed (likely a transient registry issue), but all required images are already local; continuing"
+        lineth_info "raw Docker pull output: $pull_log"
+      else
+        lineth_error "Docker image pull failed. This is usually a Docker Hub/network issue."
+        [ "${LINETH_VERBOSE:-false}" = "true" ] || tail -60 "$pull_log" | lineth_indent
+        lineth_info "missing images:$missing_images"
+        lineth_info "retry the same command, or use ./scripts/start.sh --tail --no-pull if the images are already local"
+        exit 1
+      fi
+    elif [ "${LINETH_VERBOSE:-false}" != "true" ]; then
+      lineth_ok "Docker images are available"
+      lineth_info "raw Docker pull output: $pull_log"
+    fi
   fi
 fi
 

--- a/docs/getting-started/lineth-stack/scripts/watch.sh
+++ b/docs/getting-started/lineth-stack/scripts/watch.sh
@@ -112,10 +112,14 @@ latest_blob_tx() {
     | tail -1
 }
 
+coordinator_started() {
+  docker logs --since "$WATCH_SINCE" coordinator 2>/dev/null | grep -F -q 'Started :)'
+}
+
 account_setup_progress_lines() {
   if docker inspect account-setup >/dev/null 2>&1; then
     docker logs --tail 120 account-setup 2>&1 \
-      | grep -E '\[account-setup\] (Preparing Node/ethers account setup runtime|Installing minimal workspace dependencies for TypeScript account setup|Using |Reused encrypted keystore|Wrote encrypted keystore|L1 deployer:|L1 deployer balance:|L1 deployer required minimum:|L1 safe listener start block|Wrote /accounts/addresses-precomputed.json|Pre-computed|Done)' \
+      | grep -E '\[account-setup\] (Preparing Node/ethers account setup runtime|Installing minimal workspace dependencies for TypeScript account setup|Workspace dependencies ready|Using |Reused encrypted keystore|Wrote encrypted keystore|L1 deployer:|L1 deployer balance:|L1 deployer required minimum:|L1 safe listener start block|Wrote /accounts/addresses-precomputed.json|Pre-computed|Done)' \
       | awk 'length($0) > 220 { $0 = substr($0, 1, 220) "..." } { print }' \
       | tail -8
   fi
@@ -749,6 +753,20 @@ progress_phase() {
     return
   fi
 
+  if [ -n "$(latest_finalization_tx || true)" ]; then
+    printf 'Wait for finality: finalize tx submitted; waiting for coordinator to confirm on L1 (first confirmation can lag a couple of minutes)'
+    return
+  fi
+
+  case "$coordinator_state" in
+    running\ *)
+      if ! coordinator_started; then
+        printf 'Wait for finality: coordinator is starting: one-time scan of L1 event history before proving begins (a few minutes on Sepolia, fast on local L1)'
+        return
+      fi
+      ;;
+  esac
+
   printf 'Wait for finality: waiting for first finalization'
 }
 
@@ -772,6 +790,29 @@ failure_tail() {
     | lineth_indent || true
 }
 
+container_finished_at() {
+  docker inspect -f '{{.State.FinishedAt}}' "$1" 2>/dev/null || true
+}
+
+# Containers stopped by a previous session (e.g. `docker compose stop` sends
+# SIGTERM, leaving exit code 143) keep that stale exited state until
+# `docker compose up -d` reaches them. Snapshot those pre-existing exits at
+# watch startup so check_terminal_failure only fails on exits that happen
+# during this run (a restarted container that dies gets a new FinishedAt).
+WATCH_STALE_EXITS=""
+snapshot_stale_exits() {
+  WATCH_STALE_EXITS=""
+  for name in l2-genesis-init config-render deploy-contracts runtime-config-finalize coordinator prover postman; do
+    state="$(container_state "$name")"
+    case "$state" in
+      exited\ 0|running\ *|created\ *|missing) ;;
+      exited\ *)
+        WATCH_STALE_EXITS="$WATCH_STALE_EXITS|$name=$state@$(container_finished_at "$name")|"
+        ;;
+    esac
+  done
+}
+
 check_terminal_failure() {
   for name in l2-genesis-init config-render deploy-contracts runtime-config-finalize coordinator prover postman; do
     state="$(container_state "$name")"
@@ -779,6 +820,13 @@ check_terminal_failure() {
       exited\ 0|running\ *|created\ *|missing)
         ;;
       exited\ *)
+        stale_key="|$name=$state@$(container_finished_at "$name")|"
+        case "$WATCH_STALE_EXITS" in
+          *"$stale_key"*)
+            # Stale exit recorded before this run started; not a new failure.
+            continue
+            ;;
+        esac
         lineth_error "$name $state"
         failure_tail "$name"
         return 1
@@ -802,8 +850,7 @@ progress_stream() {
   existing_addresses_notice_printed=""
   deployed_links_printed=""
   last_pipeline_event=""
-  last_blob=""
-  last_finalization=""
+  pipeline_seen_count=0
   last_finalized=""
   last_retry_noise=""
   first_finalized_seen=""
@@ -849,37 +896,45 @@ progress_stream() {
 
     deploy_phase="$(last_deploy_phase || true)"
     if [ -n "$deploy_phase" ] && [ "$deploy_phase" != "$last_seen_deploy_phase" ]; then
-      lineth_kv "Deploy step" "$deploy_phase"
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        lineth_kv "Deploy step" "$deploy_phase"
+        changed=1
+      fi
       last_seen_deploy_phase="$deploy_phase"
-      changed=1
     fi
 
     deploy_contract="$(last_deploy_contract || true)"
     if [ "${LINETH_VERBOSE:-false}" = "true" ] \
       && [ -n "$deploy_contract" ] \
       && [ "$deploy_contract" != "$last_deploy_contract" ]; then
-      lineth_kv "Deployed contract" "$deploy_contract"
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        lineth_kv "Deployed contract" "$deploy_contract"
+        changed=1
+      fi
       last_deploy_contract="$deploy_contract"
-      changed=1
     fi
 
     deploy_pending="$(last_deploy_pending || true)"
     if [ "${LINETH_VERBOSE:-false}" = "true" ] \
       && [ -n "$deploy_pending" ] \
       && [ "$deploy_pending" != "$last_deploy_pending" ]; then
-      lineth_kv "Pending deploy tx" "$deploy_pending"
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        lineth_kv "Pending deploy tx" "$deploy_pending"
+        changed=1
+      fi
       last_deploy_pending="$deploy_pending"
-      changed=1
     fi
 
     deploy_reuse_lines="$(deploy_reuse_lines || true)"
     if [ -n "$deploy_reuse_lines" ]; then
-      printf '%s\n' "$deploy_reuse_lines" | while IFS= read -r deploy_reuse; do
-        [ -n "$deploy_reuse" ] || continue
-        if ! printf '%s\n' "$printed_deploy_reuse_lines" | grep -Fxq "$deploy_reuse"; then
-          lineth_kv "Deploy reuse" "$deploy_reuse"
-        fi
-      done
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        printf '%s\n' "$deploy_reuse_lines" | while IFS= read -r deploy_reuse; do
+          [ -n "$deploy_reuse" ] || continue
+          if ! printf '%s\n' "$printed_deploy_reuse_lines" | grep -Fxq "$deploy_reuse"; then
+            lineth_kv "Deploy reuse" "$deploy_reuse"
+          fi
+        done
+      fi
       new_reuse_lines="$(printf '%s\n' "$deploy_reuse_lines" | while IFS= read -r deploy_reuse; do
         [ -n "$deploy_reuse" ] || continue
         if ! printf '%s\n' "$printed_deploy_reuse_lines" | grep -Fxq "$deploy_reuse"; then
@@ -889,24 +944,28 @@ progress_stream() {
       if [ -n "$new_reuse_lines" ]; then
         printed_deploy_reuse_lines="${printed_deploy_reuse_lines}${printed_deploy_reuse_lines:+
 }$new_reuse_lines"
-        changed=1
+        if [ "$last_progress_section" != "Wait for finality" ]; then
+          changed=1
+        fi
       fi
     fi
 
     deploy_detail="$(last_deploy_detail || true)"
     if [ -n "$deploy_detail" ] && [ "$deploy_detail" != "$last_deploy_detail" ]; then
-      case "$deploy_detail" in
-        wrote\ /deployments/addresses.json*|wrote\ /deployments/deploy-runtime.env*|Done*)
-          lineth_kv "Deploy detail" "$deploy_detail"
-          changed=1
-          ;;
-        *)
-          if [ "${LINETH_VERBOSE:-false}" = "true" ]; then
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        case "$deploy_detail" in
+          wrote\ /deployments/addresses.json*|wrote\ /deployments/deploy-runtime.env*|Done*)
             lineth_kv "Deploy detail" "$deploy_detail"
             changed=1
-          fi
-          ;;
-      esac
+            ;;
+          *)
+            if [ "${LINETH_VERBOSE:-false}" = "true" ]; then
+              lineth_kv "Deploy detail" "$deploy_detail"
+              changed=1
+            fi
+            ;;
+        esac
+      fi
       last_deploy_detail="$deploy_detail"
     fi
 
@@ -914,18 +973,22 @@ progress_stream() {
     if [ "${LINETH_VERBOSE:-false}" = "true" ] \
       && [ -n "$deploy_activity" ] \
       && [ "$deploy_activity" != "$last_deploy_activity" ]; then
-      lineth_kv "Deploy activity" "$deploy_activity"
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        lineth_kv "Deploy activity" "$deploy_activity"
+        changed=1
+      fi
       last_deploy_activity="$deploy_activity"
-      changed=1
     fi
 
     deploy_progress="$(last_deploy_progress || true)"
     if [ "${LINETH_VERBOSE:-false}" = "true" ] \
       && [ -n "$deploy_progress" ] \
       && [ "$deploy_progress" != "$last_deploy_progress" ]; then
-      lineth_kv "Deploy progress" "$deploy_progress"
+      if [ "$last_progress_section" != "Wait for finality" ]; then
+        lineth_kv "Deploy progress" "$deploy_progress"
+        changed=1
+      fi
       last_deploy_progress="$deploy_progress"
-      changed=1
     fi
 
     if [ -z "$deployed_links_printed" ] \
@@ -952,25 +1015,23 @@ progress_stream() {
         changed=1
       fi
 
-      pipeline_event="$(pipeline_events | tail -1 || true)"
-      if [ -n "$pipeline_event" ] && [ "$pipeline_event" != "$last_pipeline_event" ]; then
-        lineth_kv "Finality pipeline" "$pipeline_event"
-        last_pipeline_event="$pipeline_event"
-        changed=1
-      fi
-
-      blob="$(latest_blob_tx || true)"
-      if [ -n "$blob" ] && [ "$blob" != "$last_blob" ]; then
-        lineth_kv "Blob tx" "$blob"
-        last_blob="$blob"
-        changed=1
-      fi
-
-      finalization="$(latest_finalization_tx || true)"
-      if [ -n "$finalization" ] && [ "$finalization" != "$last_finalization" ]; then
-        lineth_kv "Finalization tx" "$finalization"
-        last_finalization="$finalization"
-        changed=1
+      pipeline_all="$(pipeline_events || true)"
+      if [ -n "$pipeline_all" ]; then
+        pipeline_count="$(printf '%s\n' "$pipeline_all" | wc -l | tr -d '[:space:]')"
+        if [ "$pipeline_count" -lt "$pipeline_seen_count" ]; then
+          # Log window reset (e.g. coordinator container recreated); replay from the start.
+          pipeline_seen_count=0
+        fi
+        if [ "$pipeline_count" -gt "$pipeline_seen_count" ]; then
+          printf '%s\n' "$pipeline_all" \
+            | tail -n "+$((pipeline_seen_count + 1))" \
+            | while IFS= read -r pipeline_event; do
+              [ -n "$pipeline_event" ] && lineth_kv "Finality pipeline" "$pipeline_event"
+            done
+          last_pipeline_event="$(printf '%s\n' "$pipeline_all" | tail -1)"
+          pipeline_seen_count="$pipeline_count"
+          changed=1
+        fi
       fi
 
       finalized="$(latest_finalized_block || true)"
@@ -1075,4 +1136,5 @@ if [ "$WATCH_MODE" = "once" ]; then
   exit 0
 fi
 
+snapshot_stale_exits
 progress_stream

--- a/docs/getting-started/lineth-stack/versions.env
+++ b/docs/getting-started/lineth-stack/versions.env
@@ -19,7 +19,8 @@ LINEA_BESU_PACKAGE_TAG=beta-v6-20260410083640-74d51b7
 # (lineth-monorepo #3519/#3520) required since Infura's 10k-block Sepolia limit.
 LINEA_COORDINATOR_TAG=0.3.0-20260707-2fc1581
 LINEA_PROVER_TAG=4ddbeba
-LINEA_POSTMAN_TAG=4ddbeba
+# Postman v1.0.1 release tag, per review feedback on #3533.
+LINEA_POSTMAN_TAG=1.0.1-20260629-7358b2f
 LINEA_SHOMEI_TAG=3.2.3
 
 # Maru (L2 consensus).

--- a/docs/getting-started/lineth-stack/versions.env
+++ b/docs/getting-started/lineth-stack/versions.env
@@ -15,7 +15,9 @@
 LINEA_BESU_PACKAGE_TAG=beta-v6-20260410083640-74d51b7
 
 # ----- L2 core ------------------------------------------------------------------
-LINEA_COORDINATOR_TAG=4ddbeba
+# Coordinator pinned ahead of prover/postman: includes the eth_getLogs range fixes
+# (lineth-monorepo #3519/#3520) required since Infura's 10k-block Sepolia limit.
+LINEA_COORDINATOR_TAG=0.3.0-20260707-2fc1581
 LINEA_PROVER_TAG=4ddbeba
 LINEA_POSTMAN_TAG=4ddbeba
 LINEA_SHOMEI_TAG=3.2.3


### PR DESCRIPTION
## Summary

Infura now rejects `eth_getLogs` spanning more than 10,000 blocks on Sepolia (rolled out 2026-07-06). The quickstart's pinned coordinator hangs at startup because of it. This PR fixes that and cleans up the boot logs that made it hard to diagnose.

### Coordinator / Infura eth_getLogs fallout
- Pin the coordinator to `0.3.0-20260707-2fc1581`, the first image with the bounded `eth_getLogs` fixes (#3519, #3520). Older pins hang forever on Sepolia.
- The fixed coordinator scans L1 history once per fresh deployment (~3 min at startup, ~2 min before it confirms the first finalization). The finality watch now explains both windows instead of showing nothing:
  - "coordinator is starting: one-time scan of L1 event history"
  - "finalize tx submitted; waiting for coordinator to confirm on L1"
- These messages are state-driven, not time-driven: when the coordinator gains a deployment-block search floor (requested, in progress), they simply stop appearing.

### Log improvements
- Step 4 (account setup) streams progress live and hides the pnpm install noise; full log is kept and shown on failure.
- Every finality pipeline event prints exactly once: duplicates removed, and fast bursts between polls are no longer skipped.
- Deploy rows no longer leak into the "Wait for finality" section.
- Containers left from a previously stopped run no longer trigger false "exited" errors on restart.
- `docker compose pull` failures no longer abort the boot when all pinned images are already local; `--pull` forces a refresh.
- The pnpm download cache survives `reset.sh`, so fresh boots reinstall dependencies in seconds; `./scripts/reset.sh --purge-deps` clears it on purpose.

## Test plan
- [x] Multiple fresh Sepolia boots (wizard option 3) reaching first L1 finalization, ~11 min end to end with the current coordinator
- [x] Stop + restart cycle (wizard option 2) resumes cleanly
- [x] `check-quickstart-static.sh` (shellcheck + static checks), `bash -n`/`sh -n`, `docker compose config` all pass

Made with [Cursor](https://cursor.com)