### PR TITLE
fix(prover-ray): repair broken logderivative pipeline tests

### DIFF
--- a/prover-ray/wiop/compilers/pipeline_test.go
+++ b/prover-ray/wiop/compilers/pipeline_test.go
@@ -38,15 +38,30 @@ func init() {
 // is safe to apply uniformly to every wioptest scenario regardless of which
 // pass the scenario is primarily exercising.
 func compileFullPipeline(sys *wiop.System) {
+	compilePipelineBeforePCS(sys)
+	compilePCS(sys)
+}
+
+// compilePipelineBeforePCS runs every pass up to (but excluding) the PCS pass:
+// range check → lookup → grand-product → log-derivative → local vanishing →
+// global quotient. After it, the Z columns and quotient shares exist and every
+// constraint is reduced to LagrangeEval claims, but the columns are still
+// transported in the clear. Split out from [compileFullPipeline] so a test can
+// inject a prover-side tamper on a compiled column before the PCS pass hides
+// and commits it.
+func compilePipelineBeforePCS(sys *wiop.System) {
 	rangecheck.Compile(sys)
 	lookuptologderivsum.Compile(sys)
 	grandproduct.Compile(sys)
 	logderivativesum.Compile(sys)
 	localvanishing.Compile(sys)
 	global.Compile(sys)
-	// FRI cannot fold a size-1 codeword, so skip the PCS pass for scenarios
-	// that declare any statically size-1 module. Left as a known gap until
-	// the PCS/FRI layer handles the D=1 edge case.
+}
+
+// compilePCS runs the PCS pass unless the system declares a statically size-1
+// module. FRI cannot fold a size-1 codeword, so those scenarios skip PCS — a
+// known gap until the PCS/FRI layer handles the D=1 edge case.
+func compilePCS(sys *wiop.System) {
 	if !hasStaticSizeOneModule(sys) {
 		pcs.Compile(sys)
 	}
@@ -221,23 +236,20 @@ func TestFullPipeline_LogDerivativeSumTamperedResult(t *testing.T) {
 func TestFullPipeline_LogDerivativeSumTamperedZ(t *testing.T) {
 	sc := wioptest.NewLDSSingleFractionAllOnesScenario()
 
+	// Compile the arithmetization first, identify the Z column, then register a
+	// prover-side tamper on an interior Z row BEFORE the PCS pass. The tamper
+	// runs during Prove after Z is assigned but before PCS commits it, so the
+	// FRI commitment and opening bind the tampered column: the PCS-local checks
+	// pass and only the recurrence — discharged by the global quotient — rejects.
 	before := snapshotModuleColumns(sc.Sys)
-	compileFullPipeline(sc.Sys)
+	compilePipelineBeforePCS(sc.Sys)
 	zCols := newExtensionColumns(sc.Sys, before)
 	require.NotEmpty(t, zCols, "logderivativesum must add Z columns")
 
+	wioptest.Mutator{Column: zCols[0], Row: 1, Tweak: wioptest.AddOne}.Compile(sc.Sys)
+	compilePCS(sc.Sys)
+
 	proof, pub := sc.Sys.Prove(sc.AssignWitness)
-	require.NoError(t, sc.Sys.Verify(proof, pub),
-		"honest log-derivative witness must verify through the full pipeline")
-
-	z := zCols[0]
-	cv := proof.Columns[z.Context.ID]
-	require.NotNil(t, cv, "the Z column must be captured in the proof")
-	ext := cv.Plain.AsExt()
-	require.GreaterOrEqual(t, len(ext), 3, "need at least one interior row to tamper")
-	one := field.OneExt()
-	ext[1].Add(&ext[1], &one) // interior row 1; endpoint (last row) left intact
-
 	assert.Error(t, sc.Sys.Verify(proof, pub),
 		"the full pipeline must reject a Z column whose interior recurrence is violated")
 }
@@ -255,27 +267,20 @@ func TestFullPipeline_LogDerivativeSumTamperedZ(t *testing.T) {
 func TestFullPipeline_PermutationTamperedZ(t *testing.T) {
 	sc := wioptest.NewPermutationSingleColumnScenario()
 
+	// Compile the arithmetization first, identify the Z column, then register a
+	// prover-side tamper on an interior Z row BEFORE the PCS pass. The endpoint
+	// (last row) and Result cell are left intact, so the grandproduct-local
+	// verifier actions still pass; only the recurrence — discharged by the
+	// global quotient — rejects the tampered interior row.
 	before := snapshotModuleColumns(sc.Sys)
-	compileFullPipeline(sc.Sys)
+	compilePipelineBeforePCS(sc.Sys)
 	zCols := newExtensionColumns(sc.Sys, before)
 	require.NotEmpty(t, zCols, "grandproduct must add Z columns")
 
-	// Sanity: the honest proof verifies.
+	wioptest.Mutator{Column: zCols[0], Row: 1, Tweak: wioptest.AddOne}.Compile(sc.Sys)
+	compilePCS(sc.Sys)
+
 	proof, pub := sc.Sys.Prove(sc.AssignHonest)
-	require.NoError(t, sc.Sys.Verify(proof, pub),
-		"honest permutation witness must verify through the full pipeline")
-
-	// Corrupt one interior row of a Z column, leaving its endpoint (last row)
-	// untouched. The endpoint openings and Result cell are unchanged, so the
-	// grandproduct-local verifier actions still pass; the recurrence does not.
-	z := zCols[0]
-	cv := proof.Columns[z.Context.ID]
-	require.NotNil(t, cv, "the Z column must be captured in the proof")
-	ext := cv.Plain.AsExt()
-	require.GreaterOrEqual(t, len(ext), 3, "need at least one interior row to tamper")
-	one := field.OneExt()
-	ext[1].Add(&ext[1], &one) // interior row 1; endpoint (last row) left intact
-
 	assert.Error(t, sc.Sys.Verify(proof, pub),
 		"the full pipeline must reject a Z column whose interior recurrence is violated")
 }


### PR DESCRIPTION
This PR fixes several broken logderivative pipeline unit tests which did not work after merging PCS. 