### PR TITLE
fix(e2e): stabilize funding with retries

### DIFF
--- a/e2e/jest.unit.config.ts
+++ b/e2e/jest.unit.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  rootDir: ".",
+  testMatch: ["<rootDir>/src/**/__tests__/**/*.test.ts"],
+  verbose: true,
+};
+
+export default config;

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "test:unit": "jest --config ./jest.unit.config.ts",
     "test:script": "jest --config ./jest.script.config.ts",
     "pretest:local:run": "pnpm --filter @lfdt-lineth/shared-utils run build",
     "test:local:run": "TEST_ENV=local jest",

--- a/e2e/src/common/utils/__tests__/wait.test.ts
+++ b/e2e/src/common/utils/__tests__/wait.test.ts
@@ -1,0 +1,120 @@
+jest.mock("@lfdt-lineth/shared-utils", () => ({
+  wait: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock("../../../config/logger/logger", () => ({
+  createTestLogger: () => ({ debug: jest.fn(), error: jest.fn(), warn: jest.fn() }),
+}));
+
+import { wait } from "@lfdt-lineth/shared-utils";
+
+import { awaitUntil, AwaitUntilTimeoutError } from "../wait";
+
+const waitMock = wait as jest.MockedFunction<typeof wait>;
+
+describe("awaitUntil", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    waitMock.mockResolvedValue(undefined);
+  });
+
+  describe("basic behaviour (no shouldRetry)", () => {
+    it("returns the result immediately when the callback succeeds on the first try", async () => {
+      const callback = jest.fn().mockResolvedValue("ok");
+
+      const result = await awaitUntil(callback, () => true, { timeoutMs: 1000 });
+
+      expect(result).toBe("ok");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries until stopRetry returns true", async () => {
+      const callback = jest
+        .fn()
+        .mockResolvedValueOnce("not-yet")
+        .mockResolvedValueOnce("not-yet")
+        .mockResolvedValue("done");
+
+      const result = await awaitUntil(callback, (v) => v === "done", { timeoutMs: 5000, pollingIntervalMs: 0 });
+
+      expect(result).toBe("done");
+      expect(callback).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries on any error when shouldRetry is not provided", async () => {
+      const error = new Error("transient");
+      const callback = jest.fn().mockRejectedValueOnce(error).mockResolvedValue("ok");
+
+      const result = await awaitUntil(callback, () => true, { timeoutMs: 5000, pollingIntervalMs: 0 });
+
+      expect(result).toBe("ok");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws AwaitUntilTimeoutError after the deadline", async () => {
+      const callback = jest.fn().mockRejectedValue(new Error("always fails"));
+
+      await expect(awaitUntil(callback, () => true, { timeoutMs: 0, pollingIntervalMs: 0 })).rejects.toBeInstanceOf(
+        AwaitUntilTimeoutError,
+      );
+    });
+  });
+
+  describe("shouldRetry predicate", () => {
+    it("retries when shouldRetry returns true", async () => {
+      const transientError = new Error("transient");
+      const callback = jest.fn().mockRejectedValueOnce(transientError).mockResolvedValue("ok");
+      const shouldRetry = jest.fn().mockReturnValue(true);
+
+      const result = await awaitUntil(callback, () => true, {
+        timeoutMs: 5000,
+        pollingIntervalMs: 0,
+        shouldRetry,
+      });
+
+      expect(result).toBe("ok");
+      expect(shouldRetry).toHaveBeenCalledWith(transientError);
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("rethrows immediately when shouldRetry returns false", async () => {
+      const fatalError = new Error("non-transient");
+      const callback = jest.fn().mockRejectedValue(fatalError);
+      const shouldRetry = jest.fn().mockReturnValue(false);
+
+      await expect(
+        awaitUntil(callback, () => true, { timeoutMs: 5000, pollingIntervalMs: 0, shouldRetry }),
+      ).rejects.toThrow(fatalError);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(shouldRetry).toHaveBeenCalledWith(fatalError);
+    });
+
+    it("rethrows a non-retryable error before the deadline is reached", async () => {
+      const transientError = new Error("transient");
+      const fatalError = new Error("fatal");
+      const callback = jest
+        .fn()
+        .mockRejectedValueOnce(transientError)
+        .mockRejectedValueOnce(fatalError)
+        .mockResolvedValue("should not reach");
+      const shouldRetry = (error: unknown) => (error as Error).message === "transient";
+
+      await expect(
+        awaitUntil(callback, () => true, { timeoutMs: 5000, pollingIntervalMs: 0, shouldRetry }),
+      ).rejects.toThrow(fatalError);
+
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws AwaitUntilTimeoutError when retryable errors persist past the deadline", async () => {
+      const transientError = new Error("transient");
+      const callback = jest.fn().mockRejectedValue(transientError);
+      const shouldRetry = jest.fn().mockReturnValue(true);
+
+      await expect(
+        awaitUntil(callback, () => true, { timeoutMs: 0, pollingIntervalMs: 0, shouldRetry }),
+      ).rejects.toBeInstanceOf(AwaitUntilTimeoutError);
+    });
+  });
+});

--- a/e2e/src/common/utils/wait.ts
+++ b/e2e/src/common/utils/wait.ts
@@ -20,6 +20,12 @@ export class AwaitUntilTimeoutError extends Error {
 export type AwaitUntilOptions = {
   pollingIntervalMs?: number;
   timeoutMs?: number;
+  /**
+   * Optional predicate called when `callback` throws. Return `true` to retry
+   * the operation, or `false` to rethrow the error immediately without waiting
+   * for the deadline. When omitted, all errors are retried until the deadline.
+   */
+  shouldRetry?: (error: unknown) => boolean;
 };
 
 export async function awaitUntil<T>(
@@ -27,7 +33,7 @@ export async function awaitUntil<T>(
   stopRetry: (value: T) => boolean,
   options: AwaitUntilOptions = {},
 ): Promise<T> {
-  const { pollingIntervalMs = 500, timeoutMs = 2 * 60 * 1000 } = options;
+  const { pollingIntervalMs = 500, timeoutMs = 2 * 60 * 1000, shouldRetry } = options;
   const deadline = Date.now() + timeoutMs;
   let lastError: Error | undefined;
   let attemptCount = 0;
@@ -41,6 +47,10 @@ export async function awaitUntil<T>(
         return result;
       }
     } catch (error) {
+      if (shouldRetry && !shouldRetry(error)) {
+        throw error;
+      }
+
       lastError = error as Error;
       attemptCount++;
 

--- a/e2e/src/config/accounts/account-funding-service.ts
+++ b/e2e/src/config/accounts/account-funding-service.ts
@@ -1,5 +1,6 @@
+import { wait } from "@lfdt-lineth/shared-utils";
 import { Mutex } from "async-mutex";
-import { Address, Client, PrivateKeyAccount, PublicActions } from "viem";
+import { Address, BaseError, Client, PrivateKeyAccount, PublicActions } from "viem";
 import { getTransactionCount, sendTransaction } from "viem/actions";
 
 import {
@@ -17,6 +18,52 @@ type FundingClient = Client & Pick<PublicActions, "estimateFeesPerGas">;
 type FeeData = Eip1559Fees;
 
 const DEFAULT_RECEIPT_TIMEOUT_MS = 30_000;
+
+// 60 s is less than half the smallest EIP-7702 test timeout (120 s), so a funding failure
+// will surface as a clear error message before Jest's deadline rather than a generic
+// "test timed out". It is also large enough to outlast brief sequencer instability windows
+// (observed ~3 s in CI) with many retries to spare at the 500 ms polling interval.
+const FUND_TIMEOUT_MS = 60_000;
+
+// One L2 block (~1 s) is usually enough for mempool pressure from concurrent test setups
+// to clear. 500 ms keeps retries responsive while giving the sequencer time to process
+// the competing transactions that caused the immediate rejection.
+const FUND_RETRY_DELAY_MS = 500;
+
+/**
+ * Typed viem error names that indicate a transient RPC / mempool condition.
+ * A brief pause and a fresh on-chain nonce are likely to resolve these on the next attempt.
+ *
+ * - NonceTooLowError         — stale cached nonce; re-fetch and retry
+ * - FeeCapTooLowError        — covers "replacement transaction underpriced" / "transaction underpriced"
+ * - TipAboveFeeCapError      — fee estimation drift between estimate and submit
+ * - TransactionRejectedRpcError — mempool full, already known, general RPC rejection
+ * - InternalRpcError         — transient sequencer / node error
+ * - LimitExceededRpcError    — pool limits or rate limiting
+ */
+const TRANSIENT_FUNDING_ERROR_NAMES = new Set([
+  "NonceTooLowError",
+  "FeeCapTooLowError",
+  "TipAboveFeeCapError",
+  "TransactionRejectedRpcError",
+  "InternalRpcError",
+  "LimitExceededRpcError",
+]);
+
+/**
+ * Returns true when the error (or any cause in its chain) is a known transient
+ * RPC / mempool condition. Uses BaseError.walk() to inspect the full cause chain,
+ * matching the same pattern used in retry.ts.
+ */
+function isTransientFundingError(error: unknown): boolean {
+  if (!(error instanceof BaseError)) return false;
+  return (
+    error.walk((cause) => {
+      const name = (cause as { name?: string }).name;
+      return typeof name === "string" && TRANSIENT_FUNDING_ERROR_NAMES.has(name);
+    }) !== null
+  );
+}
 
 /**
  * Sends funding transactions from a whale account to newly generated test accounts.
@@ -39,8 +86,12 @@ export class AccountFundingService {
 
   /**
    * Funds a single target address from the whale account.
-   * Returns the transaction result on success or null if all retry attempts are exhausted.
-   * On terminal failure, invalidates the cached nonce so the next call re-fetches from chain.
+   * Returns the transaction result on success, or null if the attempt fails.
+   *
+   * Retries within a FUND_TIMEOUT_MS deadline on transient RPC / mempool errors (e.g.
+   * immediate rejection due to nonce pressure or sequencer instability). Each retry
+   * invalidates the cached nonce so the next attempt re-fetches from chain.
+   * Non-transient errors (reverts, authorization failures, etc.) bail out immediately.
    */
   async fundAccount(
     whaleAccountWallet: PrivateKeyAccount,
@@ -48,37 +99,58 @@ export class AccountFundingService {
     targetAddress: Address,
     initialBalanceWei: bigint,
   ): Promise<TransactionResult | null> {
-    try {
-      const feeData = await this.estimateFees(whaleAccountWallet.address, targetAddress, initialBalanceWei);
-      const nonce = await this.nextNonce(whaleAccountAddress);
+    const deadline = Date.now() + FUND_TIMEOUT_MS;
+    let attempt = 0;
 
-      const result = await sendTransactionWithRetry(
-        this.client,
-        (fees) =>
-          sendTransaction(this.client, {
-            account: whaleAccountWallet,
-            chain: this.client.chain,
-            type: "eip1559",
-            to: targetAddress,
-            value: initialBalanceWei,
-            nonce,
-            gas: 21000n,
-            ...feeData,
-            ...fees,
-          }),
-        { receiptTimeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS },
-      );
+    while (Date.now() < deadline) {
+      try {
+        const feeData = await this.estimateFees(whaleAccountWallet.address, targetAddress, initialBalanceWei);
+        const nonce = await this.nextNonce(whaleAccountAddress);
 
-      this.logger.debug(
-        `Account funded. targetAddress=${targetAddress} txHash=${result.hash} whaleAccount=${whaleAccountAddress}`,
-      );
+        const result = await sendTransactionWithRetry(
+          this.client,
+          (fees) =>
+            sendTransaction(this.client, {
+              account: whaleAccountWallet,
+              chain: this.client.chain,
+              type: "eip1559",
+              to: targetAddress,
+              value: initialBalanceWei,
+              nonce,
+              gas: 21000n,
+              ...feeData,
+              ...fees,
+            }),
+          { receiptTimeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS },
+        );
 
-      return result;
-    } catch (error) {
-      this.logger.error(`Failed to fund account. address=${targetAddress} error=${(error as Error).message}`);
-      this.invalidateNonce(whaleAccountAddress);
-      return null;
+        this.logger.debug(
+          `Account funded. targetAddress=${targetAddress} txHash=${result.hash} whaleAccount=${whaleAccountAddress}`,
+        );
+
+        return result;
+      } catch (error) {
+        this.invalidateNonce(whaleAccountAddress);
+        attempt++;
+
+        if (!isTransientFundingError(error) || Date.now() >= deadline) {
+          this.logger.error(
+            `Failed to fund account. address=${targetAddress} attempt=${attempt} error=${(error as Error).message}`,
+          );
+          return null;
+        }
+
+        this.logger.warn(
+          `Transient error funding account, retrying. address=${targetAddress} attempt=${attempt} error=${(error as Error).message}`,
+        );
+        await wait(FUND_RETRY_DELAY_MS);
+      }
     }
+
+    this.logger.error(
+      `Failed to fund account: timeout after ${attempt} attempts. address=${targetAddress} timeoutMs=${FUND_TIMEOUT_MS}`,
+    );
+    return null;
   }
 
   /**

--- a/e2e/src/config/accounts/account-funding-service.ts
+++ b/e2e/src/config/accounts/account-funding-service.ts
@@ -1,9 +1,10 @@
-import { wait } from "@lfdt-lineth/shared-utils";
 import { Mutex } from "async-mutex";
 import { Address, BaseError, Client, PrivateKeyAccount, PublicActions } from "viem";
 import { getTransactionCount, sendTransaction } from "viem/actions";
 
 import {
+  awaitUntil,
+  AwaitUntilTimeoutError,
   createBlockNotFoundRetryExtension,
   estimateLineaGas,
   normalizeEip1559Fees,
@@ -99,58 +100,51 @@ export class AccountFundingService {
     targetAddress: Address,
     initialBalanceWei: bigint,
   ): Promise<TransactionResult | null> {
-    const deadline = Date.now() + FUND_TIMEOUT_MS;
-    let attempt = 0;
+    try {
+      const result = await awaitUntil(
+        async () => {
+          try {
+            const feeData = await this.estimateFees(whaleAccountWallet.address, targetAddress, initialBalanceWei);
+            const nonce = await this.nextNonce(whaleAccountAddress);
 
-    while (Date.now() < deadline) {
-      try {
-        const feeData = await this.estimateFees(whaleAccountWallet.address, targetAddress, initialBalanceWei);
-        const nonce = await this.nextNonce(whaleAccountAddress);
+            return await sendTransactionWithRetry(
+              this.client,
+              (fees) =>
+                sendTransaction(this.client, {
+                  account: whaleAccountWallet,
+                  chain: this.client.chain,
+                  type: "eip1559",
+                  to: targetAddress,
+                  value: initialBalanceWei,
+                  nonce,
+                  gas: 21000n,
+                  ...feeData,
+                  ...fees,
+                }),
+              { receiptTimeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS },
+            );
+          } catch (error) {
+            this.invalidateNonce(whaleAccountAddress);
+            throw error;
+          }
+        },
+        () => true,
+        { timeoutMs: FUND_TIMEOUT_MS, pollingIntervalMs: FUND_RETRY_DELAY_MS, shouldRetry: isTransientFundingError },
+      );
 
-        const result = await sendTransactionWithRetry(
-          this.client,
-          (fees) =>
-            sendTransaction(this.client, {
-              account: whaleAccountWallet,
-              chain: this.client.chain,
-              type: "eip1559",
-              to: targetAddress,
-              value: initialBalanceWei,
-              nonce,
-              gas: 21000n,
-              ...feeData,
-              ...fees,
-            }),
-          { receiptTimeoutMs: DEFAULT_RECEIPT_TIMEOUT_MS },
-        );
+      this.logger.debug(
+        `Account funded. targetAddress=${targetAddress} txHash=${result.hash} whaleAccount=${whaleAccountAddress}`,
+      );
 
-        this.logger.debug(
-          `Account funded. targetAddress=${targetAddress} txHash=${result.hash} whaleAccount=${whaleAccountAddress}`,
-        );
-
-        return result;
-      } catch (error) {
-        this.invalidateNonce(whaleAccountAddress);
-        attempt++;
-
-        if (!isTransientFundingError(error) || Date.now() >= deadline) {
-          this.logger.error(
-            `Failed to fund account. address=${targetAddress} attempt=${attempt} error=${(error as Error).message}`,
-          );
-          return null;
-        }
-
-        this.logger.warn(
-          `Transient error funding account, retrying. address=${targetAddress} attempt=${attempt} error=${(error as Error).message}`,
-        );
-        await wait(FUND_RETRY_DELAY_MS);
+      return result;
+    } catch (error) {
+      if (error instanceof AwaitUntilTimeoutError) {
+        this.logger.error(`Failed to fund account: timeout after ${error.timeoutMs}ms. address=${targetAddress}`);
+      } else {
+        this.logger.error(`Failed to fund account. address=${targetAddress} error=${(error as Error).message}`);
       }
+      return null;
     }
-
-    this.logger.error(
-      `Failed to fund account: timeout after ${attempt} attempts. address=${targetAddress} timeoutMs=${FUND_TIMEOUT_MS}`,
-    );
-    return null;
   }
 
   /**

--- a/ts-libs/linea-shared-utils/src/logging/__tests__/WinstonLogger.test.ts
+++ b/ts-libs/linea-shared-utils/src/logging/__tests__/WinstonLogger.test.ts
@@ -225,7 +225,7 @@ describe("WinstonLogger", () => {
       makeLogger("Test").error("oops", { error });
 
       // Stackless Errors render as `${name}: ${message}` (no stack frames to append).
-      expect(getLogOutput()).toContain("error=\"Error: no stack\"");
+      expect(getLogOutput()).toContain('error="Error: no stack"');
     });
 
     it("does not produce an error.stack key", () => {


### PR DESCRIPTION
This PR introduces retries for funding to cover potential transient/flaky setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to e2e test infrastructure and polling helpers; production paths are unaffected, with bounded retry behavior and immediate bail-out on non-transient errors.
> 
> **Overview**
> **`awaitUntil`** now accepts an optional **`shouldRetry`** predicate so callers can retry only on selected errors and fail fast on fatal ones.
> 
> **`AccountFundingService.fundAccount`** wraps fee estimation, nonce assignment, and **`sendTransactionWithRetry`** in **`awaitUntil`** (60s timeout, 500ms polling). Transient viem RPC/mempool errors (nonce too low, fee cap, pool rejection, etc.) are detected via **`BaseError.walk`** and retried with nonce cache invalidation per attempt; non-transient failures exit immediately. Timeout failures log explicitly instead of only generic errors.
> 
> Adds **`jest.unit.config.ts`**, a **`test:unit`** npm script, and unit tests for **`awaitUntil`** including **`shouldRetry`** behavior. Minor assertion quote fix in **`WinstonLogger.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04e37cc053058a0d108be93d15c72678cdfd3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->