### PR TITLE
chore(coordinator): Web3Signer and VertxHttpRestClient log request/responses  

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
@@ -19,6 +19,8 @@ import linea.web3j.transactionmanager.AsyncFriendlyTransactionManager
 import net.consensys.linea.contract.l1.Web3JLineaRollupSmartContractClient
 import net.consensys.linea.contract.l1.Web3JLineaValidiumSmartContractClient
 import net.consensys.linea.httprest.client.VertxHttpRestClient
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import org.web3j.crypto.Credentials
 import org.web3j.protocol.Web3j
 import org.web3j.service.TxSignServiceImpl
@@ -34,6 +36,7 @@ fun createTransactionManager(
   vertx: Vertx,
   signerConfig: SignerConfig,
   client: Web3j,
+  log: Logger = LogManager.getLogger("clients.web3signer"),
 ): AsyncFriendlyTransactionManager {
   fun loadKeyAndTrustStoreFromFiles(
     webClientOptions: WebClientOptions,
@@ -110,7 +113,7 @@ fun createTransactionManager(
             }
         val poolOptions = PoolOptions()
           .setHttp1MaxSize(web3SignerConfig.maxPoolSize)
-        val httpRestClient = VertxHttpRestClient(webClientOptions, poolOptions, vertx)
+        val httpRestClient = VertxHttpRestClient(webClientOptions, poolOptions, vertx, log)
         val signer = Web3SignerRestClient(httpRestClient, signerConfig.web3signer.publicKey)
         val signerAdapter = ECKeypairSignerAdapter(signer)
         val web3SignerCredentials = Credentials.create(signerAdapter)

--- a/jvm-libs/generic/http-rest/src/main/kotlin/net/consensys/linea/httprest/client/VertxHttpRestClient.kt
+++ b/jvm-libs/generic/http-rest/src/main/kotlin/net/consensys/linea/httprest/client/VertxHttpRestClient.kt
@@ -12,6 +12,7 @@ import io.vertx.ext.web.client.WebClient
 import io.vertx.ext.web.client.WebClientOptions
 import linea.error.ErrorResponse
 import net.consensys.linea.async.toSafeFuture
+import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
@@ -20,16 +21,21 @@ import java.net.URI
 class VertxHttpRestClient(
   private val webClientOptions: WebClientOptions,
   poolOptions: PoolOptions = PoolOptions(),
-  private val vertx: Vertx,
+  val vertx: Vertx,
+  private val log: Logger = LogManager.getLogger(VertxHttpRestClient::class.java),
+  private val requestResponseLogLevel: Level = Level.TRACE,
+  private val failuresLogLevel: Level = Level.DEBUG,
 ) : HttpRestClient {
   private var webClient = WebClient.create(vertx, webClientOptions, poolOptions)
-  private val log: Logger = LogManager.getLogger(this.javaClass)
 
   override fun get(
     path: String,
     params: List<Pair<String, String>>,
     resultMapper: (Any?) -> Any?,
   ): SafeFuture<Result<Any?, ErrorResponse<RestErrorType>>> {
+    val method = "GET"
+    logRequest(method, path, params)
+
     return webClient
       .get(webClientOptions.defaultPort, webClientOptions.defaultHost, path)
       .apply {
@@ -40,28 +46,17 @@ class VertxHttpRestClient(
       .send()
       .flatMap { response: HttpResponse<Buffer> ->
         if (isSuccessStatusCode(response.statusCode())) {
-          log.debug("Received response with status code: ${response.statusCode()}")
+          logResponse(isError = false, method = method, path = path, requestBody = params, response = response)
           Future.succeededFuture(Ok(resultMapper(response)))
         } else {
-          log.error(
-            "Something went wrong: " +
-              "endpoint=${URI(
-                "http",
-                null,
-                webClientOptions.defaultHost,
-                webClientOptions.defaultPort,
-                path,
-                null,
-                null,
-              ).toURL()}, " +
-              "statusMessage=${response.statusMessage()}",
-          )
+          logResponse(isError = true, method = method, path = path, requestBody = params, response = response)
           val errorType = RestErrorType.fromStatusCode(response.statusCode())
           Future.succeededFuture(Err(ErrorResponse(errorType, response.statusMessage())))
         }
       }
-      .onFailure { err ->
-        Err(ErrorResponse(RestErrorType.UNKNOWN, err.message ?: "Unknown error"))
+      .recover { err ->
+        logRequestFailure(method, path, params, err)
+        Future.succeededFuture(Err(ErrorResponse(RestErrorType.UNKNOWN, err.message ?: "Unknown error")))
       }
       .toSafeFuture()
   }
@@ -71,36 +66,87 @@ class VertxHttpRestClient(
     buffer: Buffer,
     resultMapper: (Any?) -> Any?,
   ): SafeFuture<Result<Any?, ErrorResponse<RestErrorType>>> {
+    val method = "POST"
+    logRequest(method, path, buffer)
+
     return webClient
       .post(webClientOptions.defaultPort, webClientOptions.defaultHost, path)
       .putHeader("Content-Type", "application/json")
       .sendBuffer(buffer)
       .flatMap { httpResponse: HttpResponse<Buffer> ->
         if (isSuccessStatusCode(httpResponse.statusCode())) {
-          log.debug("Received response with status code: ${httpResponse.statusCode()}")
+          logResponse(isError = false, method = method, path = path, requestBody = buffer, response = httpResponse)
           Future.succeededFuture(Ok(resultMapper(httpResponse)))
         } else {
-          log.error(
-            "Something went wrong: " +
-              "endpoint=${URI(
-                "http",
-                null,
-                webClientOptions.defaultHost,
-                webClientOptions.defaultPort,
-                path,
-                null,
-                null,
-              ).toURL()}, " +
-              "statusMessage=${httpResponse.statusMessage()}",
-          )
+          logResponse(isError = true, method = method, path = path, requestBody = buffer, response = httpResponse)
           val errorType = RestErrorType.fromStatusCode(httpResponse.statusCode())
           Future.succeededFuture(Err(ErrorResponse(errorType, httpResponse.statusMessage())))
         }
       }
-      .onFailure { err ->
-        Err(ErrorResponse(RestErrorType.UNKNOWN, err.message ?: "Unknown error"))
+      .recover { err ->
+        logRequestFailure(method, path, buffer, err)
+        Future.succeededFuture(Err(ErrorResponse(RestErrorType.UNKNOWN, err.message ?: "Unknown error")))
       }
       .toSafeFuture()
+  }
+
+  private fun buildEndpointUri(path: String): URI {
+    return URI(
+      if (webClientOptions.isSsl) "https" else "http",
+      null,
+      webClientOptions.defaultHost,
+      webClientOptions.defaultPort,
+      path,
+      null,
+      null,
+    )
+  }
+
+  private fun logRequest(method: String, path: String, body: Any?, level: Level = requestResponseLogLevel) {
+    if (!log.isEnabled(level)) return
+    log.log(level, "--> {} {} {}", method, buildEndpointUri(path), body ?: "")
+  }
+
+  private fun logResponse(
+    isError: Boolean,
+    method: String,
+    path: String,
+    requestBody: Any?,
+    response: HttpResponse<Buffer>,
+  ) {
+    val logLevel = if (isError) failuresLogLevel else requestResponseLogLevel
+    if (isError && !log.isEnabled(requestResponseLogLevel)) {
+      // in case of error, log the request that originated the error
+      // to help replicate and debug later
+      logRequest(method, path, requestBody, logLevel)
+    }
+
+    if (!log.isEnabled(logLevel)) return
+    log.log(
+      logLevel,
+      "<-- {} {} {}",
+      buildEndpointUri(path),
+      response.statusCode(),
+      response.statusMessage(),
+    )
+  }
+
+  private fun logRequestFailure(method: String, path: String, requestBody: Any?, failureCause: Throwable) {
+    if (!log.isEnabled(requestResponseLogLevel)) {
+      // request/response tracing wasn't active, log the request that originated the error
+      // to help replicate and debug later
+      logRequest(method, path, requestBody, failuresLogLevel)
+    }
+
+    if (!log.isEnabled(failuresLogLevel)) return
+    log.log(
+      failuresLogLevel,
+      "<--> {} {} failed with error={}",
+      method,
+      buildEndpointUri(path),
+      failureCause.message,
+      failureCause,
+    )
   }
 
   private fun isSuccessStatusCode(statusCode: Int): Boolean {

--- a/jvm-libs/generic/http-rest/src/main/kotlin/net/consensys/linea/httprest/client/VertxHttpRestClient.kt
+++ b/jvm-libs/generic/http-rest/src/main/kotlin/net/consensys/linea/httprest/client/VertxHttpRestClient.kt
@@ -21,10 +21,11 @@ import java.net.URI
 class VertxHttpRestClient(
   private val webClientOptions: WebClientOptions,
   poolOptions: PoolOptions = PoolOptions(),
-  val vertx: Vertx,
+  vertx: Vertx,
   private val log: Logger = LogManager.getLogger(VertxHttpRestClient::class.java),
   private val requestResponseLogLevel: Level = Level.TRACE,
   private val failuresLogLevel: Level = Level.DEBUG,
+  private val maskRequestBody: Boolean = requestResponseLogLevel != Level.TRACE,
 ) : HttpRestClient {
   private var webClient = WebClient.create(vertx, webClientOptions, poolOptions)
 
@@ -104,7 +105,15 @@ class VertxHttpRestClient(
 
   private fun logRequest(method: String, path: String, body: Any?, level: Level = requestResponseLogLevel) {
     if (!log.isEnabled(level)) return
-    log.log(level, "--> {} {} {}", method, buildEndpointUri(path), body ?: "")
+    val renderedBody = body.toString().let {
+      if (maskRequestBody) {
+        "Hidden Body: size=${it.length} (toString() characters)"
+      } else {
+        it
+      }
+    }
+
+    log.log(level, "--> {} {} {}", method, buildEndpointUri(path), renderedBody)
   }
 
   private fun logResponse(
@@ -124,7 +133,8 @@ class VertxHttpRestClient(
     if (!log.isEnabled(logLevel)) return
     log.log(
       logLevel,
-      "<-- {} {} {}",
+      "<-- {} {} {} {}",
+      method,
       buildEndpointUri(path),
       response.statusCode(),
       response.statusMessage(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and a small error-handling fix in a shared HTTP client; no auth or business-logic changes, with sensitive bodies masked unless TRACE is enabled.
> 
> **Overview**
> **`VertxHttpRestClient`** now emits structured, OkHttp-style request/response logs for GET and POST, with configurable logger, trace/debug levels, and request-body masking (full body only at TRACE). Failed HTTP responses and transport failures log the originating request when trace logging is off, and endpoint URIs use **https** when SSL is enabled.
> 
> Transport failures are handled with **`recover`** so callers still receive an **`Err`** (the previous **`onFailure`** path did not propagate that result).
> 
> The coordinator wires Web3Signer traffic through a dedicated **`clients.web3signer`** logger by passing it into **`VertxHttpRestClient`** from **`createTransactionManager`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94ac72424bb38a674afe7618c0546c34b6dfceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->