### PR TITLE
feat(coordinator): add checkCoordinatorConfigDocs validator

### DIFF
--- a/coordinator/app/build.gradle
+++ b/coordinator/app/build.gradle
@@ -122,6 +122,16 @@ distributions {
   }
 }
 
+// Fails if any Coordinator TOML config key is missing @ConfigDoc / @ConfigSection docs.
+// NOTE: not yet wired into `check` — the real config classes are annotated in a later phase;
+// wiring into `check`/CI happens once every key is documented.
+tasks.register('checkCoordinatorConfigDocs', JavaExec) {
+  group = 'verification'
+  description = 'Verifies that every Coordinator TOML config key is documented.'
+  classpath = sourceSets.main.runtimeClasspath
+  mainClass = 'linea.coordinator.config.v2.docs.ConfigDocCheckMain'
+}
+
 run {
   workingDir = rootProject.projectDir
   jvmArgs = [

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/docs/ConfigDocCheckMain.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/docs/ConfigDocCheckMain.kt
@@ -1,0 +1,40 @@
+package linea.coordinator.config.v2.docs
+
+import linea.coordinator.config.v2.toml.CoordinatorConfigFileToml
+import linea.coordinator.config.v2.toml.GasPriceCapTimeOfDayMultipliersConfigFileToml
+import linea.coordinator.config.v2.toml.SmartContractErrorCodesConfigFileToml
+import linea.coordinator.config.v2.toml.TracesLimitsConfigFileV4Toml
+import linea.coordinator.config.v2.toml.TracesLimitsConfigFileV5Toml
+import kotlin.reflect.KClass
+import kotlin.system.exitProcess
+
+/**
+ * Root Coordinator TOML config classes documented by this tooling. Each corresponds to one of
+ * the config files the coordinator loads.
+ */
+val COORDINATOR_CONFIG_ROOTS: List<KClass<*>> = listOf(
+  CoordinatorConfigFileToml::class,
+  TracesLimitsConfigFileV4Toml::class,
+  TracesLimitsConfigFileV5Toml::class,
+  GasPriceCapTimeOfDayMultipliersConfigFileToml::class,
+  SmartContractErrorCodesConfigFileToml::class,
+)
+
+/**
+ * Entry point for the `checkCoordinatorConfigDocs` Gradle task. Walks the root config classes,
+ * validates that every key is documented, prints any violations, and exits non-zero on failure
+ * so the Gradle task (and CI) fails.
+ */
+object ConfigDocCheckMain {
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val keys = ConfigSchemaWalker.walkAll(COORDINATOR_CONFIG_ROOTS)
+    val violations = ConfigDocValidator.validate(keys)
+    if (violations.isEmpty()) {
+      println("Coordinator config docs OK: ${keys.size} keys, all documented.")
+      return
+    }
+    System.err.println(ConfigDocValidator.formatViolations(violations))
+    exitProcess(1)
+  }
+}

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/docs/ConfigDocValidator.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/docs/ConfigDocValidator.kt
@@ -1,0 +1,68 @@
+package linea.coordinator.config.v2.docs
+
+/**
+ * A single documentation-completeness problem found by [ConfigDocValidator].
+ *
+ * @property path the kebab-case config path, e.g. `database.connection-timeout`.
+ * @property location the declaring `Class.property`, e.g. `DatabaseToml.connectionTimeout`.
+ * @property message what is wrong and how to fix it.
+ */
+data class ConfigDocViolation(
+  val path: String,
+  val location: String,
+  val message: String,
+)
+
+/**
+ * Validates that every config key produced by [ConfigSchemaWalker] is documented.
+ *
+ * Rules:
+ * - every leaf must carry `@ConfigDoc` and every section must carry `@ConfigSection`;
+ * - the description must be non-blank.
+ *
+ * A `replacement` is optional, even for a deprecated key/section — deprecation without a
+ * replacement (a plain removal) is valid.
+ *
+ * The validator is pure (operates on the walked [ConfigKey] list), so it is trivially testable
+ * and reused by both the Gradle check task and its unit tests.
+ */
+object ConfigDocValidator {
+  fun validate(keys: List<ConfigKey>): List<ConfigDocViolation> {
+    val violations = mutableListOf<ConfigDocViolation>()
+    for (key in keys) {
+      val location = "${key.declaringClass}.${key.propertyName}"
+      val annotation = if (key.isSection) "@ConfigSection" else "@ConfigDoc"
+
+      if (!key.annotated) {
+        violations.add(
+          ConfigDocViolation(key.path, location, "missing $annotation on the constructor parameter"),
+        )
+        continue
+      }
+
+      if (key.description.isBlank()) {
+        violations.add(
+          ConfigDocViolation(key.path, location, "$annotation.description must not be blank"),
+        )
+      }
+    }
+    return violations
+  }
+
+  /** Renders violations as a human-readable, deterministically ordered report. */
+  fun formatViolations(violations: List<ConfigDocViolation>): String {
+    val sorted = violations.sortedWith(compareBy({ it.path }, { it.message }))
+    return buildString {
+      appendLine("Missing or invalid Coordinator config documentation:")
+      appendLine()
+      for (violation in sorted) {
+        appendLine("- ${violation.path} in ${violation.location}: ${violation.message}")
+      }
+      appendLine()
+      appendLine(
+        "Every config key must be documented. Add @ConfigDoc (leaf value) or @ConfigSection " +
+          "(nested table) to the constructor parameter with a non-blank description.",
+      )
+    }
+  }
+}

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/docs/ConfigDocValidatorTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/docs/ConfigDocValidatorTest.kt
@@ -1,0 +1,118 @@
+package linea.coordinator.config.v2.docs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfigDocValidatorTest {
+  private fun leaf(
+    path: String,
+    annotated: Boolean = true,
+    description: String = "A documented value.",
+    deprecated: Boolean = false,
+    replacement: String? = null,
+    declaringClass: String = "SampleToml",
+    propertyName: String = "sample",
+  ) = ConfigKey(
+    path = path,
+    type = "String",
+    required = false,
+    default = null,
+    description = if (annotated) description else "",
+    example = null,
+    deprecated = deprecated,
+    replacement = replacement,
+    isSection = false,
+    annotated = annotated,
+    declaringClass = declaringClass,
+    propertyName = propertyName,
+  )
+
+  private fun section(
+    path: String,
+    annotated: Boolean = true,
+    description: String = "A documented section.",
+    deprecated: Boolean = false,
+    replacement: String? = null,
+  ) = leaf(
+    path = path,
+    annotated = annotated,
+    description = description,
+    deprecated = deprecated,
+    replacement = replacement,
+  ).copy(isSection = true, type = "NestedToml")
+
+  @Test
+  fun `passes when every key is documented`() {
+    val keys = listOf(
+      section("database"),
+      leaf("database.hostname"),
+      leaf("database.port"),
+    )
+    assertThat(ConfigDocValidator.validate(keys)).isEmpty()
+  }
+
+  @Test
+  fun `flags a leaf missing ConfigDoc`() {
+    val keys = listOf(leaf("database.connection-timeout", annotated = false, propertyName = "connectionTimeout"))
+
+    val violations = ConfigDocValidator.validate(keys)
+
+    assertThat(violations).singleElement().satisfies({
+      assertThat(it.path).isEqualTo("database.connection-timeout")
+      assertThat(it.location).isEqualTo("SampleToml.connectionTimeout")
+      assertThat(it.message).contains("@ConfigDoc")
+    })
+  }
+
+  @Test
+  fun `flags a section missing ConfigSection with the section-specific hint`() {
+    val violations = ConfigDocValidator.validate(listOf(section("database", annotated = false)))
+
+    assertThat(violations).singleElement().satisfies({
+      assertThat(it.message).contains("@ConfigSection")
+    })
+  }
+
+  @Test
+  fun `flags a blank description`() {
+    val keys = listOf(leaf("database.hostname").copy(description = "   "))
+
+    val violations = ConfigDocValidator.validate(keys)
+
+    assertThat(violations).singleElement().satisfies({
+      assertThat(it.message).contains("must not be blank")
+    })
+  }
+
+  @Test
+  fun `accepts a deprecated key without a replacement (plain removal)`() {
+    val keys = listOf(leaf("database.legacy-host", deprecated = true, replacement = null))
+    assertThat(ConfigDocValidator.validate(keys)).isEmpty()
+  }
+
+  @Test
+  fun `accepts a deprecated key with a replacement`() {
+    val keys = listOf(leaf("database.legacy-host", deprecated = true, replacement = "database.hostname"))
+    assertThat(ConfigDocValidator.validate(keys)).isEmpty()
+  }
+
+  @Test
+  fun `accepts a deprecated section without a replacement`() {
+    val keys = listOf(section("legacy-anchoring", deprecated = true, replacement = null))
+    assertThat(ConfigDocValidator.validate(keys)).isEmpty()
+  }
+
+  @Test
+  fun `formatViolations lists violations sorted by path with guidance`() {
+    val keys = listOf(
+      leaf("zebra", annotated = false),
+      leaf("alpha", annotated = false),
+    )
+
+    val report = ConfigDocValidator.formatViolations(ConfigDocValidator.validate(keys))
+
+    assertThat(report).contains("Missing or invalid Coordinator config documentation:")
+    assertThat(report.indexOf("alpha")).isLessThan(report.indexOf("zebra"))
+    assertThat(report).contains("Add @ConfigDoc")
+  }
+}

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/toml/ConfigDocValidatorIntegrationTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/toml/ConfigDocValidatorIntegrationTest.kt
@@ -1,0 +1,58 @@
+package linea.coordinator.config.v2.toml
+
+import linea.coordinator.config.v2.docs.ConfigDocValidator
+import linea.coordinator.config.v2.docs.ConfigSchemaWalker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the walker + validator together. Lives in the `...config.v2.toml` package so the
+ * nested sample classes are recognised as sections by [ConfigSchemaWalker].
+ */
+class ConfigDocValidatorIntegrationTest {
+  data class FullyDocumentedToml(
+    @param:ConfigDoc("The hostname.", example = "localhost")
+    val hostname: String,
+    @param:ConfigDoc("The port.", default = "5432")
+    val port: UInt = 5432u,
+    @param:ConfigSection("Nested retry settings.")
+    val retries: NestedToml = NestedToml(),
+  ) {
+    data class NestedToml(
+      @param:ConfigDoc("Max attempts.", default = "3")
+      val maxAttempts: UInt = 3u,
+    )
+  }
+
+  data class PartlyDocumentedToml(
+    @param:ConfigDoc("The hostname.")
+    val hostname: String,
+    // missing @ConfigDoc
+    val port: UInt = 5432u,
+    // section missing @ConfigSection, and its leaf is undocumented too
+    val retries: NestedToml = NestedToml(),
+  ) {
+    data class NestedToml(
+      val maxAttempts: UInt = 3u,
+    )
+  }
+
+  @Test
+  fun `a fully documented tree produces no violations`() {
+    val keys = ConfigSchemaWalker.walk(FullyDocumentedToml::class)
+    assertThat(ConfigDocValidator.validate(keys)).isEmpty()
+  }
+
+  @Test
+  fun `undocumented leaves and sections are all reported`() {
+    val keys = ConfigSchemaWalker.walk(PartlyDocumentedToml::class)
+
+    val violations = ConfigDocValidator.validate(keys)
+
+    assertThat(violations.map { it.path }).containsExactlyInAnyOrder(
+      "port",
+      "retries",
+      "retries.max-attempts",
+    )
+  }
+}


### PR DESCRIPTION
Add ConfigDocValidator (pure over the walked ConfigKey list) enforcing: every leaf carries @ConfigDoc and every section @ConfigSection, and the description is non-blank. A replacement is optional even for deprecated items (a plain removal is valid). It emits a deterministic, path-sorted violation report.

Wire it behind a ConfigDocCheckMain entrypoint and a standalone checkCoordinatorConfigDocs Gradle task that walks the five root config classes and fails on any violation.

The task is intentionally NOT wired into 'check' yet: the real config classes are annotated in a later phase, so running it now reports the currently-undocumented keys. Wiring into check/CI happens once every key is documented.

This PR implements issue(s) #2978 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Verification-only tooling and tests; no runtime coordinator behavior or config parsing changes.
> 
> **Overview**
> Adds **documentation enforcement** for Coordinator v2 TOML config: a pure `ConfigDocValidator` over walked `ConfigKey`s requires `@ConfigDoc` on leaves, `@ConfigSection` on nested tables, and non-blank descriptions (deprecated keys/sections may omit a replacement).
> 
> `ConfigDocCheckMain` runs the existing schema walker across the five root config file classes and exits non-zero with a path-sorted report on failure. A standalone Gradle task **`checkCoordinatorConfigDocs`** invokes that main class; it is **not** hooked into `check`/CI yet so builds stay green until annotations land on the real config classes.
> 
> Unit tests cover validator rules and report formatting; an integration test exercises walker + validator on sample TOML data classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdbe1667790d65ddae997311be82396f9671c925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->