### PR TITLE
feat(contracts): v9 interface and stub

### DIFF
--- a/contracts/abi/LinethRollupV9-rc.abi
+++ b/contracts/abi/LinethRollupV9-rc.abi
@@ -1,0 +1,3351 @@
+[
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addressNotFiltered",
+          "type": "address"
+        }
+      ],
+      "name": "AddressIsNotFiltered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "emptyBlobIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "BlobSubmissionDataEmpty",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BlobSubmissionDataIsMissing",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bytesLength",
+          "type": "uint256"
+        }
+      ],
+      "name": "BytesLengthNotMultipleOfTwo",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CallerIsNotYieldManager",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CallerNotLSTWithdrawalRecipient",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "EmptyBlobDataAtIndex",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        }
+      ],
+      "name": "FeePaymentFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FeeTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalBlockHashIsZeroHash",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "FinalShnarfNotSubmitted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "expected",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "FinalShnarfWrong",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalizationBlockHashIsZeroHash",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "nextForcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "FinalizationDataMissingForcedTransaction",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "l2BlockTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentBlockTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "FinalizationInTheFuture",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "expected",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "FinalizationStateIncorrect",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "ForcedTransactionExistsForBlockOrIsTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "expected",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actual",
+          "type": "uint256"
+        }
+      ],
+      "name": "InitializedVersionWrong",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidMerkleProof",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidProof",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "errorReason",
+          "type": "string"
+        }
+      ],
+      "name": "InvalidProofOrProofVerificationRanOutOfGas",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidProofType",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "IsNotPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "IsPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "L1RollingHashDoesNotExistOnL1",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "merkleRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "L2MerkleRootAlreadyAnchored",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "L2MerkleRootDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LSTWithdrawalRequiresDeficit",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LastFinalizationTimeNotLapsed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "leafIndex",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "maxAllowedIndex",
+          "type": "uint32"
+        }
+      ],
+      "name": "LeafIndexOutOfBounds",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LimitIsZero",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "MessageAlreadyClaimed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageDoesNotExistOrHasAlreadyBeenClaimed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "destination",
+          "type": "address"
+        }
+      ],
+      "name": "MessageSendingFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MissingMessageNumberForRollingHash",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "MissingRollingHashForForcedTransactionNumber",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "MissingRollingHashForMessageNumber",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NoEthSent",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyNonLivenessRecoveryOperator",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "OnlySecurityCouncilCanUnpauseIndefinitePause",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ParentShnarfNotSubmitted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "expiryEnd",
+          "type": "uint256"
+        }
+      ],
+      "name": "PauseNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PauseTypeNotUsed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "cooldownEnd",
+          "type": "uint256"
+        }
+      ],
+      "name": "PauseUnavailableDueToCooldown",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PeriodIsZero",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ProofIsEmpty",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "actual",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expected",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProofLengthDifferentThanMerkleDepth",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RateLimitExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RolesNotDifferent",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "bits",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintDowncast",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ShnarfAlreadySubmitted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ShnarfSubmissionIsZeroHash",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StartingBlockHashDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StartingRootHashDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ValueSentTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "verifierKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "VerifierKeyAlreadySet",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "verifierKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "VerifierKeyNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VerifierKeysEmpty",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddressNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroHashNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroLengthNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroValueNotAllowed",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldAddressFilter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newAddressFilter",
+          "type": "address"
+        }
+      ],
+      "name": "AddressFilterChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "resettingAddress",
+          "type": "address"
+        }
+      ],
+      "name": "AmountUsedInPeriodReset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "startBlockNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "endBlockNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "parentBlockHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "finalBlockHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DataFinalizedV4",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "parentShnarf",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "finalBlockHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DataSubmittedV4",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "FinalizedStateUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "blockNumberDeadline",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "forcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "rlpEncodedSignedTransaction",
+          "type": "bytes"
+        }
+      ],
+      "name": "ForcedTransactionAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "forcedTransactionFeeInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "ForcedTransactionFeeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "FundingReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "l2MerkleRoot",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "treeDepth",
+          "type": "uint256"
+        }
+      ],
+      "name": "L2MerkleRootAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "l2Block",
+          "type": "uint256"
+        }
+      ],
+      "name": "L2MessagingBlockAnchored",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "amountChangeBy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "amountUsedLoweredToLimit",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "usedAmountResetToZero",
+          "type": "bool"
+        }
+      ],
+      "name": "LimitAmountChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes8",
+          "name": "initialContractVersion",
+          "type": "bytes8"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "initialBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "initialL2BlockNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "genesisTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultVerifier",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitPeriodInSeconds",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitAmountInWei",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "addressWithRole",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPermissionsManager.RoleAddress[]",
+              "name": "roleAddresses",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "pauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "unpauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "verifierKeys",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultAdmin",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "shnarfProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "addressFilter",
+              "type": "address"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct ILineaRollupBase.BaseInitializationData",
+          "name": "initializationData",
+          "type": "tuple"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "genesisShnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "LineaRollupBaseInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes8",
+          "name": "previousVersion",
+          "type": "bytes8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes8",
+          "name": "newVersion",
+          "type": "bytes8"
+        }
+      ],
+      "name": "LineaRollupVersionChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "livenessRecoveryOperator",
+          "type": "address"
+        }
+      ],
+      "name": "LivenessRecoveryOperatorAddressSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "livenessRecoveryOperator",
+          "type": "address"
+        }
+      ],
+      "name": "LivenessRecoveryOperatorRoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageClaimed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_fee",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_nonce",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "_calldata",
+          "type": "bytes"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "NonSecurityCouncilCooldownEndReset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PauseTypeRoleSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PauseTypeRoleUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "PausedIndefinitely",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "periodInSeconds",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "limitInWei",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "currentPeriodEnd",
+          "type": "uint256"
+        }
+      ],
+      "name": "RateLimitInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RollingHashUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "unPauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "UnPauseTypeRoleSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "unPauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "UnPauseTypeRoleUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "UnPaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "UnPausedDueToExpiry",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "verifierAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "proofType",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "verifierSetBy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldVerifierAddress",
+          "type": "address"
+        }
+      ],
+      "name": "VerifierAddressChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32[]",
+          "name": "verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "VerifierKeysSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32[]",
+          "name": "verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "VerifierKeysUnset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldYieldManagerAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newYieldManagerAddress",
+          "type": "address"
+        }
+      ],
+      "name": "YieldManagerChanged",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "CONTRACT_VERSION",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "contractVersion",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "COOLDOWN_DURATION",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "FORCED_TRANSACTION_FEE_SETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "FORCED_TRANSACTION_SENDER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "INBOX_STATUS_RECEIVED",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "INBOX_STATUS_UNKNOWN",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OPERATOR_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OUTBOX_STATUS_RECEIVED",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OUTBOX_STATUS_SENT",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OUTBOX_STATUS_UNKNOWN",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_ALL_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_DURATION",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_FINALIZATION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_L1_L2_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_L2_L1_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_NATIVE_YIELD_STAKING_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_STATE_DATA_SUBMISSION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "RATE_LIMIT_SETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SECURITY_COUNCIL_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SET_ADDRESS_FILTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SET_VERIFIER_KEY_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SET_YIELD_MANAGER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_ALL_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_FINALIZATION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_L1_L2_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_L2_L1_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_NATIVE_YIELD_STAKING_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_STATE_DATA_SUBMISSION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNSET_VERIFIER_KEY_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "USED_RATE_LIMIT_RESETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "VERIFIER_SETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "VERIFIER_UNSETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "YIELD_PROVIDER_STAKING_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "addressFilter",
+      "outputs": [
+        {
+          "internalType": "contract IAddressFilter",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "blobShnarfExists",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "shnarfExists",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "blockHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "blockHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_fee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address payable",
+          "name": "_feeRecipient",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_calldata",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_nonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "claimMessage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32[]",
+              "name": "proof",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "messageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint32",
+              "name": "leafIndex",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "fee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "feeRecipient",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "merkleRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IL1MessageService.ClaimMessageWithProofParams",
+          "name": "_params",
+          "type": "tuple"
+        }
+      ],
+      "name": "claimMessageWithProof",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32[]",
+              "name": "proof",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "messageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint32",
+              "name": "leafIndex",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "fee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "feeRecipient",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "merkleRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IL1MessageService.ClaimMessageWithProofParams",
+          "name": "_params",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_yieldProvider",
+          "type": "address"
+        }
+      ],
+      "name": "claimMessageWithProofAndWithdrawLST",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentFinalizedShnarf",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentFinalizedState",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentL2BlockNumber",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentPeriodAmountInWei",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentPeriodEnd",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "_aggregatedProof",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_proofType",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "parentStateRootHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "parentBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "endBlockNumber",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "parentShnarf",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "snarkHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "finalStateRootHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "dataEvaluationPoint",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "dataEvaluationClaim",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct ILineaRollupBase.ShnarfData",
+              "name": "shnarfData",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastFinalizedTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "finalTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastFinalizedL1RollingHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "l1RollingHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastFinalizedL1RollingHashMessageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "l1RollingHashMessageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "l2MerkleTreesDepth",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastFinalizedForcedTransactionNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "finalForcedTransactionNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastFinalizedForcedTransactionRollingHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "finalBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "finalBlobHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "l2MerkleRoots",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "address[]",
+              "name": "filteredAddresses",
+              "type": "address[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "verifierKeys",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "bytes",
+              "name": "l2MessagingBlocksOffsets",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct ILineaRollupBase.FinalizationDataV5",
+          "name": "_finalizationData",
+          "type": "tuple"
+        }
+      ],
+      "name": "finalizeBlocks",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "forcedTransactionFeeInWei",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "forcedTransactionL2BlockNumbers",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "l2BlockNumber",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "forcedTransactionRollingHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "fund",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getRequiredForcedTransactionFields",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "finalizedState",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "previousForcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "previousForcedTransactionBlockDeadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentFinalizedL2BlockNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionFeeAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "inboxL2L1MessageStatus",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageStatus",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "initialBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "initialL2BlockNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "genesisTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultVerifier",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitPeriodInSeconds",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitAmountInWei",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "addressWithRole",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPermissionsManager.RoleAddress[]",
+              "name": "roleAddresses",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "pauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "unpauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "verifierKeys",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultAdmin",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "shnarfProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "addressFilter",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct ILineaRollupBase.BaseInitializationData",
+          "name": "_initializationData",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_livenessRecoveryOperator",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_yieldManager",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_messageNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "isMessageClaimed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isClaimed",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "isPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "pauseTypeIsPaused",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isWithdrawLSTAllowed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "merkleRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "l2MerkleRootsDepths",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "treeDepth",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "limitInWei",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "livenessRecoveryOperator",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextForcedTransactionNumber",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextMessageNumber",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nonSecurityCouncilCooldownEnd",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "outboxL1L2MessageStatus",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageStatus",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "pauseByType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "pauseTypeExpiryTimestamps",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "expiryTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "periodInSeconds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "reinitializeLineaRollupV10",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_forcedTransactionFeeInWei",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_addressFilter",
+          "type": "address"
+        }
+      ],
+      "name": "reinitializeLineaRollupV9",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_l2YieldRecipient",
+          "type": "address"
+        }
+      ],
+      "name": "reportNativeYield",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "resetAmountUsedInPeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "resetNonSecurityCouncilCooldownEnd",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "resetRateLimitAmount",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "rollingHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_fee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_calldata",
+          "type": "bytes"
+        }
+      ],
+      "name": "sendMessage",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sender",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "originalSender",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_addressFilter",
+          "type": "address"
+        }
+      ],
+      "name": "setAddressFilter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_forcedTransactionFeeInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "setForcedTransactionFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_messageNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_rollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_lastFinalizedForcedTransactionNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_lastFinalizedForcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_lastFinalizedTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "setLivenessRecoveryOperator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_newVerifierAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_proofType",
+          "type": "uint256"
+        }
+      ],
+      "name": "setVerifierAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "_verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "setVerifierKeys",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_newYieldManager",
+          "type": "address"
+        }
+      ],
+      "name": "setYieldManager",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "shnarfProvider",
+      "outputs": [
+        {
+          "internalType": "contract IProvideShnarf",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "stateRootHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "stateRootHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_forcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_blockNumberDeadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_rlpEncodedSignedTransaction",
+          "type": "bytes"
+        }
+      ],
+      "name": "storeForcedTransaction",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "_blobFinalBlockHashes",
+          "type": "bytes32[]"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_parentShnarf",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_finalBlobShnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "submitBlobs",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "systemMigrationBlock",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFundsForNativeYield",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "unPauseByExpiredType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "unPauseByType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_proofType",
+          "type": "uint256"
+        }
+      ],
+      "name": "unsetVerifierAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "_verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "unsetVerifierKeys",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_newRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "updatePauseTypeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_newRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "updateUnpauseTypeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "verifierKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "verifierKeys",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "proofType",
+          "type": "uint256"
+        }
+      ],
+      "name": "verifiers",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "verifierAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "yieldManager",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/contracts/local-deployments-artifacts/deployLinethRollupV9Stub.ts
+++ b/contracts/local-deployments-artifacts/deployLinethRollupV9Stub.ts
@@ -1,0 +1,255 @@
+import * as dotenv from "dotenv";
+import { ethers } from "ethers";
+
+import {
+  abi as LinethRollupV9StubAbi,
+  bytecode as LinethRollupV9StubBytecode,
+} from "./dynamic-artifacts/LinethRollupV9Stub.json";
+import {
+  contractName as AddressFilterContractName,
+  abi as AddressFilterAbi,
+  bytecode as AddressFilterBytecode,
+} from "./static-artifacts/AddressFilter.json";
+import {
+  abi as ForcedTransactionGatewayAbi,
+  bytecode as ForcedTransactionGatewayBytecode,
+} from "./static-artifacts/ForcedTransactionGateway.json";
+import {
+  contractName as MimcAddressContractName,
+  abi as MimcAddressAbi,
+  bytecode as MimcAddressFilterBytecode,
+} from "./static-artifacts/Mimc.json";
+import {
+  contractName as ProxyAdminContractName,
+  abi as ProxyAdminAbi,
+  bytecode as ProxyAdminBytecode,
+} from "./static-artifacts/ProxyAdmin.json";
+import {
+  abi as TransparentUpgradeableProxyAbi,
+  bytecode as TransparentUpgradeableProxyBytecode,
+} from "./static-artifacts/TransparentUpgradeableProxy.json";
+import {
+  LINEA_ROLLUP_V8_PAUSE_TYPES_ROLES,
+  LINEA_ROLLUP_V8_UNPAUSE_TYPES_ROLES,
+  LINEA_ROLLUP_V8_ROLES,
+  OPERATOR_ROLE,
+  YIELD_PROVIDER_STAKING_ROLE,
+  ADDRESS_ZERO,
+  DEAD_ADDRESS,
+  PRECOMPILES_ADDRESSES,
+  FORCED_TRANSACTION_SENDER_ROLE,
+} from "../common/constants";
+import { deployContractFromArtifacts, getDeployNonceFromEnv, getInitializerData } from "../common/helpers/deployments";
+import { getBooleanEnvVarOrDefault, getEnvVarOrDefault, getRequiredEnvVar } from "../common/helpers/environment";
+import { resolveOneModelFeeOverrides } from "../common/helpers/feeOverrides";
+import {
+  getDeploymentNetworkName,
+  requireAddressesFromRegistryOrEnv,
+  requireAddressFromRegistryOrEnv,
+} from "../common/helpers/readAddress";
+import { generateRoleAssignments } from "../common/helpers/roles";
+
+dotenv.config();
+
+async function main() {
+  const networkName = getDeploymentNetworkName();
+  const lineaRollupInitialBlockHash = getRequiredEnvVar("INITIAL_L2_BLOCK_HASH");
+  const lineaRollupInitialL2BlockNumber = getRequiredEnvVar("INITIAL_L2_BLOCK_NUMBER");
+  const lineaRollupSecurityCouncil = requireAddressFromRegistryOrEnv(
+    networkName,
+    "L1_SECURITY_COUNCIL",
+    "L1_SECURITY_COUNCIL",
+  );
+  const lineaRollupOperators = requireAddressesFromRegistryOrEnv(
+    networkName,
+    "LINEA_ROLLUP_OPERATORS",
+    "LINEA_ROLLUP_OPERATORS",
+  );
+  const lineaRollupRateLimitPeriodInSeconds = getRequiredEnvVar("LINEA_ROLLUP_RATE_LIMIT_PERIOD");
+  const lineaRollupRateLimitAmountInWei = getRequiredEnvVar("LINEA_ROLLUP_RATE_LIMIT_AMOUNT");
+  const lineaRollupGenesisTimestamp = getRequiredEnvVar("L2_GENESIS_TIMESTAMP");
+
+  // The default true preserves existing local deploy behavior; the quickstart opts into false to skip the gateway.
+  const deployForcedTransactionGateway = getBooleanEnvVarOrDefault("DEPLOY_FORCED_TRANSACTION_GATEWAY", true);
+
+  const multiCallAddress = "0xcA11bde05977b3631167028862bE2a173976CA11";
+  const lineaRollupName = "LinethRollupV9Stub";
+  const lineaRollupImplementationName = "LinethRollupV9StubImplementation";
+  const forcedTransactionGatewayName = "ForcedTransactionGateway";
+
+  const pauseTypeRoles = getEnvVarOrDefault("LINEA_ROLLUP_PAUSE_TYPES_ROLES", LINEA_ROLLUP_V8_PAUSE_TYPES_ROLES);
+  const unpauseTypeRoles = getEnvVarOrDefault("LINEA_ROLLUP_UNPAUSE_TYPES_ROLES", LINEA_ROLLUP_V8_UNPAUSE_TYPES_ROLES);
+
+  // Use random hardcoded address until we introduce YieldManager E2E tests
+  const automationServiceAddress = "0x3A9f0c2b8e7D4F6e1b5a9C2e0Fd7a4B6C8e9F1A2";
+  const defaultRoleAddresses = [
+    ...generateRoleAssignments(LINEA_ROLLUP_V8_ROLES, lineaRollupSecurityCouncil, [
+      { role: OPERATOR_ROLE, addresses: lineaRollupOperators },
+    ]),
+    { role: YIELD_PROVIDER_STAKING_ROLE, addressWithRole: automationServiceAddress },
+  ];
+  const roleAddresses = getEnvVarOrDefault("LINEA_ROLLUP_ROLE_ADDRESSES", defaultRoleAddresses);
+
+  // No real RISC-V guest-program verifier keys exist yet. submitBlobs/finalizeBlocks are no-op
+  // stubs on this contract, so a key is never actually checked against a proof - a randomly
+  // generated placeholder is enough to satisfy initialization.
+  const verifierKeys = [ethers.hexlify(ethers.randomBytes(32))];
+
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+
+  const wallet = new ethers.Wallet(process.env.DEPLOYER_PRIVATE_KEY!, provider);
+
+  // The public quickstart can pin local L1 deploy gas for deterministic boot
+  // behavior via L1_DEPLOY_GAS_PRICE_WEI; otherwise the provider's fee data is
+  // used. resolveOneModelFeeOverrides guarantees a single, complete fee model.
+  const feeOverrides = await resolveOneModelFeeOverrides(provider, "L1_DEPLOY_GAS_PRICE_WEI");
+
+  const walletNonce = await getDeployNonceFromEnv(wallet, "L1_NONCE");
+
+  const [lineaRollupImplementation, proxyAdmin, addressFilter] = await Promise.all([
+    deployContractFromArtifacts(
+      lineaRollupImplementationName,
+      LinethRollupV9StubAbi,
+      LinethRollupV9StubBytecode,
+      wallet,
+      {
+        nonce: walletNonce,
+        ...feeOverrides,
+      },
+    ),
+    deployContractFromArtifacts(ProxyAdminContractName, ProxyAdminAbi, ProxyAdminBytecode, wallet, {
+      nonce: walletNonce + 1,
+      ...feeOverrides,
+    }),
+    deployContractFromArtifacts(
+      AddressFilterContractName,
+      AddressFilterAbi,
+      AddressFilterBytecode,
+      wallet,
+      lineaRollupSecurityCouncil,
+      PRECOMPILES_ADDRESSES,
+      {
+        nonce: walletNonce + 2,
+        ...feeOverrides,
+      },
+    ),
+  ]);
+
+  const [proxyAdminAddress, lineaRollupImplementationAddress, addressFilterAddress] = await Promise.all([
+    proxyAdmin.getAddress(),
+    lineaRollupImplementation.getAddress(),
+    addressFilter.getAddress(),
+  ]);
+
+  const initializer = getInitializerData(LinethRollupV9StubAbi, "initialize", [
+    {
+      initialBlockHash: lineaRollupInitialBlockHash,
+      initialL2BlockNumber: lineaRollupInitialL2BlockNumber,
+      genesisTimestamp: lineaRollupGenesisTimestamp,
+      // finalizeBlocks is a no-op stub here, so the verifier is never invoked - DEAD_ADDRESS is a
+      // non-zero placeholder that satisfies the zero-address check without deploying a real verifier.
+      defaultVerifier: DEAD_ADDRESS,
+      rateLimitPeriodInSeconds: lineaRollupRateLimitPeriodInSeconds,
+      rateLimitAmountInWei: lineaRollupRateLimitAmountInWei,
+      roleAddresses,
+      pauseTypeRoles,
+      unpauseTypeRoles,
+      verifierKeys,
+      defaultAdmin: lineaRollupSecurityCouncil,
+      shnarfProvider: ADDRESS_ZERO,
+      addressFilter: addressFilterAddress,
+    },
+    // Liveness recovery operator
+    multiCallAddress,
+    // Use random hardcoded address temporarily until we introduce YieldManager to E2E tests
+    "0xB7De4A2cf9E1c6a0B5f8d3e7a9C4B1a2e6d0f5C8",
+  ]);
+
+  const lineaRollupContract = await deployContractFromArtifacts(
+    lineaRollupName,
+    TransparentUpgradeableProxyAbi,
+    TransparentUpgradeableProxyBytecode,
+    wallet,
+    lineaRollupImplementationAddress,
+    proxyAdminAddress,
+    initializer,
+    {
+      nonce: walletNonce + 3,
+      ...feeOverrides,
+    },
+  );
+
+  const lineaRollupAddress = await lineaRollupContract.getAddress();
+
+  if (deployForcedTransactionGateway) {
+    const destinationChainId = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID");
+    const l2BlockBuffer = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_L2_BLOCK_BUFFER");
+    const maxGasLimit = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_MAX_GAS_LIMIT");
+    const maxInputLengthBuffer = getRequiredEnvVar("FORCED_TRANSACTION_GATEWAY_MAX_INPUT_LENGTH_BUFFER");
+    const l2BlockDurationSeconds = getRequiredEnvVar("FORCED_TRANSACTION_L2_BLOCK_DURATION_SECONDS");
+    const blockNumberDeadlineBuffer = getRequiredEnvVar("FORCED_TRANSACTION_BLOCK_NUMBER_DEADLINE_BUFFER");
+    const securityCouncilPrivateKey = getRequiredEnvVar("SECURITY_COUNCIL_PRIVATE_KEY");
+
+    const mimc = await deployContractFromArtifacts(
+      MimcAddressContractName,
+      MimcAddressAbi,
+      MimcAddressFilterBytecode,
+      wallet,
+      {
+        nonce: walletNonce + 4,
+        ...feeOverrides,
+      },
+    );
+    const mimcAddress = await mimc.getAddress();
+
+    const args = [
+      lineaRollupAddress,
+      destinationChainId,
+      l2BlockBuffer,
+      maxGasLimit,
+      maxInputLengthBuffer,
+      lineaRollupSecurityCouncil,
+      addressFilterAddress,
+      l2BlockDurationSeconds,
+      blockNumberDeadlineBuffer,
+    ];
+
+    const forcedTransactionGateway = await deployContractFromArtifacts(
+      forcedTransactionGatewayName,
+      ForcedTransactionGatewayAbi,
+      ForcedTransactionGatewayBytecode,
+      wallet,
+      { libraries: { "src/libraries/Mimc.sol:Mimc": mimcAddress } },
+      ...args,
+      {
+        nonce: walletNonce + 5,
+        ...feeOverrides,
+      },
+    );
+
+    const forcedTransactionGatewayAddress = await forcedTransactionGateway.getAddress();
+    const securityCouncilWallet = new ethers.Wallet(securityCouncilPrivateKey, provider);
+    const lineaRollup = new ethers.Contract(lineaRollupAddress, LinethRollupV9StubAbi, securityCouncilWallet);
+
+    console.log(
+      `Granting FORCED_TRANSACTION_SENDER_ROLE to ForcedTransactionGateway at ${forcedTransactionGatewayAddress}...`,
+    );
+    const grantRoleTx = await lineaRollup.grantRole(
+      FORCED_TRANSACTION_SENDER_ROLE,
+      forcedTransactionGatewayAddress,
+      feeOverrides,
+    );
+    await grantRoleTx.wait();
+    console.log(`FORCED_TRANSACTION_SENDER_ROLE granted to ForcedTransactionGateway`);
+  } else {
+    console.log(
+      "DEPLOY_FORCED_TRANSACTION_GATEWAY=false; skipping Mimc and ForcedTransactionGateway deploy. " +
+        "The next L1 deploy starts after the LineaRollup proxy nonce.",
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/contracts/local-deployments-artifacts/dynamic-artifacts/LinethRollupV9Stub.json
+++ b/contracts/local-deployments-artifacts/dynamic-artifacts/LinethRollupV9Stub.json
@@ -1,0 +1,3355 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "LinethRollupV9Stub",
+  "sourceName": "src/rollup/LinethRollupV9Stub.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addressNotFiltered",
+          "type": "address"
+        }
+      ],
+      "name": "AddressIsNotFiltered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "emptyBlobIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "BlobSubmissionDataEmpty",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BlobSubmissionDataIsMissing",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bytesLength",
+          "type": "uint256"
+        }
+      ],
+      "name": "BytesLengthNotMultipleOfTwo",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CallerIsNotYieldManager",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CallerNotLSTWithdrawalRecipient",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "EmptyBlobDataAtIndex",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        }
+      ],
+      "name": "FeePaymentFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FeeTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalBlockHashIsZeroHash",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "FinalShnarfNotSubmitted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "expected",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "FinalShnarfWrong",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalizationBlockHashIsZeroHash",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "nextForcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "FinalizationDataMissingForcedTransaction",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "l2BlockTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentBlockTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "FinalizationInTheFuture",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "expected",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "FinalizationStateIncorrect",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "ForcedTransactionExistsForBlockOrIsTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "expected",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actual",
+          "type": "uint256"
+        }
+      ],
+      "name": "InitializedVersionWrong",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidMerkleProof",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidProof",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "errorReason",
+          "type": "string"
+        }
+      ],
+      "name": "InvalidProofOrProofVerificationRanOutOfGas",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidProofType",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "IsNotPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "IsPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "L1RollingHashDoesNotExistOnL1",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "merkleRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "L2MerkleRootAlreadyAnchored",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "L2MerkleRootDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LSTWithdrawalRequiresDeficit",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LastFinalizationTimeNotLapsed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "leafIndex",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "maxAllowedIndex",
+          "type": "uint32"
+        }
+      ],
+      "name": "LeafIndexOutOfBounds",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LimitIsZero",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "MessageAlreadyClaimed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageDoesNotExistOrHasAlreadyBeenClaimed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "destination",
+          "type": "address"
+        }
+      ],
+      "name": "MessageSendingFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MissingMessageNumberForRollingHash",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "MissingRollingHashForForcedTransactionNumber",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "MissingRollingHashForMessageNumber",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NoEthSent",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyNonLivenessRecoveryOperator",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "OnlySecurityCouncilCanUnpauseIndefinitePause",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ParentShnarfNotSubmitted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "expiryEnd",
+          "type": "uint256"
+        }
+      ],
+      "name": "PauseNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PauseTypeNotUsed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "cooldownEnd",
+          "type": "uint256"
+        }
+      ],
+      "name": "PauseUnavailableDueToCooldown",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PeriodIsZero",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ProofIsEmpty",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "actual",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expected",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProofLengthDifferentThanMerkleDepth",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RateLimitExceeded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RolesNotDifferent",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "bits",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintDowncast",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ShnarfAlreadySubmitted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ShnarfSubmissionIsZeroHash",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StartingBlockHashDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StartingRootHashDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ValueSentTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "verifierKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "VerifierKeyAlreadySet",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "verifierKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "VerifierKeyNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VerifierKeysEmpty",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddressNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroHashNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroLengthNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroValueNotAllowed",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldAddressFilter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newAddressFilter",
+          "type": "address"
+        }
+      ],
+      "name": "AddressFilterChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "resettingAddress",
+          "type": "address"
+        }
+      ],
+      "name": "AmountUsedInPeriodReset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "startBlockNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "endBlockNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "parentBlockHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "finalBlockHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DataFinalizedV4",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "parentShnarf",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "shnarf",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "finalBlockHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DataSubmittedV4",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "FinalizedStateUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "blockNumberDeadline",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "forcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "rlpEncodedSignedTransaction",
+          "type": "bytes"
+        }
+      ],
+      "name": "ForcedTransactionAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "forcedTransactionFeeInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "ForcedTransactionFeeSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "FundingReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "l2MerkleRoot",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "treeDepth",
+          "type": "uint256"
+        }
+      ],
+      "name": "L2MerkleRootAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "l2Block",
+          "type": "uint256"
+        }
+      ],
+      "name": "L2MessagingBlockAnchored",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "amountChangeBy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "amountUsedLoweredToLimit",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "usedAmountResetToZero",
+          "type": "bool"
+        }
+      ],
+      "name": "LimitAmountChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes8",
+          "name": "initialContractVersion",
+          "type": "bytes8"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "initialBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "initialL2BlockNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "genesisTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultVerifier",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitPeriodInSeconds",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitAmountInWei",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "addressWithRole",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPermissionsManager.RoleAddress[]",
+              "name": "roleAddresses",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "pauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "unpauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "verifierKeys",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultAdmin",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "shnarfProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "addressFilter",
+              "type": "address"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct ILineaRollupBase.BaseInitializationData",
+          "name": "initializationData",
+          "type": "tuple"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "genesisShnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "LineaRollupBaseInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes8",
+          "name": "previousVersion",
+          "type": "bytes8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes8",
+          "name": "newVersion",
+          "type": "bytes8"
+        }
+      ],
+      "name": "LineaRollupVersionChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "livenessRecoveryOperator",
+          "type": "address"
+        }
+      ],
+      "name": "LivenessRecoveryOperatorAddressSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "livenessRecoveryOperator",
+          "type": "address"
+        }
+      ],
+      "name": "LivenessRecoveryOperatorRoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageClaimed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_fee",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_nonce",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "_calldata",
+          "type": "bytes"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "MessageSent",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "NonSecurityCouncilCooldownEndReset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PauseTypeRoleSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PauseTypeRoleUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "PausedIndefinitely",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "periodInSeconds",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "limitInWei",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "currentPeriodEnd",
+          "type": "uint256"
+        }
+      ],
+      "name": "RateLimitInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RollingHashUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "unPauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "UnPauseTypeRoleSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "unPauseType",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "UnPauseTypeRoleUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "messageSender",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "UnPaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "UnPausedDueToExpiry",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "verifierAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "proofType",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "verifierSetBy",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldVerifierAddress",
+          "type": "address"
+        }
+      ],
+      "name": "VerifierAddressChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32[]",
+          "name": "verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "VerifierKeysSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32[]",
+          "name": "verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "VerifierKeysUnset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "oldYieldManagerAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newYieldManagerAddress",
+          "type": "address"
+        }
+      ],
+      "name": "YieldManagerChanged",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "CONTRACT_VERSION",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "contractVersion",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "COOLDOWN_DURATION",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "FORCED_TRANSACTION_FEE_SETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "FORCED_TRANSACTION_SENDER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "INBOX_STATUS_RECEIVED",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "INBOX_STATUS_UNKNOWN",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OPERATOR_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OUTBOX_STATUS_RECEIVED",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OUTBOX_STATUS_SENT",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "OUTBOX_STATUS_UNKNOWN",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_ALL_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_DURATION",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_FINALIZATION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_L1_L2_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_L2_L1_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_NATIVE_YIELD_STAKING_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "PAUSE_STATE_DATA_SUBMISSION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "RATE_LIMIT_SETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SECURITY_COUNCIL_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SET_ADDRESS_FILTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SET_VERIFIER_KEY_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "SET_YIELD_MANAGER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_ALL_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_FINALIZATION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_L1_L2_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_L2_L1_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_NATIVE_YIELD_STAKING_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNPAUSE_STATE_DATA_SUBMISSION_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "UNSET_VERIFIER_KEY_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "USED_RATE_LIMIT_RESETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "VERIFIER_SETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "VERIFIER_UNSETTER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "YIELD_PROVIDER_STAKING_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "addressFilter",
+      "outputs": [
+        {
+          "internalType": "contract IAddressFilter",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_shnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "blobShnarfExists",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "shnarfExists",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "blockHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "blockHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_fee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address payable",
+          "name": "_feeRecipient",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_calldata",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_nonce",
+          "type": "uint256"
+        }
+      ],
+      "name": "claimMessage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32[]",
+              "name": "proof",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "messageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint32",
+              "name": "leafIndex",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "fee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "feeRecipient",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "merkleRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IL1MessageService.ClaimMessageWithProofParams",
+          "name": "_params",
+          "type": "tuple"
+        }
+      ],
+      "name": "claimMessageWithProof",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32[]",
+              "name": "proof",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "messageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint32",
+              "name": "leafIndex",
+              "type": "uint32"
+            },
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "fee",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "feeRecipient",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "merkleRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IL1MessageService.ClaimMessageWithProofParams",
+          "name": "_params",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_yieldProvider",
+          "type": "address"
+        }
+      ],
+      "name": "claimMessageWithProofAndWithdrawLST",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentFinalizedShnarf",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentFinalizedState",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentL2BlockNumber",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentPeriodAmountInWei",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "currentPeriodEnd",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "_aggregatedProof",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_proofType",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "parentStateRootHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "parentBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "endBlockNumber",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "bytes32",
+                  "name": "parentShnarf",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "snarkHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "finalStateRootHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "dataEvaluationPoint",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "dataEvaluationClaim",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct ILineaRollupBase.ShnarfData",
+              "name": "shnarfData",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastFinalizedTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "finalTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastFinalizedL1RollingHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "l1RollingHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastFinalizedL1RollingHashMessageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "l1RollingHashMessageNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "l2MerkleTreesDepth",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastFinalizedForcedTransactionNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "finalForcedTransactionNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastFinalizedForcedTransactionRollingHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "finalBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "finalBlobHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "l2MerkleRoots",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "address[]",
+              "name": "filteredAddresses",
+              "type": "address[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "verifierKeys",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "bytes",
+              "name": "l2MessagingBlocksOffsets",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct ILineaRollupBase.FinalizationDataV5",
+          "name": "_finalizationData",
+          "type": "tuple"
+        }
+      ],
+      "name": "finalizeBlocks",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "forcedTransactionFeeInWei",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "forcedTransactionL2BlockNumbers",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "l2BlockNumber",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "forcedTransactionRollingHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "fund",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getRequiredForcedTransactionFields",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "finalizedState",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "previousForcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "previousForcedTransactionBlockDeadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "currentFinalizedL2BlockNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "forcedTransactionFeeAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "inboxL2L1MessageStatus",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageStatus",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "initialBlockHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "initialL2BlockNumber",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "genesisTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultVerifier",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitPeriodInSeconds",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rateLimitAmountInWei",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "addressWithRole",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPermissionsManager.RoleAddress[]",
+              "name": "roleAddresses",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "pauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum IPauseManager.PauseType",
+                  "name": "pauseType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "role",
+                  "type": "bytes32"
+                }
+              ],
+              "internalType": "struct IPauseManager.PauseTypeRole[]",
+              "name": "unpauseTypeRoles",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "bytes32[]",
+              "name": "verifierKeys",
+              "type": "bytes32[]"
+            },
+            {
+              "internalType": "address",
+              "name": "defaultAdmin",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "shnarfProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "addressFilter",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct ILineaRollupBase.BaseInitializationData",
+          "name": "_initializationData",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "_livenessRecoveryOperator",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_yieldManager",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_messageNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "isMessageClaimed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isClaimed",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "isPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "pauseTypeIsPaused",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isWithdrawLSTAllowed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "merkleRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "l2MerkleRootsDepths",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "treeDepth",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "limitInWei",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "livenessRecoveryOperator",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextForcedTransactionNumber",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextMessageNumber",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nonSecurityCouncilCooldownEnd",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "messageHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "outboxL1L2MessageStatus",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageStatus",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "pauseByType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "pauseTypeExpiryTimestamps",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "expiryTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "periodInSeconds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "reinitializeLineaRollupV10",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_forcedTransactionFeeInWei",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_addressFilter",
+          "type": "address"
+        }
+      ],
+      "name": "reinitializeLineaRollupV9",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_l2YieldRecipient",
+          "type": "address"
+        }
+      ],
+      "name": "reportNativeYield",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "resetAmountUsedInPeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "resetNonSecurityCouncilCooldownEnd",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "resetRateLimitAmount",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "messageNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "rollingHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "rollingHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_fee",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_calldata",
+          "type": "bytes"
+        }
+      ],
+      "name": "sendMessage",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sender",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "originalSender",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_addressFilter",
+          "type": "address"
+        }
+      ],
+      "name": "setAddressFilter",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_forcedTransactionFeeInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "setForcedTransactionFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_messageNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_rollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_lastFinalizedForcedTransactionNumber",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_lastFinalizedForcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_lastFinalizedTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "setLivenessRecoveryOperator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_newVerifierAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_proofType",
+          "type": "uint256"
+        }
+      ],
+      "name": "setVerifierAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "_verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "setVerifierKeys",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_newYieldManager",
+          "type": "address"
+        }
+      ],
+      "name": "setYieldManager",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "shnarfProvider",
+      "outputs": [
+        {
+          "internalType": "contract IProvideShnarf",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "blockNumber",
+          "type": "uint256"
+        }
+      ],
+      "name": "stateRootHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "stateRootHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_forcedTransactionRollingHash",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_blockNumberDeadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_rlpEncodedSignedTransaction",
+          "type": "bytes"
+        }
+      ],
+      "name": "storeForcedTransaction",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "_blobFinalBlockHashes",
+          "type": "bytes32[]"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_parentShnarf",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_finalBlobShnarf",
+          "type": "bytes32"
+        }
+      ],
+      "name": "submitBlobs",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "systemMigrationBlock",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFundsForNativeYield",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "unPauseByExpiredType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        }
+      ],
+      "name": "unPauseByType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_proofType",
+          "type": "uint256"
+        }
+      ],
+      "name": "unsetVerifierAddress",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32[]",
+          "name": "_verifierKeys",
+          "type": "bytes32[]"
+        }
+      ],
+      "name": "unsetVerifierKeys",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_newRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "updatePauseTypeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "enum IPauseManager.PauseType",
+          "name": "_pauseType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_newRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "updateUnpauseTypeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "verifierKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "verifierKeys",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "exists",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "proofType",
+          "type": "uint256"
+        }
+      ],
+      "name": "verifiers",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "verifierAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "yieldManager",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x6080604052348015600e575f5ffd5b506015601f565b601b601f565b60d9565b5f54610100900460ff161560895760405162461bcd60e51b815260206004820152602760248201527f496e697469616c697a61626c653a20636f6e747261637420697320696e697469604482015266616c697a696e6760c81b606482015260840160405180910390fd5b5f5460ff9081161460d7575f805460ff191660ff9081179091556040519081527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b565b6154d4806100e65f395ff3fe6080604052600436106105af575f3560e01c806376df1ecc116102e7578063add9137a11610194578063cc6f7251116100e3578063d9fe8bdd1161009d578063e196fb5d11610078578063e196fb5d1461130f578063e66c2a931461132e578063ee8289201461134d578063f5b541a614611389575f5ffd5b8063d9fe8bdd146112a8578063df5862d1146112bd578063e0960936146112f0575f5ffd5b8063cc6f7251146111bb578063cd9b9e9a146111ee578063cff5d6bb14611204578063d547741f14611237578063d714e37414611256578063d722bbfc14611275575f5ffd5b8063b9fe5cf71161014e578063c0729ab111610129578063c0729ab114611152578063c1dc0f0714611167578063c21169741461117c578063c294c9181461119b575f5ffd5b8063b9fe5cf7146110e0578063bc61e73314611100578063bf3e75051461111f575f5ffd5b8063add9137a1461101d578063ae15ceae14611049578063aea4f7451461107c578063b60d428814611090578063b837dbe914611098578063b9174ba3146110ad575f5ffd5b8063923fe894116102505780639ee8b2111161020a578063a4c4cef7116101e5578063a4c4cef714610f8a578063a505925f14610fa0578063ac1eff6814610fd3578063ad422ff014611008575f5ffd5b80639ee8b21114610f455780639f3ce55a14610f64578063a217fddf14610f77575f5ffd5b8063923fe89414610e6957806392dd3f8714610e9c57806395ba81fa14610ec857806396e6e4b314610ee7578063986fcddd14610d255780639ac25d0814610f12575f5ffd5b80638c7c363a116102a15780638c7c363a14610d975780638da8b59214610db65780638de4948714610dd5578063914e57eb14610e0857806391d1485414610e34578063921b278e14610e53575f5ffd5b806376df1ecc14610cde57806378ea198a14610cf25780637d1e8c5514610d2557806380b7af1814610d38578063874ca76014610d4c5780638be745d114610d6b575f5ffd5b806348922ab71161045f57806360e83cf3116103ae578063695378f5116103685780636e673843116103435780636e67384314610c455780637174c55914610c7857806373bd07b714610cab57806374ce962c14610cbf575f5ffd5b8063695378f514610bdd5780636a906b8014610bf35780636b78317214610c26575f5ffd5b806360e83cf314610b105780636321315514610b3c5780636463fb2a14610b6f578063670bc79514610b8e57806367e404ce14610ba2578063687e2e8114610bbe575f5ffd5b806352e576bb1161041957806358794456116103f45780635879445614610ad05780635b7eb4bd146109935780635c721a0c14610ae55780635ec775b0146106db575f5ffd5b806352e576bb14610a7c5780635334b7e614610a92578063557eac7314610ab1575f5ffd5b806348922ab714610993578063491e0936146109b95780634bb97413146109d8578063516f1a44146109f75780635230eef214610a2a57806352abf32d14610a5d575f5ffd5b80632c70645c1161051b57806338b90333116104d55780633e9ebfc2116104b05780633e9ebfc2146108f75780633fc08b6514610916578063411aa28c1461094157806342277d7014610960575f5ffd5b806338b90333146108735780633b12eccb146108a45780633c0f20fc146108d7575f5ffd5b80632c70645c146107a85780632f2ff15d146107be5780632fe35274146107dd57806334cdf78d146107f957806334db89791461082557806336568abe14610854575f5ffd5b806321b4deee1161056c57806321b4deee146106db578063248a9ca3146106f1578063248c61261461071f57806328958174146107325780632acc8df9146107515780632c3c67d014610789575f5ffd5b806301ffc9a7146105b357806303134d1d146105e7578063085b1c6f146106285780631065a3991461065b578063198330f81461067c5780632130d812146106af575b5f5ffd5b3480156105be575f5ffd5b506105d26105cd36600461479f565b6113a9565b60405190151581526020015b60405180910390f35b3480156105f2575f5ffd5b5061061a7f1ab87f7458c0e3d07e9881c14ee67f0141703614fd48ea5b15ed987e5f4b030e81565b6040519081526020016105de565b348015610633575f5ffd5b5061061a7f220bd22ef7c53d75fe3eac0a09e90815a0c5ba4f9e8da8b039542cd3db34725881565b348015610666575f5ffd5b5061067a6106753660046147d9565b6113df565b005b348015610687575f5ffd5b5061061a7f76ef52a5344b10ed112c1d48c7c06f51e919518ea6fb005f9b25b359b955e3be81565b3480156106ba575f5ffd5b5061061a6106c93660046147f2565b5f9081526101be602052604090205490565b3480156106e6575f5ffd5b5061061a6202a30081565b3480156106fc575f5ffd5b5061061a61070b3660046147f2565b5f9081526065602052604090206001015490565b61067a61072d36600461486c565b611598565b34801561073d575f5ffd5b5061067a61074c3660046147f2565b6116fc565b34801561075c575f5ffd5b506101c054610771906001600160a01b031681565b6040516001600160a01b0390911681526020016105de565b348015610794575f5ffd5b5061067a6107a33660046148d0565b611797565b3480156107b3575f5ffd5b5061061a6101835481565b3480156107c9575f5ffd5b5061067a6107d8366004614907565b6118bc565b3480156107e8575f5ffd5b50600160a01b5f5c0460ff166105d2565b348015610804575f5ffd5b5061061a6108133660046147f2565b6101c86020525f908152604090205481565b348015610830575f5ffd5b506105d261083f3660046147f2565b6101c76020525f908152604090205460ff1681565b34801561085f575f5ffd5b5061067a61086e366004614907565b6118e5565b34801561087e575f5ffd5b5060408051808201825260038152620392e360ec1b602082015290516105de9190614935565b3480156108af575f5ffd5b5061061a7fb6cc65f42901ed602aec1619cc1ead29d487cd489094a37615153eaeb991d77081565b3480156108e2575f5ffd5b506101c154610771906001600160a01b031681565b348015610902575f5ffd5b5061067a61091136600461496a565b6118f3565b348015610921575f5ffd5b5061061a6109303660046147f2565b60a56020525f908152604090205481565b34801561094c575f5ffd5b5061067a61095b366004614907565b611a0d565b34801561096b575f5ffd5b5061061a7f012c76ef7f96cd7eb95acbdc250ad5696bbe3fd2fcf0207571939fa40c2e016781565b34801561099e575f5ffd5b506109a7600181565b60405160ff90911681526020016105de565b3480156109c4575f5ffd5b5061067a6109d3366004614992565b611c01565b3480156109e3575f5ffd5b5061067a6109f2366004614907565b611e7d565b348015610a02575f5ffd5b5061061a7fb63b70db607c764adad98a6745fc4efcea212ebc7b501d5753c57d675f377a6681565b348015610a35575f5ffd5b5061061a7f0cf0d2deb70d7bdac2fa48c4ac99bc558170be0ce5fcb994caefa4bf7b96edf981565b348015610a68575f5ffd5b5061067a610a7736600461496a565b611fa3565b348015610a87575f5ffd5b5061061a6101c55481565b348015610a9d575f5ffd5b5061067a610aac3660046147f2565b6120bd565b348015610abc575f5ffd5b5061067a610acb3660046147f2565b612145565b348015610adb575f5ffd5b5061061a60995481565b348015610af0575f5ffd5b5061061a610aff3660046147f2565b60a66020525f908152604090205481565b348015610b1b575f5ffd5b5061061a610b2a3660046147f2565b6101506020525f908152604090205481565b348015610b47575f5ffd5b5061061a7fe37c272ea30e2bb381ad7cf89ae754b49153250609f36d0cbdad8b64c184bb5c81565b348015610b7a575f5ffd5b5061067a610b89366004614a32565b61220f565b348015610b99575f5ffd5b5061067a61238a565b348015610bad575f5ffd5b505f5c6001600160a01b0316610771565b348015610bc9575f5ffd5b5061067a610bd8366004614aab565b612453565b348015610be8575f5ffd5b5061061a6101195481565b348015610bfe575f5ffd5b5061061a7fd8b4c34c2ec1f3194471108c64ad2beda340c0337ee4ca35592f9ef270f4228b81565b348015610c31575f5ffd5b5061067a610c40366004614ae9565b612582565b348015610c50575f5ffd5b5061061a7f32937fd5162e282df7e9a14a5073a2425321c7966eaf70ed6c838a1006d84c4c81565b348015610c83575f5ffd5b5061061a7f4b4665d8754e6ea0608430ef3e91c1b45c72aafe8800e289cd35f38d8536185881565b348015610cb6575f5ffd5b506109a7600281565b348015610cca575f5ffd5b5061067a610cd9366004614b2c565b61271c565b348015610ce9575f5ffd5b5061067a61274f565b348015610cfd575f5ffd5b5061061a7f4df33217c89b6f12af38ba46035cb312b5e88de78d22279286830fe079b642cd81565b348015610d30575f5ffd5b506109a75f81565b348015610d43575f5ffd5b50610771612795565b348015610d57575f5ffd5b5061067a610d66366004614b47565b6127c3565b348015610d76575f5ffd5b5061061a610d853660046147f2565b61011a6020525f908152604090205481565b348015610da2575f5ffd5b5061067a610db1366004614b2c565b6127e5565b348015610dc1575f5ffd5b5061067a610dd0366004614b93565b6128a7565b348015610de0575f5ffd5b5061061a7fe1fce82838dd7a42cfe783f60dc6233c8aa2c4fc66e77817805e767ec5e349b681565b348015610e13575f5ffd5b5061061a610e223660046147f2565b61014e6020525f908152604090205481565b348015610e3f575f5ffd5b506105d2610e4e366004614907565b6128b2565b348015610e5e575f5ffd5b5061061a6101bf5481565b348015610e74575f5ffd5b5061061a7fcc10d6eec3c757d645e27b3f3001a3ba52f692da0bce25fabf58c6ecaf37645081565b348015610ea7575f5ffd5b5061061a610eb63660046147f2565b6101c36020525f908152604090205481565b348015610ed3575f5ffd5b5061067a610ee23660046147d9565b6128dc565b348015610ef2575f5ffd5b5061061a610f013660046147d9565b60de6020525f908152604090205481565b348015610f1d575f5ffd5b5061061a7f56bdc3c9ec86cb7db110a7699b2ade72f0b8819727d9f7d906b012641505fa7781565b348015610f50575f5ffd5b506105d2610f5f3660046147f2565b612a56565b61067a610f72366004614c09565b612a79565b348015610f82575f5ffd5b5061061a5f81565b348015610f95575f5ffd5b5061061a6101c25481565b348015610fab575f5ffd5b5061061a7f21aba2dd4535739d4ca4cddb3c024036bfcc88cfce067cb0847e7ad0f9cfaa5581565b348015610fde575f5ffd5b50610771610fed3660046147f2565b61011b6020525f90815260409020546001600160a01b031681565b348015611013575f5ffd5b5061061a60985481565b348015611028575f5ffd5b5061061a6110373660046147f2565b6101c46020525f908152604090205481565b348015611054575f5ffd5b5061061a7fdaafd36d8da81d5104d4fd21e3ccc58683c62ba08cd23875bcfbc0583a3f49dd81565b348015611087575f5ffd5b5061067a612a97565b61067a612af2565b3480156110a3575f5ffd5b5061061a60e45481565b3480156110b8575f5ffd5b5061061a7f430a7f0cb00b5ebbe63cecc96e82cf959a883e7c13a95110854f1fa6b3fbf59881565b3480156110eb575f5ffd5b5061061a5f51602061547f5f395f51905f5281565b34801561110b575f5ffd5b506105d261111a3660046147d9565b612b47565b34801561112a575f5ffd5b5061061a7f1185e52d62bfbbea270e57d3d09733d221b53ab7a18bae82bb3c6c74bab16d8281565b34801561115d575f5ffd5b5061061a609a5481565b348015611172575f5ffd5b5061061a60975481565b348015611187575f5ffd5b5061067a611196366004614c60565b612b6b565b3480156111a6575f5ffd5b506101c654610771906001600160a01b031681565b3480156111c6575f5ffd5b5061061a7fe8cb6172fcf5cbaae022b7c910224a4f0c20d53227e630056efff182155a5abc81565b3480156111f9575f5ffd5b5061061a6101bd5481565b34801561120f575f5ffd5b5061061a7f99632df2ab8972394e721143c15eb6f675ca3095f831425245f51ce7d1fcacde81565b348015611242575f5ffd5b5061067a611251366004614907565b612c40565b348015611261575f5ffd5b5061067a611270366004614c7c565b612c64565b348015611280575f5ffd5b5061061a7f6b5661ddfbd1fbd525c902a513e0f47d9c74f1c1ee8a2d4f1937ad305fb8f41a81565b3480156112b3575f5ffd5b5061061a60dd5481565b3480156112c8575f5ffd5b5061061a7f06d10575548d11f448aeb7dc30c867ac7c98f5fea5b08ac339c2421794e7595281565b3480156112fb575f5ffd5b5061067a61130a366004614aab565b612d93565b34801561131a575f5ffd5b5061067a6113293660046147d9565b612f04565b348015611339575f5ffd5b5061067a6113483660046147f2565b6131c2565b348015611358575f5ffd5b50611361613253565b604080519586526020860194909452928401919091526060830152608082015260a0016105de565b348015611394575f5ffd5b5061061a5f51602061545f5f395f51905f5281565b5f6001600160e01b03198216637965db0b60e01b14806113d957506301ffc9a760e01b6001600160e01b03198316145b92915050565b805f81600d8111156113f3576113f3614ce0565b03611411576040516385994c7760e01b815260040160405180910390fd5b60dc5f83600d81111561142657611426614ce0565b600d81111561143757611437614ce0565b81526020019081526020015f205461144e816132a2565b61145783612b47565b61147f5782604051630619659560e21b81526004016114769190614d14565b60405180910390fd5b5f1960de5f85600d81111561149657611496614ce0565b600d8111156114a7576114a7614ce0565b81526020019081526020015f20541480156114d657506114d45f51602061547f5f395f51905f52336128b2565b155b156114f657826040516323bb853560e21b81526004016114769190614d14565b60de5f84600d81111561150b5761150b614ce0565b600d81111561151c5761151c614ce0565b81526020019081526020015f205f905582600d81111561153e5761153e614ce0565b60da8054600190921b19909116905582600d81111561155f5761155f614ce0565b6040513381527fd071d2b85dec4489435b541d2f0e2570db09b09db9efd8703948d44a433df65a906020015b60405180910390a2505050565b7fb63b70db607c764adad98a6745fc4efcea212ebc7b501d5753c57d675f377a666115c2816132a2565b816115e05760405163afd51dbf60e01b815260040160405180910390fd5b5f84116116005760405163273e150360e21b815260040160405180910390fd5b6001600160a01b038516611627576040516342bcdf7f60e11b815260040160405180910390fd5b8561164557604051630742d05360e01b815260040160405180910390fd5b6101c28054600181019091555f1981015f9081526101c3602052604090205485908111611688576040516317d6372960e31b815260040161147691815260200190565b505f8181526101c4602090815260408083208a90556101c390915290819020869055516001600160a01b0387169082907f8fbc8fbd65675eb32c567d4a559963c7d002c2be67b5b266fb13d85b4375fce5906116eb9089908c908a908a90614d4a565b60405180910390a350505050505050565b7f6b5661ddfbd1fbd525c902a513e0f47d9c74f1c1ee8a2d4f1937ad305fb8f41a611726816132a2565b5f82815261011b602090815260408083205490516001600160a01b0390911681523392859290917f4a29db3fc6b42bda201e4b4d69ce8d575eeeba5f153509c0d0a342af0f1bd021910160405180910390a4505f90815261011b6020526040902080546001600160a01b0319169055565b6117a462f099c082614d87565b4210156117c457604051634306cbb160e01b815260040160405180910390fd5b6040805186815260208101869052908101849052606081018390526080810182905260a090206101bf541461183f576101bf546040805187815260208101879052908101859052606081018490526080810183905260a0902060405163bc5aad1160e01b815260048101929092526024820152604401611476565b6101c0546001600160a01b03166118635f51602061545f5f395f51905f52826128b2565b6118b45761187e5f51602061545f5f395f51905f52826132af565b6040516001600160a01b0382169033907f6cfaf6b76ea493a8e88b6b95f7b34cdaae196c4ed737b32e72c5d9e8d0a18518905f90a35b505050505050565b5f828152606560205260409020600101546118d6816132a2565b6118e083836132af565b505050565b6118ef8282613334565b5050565b815f81600d81111561190757611907614ce0565b03611925576040516385994c7760e01b815260040160405180910390fd5b5f51602061547f5f395f51905f5261193c816132a2565b5f60db5f86600d81111561195257611952614ce0565b600d81111561196357611963614ce0565b81526020019081526020015f2054905083810361199357604051631b807f5560e01b815260040160405180910390fd5b8360db5f87600d8111156119a9576119a9614ce0565b600d8111156119ba576119ba614ce0565b815260208101919091526040015f2055808486600d8111156119de576119de614ce0565b6040517f074bfc3728ef1e98bde10bcb5bd8cde59cff190c2bfda5d22f879f865a07bac5905f90a45050505050565b5f54600990610100900460ff16158015611a2d57505f5460ff8083169116105b611a495760405162461bcd60e51b815260040161147690614d9a565b5f805461ffff191660ff8316176101001790555f195f51602061543f5f395f51905f525c01611a7f576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d5f8311611ab05760405163273e150360e21b815260040160405180910390fd5b6001600160a01b038216611ad7576040516342bcdf7f60e11b815260040160405180910390fd5b6101c58390556101c680546001600160a01b0319166001600160a01b0384161790556040518381527fc4733b619696e38077e1b19371d193f42b20a279e3445c3b2b9f4d58db36bc6b9060200160405180910390a1604080515f81526001600160a01b03841660208201527f70a40b63da92dd99e111281bc23dfb08922b6d1337f71f895cf498eb60ff7a0b910160405180910390a160016101c255604051620382e360ec1b9062372e3160e81b907f2f8492a7a430cf917798dfb60bc5af634f68e6c40287947df0ea6f7ec0669bd8905f90a35f5f51602061543f5f395f51905f525d5f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498906020015b60405180910390a1505050565b60015f51602061543f5f395f51905f525c03611c24576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d85878484875f5a9050611c48600361336e565b8d5f805c6001600160a01b0319166001600160a01b03831617905d505f611c748f8f8f8f8c8f8f6133ce565b9050611c7f81613427565b611c91611c8c8d8f614d87565b613468565b5f5f8f6001600160a01b03168e8d8d604051611cae929190614de8565b5f6040518083038185875af1925050503d805f8114611ce8576040519150601f19603f3d011682016040523d82523d5f602084013e611ced565b606091505b509150915081611d3157805115611d075780518082602001fd5b8f604051635461344360e01b815260040161147691906001600160a01b0391909116815260200190565b5f6001600160a01b0319815c16815d5060405183907fa4c827e719e911e8f19393ccdb85b5102f08f0910604d340ba38390b7ff2ab0e905f90a2505086159050611e5d57855f849003611dec57853b158015611dea573a5a611d9561bc7c86614d87565b611d9f9190614df7565b611da99190614e0a565b915081881115611de6576001600160a01b0387166108fc611dca848b614df7565b6040518115909202915f818181858888f1935050505050611dea565b8791505b505b5f6001600160a01b03841615611e025783611e04565b335b90505f816001600160a01b03166108fc8490811502906040515f60405180830381858888f19350505050905080611e595760405163295f137d60e21b81526001600160a01b0383166004820152602401611476565b5050505b5050505050505f5f51602061543f5f395f51905f525d5050505050505050565b6002611e888161336e565b611e90612795565b6001600160a01b0316336001600160a01b031614611ec15760405163a1cfbf5960e01b815260040160405180910390fd5b6001600160a01b038216611ee8576040516342bcdf7f60e11b815260040160405180910390fd5b60e480545f9182611ef883614e21565b9091555060408051308152602081018690525f918101829052606081018790526080810183905260c060a08201819052810182905260e0902091925050611f3f82826134c5565b604080515f80825260208201889052818301859052608060608301819052820152905182916001600160a01b0387169133917fe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c919081900360a00190a45050505050565b815f81600d811115611fb757611fb7614ce0565b03611fd5576040516385994c7760e01b815260040160405180910390fd5b5f51602061547f5f395f51905f52611fec816132a2565b5f60dc5f86600d81111561200257612002614ce0565b600d81111561201357612013614ce0565b81526020019081526020015f2054905083810361204357604051631b807f5560e01b815260040160405180910390fd5b8360dc5f87600d81111561205957612059614ce0565b600d81111561206a5761206a614ce0565b815260208101919091526040015f2055808486600d81111561208e5761208e614ce0565b6040517ff8ef9f1cde7c2c0d3aeb696678f76d7c1c3e13c3b79ea3c5160a2d9eaa821cfd905f90a45050505050565b7fdaafd36d8da81d5104d4fd21e3ccc58683c62ba08cd23875bcfbc0583a3f49dd6120e7816132a2565b5f82116121075760405163273e150360e21b815260040160405180910390fd5b6101c58290556040518281527fc4733b619696e38077e1b19371d193f42b20a279e3445c3b2b9f4d58db36bc6b906020015b60405180910390a15050565b7f1185e52d62bfbbea270e57d3d09733d221b53ab7a18bae82bb3c6c74bab16d8261216f816132a2565b5f5f5f426099541015612194576097546121899042614d87565b6099555060016121a6565b609a548510156121a657849250600191505b609885905580806121b45750815b156121bf57609a8390555b6040805186815283151560208201528215159181019190915233907fbc3dc0cb5c15c51c81316450d44048838bb478b9809447d01c766a06f3e9f2c8906060015b60405180910390a25050505050565b60015f51602061543f5f395f51905f525c03612232576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d60a081018035906122579060808401614b2c565b612265610120840184614e39565b612276610100860160e08701614b2c565b5f5a905061228387613522565b851561237157855f84900361230057853b1580156122fe573a5a6122a961bc7c86614d87565b6122b39190614df7565b6122bd9190614e0a565b9150818811156122fa576001600160a01b0387166108fc6122de848b614df7565b6040518115909202915f818181858888f19350505050506122fe565b8791505b505b5f6001600160a01b038416156123165783612318565b335b90505f816001600160a01b03166108fc8490811502906040515f60405180830381858888f1935050505090508061236d5760405163295f137d60e21b81526001600160a01b0383166004820152602401611476565b5050505b5050505050505f5f51602061543f5f395f51905f525d50565b5f54600a90610100900460ff161580156123aa57505f5460ff8083169116105b6123c65760405162461bcd60e51b815260040161147690614d9a565b5f805461ffff191660ff831617610100178155604051620392e360ec1b91620382e360ec1b917f2f8492a7a430cf917798dfb60bc5af634f68e6c40287947df0ea6f7ec0669bd89190a35f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a150565b7f06d10575548d11f448aeb7dc30c867ac7c98f5fea5b08ac339c2421794e7595261247d816132a2565b8161249b57604051630313632760e31b815260040160405180910390fd5b5f5b82811015612550576101c75f8585848181106124bb576124bb614e7b565b602090810292909201358352508101919091526040015f205460ff168484838181106124e9576124e9614e7b565b90506020020135906125115760405163454f453360e01b815260040161147691815260200190565b506101c75f85858481811061252857612528614e7b565b602090810292909201358352508101919091526040015f20805460ff1916905560010161249d565b507f4e88d098b779d01013074e751eb4eea6c06624e6fbac193b318b88224cd68ea18383604051611bf4929190614ebf565b60015f51602061543f5f395f51905f525c036125a5576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d478260c00135116125da57604051630316ae7f60e51b815260040160405180910390fd5b6125ea60a0830160808401614b2c565b6001600160a01b0316336001600160a01b03161461261b57604051630a5c9f3560e01b815260040160405180910390fd5b5f61262583613788565b9050600160ff60a01b195f805c91909116600160a01b17905d50612647612795565b6001600160a01b0316633e4903b78360c086013561266b60a0880160808901614b2c565b60405160e085901b6001600160e01b03191681526001600160a01b039384166004820152602481019290925290911660448201526064015f604051808303815f87803b1580156126b9575f5ffd5b505af11580156126cb573d5f5f3e3d5ffd5b505f92505050805c60ff60a01b1916815d5060405181907fa4c827e719e911e8f19393ccdb85b5102f08f0910604d340ba38390b7ff2ab0e905f90a2505f5f51602061543f5f395f51905f525d5050565b7f76ef52a5344b10ed112c1d48c7c06f51e919518ea6fb005f9b25b359b955e3be612746816132a2565b6118ef8261384e565b5f51602061547f5f395f51905f52612766816132a2565b4260dd556040517f201956ebe50475cb4c4f2d1e8375cfcc9c1700ad498e0c8053da490688172787905f90a150565b7f594904a11ae10ad7613c91ac3c92c7c3bba397934d377ce6d3e0aaffbc17df00546001600160a01b031690565b600d6127ce8161336e565b5f51602061545f5f395f51905f526118b4816132a2565b7f012c76ef7f96cd7eb95acbdc250ad5696bbe3fd2fcf0207571939fa40c2e016761280f816132a2565b6001600160a01b038216612836576040516342bcdf7f60e11b815260040160405180910390fd5b6101c6546001600160a01b0390811690831681146118e0576101c680546001600160a01b0319166001600160a01b0385811691821790925560408051928416835260208301919091527f70a40b63da92dd99e111281bc23dfb08922b6d1337f71f895cf498eb60ff7a0b9101611bf4565b60066127ce8161336e565b5f9182526065602090815260408084206001600160a01b0393909316845291905290205460ff1690565b805f81600d8111156128f0576128f0614ce0565b0361290e576040516385994c7760e01b815260040160405180910390fd5b61291782612b47565b6129365781604051630619659560e21b81526004016114769190614d14565b60de5f83600d81111561294b5761294b614ce0565b600d81111561295c5761295c614ce0565b81526020019081526020015f20544210156129c15760de5f83600d81111561298657612986614ce0565b600d81111561299757612997614ce0565b81526020019081526020015f205460405163cfd8aa6f60e01b815260040161147691815260200190565b60de5f83600d8111156129d6576129d6614ce0565b600d8111156129e7576129e7614ce0565b81526020019081526020015f205f905581600d811115612a0957612a09614ce0565b60da8054600190921b19909116905581600d811115612a2a57612a2a614ce0565b6040517f3ddaeb19197ed3b5334f4c1cd5716f663d0f6dce30c52800bd1674da0b88e87a905f90a25050565b600881901c5f90815261014f6020526040812054600160ff84161b1615156113d9565b6002612a848161336e565b612a90858585856138fd565b5050505050565b7f0cf0d2deb70d7bdac2fa48c4ac99bc558170be0ce5fcb994caefa4bf7b96edf9612ac1816132a2565b5f609a81905560405133917fba88c025b0cbb77022c0c487beef24f759f1e4be2f51a205bc427cee19c2eaa691a250565b345f03612b125760405163717e6b7b60e01b815260040160405180910390fd5b6040513481527fe455499c2acd509bdadebaf5a8fd54c083da31dbe98e785f2a72cdff04e32e009060200160405180910390a1565b5f81600d811115612b5a57612b5a614ce0565b60da54600190911b16151592915050565b7f32937fd5162e282df7e9a14a5073a2425321c7966eaf70ed6c838a1006d84c4c612b95816132a2565b6001600160a01b038316612bbc576040516342bcdf7f60e11b815260040160405180910390fd5b5f82815261011b60209081526040918290205491516001600160a01b03928316815233928592908716917f4a29db3fc6b42bda201e4b4d69ce8d575eeeba5f153509c0d0a342af0f1bd021910160405180910390a4505f90815261011b6020526040902080546001600160a01b0319166001600160a01b0392909216919091179055565b5f82815260656020526040902060010154612c5a816132a2565b6118e083836139e1565b5f80612c715f5460ff1690565b60ff1614612cab5780612c855f5460ff1690565b604051636fdb2e9360e11b815260ff928316600482015291166024820152604401611476565b5f54600a90610100900460ff16158015612ccb57505f5460ff8083169116105b612ce75760405162461bcd60e51b815260040161147690614d9a565b5f805461ffff191660ff831617610100178155612d1b81873581604080519384526020840192909252908201526060902090565b5f8181526101be60205260409020600190559050612d398682613a47565b612d4285613e28565b612d4b84613ec1565b505f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15050505050565b7f99632df2ab8972394e721143c15eb6f675ca3095f831425245f51ce7d1fcacde612dbd816132a2565b81612ddb57604051630313632760e31b815260040160405180910390fd5b5f5b82811015612ed2575f848483818110612df857612df8614e7b565b9050602002013503612e1d57604051630742d05360e01b815260040160405180910390fd5b6101c75f858584818110612e3357612e33614e7b565b602090810292909201358352508101919091526040015f205460ff1615848483818110612e6257612e62614e7b565b9050602002013590612e8a5760405163fde61bc760e01b815260040161147691815260200190565b5060016101c75f868685818110612ea357612ea3614e7b565b602090810292909201358352508101919091526040015f20805460ff1916911515919091179055600101612ddd565b507fe67bde9ffb5b617b92d199e99ed23fed9868d9366156771e7f709c2d7514449a8383604051611bf4929190614ebf565b805f81600d811115612f1857612f18614ce0565b03612f36576040516385994c7760e01b815260040160405180910390fd5b60db5f83600d811115612f4b57612f4b614ce0565b600d811115612f5c57612f5c614ce0565b81526020019081526020015f2054612f73816132a2565b5f612f8b5f51602061547f5f395f51905f52336128b2565b9050612f9684612b47565b8015612fa0575080155b80612fde57505f1960de5f86600d811115612fbd57612fbd614ce0565b600d811115612fce57612fce614ce0565b81526020019081526020015f2054145b15612ffe5783604051631814e36b60e31b81526004016114769190614d14565b80156130a7575f1960de5f86600d81111561301b5761301b614ce0565b600d81111561302c5761302c614ce0565b815260208101919091526040015f205583600d81111561304e5761304e614ce0565b60da8054600190921b909117905583600d81111561306e5761306e614ce0565b6040805133815290517f36287ed6be33e8d1abe33ad8d38ab23b67a5126b7140660a8a25920bdc30a1999181900360200190a250505050565b60dd544281116130fb57426202a300018060de5f88600d8111156130cd576130cd614ce0565b600d8111156130de576130de614ce0565b815260208101919091526040015f20556202a3000160dd55613160565b6202a300428203116131235760405163602102f760e11b815260048101829052602401611476565b6202a300810360de5f87600d81111561313e5761313e614ce0565b600d81111561314f5761314f614ce0565b815260208101919091526040015f20555b84600d81111561317257613172614ce0565b60da8054600190921b909117905584600d81111561319257613192614ce0565b6040513381527f534f879afd40abb4e39f8e1b77a316be4c8e3521d9cf5a3a3db8959d574d455990602001612200565b60096131cd8161336e565b7f220bd22ef7c53d75fe3eac0a09e90815a0c5ba4f9e8da8b039542cd3db3472586131f7816132a2565b6131ff612795565b6001600160a01b0316637ab19c10846040518263ffffffff1660e01b81526004015f604051808303818588803b158015613237575f5ffd5b505af1158015613249573d5f5f3e3d5ffd5b5050505050505050565b5f5f5f5f5f5f60016101c2546132699190614df7565b6101bf545f9182526101c460209081526040808420546101c390925290922054610119546101c554929a93995090975095509350915050565b6132ac8133613ef0565b50565b6132b982826128b2565b6118ef575f8281526065602090815260408083206001600160a01b03851684529091529020805460ff191660011790556132f03390565b6001600160a01b0316816001600160a01b0316837f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45050565b6101c0546001600160a01b039081169082160361336457604051639395197f60e01b815260040160405180910390fd5b6118ef8282613f49565b60da5481600d81111561338357613383614ce0565b6001901b8116156133a95781604051631814e36b60e31b81526004016114769190614d14565b60028116156118ef576001604051631814e36b60e31b81526004016114769190614d14565b5f60405188815287602082015286604082015285606082015284608082015260c060a08201528260c0820152602083065f811561340c578160200390505b848660e085013790930160e001902098975050505050505050565b5f81815260a660205260409020546001146134585760405163992d87c360e01b815260048101829052602401611476565b5f90815260a66020526040812055565b80156132ac5742609954101561348d576097546134859042614d87565b60995561349d565b609a5461349a9082614d87565b90505b6098548111156134c05760405163a74c1c5f60e01b815260040160405180910390fd5b609a55565b5f1982015f90815261014e60208181526040808420548452848252808420868552929091528083208290555190918391839186917fea3b023b4c8680d4b4824f0143132c95476359a2bb70a81d6c5a36f6918f63399190a4505050565b61352c600361336e565b6101008101355f90815261015060205260408120549081900361356257604051634e68667560e01b815260040160405180910390fd5b61356c8280614ed2565b905081146135a2578061357f8380614ed2565b604051635e3fd6ad60e01b81526004810193909352602483015250604401611476565b6135af8260200135613fc3565b6135c4611c8c60c084013560a0850135614d87565b5f61360a6135d86080850160608601614b2c565b6135e860a0860160808701614b2c565b60a086013560c087013560208801356136056101208a018a614e39565b6133ce565b90506136358161361a8580614ed2565b61362a6060880160408901614f17565b876101000135614022565b6136525760405163582f497d60e11b815260040160405180910390fd5b6136626080840160608501614b2c565b5f805c6001600160a01b0319166001600160a01b03831617905d505f8061368f60a0860160808701614b2c565b6001600160a01b031660c08601356136ab610120880188614e39565b6040516136b9929190614de8565b5f6040518083038185875af1925050503d805f81146136f3576040519150601f19603f3d011682016040523d82523d5f602084013e6136f8565b606091505b509150915081613747578051156137125780518082602001fd5b61372260a0860160808701614b2c565b604051635461344360e01b81526001600160a01b039091166004820152602401611476565b5f6001600160a01b0319815c16815d5060405183907fa4c827e719e911e8f19393ccdb85b5102f08f0910604d340ba38390b7ff2ab0e905f90a25050505050565b5f613793600361336e565b6101008201355f9081526101506020526040812054908190036137c957604051634e68667560e01b815260040160405180910390fd5b6137d38380614ed2565b905081146137e6578061357f8480614ed2565b6137f38360200135613fc3565b613808611c8c60c085013560a0860135614d87565b61381b6135d86080850160608601614b2c565b915061382b8261361a8580614ed2565b6138485760405163582f497d60e11b815260040160405180910390fd5b50919050565b61385781614116565b7feb44f28f73dc4d72ac2ee43ebf59a1e0c84c11c4d614746c0dc99d9071abd8f97f594904a11ae10ad7613c91ac3c92c7c3bba397934d377ce6d3e0aaffbc17df0054604080516001600160a01b03928316815291841660208301520160405180910390a17f594904a11ae10ad7613c91ac3c92c7c3bba397934d377ce6d3e0aaffbc17df0080546001600160a01b0319166001600160a01b0392909216919091179055565b6001600160a01b038416613924576040516342bcdf7f60e11b815260040160405180910390fd5b348311156139455760405163581db49960e11b815260040160405180910390fd5b60e480545f918261395583614e21565b9091555090505f6139668534614df7565b90505f61397833888885878a8a6133ce565b905061398483826134c5565b80876001600160a01b0316336001600160a01b03167fe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c8986888b8b6040516139d0959493929190614f3a565b60405180910390a450505050505050565b6139eb82826128b2565b156118ef575f8281526065602090815260408083206001600160a01b0385168085529252808320805460ff1916905551339285917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a45050565b5f54610100900460ff16613a6d5760405162461bcd60e51b815260040161147690614f6a565b5f613a7e6080840160608501614b2c565b6001600160a01b031603613aa5576040516342bcdf7f60e11b815260040160405180910390fd5b5f613ab86101a084016101808501614b2c565b6001600160a01b031603613adf576040516342bcdf7f60e11b815260040160405180910390fd5b613b02613aef60e0840184614fb5565b613afd610100860186614fb5565b61413d565b613b1482608001358360a00135614374565b5f613b2761016084016101408501614b2c565b6001600160a01b031603613b4e576040516342bcdf7f60e11b815260040160405180910390fd5b613b695f613b6461016085016101408601614b2c565b6132af565b613b7e613b7960c0840184614fb5565b6143c5565b613b8e6080830160608401614b2c565b5f805261011b6020527f033d11f27e62ab919708ec716731da80d261a6e4253259b7acde9bf89d28ec1880546001600160a01b0319166001600160a01b03929092169190911790558135613bf557604051630742d05360e01b815260040160405180910390fd5b6020828101356101198190555f9081526101c882526040808220853590556101bd849055805182815292830182905282810182905260608301829052840135608083015260a09091206101bf5560016101c255613c5a61018084016101608501614b2c565b90506001600160a01b038116613c6d5750305b6101c180546001600160a01b0319166001600160a01b038316179055613c9b6101a084016101808501614b2c565b6101c680546001600160a01b0319166001600160a01b03929092169190911790555f5b613ccc610120850185614ed2565b9050811015613d6c575f613ce4610120860186614ed2565b83818110613cf457613cf4614e7b565b9050602002013503613d1957604051630742d05360e01b815260040160405180910390fd5b60016101c75f613d2d610120880188614ed2565b85818110613d3d57613d3d614e7b565b602090810292909201358352508101919091526040015f20805460ff1916911515919091179055600101613cbe565b505f613d7c610120850185614ed2565b90501115613dca577fe67bde9ffb5b617b92d199e99ed23fed9868d9366156771e7f709c2d7514449a613db3610120850185614ed2565b604051613dc1929190614ebf565b60405180910390a15b6040805180820190915260038152620392e360ec1b6020820152613ded90614ffa565b6001600160c01b0319167f31e960f67e4fae468b10f504b116ec2791f36d5f18a31e6112c960313b6e0607848460405161158b929190615154565b5f54610100900460ff16613e4e5760405162461bcd60e51b815260040161147690614f6a565b6001600160a01b038116613e75576040516342bcdf7f60e11b815260040160405180910390fd5b6101c080546001600160a01b0319166001600160a01b03831690811790915560405133907fb341a9e6d33f272cb7b5a20b337763606cbb6c728e7a34cbd3191cdfa0f0cd07905f90a350565b5f54610100900460ff16613ee75760405162461bcd60e51b815260040161147690614f6a565b6132ac8161384e565b613efa82826128b2565b6118ef57613f07816144d1565b613f128360206144e3565b604051602001613f239291906152c9565b60408051601f198184030181529082905262461bcd60e51b825261147691600401614935565b6001600160a01b0381163314613fb95760405162461bcd60e51b815260206004820152602f60248201527f416363657373436f6e74726f6c3a2063616e206f6e6c792072656e6f756e636560448201526e103937b632b9903337b91039b2b63360891b6064820152608401611476565b6118ef82826139e1565b600881901c5f90815261014f6020526040902054600160ff83161b161561400057604051630335a4a960e41b815260048101829052602401611476565b600881901c5f90815261014f602052604090208054600160ff84161b17905550565b5f80614043600161403487600261540a565b61403e9190614df7565b61467f565b90508063ffffffff168463ffffffff1611156140825760405163f7ec909760e01b815263ffffffff808616600483015282166024820152604401611476565b865f5b8681101561410857600163ffffffff8716821c811690036140d2576140cb8888838181106140b5576140b5614e7b565b90506020020135835f9182526020526040902090565b9150614100565b6140fd828989848181106140e8576140e8614e7b565b905060200201355f9182526020526040902090565b91505b600101614085565b509092149695505050505050565b6001600160a01b0381166132ac576040516342bcdf7f60e11b815260040160405180910390fd5b5f54610100900460ff166141635760405162461bcd60e51b815260040161147690614f6a565b5f5b8381101561426b5784848281811061417f5761417f614e7b565b9050604002016020013560db5f87878581811061419e5761419e614e7b565b6141b492602060409092020190810191506147d9565b600d8111156141c5576141c5614ce0565b600d8111156141d6576141d6614ce0565b815260208101919091526040015f20558484828181106141f8576141f8614e7b565b9050604002016020013585858381811061421457614214614e7b565b61422a92602060409092020190810191506147d9565b600d81111561423b5761423b614ce0565b6040517f33aa8fd1ce49e1761bc8d27fd53414bfefc45d690feed0ce55019d7d3aec6091905f90a3600101614165565b505f5b81811015612a905782828281811061428857614288614e7b565b9050604002016020013560dc5f8585858181106142a7576142a7614e7b565b6142bd92602060409092020190810191506147d9565b600d8111156142ce576142ce614ce0565b600d8111156142df576142df614ce0565b815260208101919091526040015f205582828281811061430157614301614e7b565b9050604002016020013583838381811061431d5761431d614e7b565b61433392602060409092020190810191506147d9565b600d81111561434457614344614ce0565b6040517fe7bf4b8dc0c17a52dc9e52323a3ab61cb2079db35f969125b1f8a3d984c6f6c2905f90a360010161426e565b5f54610100900460ff1661439a5760405162461bcd60e51b815260040161147690614f6a565b6143a26146b3565b6143aa6146b3565b6143b26146b3565b6143bc82826146db565b5050600160e455565b5f54610100900460ff166143eb5760405162461bcd60e51b815260040161147690614f6a565b5f5b818110156118e0575f83838381811061440857614408614e7b565b61441e9260206040909202019081019150614b2c565b6001600160a01b031603614445576040516342bcdf7f60e11b815260040160405180910390fd5b82828281811061445757614457614e7b565b905060400201602001355f5f1b0361448257604051630742d05360e01b815260040160405180910390fd5b6144c983838381811061449757614497614e7b565b905060400201602001358484848181106144b3576144b3614e7b565b613b649260206040909202019081019150614b2c565b6001016143ed565b60606113d96001600160a01b03831660145b60605f6144f1836002614e0a565b6144fc906002614d87565b6001600160401b0381111561451357614513615415565b6040519080825280601f01601f19166020018201604052801561453d576020820181803683370190505b509050600360fc1b815f8151811061455757614557614e7b565b60200101906001600160f81b03191690815f1a905350600f60fb1b8160018151811061458557614585614e7b565b60200101906001600160f81b03191690815f1a9053505f6145a7846002614e0a565b6145b2906001614d87565b90505b6001811115614629576f181899199a1a9b1b9c1cb0b131b232b360811b85600f16601081106145e6576145e6614e7b565b1a60f81b8282815181106145fc576145fc614e7b565b60200101906001600160f81b03191690815f1a90535060049490941c9361462281615429565b90506145b5565b5083156146785760405162461bcd60e51b815260206004820181905260248201527f537472696e67733a20686578206c656e67746820696e73756666696369656e746044820152606401611476565b9392505050565b5f63ffffffff8211156146af576040516306dfcc6560e41b81526020600482015260248101839052604401611476565b5090565b5f54610100900460ff166146d95760405162461bcd60e51b815260040161147690614f6a565b565b5f54610100900460ff166147015760405162461bcd60e51b815260040161147690614f6a565b815f036147215760405163b5ed5a3b60e01b815260040160405180910390fd5b805f036147415760405163d10d72bb60e01b815260040160405180910390fd5b609782905560988190556147558242614d87565b60998190556097546098546040805192835260208301919091528101919091527f8f805c372b66240792580418b7328c0c554ae235f0932475c51b026887fe26a990606001612139565b5f602082840312156147af575f5ffd5b81356001600160e01b031981168114614678575f5ffd5b8035600e81106147d4575f5ffd5b919050565b5f602082840312156147e9575f5ffd5b614678826147c6565b5f60208284031215614802575f5ffd5b5035919050565b6001600160a01b03811681146132ac575f5ffd5b80356147d481614809565b5f5f83601f840112614838575f5ffd5b5081356001600160401b0381111561484e575f5ffd5b602083019150836020828501011115614865575f5ffd5b9250929050565b5f5f5f5f5f60808688031215614880575f5ffd5b85359450602086013561489281614809565b93506040860135925060608601356001600160401b038111156148b3575f5ffd5b6148bf88828901614828565b969995985093965092949392505050565b5f5f5f5f5f60a086880312156148e4575f5ffd5b505083359560208501359550604085013594606081013594506080013592509050565b5f5f60408385031215614918575f5ffd5b82359150602083013561492a81614809565b809150509250929050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b5f5f6040838503121561497b575f5ffd5b614984836147c6565b946020939093013593505050565b5f5f5f5f5f5f5f5f60e0898b0312156149a9575f5ffd5b88356149b481614809565b975060208901356149c481614809565b9650604089013595506060890135945060808901356149e281614809565b935060a08901356001600160401b038111156149fc575f5ffd5b614a088b828c01614828565b999c989b50969995989497949560c00135949350505050565b5f6101408284031215613848575f5ffd5b5f60208284031215614a42575f5ffd5b81356001600160401b03811115614a57575f5ffd5b614a6384828501614a21565b949350505050565b5f5f83601f840112614a7b575f5ffd5b5081356001600160401b03811115614a91575f5ffd5b6020830191508360208260051b8501011115614865575f5ffd5b5f5f60208385031215614abc575f5ffd5b82356001600160401b03811115614ad1575f5ffd5b614add85828601614a6b565b90969095509350505050565b5f5f60408385031215614afa575f5ffd5b82356001600160401b03811115614b0f575f5ffd5b614b1b85828601614a21565b925050602083013561492a81614809565b5f60208284031215614b3c575f5ffd5b813561467881614809565b5f5f5f5f60608587031215614b5a575f5ffd5b84356001600160401b03811115614b6f575f5ffd5b614b7b87828801614a6b565b90989097506020870135966040013595509350505050565b5f5f5f5f60608587031215614ba6575f5ffd5b84356001600160401b03811115614bbb575f5ffd5b614bc787828801614828565b9095509350506020850135915060408501356001600160401b03811115614bec575f5ffd5b85016103008188031215614bfe575f5ffd5b939692955090935050565b5f5f5f5f60608587031215614c1c575f5ffd5b8435614c2781614809565b93506020850135925060408501356001600160401b03811115614c48575f5ffd5b614c5487828801614828565b95989497509550505050565b5f5f60408385031215614c71575f5ffd5b823561498481614809565b5f5f5f60608486031215614c8e575f5ffd5b83356001600160401b03811115614ca3575f5ffd5b84016101a08187031215614cb5575f5ffd5b92506020840135614cc581614809565b91506040840135614cd581614809565b809150509250925092565b634e487b7160e01b5f52602160045260245ffd5b600e8110614d1057634e487b7160e01b5f52602160045260245ffd5b9052565b602081016113d98284614cf4565b81835281816020850137505f828201602090810191909152601f909101601f19169091010190565b848152836020820152606060408201525f614d69606083018486614d22565b9695505050505050565b634e487b7160e01b5f52601160045260245ffd5b808201808211156113d9576113d9614d73565b6020808252602e908201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160408201526d191e481a5b9a5d1a585b1a5e995960921b606082015260800190565b818382375f9101908152919050565b818103818111156113d9576113d9614d73565b80820281158282048414176113d9576113d9614d73565b5f60018201614e3257614e32614d73565b5060010190565b5f5f8335601e19843603018112614e4e575f5ffd5b8301803591506001600160401b03821115614e67575f5ffd5b602001915036819003821315614865575f5ffd5b634e487b7160e01b5f52603260045260245ffd5b8183525f6001600160fb1b03831115614ea6575f5ffd5b8260051b80836020870137939093016020019392505050565b602081525f614a63602083018486614e8f565b5f5f8335601e19843603018112614ee7575f5ffd5b8301803591506001600160401b03821115614f00575f5ffd5b6020019150600581901b3603821315614865575f5ffd5b5f60208284031215614f27575f5ffd5b813563ffffffff81168114614678575f5ffd5b858152846020820152836040820152608060608201525f614f5f608083018486614d22565b979650505050505050565b6020808252602b908201527f496e697469616c697a61626c653a20636f6e7472616374206973206e6f74206960408201526a6e697469616c697a696e6760a81b606082015260800190565b5f5f8335601e19843603018112614fca575f5ffd5b8301803591506001600160401b03821115614fe3575f5ffd5b6020019150600681901b3603821315614865575f5ffd5b805160208201516001600160c01b0319811691906008821015615031576001600160c01b0319600883900360031b81901b82161692505b5050919050565b5f5f8335601e1984360301811261504d575f5ffd5b83016020810192503590506001600160401b0381111561506b575f5ffd5b8060061b3603821315614865575f5ffd5b8183526020830192505f815f5b848110156150c357813561509c81614809565b6001600160a01b031686526020828101359087015260409586019590910190600101615089565b5093949350505050565b8183526020830192505f815f5b848110156150c3576150f4866150ef846147c6565b614cf4565b60208281013590870152604095860195909101906001016150da565b5f5f8335601e19843603018112615125575f5ffd5b83016020810192503590506001600160401b03811115615143575f5ffd5b8060051b3603821315614865575f5ffd5b604080825283358282015260208401356060808401919091529084013560808301525f9061518390850161481d565b6001600160a01b03811660a084015250608084013560c08381019190915260a085013560e08401526151b790850185615038565b6101a06101008501526151cf6101e08501828461507c565b9150506151df60e0860186615038565b848303603f19016101208601526151f78382846150cd565b92505050615209610100860186615038565b848303603f19016101408601526152218382846150cd565b92505050615233610120860186615110565b848303603f190161016086015261524b838284614e8f565b9250505061525c610140860161481d565b6001600160a01b0316610180840152615278610160860161481d565b6001600160a01b03166101a0840152615294610180860161481d565b6001600160a01b03166101c084015260209092019290925292915050565b5f81518060208401855e5f93019283525090919050565b7f416363657373436f6e74726f6c3a206163636f756e742000000000000000000081525f6152fa60178301856152b2565b7001034b99036b4b9b9b4b733903937b6329607d1b815261531e60118201856152b2565b95945050505050565b6001815b60018411156153625780850481111561534657615346614d73565b600184161561535457908102905b60019390931c92800261532b565b935093915050565b5f82615378575060016113d9565b8161538457505f6113d9565b816001811461539a57600281146153a4576153c0565b60019150506113d9565b60ff8411156153b5576153b5614d73565b50506001821b6113d9565b5060208310610133831016604e8410600b84101617156153e3575081810a6113d9565b6153ef5f198484615327565b805f190482111561540257615402614d73565b029392505050565b5f614678838361536a565b634e487b7160e01b5f52604160045260245ffd5b5f8161543757615437614d73565b505f19019056fe084edf88d5959696dcc7aab5c8674a33a1ef78f37dda21b782ed03bddb22ade497667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b9291453a531db80c85f2d944d498709d84959bc5bf839eefe9acb784571e5a32118a2646970667358221220347c486925980e7caa5d5102df8ba3ca3ac9883070b5038821b21ca2e4e6aed864736f6c63430008210033",
+  "deployedBytecode": "0x6080604052600436106105af575f3560e01c806376df1ecc116102e7578063add9137a11610194578063cc6f7251116100e3578063d9fe8bdd1161009d578063e196fb5d11610078578063e196fb5d1461130f578063e66c2a931461132e578063ee8289201461134d578063f5b541a614611389575f5ffd5b8063d9fe8bdd146112a8578063df5862d1146112bd578063e0960936146112f0575f5ffd5b8063cc6f7251146111bb578063cd9b9e9a146111ee578063cff5d6bb14611204578063d547741f14611237578063d714e37414611256578063d722bbfc14611275575f5ffd5b8063b9fe5cf71161014e578063c0729ab111610129578063c0729ab114611152578063c1dc0f0714611167578063c21169741461117c578063c294c9181461119b575f5ffd5b8063b9fe5cf7146110e0578063bc61e73314611100578063bf3e75051461111f575f5ffd5b8063add9137a1461101d578063ae15ceae14611049578063aea4f7451461107c578063b60d428814611090578063b837dbe914611098578063b9174ba3146110ad575f5ffd5b8063923fe894116102505780639ee8b2111161020a578063a4c4cef7116101e5578063a4c4cef714610f8a578063a505925f14610fa0578063ac1eff6814610fd3578063ad422ff014611008575f5ffd5b80639ee8b21114610f455780639f3ce55a14610f64578063a217fddf14610f77575f5ffd5b8063923fe89414610e6957806392dd3f8714610e9c57806395ba81fa14610ec857806396e6e4b314610ee7578063986fcddd14610d255780639ac25d0814610f12575f5ffd5b80638c7c363a116102a15780638c7c363a14610d975780638da8b59214610db65780638de4948714610dd5578063914e57eb14610e0857806391d1485414610e34578063921b278e14610e53575f5ffd5b806376df1ecc14610cde57806378ea198a14610cf25780637d1e8c5514610d2557806380b7af1814610d38578063874ca76014610d4c5780638be745d114610d6b575f5ffd5b806348922ab71161045f57806360e83cf3116103ae578063695378f5116103685780636e673843116103435780636e67384314610c455780637174c55914610c7857806373bd07b714610cab57806374ce962c14610cbf575f5ffd5b8063695378f514610bdd5780636a906b8014610bf35780636b78317214610c26575f5ffd5b806360e83cf314610b105780636321315514610b3c5780636463fb2a14610b6f578063670bc79514610b8e57806367e404ce14610ba2578063687e2e8114610bbe575f5ffd5b806352e576bb1161041957806358794456116103f45780635879445614610ad05780635b7eb4bd146109935780635c721a0c14610ae55780635ec775b0146106db575f5ffd5b806352e576bb14610a7c5780635334b7e614610a92578063557eac7314610ab1575f5ffd5b806348922ab714610993578063491e0936146109b95780634bb97413146109d8578063516f1a44146109f75780635230eef214610a2a57806352abf32d14610a5d575f5ffd5b80632c70645c1161051b57806338b90333116104d55780633e9ebfc2116104b05780633e9ebfc2146108f75780633fc08b6514610916578063411aa28c1461094157806342277d7014610960575f5ffd5b806338b90333146108735780633b12eccb146108a45780633c0f20fc146108d7575f5ffd5b80632c70645c146107a85780632f2ff15d146107be5780632fe35274146107dd57806334cdf78d146107f957806334db89791461082557806336568abe14610854575f5ffd5b806321b4deee1161056c57806321b4deee146106db578063248a9ca3146106f1578063248c61261461071f57806328958174146107325780632acc8df9146107515780632c3c67d014610789575f5ffd5b806301ffc9a7146105b357806303134d1d146105e7578063085b1c6f146106285780631065a3991461065b578063198330f81461067c5780632130d812146106af575b5f5ffd5b3480156105be575f5ffd5b506105d26105cd36600461479f565b6113a9565b60405190151581526020015b60405180910390f35b3480156105f2575f5ffd5b5061061a7f1ab87f7458c0e3d07e9881c14ee67f0141703614fd48ea5b15ed987e5f4b030e81565b6040519081526020016105de565b348015610633575f5ffd5b5061061a7f220bd22ef7c53d75fe3eac0a09e90815a0c5ba4f9e8da8b039542cd3db34725881565b348015610666575f5ffd5b5061067a6106753660046147d9565b6113df565b005b348015610687575f5ffd5b5061061a7f76ef52a5344b10ed112c1d48c7c06f51e919518ea6fb005f9b25b359b955e3be81565b3480156106ba575f5ffd5b5061061a6106c93660046147f2565b5f9081526101be602052604090205490565b3480156106e6575f5ffd5b5061061a6202a30081565b3480156106fc575f5ffd5b5061061a61070b3660046147f2565b5f9081526065602052604090206001015490565b61067a61072d36600461486c565b611598565b34801561073d575f5ffd5b5061067a61074c3660046147f2565b6116fc565b34801561075c575f5ffd5b506101c054610771906001600160a01b031681565b6040516001600160a01b0390911681526020016105de565b348015610794575f5ffd5b5061067a6107a33660046148d0565b611797565b3480156107b3575f5ffd5b5061061a6101835481565b3480156107c9575f5ffd5b5061067a6107d8366004614907565b6118bc565b3480156107e8575f5ffd5b50600160a01b5f5c0460ff166105d2565b348015610804575f5ffd5b5061061a6108133660046147f2565b6101c86020525f908152604090205481565b348015610830575f5ffd5b506105d261083f3660046147f2565b6101c76020525f908152604090205460ff1681565b34801561085f575f5ffd5b5061067a61086e366004614907565b6118e5565b34801561087e575f5ffd5b5060408051808201825260038152620392e360ec1b602082015290516105de9190614935565b3480156108af575f5ffd5b5061061a7fb6cc65f42901ed602aec1619cc1ead29d487cd489094a37615153eaeb991d77081565b3480156108e2575f5ffd5b506101c154610771906001600160a01b031681565b348015610902575f5ffd5b5061067a61091136600461496a565b6118f3565b348015610921575f5ffd5b5061061a6109303660046147f2565b60a56020525f908152604090205481565b34801561094c575f5ffd5b5061067a61095b366004614907565b611a0d565b34801561096b575f5ffd5b5061061a7f012c76ef7f96cd7eb95acbdc250ad5696bbe3fd2fcf0207571939fa40c2e016781565b34801561099e575f5ffd5b506109a7600181565b60405160ff90911681526020016105de565b3480156109c4575f5ffd5b5061067a6109d3366004614992565b611c01565b3480156109e3575f5ffd5b5061067a6109f2366004614907565b611e7d565b348015610a02575f5ffd5b5061061a7fb63b70db607c764adad98a6745fc4efcea212ebc7b501d5753c57d675f377a6681565b348015610a35575f5ffd5b5061061a7f0cf0d2deb70d7bdac2fa48c4ac99bc558170be0ce5fcb994caefa4bf7b96edf981565b348015610a68575f5ffd5b5061067a610a7736600461496a565b611fa3565b348015610a87575f5ffd5b5061061a6101c55481565b348015610a9d575f5ffd5b5061067a610aac3660046147f2565b6120bd565b348015610abc575f5ffd5b5061067a610acb3660046147f2565b612145565b348015610adb575f5ffd5b5061061a60995481565b348015610af0575f5ffd5b5061061a610aff3660046147f2565b60a66020525f908152604090205481565b348015610b1b575f5ffd5b5061061a610b2a3660046147f2565b6101506020525f908152604090205481565b348015610b47575f5ffd5b5061061a7fe37c272ea30e2bb381ad7cf89ae754b49153250609f36d0cbdad8b64c184bb5c81565b348015610b7a575f5ffd5b5061067a610b89366004614a32565b61220f565b348015610b99575f5ffd5b5061067a61238a565b348015610bad575f5ffd5b505f5c6001600160a01b0316610771565b348015610bc9575f5ffd5b5061067a610bd8366004614aab565b612453565b348015610be8575f5ffd5b5061061a6101195481565b348015610bfe575f5ffd5b5061061a7fd8b4c34c2ec1f3194471108c64ad2beda340c0337ee4ca35592f9ef270f4228b81565b348015610c31575f5ffd5b5061067a610c40366004614ae9565b612582565b348015610c50575f5ffd5b5061061a7f32937fd5162e282df7e9a14a5073a2425321c7966eaf70ed6c838a1006d84c4c81565b348015610c83575f5ffd5b5061061a7f4b4665d8754e6ea0608430ef3e91c1b45c72aafe8800e289cd35f38d8536185881565b348015610cb6575f5ffd5b506109a7600281565b348015610cca575f5ffd5b5061067a610cd9366004614b2c565b61271c565b348015610ce9575f5ffd5b5061067a61274f565b348015610cfd575f5ffd5b5061061a7f4df33217c89b6f12af38ba46035cb312b5e88de78d22279286830fe079b642cd81565b348015610d30575f5ffd5b506109a75f81565b348015610d43575f5ffd5b50610771612795565b348015610d57575f5ffd5b5061067a610d66366004614b47565b6127c3565b348015610d76575f5ffd5b5061061a610d853660046147f2565b61011a6020525f908152604090205481565b348015610da2575f5ffd5b5061067a610db1366004614b2c565b6127e5565b348015610dc1575f5ffd5b5061067a610dd0366004614b93565b6128a7565b348015610de0575f5ffd5b5061061a7fe1fce82838dd7a42cfe783f60dc6233c8aa2c4fc66e77817805e767ec5e349b681565b348015610e13575f5ffd5b5061061a610e223660046147f2565b61014e6020525f908152604090205481565b348015610e3f575f5ffd5b506105d2610e4e366004614907565b6128b2565b348015610e5e575f5ffd5b5061061a6101bf5481565b348015610e74575f5ffd5b5061061a7fcc10d6eec3c757d645e27b3f3001a3ba52f692da0bce25fabf58c6ecaf37645081565b348015610ea7575f5ffd5b5061061a610eb63660046147f2565b6101c36020525f908152604090205481565b348015610ed3575f5ffd5b5061067a610ee23660046147d9565b6128dc565b348015610ef2575f5ffd5b5061061a610f013660046147d9565b60de6020525f908152604090205481565b348015610f1d575f5ffd5b5061061a7f56bdc3c9ec86cb7db110a7699b2ade72f0b8819727d9f7d906b012641505fa7781565b348015610f50575f5ffd5b506105d2610f5f3660046147f2565b612a56565b61067a610f72366004614c09565b612a79565b348015610f82575f5ffd5b5061061a5f81565b348015610f95575f5ffd5b5061061a6101c25481565b348015610fab575f5ffd5b5061061a7f21aba2dd4535739d4ca4cddb3c024036bfcc88cfce067cb0847e7ad0f9cfaa5581565b348015610fde575f5ffd5b50610771610fed3660046147f2565b61011b6020525f90815260409020546001600160a01b031681565b348015611013575f5ffd5b5061061a60985481565b348015611028575f5ffd5b5061061a6110373660046147f2565b6101c46020525f908152604090205481565b348015611054575f5ffd5b5061061a7fdaafd36d8da81d5104d4fd21e3ccc58683c62ba08cd23875bcfbc0583a3f49dd81565b348015611087575f5ffd5b5061067a612a97565b61067a612af2565b3480156110a3575f5ffd5b5061061a60e45481565b3480156110b8575f5ffd5b5061061a7f430a7f0cb00b5ebbe63cecc96e82cf959a883e7c13a95110854f1fa6b3fbf59881565b3480156110eb575f5ffd5b5061061a5f51602061547f5f395f51905f5281565b34801561110b575f5ffd5b506105d261111a3660046147d9565b612b47565b34801561112a575f5ffd5b5061061a7f1185e52d62bfbbea270e57d3d09733d221b53ab7a18bae82bb3c6c74bab16d8281565b34801561115d575f5ffd5b5061061a609a5481565b348015611172575f5ffd5b5061061a60975481565b348015611187575f5ffd5b5061067a611196366004614c60565b612b6b565b3480156111a6575f5ffd5b506101c654610771906001600160a01b031681565b3480156111c6575f5ffd5b5061061a7fe8cb6172fcf5cbaae022b7c910224a4f0c20d53227e630056efff182155a5abc81565b3480156111f9575f5ffd5b5061061a6101bd5481565b34801561120f575f5ffd5b5061061a7f99632df2ab8972394e721143c15eb6f675ca3095f831425245f51ce7d1fcacde81565b348015611242575f5ffd5b5061067a611251366004614907565b612c40565b348015611261575f5ffd5b5061067a611270366004614c7c565b612c64565b348015611280575f5ffd5b5061061a7f6b5661ddfbd1fbd525c902a513e0f47d9c74f1c1ee8a2d4f1937ad305fb8f41a81565b3480156112b3575f5ffd5b5061061a60dd5481565b3480156112c8575f5ffd5b5061061a7f06d10575548d11f448aeb7dc30c867ac7c98f5fea5b08ac339c2421794e7595281565b3480156112fb575f5ffd5b5061067a61130a366004614aab565b612d93565b34801561131a575f5ffd5b5061067a6113293660046147d9565b612f04565b348015611339575f5ffd5b5061067a6113483660046147f2565b6131c2565b348015611358575f5ffd5b50611361613253565b604080519586526020860194909452928401919091526060830152608082015260a0016105de565b348015611394575f5ffd5b5061061a5f51602061545f5f395f51905f5281565b5f6001600160e01b03198216637965db0b60e01b14806113d957506301ffc9a760e01b6001600160e01b03198316145b92915050565b805f81600d8111156113f3576113f3614ce0565b03611411576040516385994c7760e01b815260040160405180910390fd5b60dc5f83600d81111561142657611426614ce0565b600d81111561143757611437614ce0565b81526020019081526020015f205461144e816132a2565b61145783612b47565b61147f5782604051630619659560e21b81526004016114769190614d14565b60405180910390fd5b5f1960de5f85600d81111561149657611496614ce0565b600d8111156114a7576114a7614ce0565b81526020019081526020015f20541480156114d657506114d45f51602061547f5f395f51905f52336128b2565b155b156114f657826040516323bb853560e21b81526004016114769190614d14565b60de5f84600d81111561150b5761150b614ce0565b600d81111561151c5761151c614ce0565b81526020019081526020015f205f905582600d81111561153e5761153e614ce0565b60da8054600190921b19909116905582600d81111561155f5761155f614ce0565b6040513381527fd071d2b85dec4489435b541d2f0e2570db09b09db9efd8703948d44a433df65a906020015b60405180910390a2505050565b7fb63b70db607c764adad98a6745fc4efcea212ebc7b501d5753c57d675f377a666115c2816132a2565b816115e05760405163afd51dbf60e01b815260040160405180910390fd5b5f84116116005760405163273e150360e21b815260040160405180910390fd5b6001600160a01b038516611627576040516342bcdf7f60e11b815260040160405180910390fd5b8561164557604051630742d05360e01b815260040160405180910390fd5b6101c28054600181019091555f1981015f9081526101c3602052604090205485908111611688576040516317d6372960e31b815260040161147691815260200190565b505f8181526101c4602090815260408083208a90556101c390915290819020869055516001600160a01b0387169082907f8fbc8fbd65675eb32c567d4a559963c7d002c2be67b5b266fb13d85b4375fce5906116eb9089908c908a908a90614d4a565b60405180910390a350505050505050565b7f6b5661ddfbd1fbd525c902a513e0f47d9c74f1c1ee8a2d4f1937ad305fb8f41a611726816132a2565b5f82815261011b602090815260408083205490516001600160a01b0390911681523392859290917f4a29db3fc6b42bda201e4b4d69ce8d575eeeba5f153509c0d0a342af0f1bd021910160405180910390a4505f90815261011b6020526040902080546001600160a01b0319169055565b6117a462f099c082614d87565b4210156117c457604051634306cbb160e01b815260040160405180910390fd5b6040805186815260208101869052908101849052606081018390526080810182905260a090206101bf541461183f576101bf546040805187815260208101879052908101859052606081018490526080810183905260a0902060405163bc5aad1160e01b815260048101929092526024820152604401611476565b6101c0546001600160a01b03166118635f51602061545f5f395f51905f52826128b2565b6118b45761187e5f51602061545f5f395f51905f52826132af565b6040516001600160a01b0382169033907f6cfaf6b76ea493a8e88b6b95f7b34cdaae196c4ed737b32e72c5d9e8d0a18518905f90a35b505050505050565b5f828152606560205260409020600101546118d6816132a2565b6118e083836132af565b505050565b6118ef8282613334565b5050565b815f81600d81111561190757611907614ce0565b03611925576040516385994c7760e01b815260040160405180910390fd5b5f51602061547f5f395f51905f5261193c816132a2565b5f60db5f86600d81111561195257611952614ce0565b600d81111561196357611963614ce0565b81526020019081526020015f2054905083810361199357604051631b807f5560e01b815260040160405180910390fd5b8360db5f87600d8111156119a9576119a9614ce0565b600d8111156119ba576119ba614ce0565b815260208101919091526040015f2055808486600d8111156119de576119de614ce0565b6040517f074bfc3728ef1e98bde10bcb5bd8cde59cff190c2bfda5d22f879f865a07bac5905f90a45050505050565b5f54600990610100900460ff16158015611a2d57505f5460ff8083169116105b611a495760405162461bcd60e51b815260040161147690614d9a565b5f805461ffff191660ff8316176101001790555f195f51602061543f5f395f51905f525c01611a7f576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d5f8311611ab05760405163273e150360e21b815260040160405180910390fd5b6001600160a01b038216611ad7576040516342bcdf7f60e11b815260040160405180910390fd5b6101c58390556101c680546001600160a01b0319166001600160a01b0384161790556040518381527fc4733b619696e38077e1b19371d193f42b20a279e3445c3b2b9f4d58db36bc6b9060200160405180910390a1604080515f81526001600160a01b03841660208201527f70a40b63da92dd99e111281bc23dfb08922b6d1337f71f895cf498eb60ff7a0b910160405180910390a160016101c255604051620382e360ec1b9062372e3160e81b907f2f8492a7a430cf917798dfb60bc5af634f68e6c40287947df0ea6f7ec0669bd8905f90a35f5f51602061543f5f395f51905f525d5f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498906020015b60405180910390a1505050565b60015f51602061543f5f395f51905f525c03611c24576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d85878484875f5a9050611c48600361336e565b8d5f805c6001600160a01b0319166001600160a01b03831617905d505f611c748f8f8f8f8c8f8f6133ce565b9050611c7f81613427565b611c91611c8c8d8f614d87565b613468565b5f5f8f6001600160a01b03168e8d8d604051611cae929190614de8565b5f6040518083038185875af1925050503d805f8114611ce8576040519150601f19603f3d011682016040523d82523d5f602084013e611ced565b606091505b509150915081611d3157805115611d075780518082602001fd5b8f604051635461344360e01b815260040161147691906001600160a01b0391909116815260200190565b5f6001600160a01b0319815c16815d5060405183907fa4c827e719e911e8f19393ccdb85b5102f08f0910604d340ba38390b7ff2ab0e905f90a2505086159050611e5d57855f849003611dec57853b158015611dea573a5a611d9561bc7c86614d87565b611d9f9190614df7565b611da99190614e0a565b915081881115611de6576001600160a01b0387166108fc611dca848b614df7565b6040518115909202915f818181858888f1935050505050611dea565b8791505b505b5f6001600160a01b03841615611e025783611e04565b335b90505f816001600160a01b03166108fc8490811502906040515f60405180830381858888f19350505050905080611e595760405163295f137d60e21b81526001600160a01b0383166004820152602401611476565b5050505b5050505050505f5f51602061543f5f395f51905f525d5050505050505050565b6002611e888161336e565b611e90612795565b6001600160a01b0316336001600160a01b031614611ec15760405163a1cfbf5960e01b815260040160405180910390fd5b6001600160a01b038216611ee8576040516342bcdf7f60e11b815260040160405180910390fd5b60e480545f9182611ef883614e21565b9091555060408051308152602081018690525f918101829052606081018790526080810183905260c060a08201819052810182905260e0902091925050611f3f82826134c5565b604080515f80825260208201889052818301859052608060608301819052820152905182916001600160a01b0387169133917fe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c919081900360a00190a45050505050565b815f81600d811115611fb757611fb7614ce0565b03611fd5576040516385994c7760e01b815260040160405180910390fd5b5f51602061547f5f395f51905f52611fec816132a2565b5f60dc5f86600d81111561200257612002614ce0565b600d81111561201357612013614ce0565b81526020019081526020015f2054905083810361204357604051631b807f5560e01b815260040160405180910390fd5b8360dc5f87600d81111561205957612059614ce0565b600d81111561206a5761206a614ce0565b815260208101919091526040015f2055808486600d81111561208e5761208e614ce0565b6040517ff8ef9f1cde7c2c0d3aeb696678f76d7c1c3e13c3b79ea3c5160a2d9eaa821cfd905f90a45050505050565b7fdaafd36d8da81d5104d4fd21e3ccc58683c62ba08cd23875bcfbc0583a3f49dd6120e7816132a2565b5f82116121075760405163273e150360e21b815260040160405180910390fd5b6101c58290556040518281527fc4733b619696e38077e1b19371d193f42b20a279e3445c3b2b9f4d58db36bc6b906020015b60405180910390a15050565b7f1185e52d62bfbbea270e57d3d09733d221b53ab7a18bae82bb3c6c74bab16d8261216f816132a2565b5f5f5f426099541015612194576097546121899042614d87565b6099555060016121a6565b609a548510156121a657849250600191505b609885905580806121b45750815b156121bf57609a8390555b6040805186815283151560208201528215159181019190915233907fbc3dc0cb5c15c51c81316450d44048838bb478b9809447d01c766a06f3e9f2c8906060015b60405180910390a25050505050565b60015f51602061543f5f395f51905f525c03612232576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d60a081018035906122579060808401614b2c565b612265610120840184614e39565b612276610100860160e08701614b2c565b5f5a905061228387613522565b851561237157855f84900361230057853b1580156122fe573a5a6122a961bc7c86614d87565b6122b39190614df7565b6122bd9190614e0a565b9150818811156122fa576001600160a01b0387166108fc6122de848b614df7565b6040518115909202915f818181858888f19350505050506122fe565b8791505b505b5f6001600160a01b038416156123165783612318565b335b90505f816001600160a01b03166108fc8490811502906040515f60405180830381858888f1935050505090508061236d5760405163295f137d60e21b81526001600160a01b0383166004820152602401611476565b5050505b5050505050505f5f51602061543f5f395f51905f525d50565b5f54600a90610100900460ff161580156123aa57505f5460ff8083169116105b6123c65760405162461bcd60e51b815260040161147690614d9a565b5f805461ffff191660ff831617610100178155604051620392e360ec1b91620382e360ec1b917f2f8492a7a430cf917798dfb60bc5af634f68e6c40287947df0ea6f7ec0669bd89190a35f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a150565b7f06d10575548d11f448aeb7dc30c867ac7c98f5fea5b08ac339c2421794e7595261247d816132a2565b8161249b57604051630313632760e31b815260040160405180910390fd5b5f5b82811015612550576101c75f8585848181106124bb576124bb614e7b565b602090810292909201358352508101919091526040015f205460ff168484838181106124e9576124e9614e7b565b90506020020135906125115760405163454f453360e01b815260040161147691815260200190565b506101c75f85858481811061252857612528614e7b565b602090810292909201358352508101919091526040015f20805460ff1916905560010161249d565b507f4e88d098b779d01013074e751eb4eea6c06624e6fbac193b318b88224cd68ea18383604051611bf4929190614ebf565b60015f51602061543f5f395f51905f525c036125a5576337ed32e85f526004601cfd5b60015f51602061543f5f395f51905f525d478260c00135116125da57604051630316ae7f60e51b815260040160405180910390fd5b6125ea60a0830160808401614b2c565b6001600160a01b0316336001600160a01b03161461261b57604051630a5c9f3560e01b815260040160405180910390fd5b5f61262583613788565b9050600160ff60a01b195f805c91909116600160a01b17905d50612647612795565b6001600160a01b0316633e4903b78360c086013561266b60a0880160808901614b2c565b60405160e085901b6001600160e01b03191681526001600160a01b039384166004820152602481019290925290911660448201526064015f604051808303815f87803b1580156126b9575f5ffd5b505af11580156126cb573d5f5f3e3d5ffd5b505f92505050805c60ff60a01b1916815d5060405181907fa4c827e719e911e8f19393ccdb85b5102f08f0910604d340ba38390b7ff2ab0e905f90a2505f5f51602061543f5f395f51905f525d5050565b7f76ef52a5344b10ed112c1d48c7c06f51e919518ea6fb005f9b25b359b955e3be612746816132a2565b6118ef8261384e565b5f51602061547f5f395f51905f52612766816132a2565b4260dd556040517f201956ebe50475cb4c4f2d1e8375cfcc9c1700ad498e0c8053da490688172787905f90a150565b7f594904a11ae10ad7613c91ac3c92c7c3bba397934d377ce6d3e0aaffbc17df00546001600160a01b031690565b600d6127ce8161336e565b5f51602061545f5f395f51905f526118b4816132a2565b7f012c76ef7f96cd7eb95acbdc250ad5696bbe3fd2fcf0207571939fa40c2e016761280f816132a2565b6001600160a01b038216612836576040516342bcdf7f60e11b815260040160405180910390fd5b6101c6546001600160a01b0390811690831681146118e0576101c680546001600160a01b0319166001600160a01b0385811691821790925560408051928416835260208301919091527f70a40b63da92dd99e111281bc23dfb08922b6d1337f71f895cf498eb60ff7a0b9101611bf4565b60066127ce8161336e565b5f9182526065602090815260408084206001600160a01b0393909316845291905290205460ff1690565b805f81600d8111156128f0576128f0614ce0565b0361290e576040516385994c7760e01b815260040160405180910390fd5b61291782612b47565b6129365781604051630619659560e21b81526004016114769190614d14565b60de5f83600d81111561294b5761294b614ce0565b600d81111561295c5761295c614ce0565b81526020019081526020015f20544210156129c15760de5f83600d81111561298657612986614ce0565b600d81111561299757612997614ce0565b81526020019081526020015f205460405163cfd8aa6f60e01b815260040161147691815260200190565b60de5f83600d8111156129d6576129d6614ce0565b600d8111156129e7576129e7614ce0565b81526020019081526020015f205f905581600d811115612a0957612a09614ce0565b60da8054600190921b19909116905581600d811115612a2a57612a2a614ce0565b6040517f3ddaeb19197ed3b5334f4c1cd5716f663d0f6dce30c52800bd1674da0b88e87a905f90a25050565b600881901c5f90815261014f6020526040812054600160ff84161b1615156113d9565b6002612a848161336e565b612a90858585856138fd565b5050505050565b7f0cf0d2deb70d7bdac2fa48c4ac99bc558170be0ce5fcb994caefa4bf7b96edf9612ac1816132a2565b5f609a81905560405133917fba88c025b0cbb77022c0c487beef24f759f1e4be2f51a205bc427cee19c2eaa691a250565b345f03612b125760405163717e6b7b60e01b815260040160405180910390fd5b6040513481527fe455499c2acd509bdadebaf5a8fd54c083da31dbe98e785f2a72cdff04e32e009060200160405180910390a1565b5f81600d811115612b5a57612b5a614ce0565b60da54600190911b16151592915050565b7f32937fd5162e282df7e9a14a5073a2425321c7966eaf70ed6c838a1006d84c4c612b95816132a2565b6001600160a01b038316612bbc576040516342bcdf7f60e11b815260040160405180910390fd5b5f82815261011b60209081526040918290205491516001600160a01b03928316815233928592908716917f4a29db3fc6b42bda201e4b4d69ce8d575eeeba5f153509c0d0a342af0f1bd021910160405180910390a4505f90815261011b6020526040902080546001600160a01b0319166001600160a01b0392909216919091179055565b5f82815260656020526040902060010154612c5a816132a2565b6118e083836139e1565b5f80612c715f5460ff1690565b60ff1614612cab5780612c855f5460ff1690565b604051636fdb2e9360e11b815260ff928316600482015291166024820152604401611476565b5f54600a90610100900460ff16158015612ccb57505f5460ff8083169116105b612ce75760405162461bcd60e51b815260040161147690614d9a565b5f805461ffff191660ff831617610100178155612d1b81873581604080519384526020840192909252908201526060902090565b5f8181526101be60205260409020600190559050612d398682613a47565b612d4285613e28565b612d4b84613ec1565b505f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15050505050565b7f99632df2ab8972394e721143c15eb6f675ca3095f831425245f51ce7d1fcacde612dbd816132a2565b81612ddb57604051630313632760e31b815260040160405180910390fd5b5f5b82811015612ed2575f848483818110612df857612df8614e7b565b9050602002013503612e1d57604051630742d05360e01b815260040160405180910390fd5b6101c75f858584818110612e3357612e33614e7b565b602090810292909201358352508101919091526040015f205460ff1615848483818110612e6257612e62614e7b565b9050602002013590612e8a5760405163fde61bc760e01b815260040161147691815260200190565b5060016101c75f868685818110612ea357612ea3614e7b565b602090810292909201358352508101919091526040015f20805460ff1916911515919091179055600101612ddd565b507fe67bde9ffb5b617b92d199e99ed23fed9868d9366156771e7f709c2d7514449a8383604051611bf4929190614ebf565b805f81600d811115612f1857612f18614ce0565b03612f36576040516385994c7760e01b815260040160405180910390fd5b60db5f83600d811115612f4b57612f4b614ce0565b600d811115612f5c57612f5c614ce0565b81526020019081526020015f2054612f73816132a2565b5f612f8b5f51602061547f5f395f51905f52336128b2565b9050612f9684612b47565b8015612fa0575080155b80612fde57505f1960de5f86600d811115612fbd57612fbd614ce0565b600d811115612fce57612fce614ce0565b81526020019081526020015f2054145b15612ffe5783604051631814e36b60e31b81526004016114769190614d14565b80156130a7575f1960de5f86600d81111561301b5761301b614ce0565b600d81111561302c5761302c614ce0565b815260208101919091526040015f205583600d81111561304e5761304e614ce0565b60da8054600190921b909117905583600d81111561306e5761306e614ce0565b6040805133815290517f36287ed6be33e8d1abe33ad8d38ab23b67a5126b7140660a8a25920bdc30a1999181900360200190a250505050565b60dd544281116130fb57426202a300018060de5f88600d8111156130cd576130cd614ce0565b600d8111156130de576130de614ce0565b815260208101919091526040015f20556202a3000160dd55613160565b6202a300428203116131235760405163602102f760e11b815260048101829052602401611476565b6202a300810360de5f87600d81111561313e5761313e614ce0565b600d81111561314f5761314f614ce0565b815260208101919091526040015f20555b84600d81111561317257613172614ce0565b60da8054600190921b909117905584600d81111561319257613192614ce0565b6040513381527f534f879afd40abb4e39f8e1b77a316be4c8e3521d9cf5a3a3db8959d574d455990602001612200565b60096131cd8161336e565b7f220bd22ef7c53d75fe3eac0a09e90815a0c5ba4f9e8da8b039542cd3db3472586131f7816132a2565b6131ff612795565b6001600160a01b0316637ab19c10846040518263ffffffff1660e01b81526004015f604051808303818588803b158015613237575f5ffd5b505af1158015613249573d5f5f3e3d5ffd5b5050505050505050565b5f5f5f5f5f5f60016101c2546132699190614df7565b6101bf545f9182526101c460209081526040808420546101c390925290922054610119546101c554929a93995090975095509350915050565b6132ac8133613ef0565b50565b6132b982826128b2565b6118ef575f8281526065602090815260408083206001600160a01b03851684529091529020805460ff191660011790556132f03390565b6001600160a01b0316816001600160a01b0316837f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45050565b6101c0546001600160a01b039081169082160361336457604051639395197f60e01b815260040160405180910390fd5b6118ef8282613f49565b60da5481600d81111561338357613383614ce0565b6001901b8116156133a95781604051631814e36b60e31b81526004016114769190614d14565b60028116156118ef576001604051631814e36b60e31b81526004016114769190614d14565b5f60405188815287602082015286604082015285606082015284608082015260c060a08201528260c0820152602083065f811561340c578160200390505b848660e085013790930160e001902098975050505050505050565b5f81815260a660205260409020546001146134585760405163992d87c360e01b815260048101829052602401611476565b5f90815260a66020526040812055565b80156132ac5742609954101561348d576097546134859042614d87565b60995561349d565b609a5461349a9082614d87565b90505b6098548111156134c05760405163a74c1c5f60e01b815260040160405180910390fd5b609a55565b5f1982015f90815261014e60208181526040808420548452848252808420868552929091528083208290555190918391839186917fea3b023b4c8680d4b4824f0143132c95476359a2bb70a81d6c5a36f6918f63399190a4505050565b61352c600361336e565b6101008101355f90815261015060205260408120549081900361356257604051634e68667560e01b815260040160405180910390fd5b61356c8280614ed2565b905081146135a2578061357f8380614ed2565b604051635e3fd6ad60e01b81526004810193909352602483015250604401611476565b6135af8260200135613fc3565b6135c4611c8c60c084013560a0850135614d87565b5f61360a6135d86080850160608601614b2c565b6135e860a0860160808701614b2c565b60a086013560c087013560208801356136056101208a018a614e39565b6133ce565b90506136358161361a8580614ed2565b61362a6060880160408901614f17565b876101000135614022565b6136525760405163582f497d60e11b815260040160405180910390fd5b6136626080840160608501614b2c565b5f805c6001600160a01b0319166001600160a01b03831617905d505f8061368f60a0860160808701614b2c565b6001600160a01b031660c08601356136ab610120880188614e39565b6040516136b9929190614de8565b5f6040518083038185875af1925050503d805f81146136f3576040519150601f19603f3d011682016040523d82523d5f602084013e6136f8565b606091505b509150915081613747578051156137125780518082602001fd5b61372260a0860160808701614b2c565b604051635461344360e01b81526001600160a01b039091166004820152602401611476565b5f6001600160a01b0319815c16815d5060405183907fa4c827e719e911e8f19393ccdb85b5102f08f0910604d340ba38390b7ff2ab0e905f90a25050505050565b5f613793600361336e565b6101008201355f9081526101506020526040812054908190036137c957604051634e68667560e01b815260040160405180910390fd5b6137d38380614ed2565b905081146137e6578061357f8480614ed2565b6137f38360200135613fc3565b613808611c8c60c085013560a0860135614d87565b61381b6135d86080850160608601614b2c565b915061382b8261361a8580614ed2565b6138485760405163582f497d60e11b815260040160405180910390fd5b50919050565b61385781614116565b7feb44f28f73dc4d72ac2ee43ebf59a1e0c84c11c4d614746c0dc99d9071abd8f97f594904a11ae10ad7613c91ac3c92c7c3bba397934d377ce6d3e0aaffbc17df0054604080516001600160a01b03928316815291841660208301520160405180910390a17f594904a11ae10ad7613c91ac3c92c7c3bba397934d377ce6d3e0aaffbc17df0080546001600160a01b0319166001600160a01b0392909216919091179055565b6001600160a01b038416613924576040516342bcdf7f60e11b815260040160405180910390fd5b348311156139455760405163581db49960e11b815260040160405180910390fd5b60e480545f918261395583614e21565b9091555090505f6139668534614df7565b90505f61397833888885878a8a6133ce565b905061398483826134c5565b80876001600160a01b0316336001600160a01b03167fe856c2b8bd4eb0027ce32eeaf595c21b0b6b4644b326e5b7bd80a1cf8db72e6c8986888b8b6040516139d0959493929190614f3a565b60405180910390a450505050505050565b6139eb82826128b2565b156118ef575f8281526065602090815260408083206001600160a01b0385168085529252808320805460ff1916905551339285917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a45050565b5f54610100900460ff16613a6d5760405162461bcd60e51b815260040161147690614f6a565b5f613a7e6080840160608501614b2c565b6001600160a01b031603613aa5576040516342bcdf7f60e11b815260040160405180910390fd5b5f613ab86101a084016101808501614b2c565b6001600160a01b031603613adf576040516342bcdf7f60e11b815260040160405180910390fd5b613b02613aef60e0840184614fb5565b613afd610100860186614fb5565b61413d565b613b1482608001358360a00135614374565b5f613b2761016084016101408501614b2c565b6001600160a01b031603613b4e576040516342bcdf7f60e11b815260040160405180910390fd5b613b695f613b6461016085016101408601614b2c565b6132af565b613b7e613b7960c0840184614fb5565b6143c5565b613b8e6080830160608401614b2c565b5f805261011b6020527f033d11f27e62ab919708ec716731da80d261a6e4253259b7acde9bf89d28ec1880546001600160a01b0319166001600160a01b03929092169190911790558135613bf557604051630742d05360e01b815260040160405180910390fd5b6020828101356101198190555f9081526101c882526040808220853590556101bd849055805182815292830182905282810182905260608301829052840135608083015260a09091206101bf5560016101c255613c5a61018084016101608501614b2c565b90506001600160a01b038116613c6d5750305b6101c180546001600160a01b0319166001600160a01b038316179055613c9b6101a084016101808501614b2c565b6101c680546001600160a01b0319166001600160a01b03929092169190911790555f5b613ccc610120850185614ed2565b9050811015613d6c575f613ce4610120860186614ed2565b83818110613cf457613cf4614e7b565b9050602002013503613d1957604051630742d05360e01b815260040160405180910390fd5b60016101c75f613d2d610120880188614ed2565b85818110613d3d57613d3d614e7b565b602090810292909201358352508101919091526040015f20805460ff1916911515919091179055600101613cbe565b505f613d7c610120850185614ed2565b90501115613dca577fe67bde9ffb5b617b92d199e99ed23fed9868d9366156771e7f709c2d7514449a613db3610120850185614ed2565b604051613dc1929190614ebf565b60405180910390a15b6040805180820190915260038152620392e360ec1b6020820152613ded90614ffa565b6001600160c01b0319167f31e960f67e4fae468b10f504b116ec2791f36d5f18a31e6112c960313b6e0607848460405161158b929190615154565b5f54610100900460ff16613e4e5760405162461bcd60e51b815260040161147690614f6a565b6001600160a01b038116613e75576040516342bcdf7f60e11b815260040160405180910390fd5b6101c080546001600160a01b0319166001600160a01b03831690811790915560405133907fb341a9e6d33f272cb7b5a20b337763606cbb6c728e7a34cbd3191cdfa0f0cd07905f90a350565b5f54610100900460ff16613ee75760405162461bcd60e51b815260040161147690614f6a565b6132ac8161384e565b613efa82826128b2565b6118ef57613f07816144d1565b613f128360206144e3565b604051602001613f239291906152c9565b60408051601f198184030181529082905262461bcd60e51b825261147691600401614935565b6001600160a01b0381163314613fb95760405162461bcd60e51b815260206004820152602f60248201527f416363657373436f6e74726f6c3a2063616e206f6e6c792072656e6f756e636560448201526e103937b632b9903337b91039b2b63360891b6064820152608401611476565b6118ef82826139e1565b600881901c5f90815261014f6020526040902054600160ff83161b161561400057604051630335a4a960e41b815260048101829052602401611476565b600881901c5f90815261014f602052604090208054600160ff84161b17905550565b5f80614043600161403487600261540a565b61403e9190614df7565b61467f565b90508063ffffffff168463ffffffff1611156140825760405163f7ec909760e01b815263ffffffff808616600483015282166024820152604401611476565b865f5b8681101561410857600163ffffffff8716821c811690036140d2576140cb8888838181106140b5576140b5614e7b565b90506020020135835f9182526020526040902090565b9150614100565b6140fd828989848181106140e8576140e8614e7b565b905060200201355f9182526020526040902090565b91505b600101614085565b509092149695505050505050565b6001600160a01b0381166132ac576040516342bcdf7f60e11b815260040160405180910390fd5b5f54610100900460ff166141635760405162461bcd60e51b815260040161147690614f6a565b5f5b8381101561426b5784848281811061417f5761417f614e7b565b9050604002016020013560db5f87878581811061419e5761419e614e7b565b6141b492602060409092020190810191506147d9565b600d8111156141c5576141c5614ce0565b600d8111156141d6576141d6614ce0565b815260208101919091526040015f20558484828181106141f8576141f8614e7b565b9050604002016020013585858381811061421457614214614e7b565b61422a92602060409092020190810191506147d9565b600d81111561423b5761423b614ce0565b6040517f33aa8fd1ce49e1761bc8d27fd53414bfefc45d690feed0ce55019d7d3aec6091905f90a3600101614165565b505f5b81811015612a905782828281811061428857614288614e7b565b9050604002016020013560dc5f8585858181106142a7576142a7614e7b565b6142bd92602060409092020190810191506147d9565b600d8111156142ce576142ce614ce0565b600d8111156142df576142df614ce0565b815260208101919091526040015f205582828281811061430157614301614e7b565b9050604002016020013583838381811061431d5761431d614e7b565b61433392602060409092020190810191506147d9565b600d81111561434457614344614ce0565b6040517fe7bf4b8dc0c17a52dc9e52323a3ab61cb2079db35f969125b1f8a3d984c6f6c2905f90a360010161426e565b5f54610100900460ff1661439a5760405162461bcd60e51b815260040161147690614f6a565b6143a26146b3565b6143aa6146b3565b6143b26146b3565b6143bc82826146db565b5050600160e455565b5f54610100900460ff166143eb5760405162461bcd60e51b815260040161147690614f6a565b5f5b818110156118e0575f83838381811061440857614408614e7b565b61441e9260206040909202019081019150614b2c565b6001600160a01b031603614445576040516342bcdf7f60e11b815260040160405180910390fd5b82828281811061445757614457614e7b565b905060400201602001355f5f1b0361448257604051630742d05360e01b815260040160405180910390fd5b6144c983838381811061449757614497614e7b565b905060400201602001358484848181106144b3576144b3614e7b565b613b649260206040909202019081019150614b2c565b6001016143ed565b60606113d96001600160a01b03831660145b60605f6144f1836002614e0a565b6144fc906002614d87565b6001600160401b0381111561451357614513615415565b6040519080825280601f01601f19166020018201604052801561453d576020820181803683370190505b509050600360fc1b815f8151811061455757614557614e7b565b60200101906001600160f81b03191690815f1a905350600f60fb1b8160018151811061458557614585614e7b565b60200101906001600160f81b03191690815f1a9053505f6145a7846002614e0a565b6145b2906001614d87565b90505b6001811115614629576f181899199a1a9b1b9c1cb0b131b232b360811b85600f16601081106145e6576145e6614e7b565b1a60f81b8282815181106145fc576145fc614e7b565b60200101906001600160f81b03191690815f1a90535060049490941c9361462281615429565b90506145b5565b5083156146785760405162461bcd60e51b815260206004820181905260248201527f537472696e67733a20686578206c656e67746820696e73756666696369656e746044820152606401611476565b9392505050565b5f63ffffffff8211156146af576040516306dfcc6560e41b81526020600482015260248101839052604401611476565b5090565b5f54610100900460ff166146d95760405162461bcd60e51b815260040161147690614f6a565b565b5f54610100900460ff166147015760405162461bcd60e51b815260040161147690614f6a565b815f036147215760405163b5ed5a3b60e01b815260040160405180910390fd5b805f036147415760405163d10d72bb60e01b815260040160405180910390fd5b609782905560988190556147558242614d87565b60998190556097546098546040805192835260208301919091528101919091527f8f805c372b66240792580418b7328c0c554ae235f0932475c51b026887fe26a990606001612139565b5f602082840312156147af575f5ffd5b81356001600160e01b031981168114614678575f5ffd5b8035600e81106147d4575f5ffd5b919050565b5f602082840312156147e9575f5ffd5b614678826147c6565b5f60208284031215614802575f5ffd5b5035919050565b6001600160a01b03811681146132ac575f5ffd5b80356147d481614809565b5f5f83601f840112614838575f5ffd5b5081356001600160401b0381111561484e575f5ffd5b602083019150836020828501011115614865575f5ffd5b9250929050565b5f5f5f5f5f60808688031215614880575f5ffd5b85359450602086013561489281614809565b93506040860135925060608601356001600160401b038111156148b3575f5ffd5b6148bf88828901614828565b969995985093965092949392505050565b5f5f5f5f5f60a086880312156148e4575f5ffd5b505083359560208501359550604085013594606081013594506080013592509050565b5f5f60408385031215614918575f5ffd5b82359150602083013561492a81614809565b809150509250929050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b5f5f6040838503121561497b575f5ffd5b614984836147c6565b946020939093013593505050565b5f5f5f5f5f5f5f5f60e0898b0312156149a9575f5ffd5b88356149b481614809565b975060208901356149c481614809565b9650604089013595506060890135945060808901356149e281614809565b935060a08901356001600160401b038111156149fc575f5ffd5b614a088b828c01614828565b999c989b50969995989497949560c00135949350505050565b5f6101408284031215613848575f5ffd5b5f60208284031215614a42575f5ffd5b81356001600160401b03811115614a57575f5ffd5b614a6384828501614a21565b949350505050565b5f5f83601f840112614a7b575f5ffd5b5081356001600160401b03811115614a91575f5ffd5b6020830191508360208260051b8501011115614865575f5ffd5b5f5f60208385031215614abc575f5ffd5b82356001600160401b03811115614ad1575f5ffd5b614add85828601614a6b565b90969095509350505050565b5f5f60408385031215614afa575f5ffd5b82356001600160401b03811115614b0f575f5ffd5b614b1b85828601614a21565b925050602083013561492a81614809565b5f60208284031215614b3c575f5ffd5b813561467881614809565b5f5f5f5f60608587031215614b5a575f5ffd5b84356001600160401b03811115614b6f575f5ffd5b614b7b87828801614a6b565b90989097506020870135966040013595509350505050565b5f5f5f5f60608587031215614ba6575f5ffd5b84356001600160401b03811115614bbb575f5ffd5b614bc787828801614828565b9095509350506020850135915060408501356001600160401b03811115614bec575f5ffd5b85016103008188031215614bfe575f5ffd5b939692955090935050565b5f5f5f5f60608587031215614c1c575f5ffd5b8435614c2781614809565b93506020850135925060408501356001600160401b03811115614c48575f5ffd5b614c5487828801614828565b95989497509550505050565b5f5f60408385031215614c71575f5ffd5b823561498481614809565b5f5f5f60608486031215614c8e575f5ffd5b83356001600160401b03811115614ca3575f5ffd5b84016101a08187031215614cb5575f5ffd5b92506020840135614cc581614809565b91506040840135614cd581614809565b809150509250925092565b634e487b7160e01b5f52602160045260245ffd5b600e8110614d1057634e487b7160e01b5f52602160045260245ffd5b9052565b602081016113d98284614cf4565b81835281816020850137505f828201602090810191909152601f909101601f19169091010190565b848152836020820152606060408201525f614d69606083018486614d22565b9695505050505050565b634e487b7160e01b5f52601160045260245ffd5b808201808211156113d9576113d9614d73565b6020808252602e908201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160408201526d191e481a5b9a5d1a585b1a5e995960921b606082015260800190565b818382375f9101908152919050565b818103818111156113d9576113d9614d73565b80820281158282048414176113d9576113d9614d73565b5f60018201614e3257614e32614d73565b5060010190565b5f5f8335601e19843603018112614e4e575f5ffd5b8301803591506001600160401b03821115614e67575f5ffd5b602001915036819003821315614865575f5ffd5b634e487b7160e01b5f52603260045260245ffd5b8183525f6001600160fb1b03831115614ea6575f5ffd5b8260051b80836020870137939093016020019392505050565b602081525f614a63602083018486614e8f565b5f5f8335601e19843603018112614ee7575f5ffd5b8301803591506001600160401b03821115614f00575f5ffd5b6020019150600581901b3603821315614865575f5ffd5b5f60208284031215614f27575f5ffd5b813563ffffffff81168114614678575f5ffd5b858152846020820152836040820152608060608201525f614f5f608083018486614d22565b979650505050505050565b6020808252602b908201527f496e697469616c697a61626c653a20636f6e7472616374206973206e6f74206960408201526a6e697469616c697a696e6760a81b606082015260800190565b5f5f8335601e19843603018112614fca575f5ffd5b8301803591506001600160401b03821115614fe3575f5ffd5b6020019150600681901b3603821315614865575f5ffd5b805160208201516001600160c01b0319811691906008821015615031576001600160c01b0319600883900360031b81901b82161692505b5050919050565b5f5f8335601e1984360301811261504d575f5ffd5b83016020810192503590506001600160401b0381111561506b575f5ffd5b8060061b3603821315614865575f5ffd5b8183526020830192505f815f5b848110156150c357813561509c81614809565b6001600160a01b031686526020828101359087015260409586019590910190600101615089565b5093949350505050565b8183526020830192505f815f5b848110156150c3576150f4866150ef846147c6565b614cf4565b60208281013590870152604095860195909101906001016150da565b5f5f8335601e19843603018112615125575f5ffd5b83016020810192503590506001600160401b03811115615143575f5ffd5b8060051b3603821315614865575f5ffd5b604080825283358282015260208401356060808401919091529084013560808301525f9061518390850161481d565b6001600160a01b03811660a084015250608084013560c08381019190915260a085013560e08401526151b790850185615038565b6101a06101008501526151cf6101e08501828461507c565b9150506151df60e0860186615038565b848303603f19016101208601526151f78382846150cd565b92505050615209610100860186615038565b848303603f19016101408601526152218382846150cd565b92505050615233610120860186615110565b848303603f190161016086015261524b838284614e8f565b9250505061525c610140860161481d565b6001600160a01b0316610180840152615278610160860161481d565b6001600160a01b03166101a0840152615294610180860161481d565b6001600160a01b03166101c084015260209092019290925292915050565b5f81518060208401855e5f93019283525090919050565b7f416363657373436f6e74726f6c3a206163636f756e742000000000000000000081525f6152fa60178301856152b2565b7001034b99036b4b9b9b4b733903937b6329607d1b815261531e60118201856152b2565b95945050505050565b6001815b60018411156153625780850481111561534657615346614d73565b600184161561535457908102905b60019390931c92800261532b565b935093915050565b5f82615378575060016113d9565b8161538457505f6113d9565b816001811461539a57600281146153a4576153c0565b60019150506113d9565b60ff8411156153b5576153b5614d73565b50506001821b6113d9565b5060208310610133831016604e8410600b84101617156153e3575081810a6113d9565b6153ef5f198484615327565b805f190482111561540257615402614d73565b029392505050565b5f614678838361536a565b634e487b7160e01b5f52604160045260245ffd5b5f8161543757615437614d73565b505f19019056fe084edf88d5959696dcc7aab5c8674a33a1ef78f37dda21b782ed03bddb22ade497667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b9291453a531db80c85f2d944d498709d84959bc5bf839eefe9acb784571e5a32118a2646970667358221220347c486925980e7caa5d5102df8ba3ca3ac9883070b5038821b21ca2e4e6aed864736f6c63430008210033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/contracts/makefile-contracts.mk
+++ b/contracts/makefile-contracts.mk
@@ -67,6 +67,31 @@ deploy-linea-rollup-v7: deploy-linea-rollup-v7_1
 deploy-linea-rollup-v8:
 		$(MAKE) deploy-linea-rollup L1_CONTRACT_VERSION=8
 
