### PR TITLE
docs(misc): correct overstated protocol safety claims in yield docs

### DIFF
--- a/docs/features/yield-management.md
+++ b/docs/features/yield-management.md
@@ -2,11 +2,24 @@
 
 > Earning yield on bridged ETH via Lido staking, with on-chain withdrawal reserve management and validator proof verification.
 
+> Canonical spec: <https://hackmd.io/@kyzooroast/Hk7DQXH6lx>. This document is a plain-language overview. If it conflicts with the spec, the spec governs. Safety and liveness properties are stated precisely there; descriptions here may paraphrase and are not standalone security guarantees.
+
 ## Overview
 
-The YieldManager allows Linea to stake bridged ETH held in the LineaRollup contract into yield-bearing protocols (currently Lido stVaults). Revenue is reported to L2 yield recipients. The system maintains withdrawal reserves to ensure bridge redemptions remain liquid.
+Users bridge ETH from Ethereum L1 into Linea. Instead of letting it sit idle, Linea stakes the surplus in Lido V3 stVaults and reports the earned yield to L2 for distribution. The ETH kept on L1 - held by the `L1MessageService` contract - is the withdrawal reserve that pays out bridge redemptions. Under normal operation an automation service rebalances the reserve between configured minimum and target levels; if it falls into deficit, anyone can permissionlessly trigger replenishment, and a last-resort LST withdrawal path remains available to users.
 
-Key invariant: user funds in the rollup must always be redeemable. The withdrawal reserve mechanism enforces minimum and target reserve levels, triggering unstaking when reserves fall below thresholds.
+### Safety and liveness
+
+Safety properties - must hold at all times:
+
+- Yield reports exclude all accumulated system obligations from the amount sent to L2.
+- User principal (L1 deposits plus L2 circulating ETH) is never used to settle obligations; obligations are paid only from unreported yield.
+- New beacon-chain deposits are paused whenever the reserve is in deficit, stETH liabilities are outstanding, or ossification (a permanent freeze of a yield provider) is initiated or completed.
+
+Liveness properties - must eventually hold, though timing is not guaranteed:
+
+- At least one withdrawal path stays available to users, even if delayed. Permissionless unstaking and reserve replenishment activate during reserve deficits, and replenishment takes precedence over repaying obligations.
+- Vault accounting reports are refreshed at least every 48 hours; stale reports block withdrawals and LST minting until updated.
 
 ## Components
 
@@ -24,13 +37,13 @@ Key invariant: user funds in the rollup must always be redeemable. The withdrawa
 
 ```mermaid
 flowchart TD
-    LR[LineaRollup] -->|"transferFundsToReserve / receiveFundsFromReserve"| YM[YieldManager]
+    L1["L1MessageService (withdrawal reserve)"] -->|"transferFundsForNativeYield / receiveFundsFromReserve"| YM[YieldManager]
     YM -->|"fundYieldProvider"| LP[LidoStVaultYieldProvider]
     LP -->|stake| Lido[Lido stVault]
     YM -->|"reportYield"| L2[L2 Yield Recipient]
     YM -->|"unstake / unstakePermissionless"| LP
     LP -->|withdraw| YM
-    VCP[ValidatorContainerProofVerifier] -->|"prove validator status"| YM
+    VCP[ValidatorContainerProofVerifier] -->|"verify validator container vs EIP-4788 root"| YM
 ```
 
 ## Withdrawal Reserve
@@ -44,7 +57,7 @@ The reserve system uses four parameters:
 | `targetWithdrawalReservePercentageBps` | Target reserve % (higher than minimum) |
 | `targetWithdrawalReserveAmount` | Target reserve absolute amount |
 
-The effective reserve is `max(percentageBased, absoluteAmount)`. When the reserve falls below minimum, `replenishWithdrawalReserve` triggers unstaking from yield providers.
+The effective reserve is `max(percentageBased, absoluteAmount)`. When the reserve drops below the minimum threshold, anyone may call `replenishWithdrawalReserve` to permissionlessly withdraw ETH from yield providers into the `L1MessageService`, restoring the reserve up to the target (not just the minimum). The call is only available while the reserve is in deficit.
 
 ## Roles
 
@@ -62,7 +75,7 @@ The effective reserve is `max(percentageBased, absoluteAmount)`. When the reserv
 
 ## Permissionless Unstaking
 
