### PR TITLE
chore(docker): bump maru, geth and linea-besu in getting-started compose files

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -13,7 +13,7 @@ services:
       - ./config/coordinator/coordinator-config-v2.toml:/coordinator/coordinator-config-v2.toml:ro
 
   maru:
-    image: consensys/maru:${MARU_TAG:-v1.2.1-20260410142843-d326b73}
+    image: consensys/maru:${MARU_TAG:-1.3.0-20260714-ced387a}
     hostname: maru
     container_name: maru
     profiles: [ "l2", "l2-bc", "debug" ]

--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -85,7 +85,7 @@ services:
   geth-node:
     hostname: el-client
     container_name: geth-node
-    image: ethereum/client-go:v1.16.9
+    image: ethereum/client-go:v1.17.4
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s

--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -57,7 +57,7 @@ services:
   maru-node:
     hostname: linea-maru
     container_name: linea-maru
-    image: consensys/maru:v1.2.1-20260410142843-d326b73
+    image: consensys/maru:1.3.0-20260714-ced387a
     restart: unless-stopped
     ports:
       - "8080:8080" # Beacon/REST API

--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   besu-node:
     hostname: el-client
     container_name: linea-besu
-    image: consensys/linea-besu-package:beta-v6.2-20260413130658-9cb6f11
+    image: consensys/linea-besu-package:2.0.0-20260714-6a92ee2
     platform: linux/amd64
     healthcheck:
       test: ["CMD-SHELL", "bash -c '[ -f /tmp/pid ]'"]

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -85,7 +85,7 @@ services:
   geth-node:
     hostname: el-client
     container_name: geth-node
-    image: ethereum/client-go:v1.16.9
+    image: ethereum/client-go:v1.17.4
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -57,7 +57,7 @@ services:
   maru-node:
     hostname: linea-maru
     container_name: linea-maru
-    image: consensys/maru:v1.2.1-20260410142843-d326b73
+    image: consensys/maru:1.3.0-20260714-ced387a
     restart: unless-stopped
     ports:
       - "8080:8080" # Beacon/REST API

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   besu-node:
     hostname: el-client
     container_name: linea-besu
-    image: consensys/linea-besu-package:beta-v6.2-20260413130658-9cb6f11
+    image: consensys/linea-besu-package:2.0.0-20260714-6a92ee2
     platform: linux/amd64
     healthcheck:
       test: ["CMD-SHELL", "bash -c '[ -f /tmp/pid ]'"]


### PR DESCRIPTION
## Summary
- Bump `consensys/maru` image tag from `v1.2.1-20260410142843-d326b73` to `1.3.0-20260714-ced387a` in the `linea-mainnet` and `linea-sepolia` getting-started docker-compose files.
- Bump `ethereum/client-go` image tag from `v1.16.9` to `v1.17.4` in the same two files.
- Bump `consensys/linea-besu-package` image tag from `beta-v6.2-20260413130658-9cb6f11` to `2.0.0-20260714-6a92ee2` in the same two files.

## Notes
- Geth v1.17.0+ release notes mention the p2p nodekey format changed; existing `nodekey` files should be regenerated, which changes the node ID and may break static peers. Operators upgrading an existing stack should be aware.
- The new `linea-besu-package` image bundles Besu 26.6.1; it was built and validated via the `linea-besu-release.yml` workflow (profile tests + E2E passed).

## Test plan
- [x] `docker compose -f docs/getting-started/linea-mainnet/docker-compose.yml up` starts cleanly
- [x] `docker compose -f docs/getting-started/linea-sepolia/docker-compose.yml up` starts cleanly
- [x] Engine API handshake between geth-node and maru-node succeeds