+deploy-lineth-rollup-v9-stub:
+		# WARNING: FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE
+		# Deploys LinethRollupV9Stub, a temporary placeholder rollup implementation whose
+		# submitBlobs/finalizeBlocks are no-ops. No PlonkVerifier is deployed and guest-program
+		# verifier keys are randomly generated, since neither is exercised by this stub.
+		export FORK_TIMESTAMP=$$(cat docker/config/l2-genesis-initialization/fork-timestamp.txt 2>/dev/null || true) && \
+		cd $(contracts_package_dir); \
+		DEPLOYER_PRIVATE_KEY=$${DEPLOYMENT_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80} \
+		RPC_URL=http:\\localhost:8445/ \
+		INITIAL_L2_BLOCK_HASH=0x01d9afcd495c870f3ae9d8362cd0257a7de2057055058183596719285cae6101 \
+		INITIAL_L2_BLOCK_NUMBER=0 \
+		L2_GENESIS_TIMESTAMP=$${FORK_TIMESTAMP:-1683325137} \
+		L1_SECURITY_COUNCIL=0x90F79bf6EB2c4f870365E785982E1f101E93b906 \
+		LINEA_ROLLUP_OPERATORS=$${LINEA_ROLLUP_OPERATORS:-0x70997970C51812dc3A010C7d01b50e0d17dc79C8,0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC} \
+		LINEA_ROLLUP_RATE_LIMIT_PERIOD=86400 \
+		LINEA_ROLLUP_RATE_LIMIT_AMOUNT=1000000000000000000000 \
+		FORCED_TRANSACTION_GATEWAY_L2_CHAIN_ID=1337 \
+		FORCED_TRANSACTION_GATEWAY_L2_BLOCK_BUFFER=2000 \
+		FORCED_TRANSACTION_GATEWAY_MAX_GAS_LIMIT=300000 \
+		FORCED_TRANSACTION_GATEWAY_MAX_INPUT_LENGTH_BUFFER=1000 \
+		FORCED_TRANSACTION_L2_BLOCK_DURATION_SECONDS=2 \
+		FORCED_TRANSACTION_BLOCK_NUMBER_DEADLINE_BUFFER=10 \
+		SECURITY_COUNCIL_PRIVATE_KEY=0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6 \
+		pnpm exec ts-node local-deployments-artifacts/deployLinethRollupV9Stub.ts
+
 deploy-validium: L1_CONTRACT_VERSION:=2
 deploy-validium:
 		# WARNING: FOR LOCAL DEV ONLY - DO NOT REUSE THESE KEYS ELSEWHERE


### PR DESCRIPTION
This provides a new interface for V "9.0" of the rollup contract and a stub for blob and finalization submission

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New ABI artifact and local-only deploy script; no on-chain production rollout or runtime logic changes in this diff.
> 
> **Overview**
> Adds **`contracts/abi/LinethRollupV9-rc.abi`**, a checked-in ABI for the rollup **V9 release-candidate** surface (e.g. `submitBlobs`, `finalizeBlocks` with `FinalizationDataV5`, yield/LST helpers, verifier keys, and V9/V10 reinit hooks) so off-chain tooling can target the new contract shape before production bytecode lands.
> 
> Adds **`deployLinethRollupV9Stub.ts`** for local L1 deploys: implementation + transparent proxy + `AddressFilter`, initialized with V8-style roles/pauses, a random placeholder verifier key, `DEAD_ADDRESS` as default verifier, and stub yield/liveness addresses. **`DEPLOY_FORCED_TRANSACTION_GATEWAY`** (default `true`) optionally deploys Mimc + `ForcedTransactionGateway` and grants **`FORCED_TRANSACTION_SENDER_ROLE`**; quickstart can set it `false` to skip those contracts and nonces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a508996da3722e3a153dfffe8efdf8414bf366ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->