### PR TITLE
feat(prover-ray): added pcs compilation in the pipeline

### DIFF
--- a/prover-ray/crypto/koalabear/fri/commitment.go
+++ b/prover-ray/crypto/koalabear/fri/commitment.go
@@ -6,6 +6,25 @@ import (
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/utils"
 )
 
+// leafDomainTag domain-separates Merkle leaves so a table with the same row
+// values but a different (BaseWidth, ExtWidth) shape hashes to a different
+// digest. Without this, e.g. an all-zero base row and an all-zero ext row
+// collide, letting two structurally distinct commitments share a Merkle root
+// and get deduplicated inside inputOpeningRoots.
+const leafDomainTag uint64 = 0x4c66_7269_5f6c_6631 // "Lfri_lf1"
+
+// absorbLeafHeader writes the domain tag and (baseWidth, extWidth) into h
+// before any row values. Prover ([MultiSizeTable.Merkleize]) and verifier
+// ([hashRowOpening]) MUST call this identically or roots will not
+// reconstruct.
+func absorbLeafHeader(h *poseidon2.MDHasher, baseWidth, extWidth int) {
+	var tag, b, e field.Element
+	tag.SetUint64(leafDomainTag)
+	b.SetUint64(uint64(baseWidth))
+	e.SetUint64(uint64(extWidth))
+	h.WriteElements(tag, b, e)
+}
+
 // CommitterState collects the data that are built during the commitment phase
 // of FRI. This includes the RS codewords and their Merkle tree.
 type CommitterState struct {
@@ -82,6 +101,7 @@ func (table MultiSizeTable) Merkleize() *Tree {
 
 		for j := range size {
 			hasher.Reset()
+			absorbLeafHeader(hasher, len(table[i].Base), len(table[i].Ext))
 
 			for k := range table[i].Base {
 				hasher.WriteElements(table[i].Base[k][j])

--- a/prover-ray/crypto/koalabear/fri/pcs.go
+++ b/prover-ray/crypto/koalabear/fri/pcs.go
@@ -1024,6 +1024,7 @@ func openEncodedRow(table SizedTable, row int) RowOpening {
 
 func hashRowOpening(row RowOpening) field.Octuplet {
 	hasher := poseidon2.NewMDHasher()
+	absorbLeafHeader(hasher, len(row.Base), len(row.Ext))
 	for _, base := range row.Base {
 		hasher.WriteElements(base)
 	}

--- a/prover-ray/wiop/compilers/pcs/pcs.go
+++ b/prover-ray/wiop/compilers/pcs/pcs.go
@@ -45,13 +45,16 @@ import (
 const (
 	// friInverseRate is the FRI blow-up factor (codeword size / plaintext size).
 	friInverseRate = 2
-	// friNumQueries is the number of FRI query openings. This is obtained from
-	// https://github.com/ethereum/soundcalc
-	//
-	// To match 128 bits of security, we determined that the following number of
-	// queries is required.
-	friNumQueries = 229
 )
+
+// friNumQueries is the number of FRI query openings. This is obtained from
+// https://github.com/ethereum/soundcalc
+//
+// To match 128 bits of security, we determined that the following number of
+// queries is required. It is a variable (rather than a constant) so tests
+// exercising the full compilation pipeline can lower it via
+// [SetFRINumQueriesForTest]; production callers must never mutate it.
+var friNumQueries = 229
 
 var (
 	// maxCommittableSizeLog2 is the fixed capacity of the static FRI parameters:

--- a/prover-ray/wiop/compilers/pcs/pcs_testhook.go
+++ b/prover-ray/wiop/compilers/pcs/pcs_testhook.go
@@ -1,0 +1,13 @@
+package pcs
+
+import "sync"
+
+// SetFRINumQueriesForTest overrides [friNumQueries] and resets the process-wide
+// static FRI parameters so the next call to [staticFRI] rebuilds them at the
+// new query count. It is intended solely for tests that exercise the full
+// compilation pipeline with a low query count; production code must never call
+// it.
+func SetFRINumQueriesForTest(n int) {
+	friNumQueries = n
+	staticFRIOnce = sync.Once{}
+}

--- a/prover-ray/wiop/compilers/pipeline_test.go
+++ b/prover-ray/wiop/compilers/pipeline_test.go
@@ -8,11 +8,19 @@ import (
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/localvanishing"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/logderivativesum"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/lookuptologderivsum"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/pcs"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/compilers/rangecheck"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/wiop/wioptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func init() {
+	// Full-pipeline tests exercise the PCS end-to-end; keep the query count
+	// tiny so the suite stays fast. Production callers never touch this
+	// variable (see pcs.SetFRINumQueriesForTest).
+	pcs.SetFRINumQueriesForTest(2)
+}
 
 // compileFullPipeline runs every wiop compilation pass in the canonical
 // order so that each pass can consume the previous one's output:
@@ -22,6 +30,7 @@ import (
 //  3. logderivativesum:     LogDerivativeSum → recurrence Vanishings + endpoint openings
 //  4. localvanishing:       scalar Vanishings → multi-valued Vanishings via the Lagrange lift
 //  5. global:               multi-valued Vanishings → quotient shares + LagrangeEval claims
+//  6. pcs:                  commit every committed round, open every LagrangeEval claim
 //
 // Each pass is a no-op when its input queries are absent, so this ordering
 // is safe to apply uniformly to every wioptest scenario regardless of which
@@ -32,6 +41,24 @@ func compileFullPipeline(sys *wiop.System) {
 	logderivativesum.Compile(sys)
 	localvanishing.Compile(sys)
 	global.Compile(sys)
+	// FRI cannot fold a size-1 codeword, so skip the PCS pass for scenarios
+	// that declare any statically size-1 module. Left as a known gap until
+	// the PCS/FRI layer handles the D=1 edge case.
+	if !hasStaticSizeOneModule(sys) {
+		pcs.Compile(sys)
+	}
+}
+
+// hasStaticSizeOneModule reports whether sys declares any statically-sized
+// module of size 1. Dynamic modules whose runtime size happens to be 1 are
+// not detected here; those scenarios would still panic during Prove.
+func hasStaticSizeOneModule(sys *wiop.System) bool {
+	for _, m := range sys.Modules {
+		if !m.IsDynamic() && m.Size() == 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // These tests drive every scenario through the full


### PR DESCRIPTION
Added the pcs compilation phase in the wiop pipeline tests. Fixed a collision issue in the merkle trees -> domain separation was missing 