-`unstakePermissionless` allows anyone to trigger unstaking for a validator by providing a beacon chain proof (via `ValidatorContainerProofVerifier`) that the validator has exited. This prevents yield providers from indefinitely locking funds.
+`unstakePermissionless` lets anyone request a partial withdrawal from a single validator when the reserve is in deficit. The caller supplies a validator-container proof - pubkey, withdrawal credentials, effective balance, and activation epochs - which `ValidatorContainerProofVerifier` checks against the EIP-4788 beacon chain root. The amount is capped to the remaining reserve deficit that other liquidity sources cannot cover. This gives a censorship-resistant way to start replenishment when the operator is unavailable; the beacon chain still takes time to fulfil the withdrawal.
 
 ## Ossification
 

--- a/operations/native-yield/lido-governance-monitor/docs/architecture.md
+++ b/operations/native-yield/lido-governance-monitor/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Linea's Yield Boost depends on Lido V3 StakingVaults, which are governed by **Lido's on-chain governance process**. Governance decisions - particularly contract upgrades, parameter changes, or governance process changes - represent a primary external risk vector for Yield Boost.
 
-A malicious, compromised, or poorly designed governance change affecting the StakingVault or closely related contracts could materially impact Yield Boost operations, including withdrawal guarantees or yield accounting. Linea must gain early visibility into governance proposals *before execution*, with sufficient time for the Security Council to evaluate risk and take protective actions such as ossifying the vault.
+A malicious, compromised, or poorly designed governance change affecting the StakingVault or closely related contracts could materially impact Yield Boost operations, including withdrawal liveness or yield accounting. Linea must gain early visibility into governance proposals *before execution*, with sufficient time for the Security Council to evaluate risk and take protective actions such as ossifying the vault.
 
 The **Lido Governance Monitor** is an off-chain service that provides this early warning. It regularly checks the Lido governance proposal pipeline, evaluates proposals for risk to Yield Boost using an AI-assisted judge, and escalates proposals that may pose a material risk to the Security Council.
 


### PR DESCRIPTION
This PR implements issue(s) #None

### Summary

- Corrects inaccurate and overstated protocol safety claims in Yield Boost documentation that could be mis-cited by bug bounty reporters.
- Aligns repo docs with the canonical technical spec: https://hackmd.io/@kyzooroast/Hk7DQXH6lx

### Problem

`docs/features/yield-management.md` and `operations/native-yield/lido-governance-monitor/docs/architecture.md` are standing security-referenced docs (active bug bounty). Several claims overstated protocol guarantees:

- "Key invariant: user funds...must always be redeemable...enforces...triggering unstaking" - the spec frames censorship-resistant withdrawals as eventual liveness; only A/B/C are hard safety properties, and nothing auto-fires on a threshold breach.
- `unstakePermissionless` was described as proving "the validator has exited" - the proof verifies the validator container against the EIP-4788 root, not exit status. Also omitted the deficit precondition and amount cap.
- Reserve holder was labeled `LineaRollup`; per spec and `YieldManager.sol:133`, it is `L1MessageService`.
- "ensure bridge redemptions remain liquid", "replenishWithdrawalReserve triggers unstaking", and "withdrawal guarantees" overstate automatic/absolute behavior.

### Solution

- Added a canonical-spec banner at the top of `docs/features/yield-management.md` linking the HackMD spec and disclaiming the repo doc as a non-authoritative overview.
- Replaced the "Key invariant" line with a Safety and liveness section stating the three hard safety properties (A/B/C) and two liveness properties, using the spec's "must hold at all times" vs "eventual" distinction.
- Rewrote `unstakePermissionless`, `replenishWithdrawalReserve`, and the Overview to match the spec (deficit-gated, permissionless, asynchronous fulfilment, correct reserve holder).
- Fixed the architecture diagram (`L1MessageService` reserve edge, `transferFundsForNativeYield`, validator-container verification wording).
- Changed "withdrawal guarantees" to "withdrawal liveness" in the governance monitor architecture doc.

No code, contract, or test changes - markdown only.

### Related

None

### Test Plan

- [x] N/A - documentation only; no build, tests, or deployments affected.
- [x] Mermaid diagram syntax preserved; markdown renders.

### Checklist

* [ ] I wrote new tests for my new core changes. - N/A (docs only)
* [x] I have successfully ran tests, style checker and build against my new changes locally. - N/A (docs only)
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this PR. - N/A
* [ ] I have informed the team of any breaking changes if there are any. - No breaking changes

Made with [Cursor](https://cursor.com)