### PR TITLE
feat(coordinator): Add inital block number config for finalized state search

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
@@ -182,6 +182,7 @@ class L1DependentApp(
           vertx = vertx,
         ),
       ),
+      finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber,
     )
   }
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1DependentApp.kt
@@ -20,6 +20,7 @@ import linea.coordinator.config.v2.isDisabled
 import linea.coordinator.config.v2.isEnabled
 import linea.domain.BlobSubmittedEvent
 import linea.domain.BlockNumberAndHash
+import linea.domain.BlockParameter
 import linea.domain.FinalizationSubmittedEvent
 import linea.domain.RetryConfig
 import linea.ethapi.EthApiClient
@@ -182,7 +183,8 @@ class L1DependentApp(
           vertx = vertx,
         ),
       ),
-      finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber,
+      finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
+        ?: BlockParameter.Tag.EARLIEST,
     )
   }
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
@@ -158,6 +158,7 @@ class ConflationApp(
             vertx = vertx,
           ),
         ),
+        finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber,
       )
       ForcedTransactionsApp.create(
         config = config,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationApp.kt
@@ -43,6 +43,7 @@ import linea.coordinator.clients.prover.ProverClientFactory
 import linea.coordinator.config.toJsonRpcRetry
 import linea.coordinator.config.v2.CoordinatorConfig
 import linea.domain.BlobRecord
+import linea.domain.BlockParameter
 import linea.domain.BlocksConflation
 import linea.encoding.BlockRLPEncoder
 import linea.ethapi.EthApiClient
@@ -158,7 +159,8 @@ class ConflationApp(
             vertx = vertx,
           ),
         ),
