### PR TITLE
chore(docker): bump geth to v1.17.4 in getting-started compose

### DIFF
--- a/docs/getting-started/linea-mainnet/docker-compose.yml
+++ b/docs/getting-started/linea-mainnet/docker-compose.yml
@@ -85,7 +85,7 @@ services:
   geth-node:
     hostname: el-client
     container_name: geth-node
-    image: ethereum/client-go:v1.16.9
+    image: ethereum/client-go:v1.17.4
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s

--- a/docs/getting-started/linea-sepolia/docker-compose.yml
+++ b/docs/getting-started/linea-sepolia/docker-compose.yml
@@ -85,7 +85,7 @@ services:
   geth-node:
     hostname: el-client
     container_name: geth-node
-    image: ethereum/client-go:v1.16.9
+    image: ethereum/client-go:v1.17.4
     pull_policy: always
     restart: unless-stopped
     stop_grace_period: 30s


### PR DESCRIPTION
## Summary
- Bump `ethereum/client-go` image tag from `v1.16.9` to `v1.17.4` in the `linea-mainnet` and `linea-sepolia` getting-started docker-compose files.

## Notes
- Geth v1.17.0+ release notes mention the p2p nodekey format changed; existing `nodekey` files should be regenerated, which changes the node ID and may break static peers. Operators upgrading an existing stack should be aware.

## Test plan
- [ ] `docker compose -f docs/getting-started/linea-mainnet/docker-compose.yml up geth-node` starts and syncs
- [ ] `docker compose -f docs/getting-started/linea-sepolia/docker-compose.yml up geth-node` starts and syncs
- [ ] Engine API handshake with Maru succeeds

Made with [Cursor](https://cursor.com)