### PR TITLE
chore(linea-besu): tidy v2.0.0 changelog entries

### DIFF
--- a/linea-besu/package/CHANGELOG.md
+++ b/linea-besu/package/CHANGELOG.md
@@ -1,18 +1,11 @@
 ## [2.0.0] - 2026-07-14
 
-### 🚀 Features
-
-- *(coordinator)* [**breaking**] Web3j upgrade to onboard 7594 support (#3514)
-
 ### 🐛 Bug Fixes
 
-- *(misc)* Web3j-solc solidity resolution workaround (#3516)
 - *(linea-besu)* Updating Besu version (#3535)
 
 ### ⚙️ Miscellaneous Tasks
 
-- *(coordinator)* Update kotlin to v2.4 (#3454)
-- *(ci)* Update image tags (#3553)
 - *(deps)* Align bouncycastle catalog pin to 1.84 (#3562)
 ## [1.1.1] - 2026-06-26
 


### PR DESCRIPTION
## Summary
- Remove non-Besu entries that leaked into the `linea-besu-package` v2.0.0 changelog section via the shared version catalog include-path.
- Keep only the two entries that actually relate to the Besu image: the Besu version bump (#3535) and the bouncycastle catalog pin alignment (#3562).

## Context
The v2.0.0 changelog section included entries scoped to `coordinator`, `misc`, and `ci` because the git-cliff `--include-path` filter for `linea-besu-package` includes `gradle/libs.versions.toml` (the shared version catalog). Any commit touching that file gets pulled into the Besu changelog regardless of its scope. This PR is a manual cleanup of the released v2.0.0 section; the underlying include-path/config behavior is left unchanged for now and will be addressed separately.

Made with [Cursor](https://cursor.com)