-        finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber,
+        finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
+          ?: BlockParameter.Tag.EARLIEST,
       )
       ForcedTransactionsApp.create(
         config = config,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ProtocolConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ProtocolConfig.kt
@@ -39,6 +39,7 @@ data class ProtocolConfig(
   data class Layer1Config(
     val contractAddress: String,
     val blockTime: Duration,
+    val contractDeploymentBlockNumber: BlockParameter.BlockNumber?,
   )
 
   data class Layer2Config(

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ProtocolToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ProtocolToml.kt
@@ -36,6 +36,7 @@ data class ProtocolToml(
   data class Layer1Config(
     val contractAddress: String,
     val blockTime: Duration = 12.seconds,
+    val contractDeploymentBlockNumber: ULong?,
   )
 
   data class Layer2Config(
@@ -55,6 +56,8 @@ data class ProtocolToml(
       ProtocolConfig.Layer1Config(
         contractAddress = this.l1.contractAddress,
         blockTime = this.l1.blockTime,
+        contractDeploymentBlockNumber = this.l1.contractDeploymentBlockNumber
+          ?.let { BlockParameter.BlockNumber(it) },
       ),
       l2 =
       ProtocolConfig.Layer2Config(

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ProtocolParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ProtocolParsingTest.kt
@@ -33,6 +33,7 @@ class ProtocolParsingTest {
         ProtocolToml.Layer1Config(
           contractAddress = "0x0000000000000000000000000000000000000001",
           blockTime = 2.seconds,
+          contractDeploymentBlockNumber = null,
         ),
         l2 =
         ProtocolToml.Layer2Config(
@@ -63,6 +64,7 @@ class ProtocolParsingTest {
         ProtocolToml.Layer1Config(
           contractAddress = "0x0000000000000000000000000000000000000001",
           blockTime = 12.seconds,
+          contractDeploymentBlockNumber = null,
         ),
         l2 =
         ProtocolToml.Layer2Config(

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -27,6 +27,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   val contractAddress: String,
   private val ethLogsSearcher: EthLogsSearcher,
   private val l1EventSearchMaxBlockRange: UInt = 10_000u,
+  private val finalizedStateSearchInitialBlockParameter: BlockParameter? = null,
   private val log: Logger = LogManager.getLogger(Web3JLineaRollupSmartContractClientReadOnly::class.java),
 ) : LineaRollupSmartContractClientReadOnly,
   LineaRollupSmartContractClientReadOnlyFinalizedStateProvider,
@@ -219,7 +220,9 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   // forward search instead of a full-chain binary search. A full-range fallback covers the rare case
   // where the cached window overshoots (e.g. an L1 reorg moved the event earlier, or a caller queries
   // a historical block).
-  private val finalizedStateSearchFromBlock = AtomicReference<BlockParameter>(BlockParameter.Tag.EARLIEST)
+  private val finalizedStateSearchFromBlock = AtomicReference<BlockParameter>(
+    finalizedStateSearchInitialBlockParameter ?: BlockParameter.Tag.EARLIEST,
+  )
 
   internal fun findFinalizedStateEvent(
     upToBlock: BlockParameter,

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -27,7 +27,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   val contractAddress: String,
   private val ethLogsSearcher: EthLogsSearcher,
   private val l1EventSearchMaxBlockRange: UInt = 10_000u,
-  private val finalizedStateSearchInitialBlockParameter: BlockParameter? = null,
+  private val finalizedStateSearchInitialBlockParameter: BlockParameter = BlockParameter.Tag.EARLIEST,
   private val log: Logger = LogManager.getLogger(Web3JLineaRollupSmartContractClientReadOnly::class.java),
 ) : LineaRollupSmartContractClientReadOnly,
   LineaRollupSmartContractClientReadOnlyFinalizedStateProvider,
@@ -221,19 +221,19 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   // where the cached window overshoots (e.g. an L1 reorg moved the event earlier, or a caller queries
   // a historical block).
   private val finalizedStateSearchFromBlock = AtomicReference<BlockParameter>(
-    finalizedStateSearchInitialBlockParameter ?: BlockParameter.Tag.EARLIEST,
+    finalizedStateSearchInitialBlockParameter,
   )
 
   internal fun findFinalizedStateEvent(
     upToBlock: BlockParameter,
-    finalisedBlockNumber: ULong,
+    finalizedBlockNumber: ULong,
   ): SafeFuture<FinalizedStateUpdatedEvent?> {
     val fromBlock = finalizedStateSearchFromBlock.get()
     val search =
       if (fromBlock == BlockParameter.Tag.EARLIEST) {
-        searchFinalizedStateEvent(BlockParameter.Tag.EARLIEST, upToBlock, finalisedBlockNumber)
+        searchFinalizedStateEvent(BlockParameter.Tag.EARLIEST, upToBlock, finalizedBlockNumber)
       } else {
-        searchFinalizedStateEvent(fromBlock, upToBlock, finalisedBlockNumber)
+        searchFinalizedStateEvent(fromBlock, upToBlock, finalizedBlockNumber)
           // The cached forward window is only an optimization: on a miss OR any failure (e.g. it sits
           // after a historical upToBlock, which EthLogsSearcher rejects as an invalid range) fall back
           // to the authoritative full-range search, which re-surfaces any genuine (e.g. RPC) error.
@@ -242,7 +242,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
             if (event != null) {
               SafeFuture.completedFuture(event)
             } else {
-              searchFinalizedStateEvent(BlockParameter.Tag.EARLIEST, upToBlock, finalisedBlockNumber)
+              searchFinalizedStateEvent(finalizedStateSearchInitialBlockParameter, upToBlock, finalizedBlockNumber)
             }
           }
       }
@@ -255,7 +255,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   private fun searchFinalizedStateEvent(
     fromBlock: BlockParameter,
     upToBlock: BlockParameter,
-    finalisedBlockNumber: ULong,
+    finalizedBlockNumber: ULong,
   ): SafeFuture<EthLogEvent<FinalizedStateUpdatedEvent>?> {
     // FinalizedStateUpdated has a unique, monotonically-increasing indexed blockNumber, so we binary
     // search for it in bounded chunks instead of an unbounded getLogs(EARLIEST..upToBlock) query,
@@ -269,8 +269,8 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
     ) { ethLog ->
       val foundBlockNumber = FinalizedStateUpdatedEvent.fromEthLog(ethLog).event.blockNumber
       when {
-        foundBlockNumber < finalisedBlockNumber -> SearchDirection.FORWARD
-        foundBlockNumber > finalisedBlockNumber -> SearchDirection.BACKWARD
+        foundBlockNumber < finalizedBlockNumber -> SearchDirection.FORWARD
+        foundBlockNumber > finalizedBlockNumber -> SearchDirection.BACKWARD
         else -> null
       }
     }.thenApply { ethLog ->
@@ -282,7 +282,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
     upToBlock: BlockParameter,
     finalisedBlockNumber: ULong,
   ): SafeFuture<FinalizedStateUpdatedEvent> {
-    return findFinalizedStateEvent(upToBlock = upToBlock, finalisedBlockNumber = finalisedBlockNumber)
+    return findFinalizedStateEvent(upToBlock = upToBlock, finalizedBlockNumber = finalisedBlockNumber)
       .thenApply { event ->
         // it means contract was just upgraded but no event published yet,
         // we cannot deterministically get the finalized fields

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
@@ -52,7 +52,7 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
 
     val result = client.findFinalizedStateEvent(
       upToBlock = BlockParameter.Tag.LATEST,
-      finalisedBlockNumber = 200UL,
+      finalizedBlockNumber = 200UL,
     ).get()
 
     assertThat(result).isNotNull
@@ -71,7 +71,7 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
 
     val result = client.findFinalizedStateEvent(
       upToBlock = BlockParameter.Tag.LATEST,
-      finalisedBlockNumber = 999UL,
+      finalizedBlockNumber = 999UL,
     ).get()
 
     assertThat(result).isNull()
@@ -89,12 +89,12 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
     l1Client.setLatestBlockTag(6_000UL)
 
     // Advance the high-water-mark to the latest finalization (L1 block 5_000).
-    assertThat(client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalisedBlockNumber = 300UL).get())
+    assertThat(client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalizedBlockNumber = 300UL).get())
       .isNotNull
 
     // A subsequent query for an earlier finalization sits before the cached window, so the bounded
     // search misses and the full-range fallback must still resolve it.
-    val result = client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalisedBlockNumber = 200UL).get()
+    val result = client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalizedBlockNumber = 200UL).get()
 
     assertThat(result).isNotNull
     assertThat(result!!.blockNumber).isEqualTo(200UL)
@@ -113,14 +113,14 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
     l1Client.setLatestBlockTag(6_000UL)
 
     // Advance the high-water-mark to L1 block 5_000.
-    assertThat(client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalisedBlockNumber = 300UL).get())
+    assertThat(client.findFinalizedStateEvent(BlockParameter.Tag.LATEST, finalizedBlockNumber = 300UL).get())
       .isNotNull
 
     // Query a historical upToBlock (2_000) that is before the cached window, so the bounded search
     // would be an invalid range; it must recover via the full-range fallback.
     val result = client.findFinalizedStateEvent(
       upToBlock = 2_000UL.toBlockParameter(),
-      finalisedBlockNumber = 100UL,
+      finalizedBlockNumber = 100UL,
     ).get()
 
     assertThat(result).isNotNull


### PR DESCRIPTION

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mis-set deployment block could skip `FinalizedStateUpdated` events and break finalization/FTX state; behavior when unset matches the previous full-chain search.
> 
> **Overview**
> Adds optional **`protocol.l1.contractDeploymentBlockNumber`** (TOML → config, same pattern as L2) so L1 rollup log scans for **`FinalizedStateUpdated`** do not start at chain genesis when the contract was deployed later.
> 
> **`Web3JLineaRollupSmartContractClientReadOnly`** gains **`finalizedStateSearchInitialBlockParameter`** (default **`EARLIEST`**). The forward-search cache and full-range fallback now use that bound instead of always **`EARLIEST`**, shrinking **`getLogs`** ranges for rate-limited RPC providers.
> 
> **`L1DependentApp`** (finalization monitor) and **`ConflationApp`** (forced-transactions contract client) pass **`configs.protocol.l1.contractDeploymentBlockNumber ?: EARLIEST`**. Internal **`finalisedBlockNumber`** parameters in the finalized-state search path are renamed to **`finalizedBlockNumber`**; protocol parsing tests are updated for the new L1 field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a20921351f958546f2888cf104a31eac0cf490a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->