### PR TITLE
refactor(coordinator): decompose L1DependentApp into smaller scoped apps

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
@@ -170,6 +170,7 @@ fun createLineaContractClient(
   gasConfig: L1SubmissionConfig.GasConfig,
   l1MinPriorityFeeCalculator: FeesCalculator,
   dataAvailabilityType: L1SubmissionConfig.DataAvailability,
+  useEthEstimateGas: Boolean = false,
 ): LineaSmartContractClient {
   val l1DataSubmissionPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
     BoundableFeeCalculator.Config(
@@ -208,6 +209,6 @@ fun createLineaContractClient(
     smartContractErrors = smartContractErrors,
     // eth_estimateGas would fail because we submit multiple blob tx
     // and 2nd would fail with revert reason
-    useEthEstimateGas = false,
+    useEthEstimateGas = useEthEstimateGas,
   )
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
@@ -125,6 +125,10 @@ fun createTransactionManager(
   return AsyncFriendlyTransactionManager(client, transactionSignService, -1L)
 }
 
+/**
+ * @param useEthEstimateGas `eth_estimateGas` may revert for multi-blob data-submission txs;
+ * disable it if it's the case.
+ */
 fun createLineaContractClient(
   vertx: Vertx,
   dataAvailabilityType: L1SubmissionConfig.DataAvailability,
@@ -159,6 +163,10 @@ fun createLineaContractClient(
   }
 }
 
+/**
+ * @param useEthEstimateGas `eth_estimateGas` may revert for multi-blob data-submission txs;
+ * disable it if it's the case.
+ */
 fun createLineaContractClient(
   l1ChainId: ULong,
   contractAddress: String,
@@ -207,8 +215,6 @@ fun createLineaContractClient(
     contractGasProvider = primaryOrFallbackGasProvider,
     web3jClient = l1Web3jClient,
     smartContractErrors = smartContractErrors,
-    // eth_estimateGas would fail because we submit multiple blob tx
-    // and 2nd would fail with revert reason
     useEthEstimateGas = useEthEstimateGas,
   )
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
@@ -18,6 +18,10 @@ import linea.web3j.ethapi.createEthApiClient
 import linea.web3j.transactionmanager.AsyncFriendlyTransactionManager
 import net.consensys.linea.contract.l1.Web3JLineaRollupSmartContractClient
 import net.consensys.linea.contract.l1.Web3JLineaValidiumSmartContractClient
+import net.consensys.linea.ethereum.gaspricing.BoundableFeeCalculator
+import net.consensys.linea.ethereum.gaspricing.FeesCalculator
+import net.consensys.linea.ethereum.gaspricing.FeesFetcher
+import net.consensys.linea.ethereum.gaspricing.WMAGasProvider
 import net.consensys.linea.httprest.client.VertxHttpRestClient
 import org.web3j.crypto.Credentials
 import org.web3j.protocol.Web3j
@@ -153,4 +157,57 @@ fun createLineaContractClient(
         useEthEstimateGas = useEthEstimateGas,
       )
   }
+}
+
+fun createLineaContractClient(
+  l1ChainId: ULong,
+  contractAddress: String,
+  smartContractErrors: SmartContractErrors,
+  vertx: Vertx,
+  l1Web3jClient: Web3j,
+  feesFetcher: FeesFetcher,
+  signerConfig: SignerConfig,
+  gasConfig: L1SubmissionConfig.GasConfig,
+  l1MinPriorityFeeCalculator: FeesCalculator,
+  dataAvailabilityType: L1SubmissionConfig.DataAvailability,
+): LineaSmartContractClient {
+  val l1DataSubmissionPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
+    BoundableFeeCalculator.Config(
+      feeUpperBound = gasConfig.fallback.priorityFeePerGasUpperBound.toDouble(),
+      feeLowerBound = gasConfig.fallback.priorityFeePerGasLowerBound.toDouble(),
+      feeMargin = 0.0,
+    ),
+    l1MinPriorityFeeCalculator,
+  )
+  // The below gas provider will act as the primary gas provider if L1
+  // dynamic gas pricing is disabled and will act as a fallback gas provider
+  // if L1 dynamic gas pricing is enabled
+  val primaryOrFallbackGasProvider = WMAGasProvider(
+    chainId = l1ChainId.toLong(),
+    feesFetcher = feesFetcher,
+    priorityFeeCalculator = l1DataSubmissionPriorityFeeCalculator,
+    config = WMAGasProvider.Config(
+      gasLimit = gasConfig.gasLimit,
+      maxFeePerGasCap = gasConfig.maxFeePerGasCap,
+      maxPriorityFeePerGasCap = gasConfig.maxPriorityFeePerGasCap,
+      maxFeePerBlobGasCap = gasConfig.maxFeePerBlobGasCap,
+    ),
+  )
+  val transactionManager = createTransactionManager(
+    vertx = vertx,
+    signerConfig = signerConfig,
+    client = l1Web3jClient,
+  )
+  return createLineaContractClient(
+    vertx = vertx,
+    dataAvailabilityType = dataAvailabilityType,
+    contractAddress = contractAddress,
+    transactionManager = transactionManager,
+    contractGasProvider = primaryOrFallbackGasProvider,
+    web3jClient = l1Web3jClient,
+    smartContractErrors = smartContractErrors,
+    // eth_estimateGas would fail because we submit multiple blob tx
+    // and 2nd would fail with revert reason
+    useEthEstimateGas = false,
+  )
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/BlockchainClientHelper.kt
@@ -172,7 +172,7 @@ fun createLineaContractClient(
   dataAvailabilityType: L1SubmissionConfig.DataAvailability,
   useEthEstimateGas: Boolean = false,
 ): LineaSmartContractClient {
-  val l1DataSubmissionPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
+  val l1PriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
     BoundableFeeCalculator.Config(
       feeUpperBound = gasConfig.fallback.priorityFeePerGasUpperBound.toDouble(),
       feeLowerBound = gasConfig.fallback.priorityFeePerGasLowerBound.toDouble(),
@@ -186,7 +186,7 @@ fun createLineaContractClient(
   val primaryOrFallbackGasProvider = WMAGasProvider(
     chainId = l1ChainId.toLong(),
     feesFetcher = feesFetcher,
-    priorityFeeCalculator = l1DataSubmissionPriorityFeeCalculator,
+    priorityFeeCalculator = l1PriorityFeeCalculator,
     config = WMAGasProvider.Config(
       gasLimit = gasConfig.gasLimit,
       maxFeePerGasCap = gasConfig.maxFeePerGasCap,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppMain.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppMain.kt
@@ -29,7 +29,7 @@ class CoordinatorAppMain {
     }
 
     private fun startApp(configs: CoordinatorConfig) {
-      val app = CoordinatorApp(configs)
+      val app = CoordinatorAppV2(configs)
       Runtime.getRuntime()
         .addShutdownHook(
           Thread {

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppV2.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppV2.kt
@@ -1,0 +1,370 @@
+package linea.coordinator.app
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.vertx.core.Vertx
+import io.vertx.micrometer.backends.BackendRegistries
+import io.vertx.micrometer.backends.NoopBackendRegistry
+import io.vertx.sqlclient.SqlClient
+import linea.DisabledService
+import linea.LongRunningService
+import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
+import linea.coordinator.api.Api
+import linea.coordinator.app.conflation.ConflationAppV1
+import linea.coordinator.app.conflationbacktesting.ConflationBacktestingService
+import linea.coordinator.config.v2.CoordinatorConfig
+import linea.coordinator.config.v2.DatabaseConfig
+import linea.coordinator.config.v2.isEnabled
+import linea.coordinator.config.v2.logPretty
+import linea.coordinator.extensions.CoordinatorContext
+import linea.coordinator.extensions.CoordinatorExtensionFactory
+import linea.domain.BlockParameter
+import linea.domain.RetryConfig
+import linea.ethapi.EthLogsSearcherImpl
+import linea.persistence.DisabledForcedTransactionsDao
+import linea.persistence.FeeHistoriesPostgresDao
+import linea.persistence.conflation.AggregationsRepositoryImpl
+import linea.persistence.conflation.BatchesPostgresDao
+import linea.persistence.conflation.BlobsPostgresDao
+import linea.persistence.conflation.BlobsRepositoryImpl
+import linea.persistence.conflation.PostgresAggregationsDao
+import linea.persistence.conflation.PostgresBatchesRepository
+import linea.persistence.conflation.RetryingBatchesPostgresDao
+import linea.persistence.conflation.RetryingBlobsPostgresDao
+import linea.persistence.conflation.RetryingPostgresAggregationsDao
+import linea.persistence.db.Db
+import linea.persistence.db.PersistenceRetryer
+import linea.persistence.ftx.PostgresForcedTransactionsDao
+import linea.persistence.ftx.RetryingPostgresForcedTransactionsDao
+import linea.web3j.createWeb3jHttpClient
+import linea.web3j.ethapi.createEthApiClient
+import net.consensys.linea.async.toSafeFuture
+import net.consensys.linea.jsonrpc.client.LoadBalancingJsonRpcClient
+import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
+import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
+import net.consensys.linea.vertx.loadVertxConfig
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+class CoordinatorAppV2(
+  private val configs: CoordinatorConfig,
+  private val clock: Clock = Clock.System,
+  // Single seam for the enterprise distribution: contributes extra services and JSON-RPC
+  // handlers that share this app's Vertx, metrics and DB. Defaults to no-op so the OSS app
+  // behaves identically when no extension is supplied.
+  extensionsFactory: CoordinatorExtensionFactory = CoordinatorExtensionFactory.NOOP,
+) {
+  private val log: Logger = LogManager.getLogger(this::class.java)
+  private val vertx: Vertx =
+    run {
+      log.trace("System properties: {}", System.getProperties())
+      val vertxConfig = loadVertxConfig()
+      log.debug("Vertx full configs: {}", vertxConfig)
+      // Raw single-line dump kept for existing tooling that parses this line.
+      log.info("App configs: {}", configs)
+      // Human-readable form: one fully-qualified `path: value` per INFO event so each config is a
+      // separate line in log aggregators (Grafana/Loki) instead of a collapsed multi-line blob.
+      configs.logPretty(log)
+      log.trace(
+        "Full smartContractErrors ({} entries): {}",
+        configs.smartContractErrors.size,
+        configs.smartContractErrors,
+      )
+      configs.l1Submission?.dynamicGasPriceCap?.let { dgc ->
+        log.trace("dynamicGasPriceCap.timeOfDayMultipliers: {}", dgc.timeOfDayMultipliers)
+        log.trace(
+          "dynamicGasPriceCap.gasPriceCapCalculation.timeOfTheDayMultipliers: {}",
+          dgc.gasPriceCapCalculation.timeOfTheDayMultipliers,
+        )
+      }
+
+      Vertx.vertx(vertxConfig)
+    }
+  private val meterRegistry: MeterRegistry = BackendRegistries.getDefaultNow()
+  private val micrometerMetricsFacade = MicrometerMetricsFacade(meterRegistry, "linea")
+  private val httpJsonRpcClientFactory =
+    VertxHttpJsonRpcClientFactory(
+      vertx = vertx,
+      metricsFacade = micrometerMetricsFacade,
+      requestResponseLogLevel = Level.TRACE,
+      failuresLogLevel = Level.WARN,
+    )
+
+  private val conflationBacktestingService = ConflationBacktestingService(
+    vertx = vertx,
+    configs = configs,
+    metricsFacade = MicrometerMetricsFacade(NoopBackendRegistry.INSTANCE.meterRegistry, "conflationbacktesting"),
+  )
+
+  private val persistenceRetryer =
+    PersistenceRetryer(
+      vertx = vertx,
+      config =
+      PersistenceRetryer.Config(
+        backoffDelay = configs.database.persistenceRetries.backoffDelay,
+        maxRetries = configs.database.persistenceRetries.maxRetries?.toInt(),
+        timeout = configs.database.persistenceRetries.timeout,
+        ignoreFirstExceptionsUntilTimeElapsed =
+        configs.database.persistenceRetries.ignoreFirstExceptionsUntilTimeElapsed,
+      ),
+    )
+
+  private val sqlClient: SqlClient = initDb(configs.database)
+  private val batchesRepository =
+    PostgresBatchesRepository(
+      batchesDao =
+      RetryingBatchesPostgresDao(
+        delegate =
+        BatchesPostgresDao(
+          connection = sqlClient,
+        ),
+        persistenceRetryer = persistenceRetryer,
+      ),
+    )
+  private val blobsRepository =
+    BlobsRepositoryImpl(
+      blobsDao =
+      RetryingBlobsPostgresDao(
+        delegate =
+        BlobsPostgresDao(
+          config =
+          BlobsPostgresDao.Config(
+            maxBlobsToReturn = configs.l1Submission?.blob?.dbMaxBlobsToReturn ?: 50u,
+          ),
+          connection = sqlClient,
+        ),
+        persistenceRetryer = persistenceRetryer,
+      ),
+    )
+  private val aggregationsRepository =
+    AggregationsRepositoryImpl(
+      aggregationsPostgresDao =
+      RetryingPostgresAggregationsDao(
+        delegate =
+        PostgresAggregationsDao(
+          connection = sqlClient,
+        ),
+        persistenceRetryer = persistenceRetryer,
+      ),
+    )
+  private val forcedTransactionsDao = run {
+    if (configs.forcedTransactions?.disabled ?: true) {
+      DisabledForcedTransactionsDao()
+    } else {
+      RetryingPostgresForcedTransactionsDao(
+        delegate =
+        PostgresForcedTransactionsDao(
+          connection = sqlClient,
+        ),
+        persistenceRetryer = persistenceRetryer,
+      )
+    }
+  }
+  private val feeHistoriesDao = FeeHistoriesPostgresDao(sqlClient)
+
+  private val l1ChainId: ULong = createEthApiClient(
+    rpcUrl = configs.l1FinalizationMonitor.l1Endpoint.toString(),
+    log = LogManager.getLogger("clients.l1.eth"),
+    vertx = vertx,
+    requestRetryConfig = RetryConfig.endlessRetry(
+      backoffDelay = 1.seconds,
+      failuresWarningThreshold = 3u,
+    ),
+  ).ethChainId().get()
+
+  private val lineaRollupClientForFinalizationMonitor = run {
+    val web3j = createWeb3jHttpClient(
+      rpcUrl = configs.l1FinalizationMonitor.l1Endpoint.toString(),
+      log = LogManager.getLogger("clients.l1.eth.finalization-monitor"),
+    )
+    Web3JLineaRollupSmartContractClientReadOnly(
+      contractAddress = configs.protocol.l1.contractAddress,
+      web3j = web3j,
+      ethLogsSearcher = EthLogsSearcherImpl(
+        vertx = vertx,
+        ethApiClient = createEthApiClient(
+          web3jClient = web3j,
+          requestRetryConfig = configs.l1FinalizationMonitor.l1RequestRetries,
+          vertx = vertx,
+        ),
+      ),
+      finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
+        ?: BlockParameter.Tag.EARLIEST,
+    )
+  }
+
+  private val lastFinalizedBlock: ULong = L1BasedLastFinalizedBlockProvider(
+    vertx,
+    lineaRollupSmartContractClient = lineaRollupClientForFinalizationMonitor,
+    consistentNumberOfBlocksOnL1 = configs.conflation.consistentNumberOfBlocksOnL1ToWait,
+  ).getLastFinalizedBlock().get()
+
+  private val conflationApp: ConflationAppV1 = ConflationAppV1(
+    vertx = vertx,
+    clock = clock,
+    batchesRepository = batchesRepository,
+    blobsRepository = blobsRepository,
+    aggregationsRepository = aggregationsRepository,
+    forcedTransactionsDao = forcedTransactionsDao,
+    lastFinalizedBlock = lastFinalizedBlock,
+    configs = configs,
+    metricsFacade = micrometerMetricsFacade,
+    httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+  )
+
+  private val l1FinalizationMonitorApp = L1FinalizationMonitorApp(
+    configs = configs,
+    vertx = vertx,
+    httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+    finalizedStateDataProvider = lineaRollupClientForFinalizationMonitor,
+    lastFinalizedBlock = lastFinalizedBlock,
+    batchesRepository = batchesRepository,
+    blobsRepository = blobsRepository,
+    aggregationsRepository = aggregationsRepository,
+    forcedTransactionsDao = forcedTransactionsDao,
+    metricsFacade = micrometerMetricsFacade,
+    l1FinalizationUpdateHandler = conflationApp::updateLatestL1FinalizedBlock,
+  )
+
+  private val messageAnchoringApp: LongRunningService = MessageAnchoringAppConfigurator.create(
+    vertx = vertx,
+    configs = configs,
+  )
+
+  private val l1RelayingAppV1 = run {
+    if (configs.l1Submission.isEnabled()) {
+      L1RelayingAppV1(
+        configs = configs,
+        l1SubmissionConfig = configs.l1Submission!!,
+        vertx = vertx,
+        l1ChainId = l1ChainId,
+        lastFinalizedBlock = lastFinalizedBlock,
+        smartContractErrors = configs.smartContractErrors,
+        metricsFacade = micrometerMetricsFacade,
+        feeHistoriesDao = feeHistoriesDao,
+        blobsRepository = blobsRepository,
+        aggregationsRepository = aggregationsRepository,
+      )
+    } else {
+      log.warn("L1 submission disabled for blobs and aggregations")
+      DisabledService("L1RelayingApp")
+    }
+  }
+
+  private val l2PricingApp: LongRunningService =
+    if (configs.l2NetworkGasPricing.isEnabled()) {
+      L2PricingApp(
+        l2NetworkGasPricingConfig = configs.l2NetworkGasPricing!!,
+        vertx = vertx,
+        metricsFacade = micrometerMetricsFacade,
+        httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+      )
+    } else {
+      log.warn("L2 Network dynamic gas pricing is disabled")
+      DisabledService("L2PricingApp")
+    }
+
+  // Resolve extensions once, against the infrastructure already built above. Done before any
+  // service is started so their services join the lifecycle and their handlers join the router.
+  private val extensions =
+    extensionsFactory.create(
+      object : CoordinatorContext {
+        override val vertx: Vertx = this@CoordinatorAppV2.vertx
+        override val metricsFacade = micrometerMetricsFacade
+        override val sqlClient: SqlClient = this@CoordinatorAppV2.sqlClient
+      },
+    )
+  private val extensionServices = extensions.flatMap { it.services() }
+  private val extensionRpcHandlers = extensions.flatMap { it.jsonRpcHandlers().entries }
+    .associate { it.key to it.value }
+    .also { handlers ->
+      if (handlers.isNotEmpty()) {
+        log.info("Registered {} extension JSON-RPC handler(s): {}", handlers.size, handlers.keys)
+      }
+    }
+
+  private val api =
+    Api(
+      configs = Api.Config(
+        observabilityPort = configs.api.observabilityPort,
+        jsonRpcPort = configs.api.jsonRpcPort,
+        jsonRpcPath = configs.api.jsonRpcPath,
+        jsonRpcServerVerticles = configs.api.jsonRpcServerVerticles,
+      ),
+      vertx = vertx,
+      conflationBacktestingService = conflationBacktestingService,
+      metricsFacade = micrometerMetricsFacade,
+      conflationCheckpointResumeLatch = conflationApp::signalTargetCheckpointResumeFromApi,
+      additionalRequestHandlers = extensionRpcHandlers,
+    )
+
+  init {
+    log.info("Coordinator app instantiated")
+  }
+
+  fun start() {
+    SafeFuture.completedFuture(Unit)
+      .thenCompose { l1FinalizationMonitorApp.start() }
+      .thenCompose { conflationApp.start() }
+      .thenCompose { l1RelayingAppV1.start() }
+      .thenCompose { messageAnchoringApp.start() }
+      .thenCompose { l2PricingApp.start() }
+      .thenCompose { conflationBacktestingService.start() }
+      .thenCompose {
+        SafeFuture.allOf(*extensionServices.map { it.start().toSafeFuture() }.toTypedArray())
+      }
+      .thenCompose { api.start() }
+      .get()
+
+    log.info("Started :)")
+  }
+
+  fun stop(): Int {
+    return try {
+      SafeFuture.allOf(
+        SafeFuture.allOf(*extensionServices.map { it.stop().toSafeFuture() }.toTypedArray()),
+        l2PricingApp.stop(),
+        messageAnchoringApp.stop(),
+        l1RelayingAppV1.stop(),
+        conflationApp.stop(),
+        l1FinalizationMonitorApp.stop(),
+        api.stop(),
+        conflationBacktestingService.stop(),
+      ).thenApply {
+        LoadBalancingJsonRpcClient.stop()
+      }.thenCompose {
+        vertx.close().toSafeFuture().thenApply { log.info("vertx Stopped") }
+      }.thenApply {
+        log.info("CoordinatorApp Stopped")
+      }.get()
+      0
+    } catch (e: Exception) {
+      log.error("CoordinatorApp Stopped with error: errorMessage={}", e.message, e)
+      1
+    }
+  }
+
+  private fun initDb(dbConfig: DatabaseConfig): SqlClient {
+    Db.applyDbMigrations(
+      host = dbConfig.host,
+      port = dbConfig.port,
+      database = dbConfig.schema,
+      target = dbConfig.schemaVersion.toString(),
+      username = dbConfig.username,
+      password = dbConfig.password.value,
+    )
+    return Db.vertxSqlClient(
+      vertx = vertx,
+      host = dbConfig.host,
+      port = dbConfig.port,
+      database = dbConfig.schema,
+      username = dbConfig.username,
+      password = dbConfig.password.value,
+      maxPoolSize = dbConfig.transactionalPoolSize,
+      pipeliningLimit = dbConfig.readPipeliningLimit,
+    )
+  }
+}

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
@@ -48,9 +48,14 @@ class L1FinalizationMonitorApp(
   private val forcedTransactionsDao: ForcedTransactionsDao,
   private val metricsFacade: MetricsFacade,
   private val l1FinalizationUpdateHandler: (blockNumber: Long) -> SafeFuture<Unit>,
+  private val l2EthApiClient: EthApiClient = createEthApiClient(
+    rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
+    log = LogManager.getLogger("clients.l2.eth.finalization-monitor"),
+    requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
+    vertx = vertx,
+  ),
 ) : LongRunningService {
   private val log = LogManager.getLogger(this::class.java)
-
   private val l1FinalizationMonitor =
     FinalizationMonitorImpl(
       config =
@@ -59,12 +64,7 @@ class L1FinalizationMonitorApp(
         l1QueryBlockTag = configs.l1FinalizationMonitor.l1QueryBlockTag,
       ),
       finalizedStateDataProvider = finalizedStateDataProvider,
-      l2EthApiClient = createEthApiClient(
-        rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
-        log = LogManager.getLogger("clients.l2.eth.finalization-monitor"),
-        requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
-        vertx = vertx,
-      ),
+      l2EthApiClient = l2EthApiClient,
       vertx = vertx,
     )
   private val highestAcceptedFinalizationTracker = HighestULongTracker(lastFinalizedBlock).also {
@@ -79,6 +79,7 @@ class L1FinalizationMonitorApp(
     type2StateProofProviderConfig = configs.type2StateProofProvider,
     httpJsonRpcClientFactory = httpJsonRpcClientFactory,
     finalizedStateDataProvider = finalizedStateDataProvider,
+    l2EthApiClient = l2EthApiClient,
     vertx = vertx,
   )
 

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
@@ -1,0 +1,180 @@
+package linea.coordinator.app
+
+import io.vertx.core.Vertx
+import linea.LongRunningService
+import linea.contract.l1.FinalizedStateDataProvider
+import linea.coordination.HighestULongTracker
+import linea.coordination.blockcreation.ForkChoiceUpdaterImpl
+import linea.coordinator.clients.ShomeiClient
+import linea.coordinator.config.toJsonRpcRetry
+import linea.coordinator.config.v2.CoordinatorConfig
+import linea.coordinator.config.v2.Type2StateProofManagerConfig
+import linea.coordinator.config.v2.isDisabled
+import linea.domain.BlockNumberAndHash
+import linea.ethapi.EthApiClient
+import linea.finalization.FinalizationHandler
+import linea.finalization.FinalizationMonitor
+import linea.finalization.FinalizationMonitorImpl
+import linea.metrics.LineaMetricsCategory
+import linea.persistence.AggregationsRepository
+import linea.persistence.BatchesRepository
+import linea.persistence.BlobsRepository
+import linea.persistence.ForcedTransactionsDao
+import linea.persistence.conflation.RecordsCleanupFinalizationHandler
+import linea.web3j.ethapi.createEthApiClient
+import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
+import net.consensys.linea.metrics.MetricsFacade
+import org.apache.logging.log4j.LogManager
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Responsibilities:
+ *   - poll L1 for finalization updates and dispatch them to:
+ *     - the conflation app's last proven block number provider
+ *     - the finalized records DB cleanup
+ *     - the highest accepted finalization metric
+ *   - notify type 2 state proof providers (Shomei frontend) of L1 finalizations
+ */
+class L1FinalizationMonitorApp(
+  private val configs: CoordinatorConfig,
+  private val vertx: Vertx,
+  private val httpJsonRpcClientFactory: VertxHttpJsonRpcClientFactory,
+  private val finalizedStateDataProvider: FinalizedStateDataProvider,
+  private val lastFinalizedBlock: ULong,
+  private val batchesRepository: BatchesRepository,
+  private val blobsRepository: BlobsRepository,
+  private val aggregationsRepository: AggregationsRepository,
+  private val forcedTransactionsDao: ForcedTransactionsDao,
+  private val metricsFacade: MetricsFacade,
+  private val l1FinalizationUpdateHandler: (blockNumber: Long) -> SafeFuture<Unit>,
+) : LongRunningService {
+  private val log = LogManager.getLogger(this::class.java)
+
+  private val l1FinalizationMonitor = run {
+    FinalizationMonitorImpl(
+      config =
+      FinalizationMonitorImpl.Config(
+        pollingInterval = configs.l1FinalizationMonitor.l1PollingInterval,
+        l1QueryBlockTag = configs.l1FinalizationMonitor.l1QueryBlockTag,
+      ),
+      finalizedStateDataProvider = finalizedStateDataProvider,
+      l2EthApiClient = createEthApiClient(
+        rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
+        log = LogManager.getLogger("clients.l2.eth.finalization-monitor"),
+        requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
+        vertx = vertx,
+      ),
+      vertx = vertx,
+    )
+  }
+
+  private val l1FinalizationHandlerForShomeiRpc: LongRunningService = run {
+    val l2EthApiClient: EthApiClient = createEthApiClient(
+      rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
+      log = LogManager.getLogger("clients.l2.eth.shomei-frontend"),
+      requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
+      vertx = vertx,
+    )
+    setupL1FinalizationMonitorForShomeiFrontend(
+      type2StateProofProviderConfig = configs.type2StateProofProvider,
+      httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+      finalizedStateDataProvider = finalizedStateDataProvider,
+      l2EthApiClient = l2EthApiClient,
+      vertx = vertx,
+    )
+  }
+
+  val highestAcceptedFinalizationTracker = HighestULongTracker(lastFinalizedBlock).also {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.AGGREGATION,
+      name = "highest.accepted.block.number",
+      description = "Highest finalized accepted end block number",
+      measurementSupplier = it,
+    )
+  }
+
+  init {
+    mapOf(
+      "last_proven_block_provider" to FinalizationHandler { update: FinalizationMonitor.FinalizationUpdate ->
+        l1FinalizationUpdateHandler(update.blockNumber.toLong())
+      },
+      "finalized records cleanup" to RecordsCleanupFinalizationHandler(
+        batchesRepository = batchesRepository,
+        blobsRepository = blobsRepository,
+        aggregationsRepository = aggregationsRepository,
+        forcedTransactionsDao = forcedTransactionsDao,
+      ),
+      "highest_accepted_finalization_on_l1" to FinalizationHandler { update: FinalizationMonitor.FinalizationUpdate ->
+        highestAcceptedFinalizationTracker(update.blockNumber)
+      },
+    )
+      .forEach { (handlerName, handler) ->
+        l1FinalizationMonitor.addFinalizationHandler(handlerName, handler)
+      }
+  }
+
+  override fun start(): CompletableFuture<Unit> {
+    return l1FinalizationMonitor.start()
+      .thenCompose { l1FinalizationHandlerForShomeiRpc.start() }
+      .thenPeek {
+        log.info("L1FinalizationMonitorApp started")
+      }
+  }
+
+  override fun stop(): CompletableFuture<Unit> {
+    return SafeFuture.allOf(
+      l1FinalizationMonitor.stop(),
+      l1FinalizationHandlerForShomeiRpc.stop(),
+    )
+      .thenApply { log.info("L1FinalizationMonitorApp Stopped") }
+  }
+
+  companion object {
+    fun setupL1FinalizationMonitorForShomeiFrontend(
+      type2StateProofProviderConfig: Type2StateProofManagerConfig,
+      httpJsonRpcClientFactory: VertxHttpJsonRpcClientFactory,
+      finalizedStateDataProvider: FinalizedStateDataProvider,
+      l2EthApiClient: EthApiClient,
+      vertx: Vertx,
+    ): LongRunningService {
+      if (type2StateProofProviderConfig.isDisabled()) {
+        return DisabledLongRunningService
+      }
+
+      val finalizedBlockNotifier = run {
+        val log = LogManager.getLogger("clients.ForkChoiceUpdaterShomeiClient")
+        val type2StateProofProviderClients = type2StateProofProviderConfig.endpoints.map {
+          ShomeiClient(
+            vertx = vertx,
+            rpcClient = httpJsonRpcClientFactory.create(it, log = log),
+            retryConfig = type2StateProofProviderConfig.requestRetries.toJsonRpcRetry(),
+            log = log,
+          )
+        }
+
+        ForkChoiceUpdaterImpl(type2StateProofProviderClients)
+      }
+
+      val l1FinalizationMonitor =
+        FinalizationMonitorImpl(
+          config =
+          FinalizationMonitorImpl.Config(
+            pollingInterval = type2StateProofProviderConfig.l1PollingInterval,
+            l1QueryBlockTag = type2StateProofProviderConfig.l1QueryBlockTag,
+          ),
+          finalizedStateDataProvider = finalizedStateDataProvider,
+          l2EthApiClient = l2EthApiClient,
+          vertx = vertx,
+        )
+
+      l1FinalizationMonitor.addFinalizationHandler("type 2 state proof provider finalization updates", {
+        finalizedBlockNotifier.updateFinalizedBlock(
+          BlockNumberAndHash(it.blockNumber, it.blockHash.toArray()),
+        )
+      })
+
+      return l1FinalizationMonitor
+    }
+  }
+}

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
@@ -11,7 +11,6 @@ import linea.coordinator.config.v2.CoordinatorConfig
 import linea.coordinator.config.v2.Type2StateProofManagerConfig
 import linea.coordinator.config.v2.isDisabled
 import linea.domain.BlockNumberAndHash
-import linea.ethapi.EthApiClient
 import linea.finalization.FinalizationHandler
 import linea.finalization.FinalizationMonitor
 import linea.finalization.FinalizationMonitorImpl
@@ -51,7 +50,7 @@ class L1FinalizationMonitorApp(
 ) : LongRunningService {
   private val log = LogManager.getLogger(this::class.java)
 
-  private val l1FinalizationMonitor = run {
+  private val l1FinalizationMonitor =
     FinalizationMonitorImpl(
       config =
       FinalizationMonitorImpl.Config(
@@ -67,25 +66,7 @@ class L1FinalizationMonitorApp(
       ),
       vertx = vertx,
     )
-  }
-
-  private val l1FinalizationHandlerForShomeiRpc: LongRunningService = run {
-    val l2EthApiClient: EthApiClient = createEthApiClient(
-      rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
-      log = LogManager.getLogger("clients.l2.eth.shomei-frontend"),
-      requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
-      vertx = vertx,
-    )
-    setupL1FinalizationMonitorForShomeiFrontend(
-      type2StateProofProviderConfig = configs.type2StateProofProvider,
-      httpJsonRpcClientFactory = httpJsonRpcClientFactory,
-      finalizedStateDataProvider = finalizedStateDataProvider,
-      l2EthApiClient = l2EthApiClient,
-      vertx = vertx,
-    )
-  }
-
-  val highestAcceptedFinalizationTracker = HighestULongTracker(lastFinalizedBlock).also {
+  private val highestAcceptedFinalizationTracker = HighestULongTracker(lastFinalizedBlock).also {
     metricsFacade.createGauge(
       category = LineaMetricsCategory.AGGREGATION,
       name = "highest.accepted.block.number",
@@ -95,6 +76,12 @@ class L1FinalizationMonitorApp(
   }
 
   init {
+    setupShomeiFrontendFinalizationNotifier(
+      l1FinalizationMonitor = l1FinalizationMonitor,
+      type2StateProofProviderConfig = configs.type2StateProofProvider,
+      httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+      vertx = vertx,
+    )
     mapOf(
       "last_proven_block_provider" to FinalizationHandler { update: FinalizationMonitor.FinalizationUpdate ->
         l1FinalizationUpdateHandler(update.blockNumber.toLong())
@@ -116,7 +103,6 @@ class L1FinalizationMonitorApp(
 
   override fun start(): CompletableFuture<Unit> {
     return l1FinalizationMonitor.start()
-      .thenCompose { l1FinalizationHandlerForShomeiRpc.start() }
       .thenPeek {
         log.info("L1FinalizationMonitorApp started")
       }
@@ -125,21 +111,19 @@ class L1FinalizationMonitorApp(
   override fun stop(): CompletableFuture<Unit> {
     return SafeFuture.allOf(
       l1FinalizationMonitor.stop(),
-      l1FinalizationHandlerForShomeiRpc.stop(),
     )
       .thenApply { log.info("L1FinalizationMonitorApp Stopped") }
   }
 
   companion object {
-    fun setupL1FinalizationMonitorForShomeiFrontend(
+    private fun setupShomeiFrontendFinalizationNotifier(
+      l1FinalizationMonitor: FinalizationMonitor,
       type2StateProofProviderConfig: Type2StateProofManagerConfig,
       httpJsonRpcClientFactory: VertxHttpJsonRpcClientFactory,
-      finalizedStateDataProvider: FinalizedStateDataProvider,
-      l2EthApiClient: EthApiClient,
       vertx: Vertx,
-    ): LongRunningService {
+    ) {
       if (type2StateProofProviderConfig.isDisabled()) {
-        return DisabledLongRunningService
+        return
       }
 
       val finalizedBlockNotifier = run {
@@ -156,25 +140,11 @@ class L1FinalizationMonitorApp(
         ForkChoiceUpdaterImpl(type2StateProofProviderClients)
       }
 
-      val l1FinalizationMonitor =
-        FinalizationMonitorImpl(
-          config =
-          FinalizationMonitorImpl.Config(
-            pollingInterval = type2StateProofProviderConfig.l1PollingInterval,
-            l1QueryBlockTag = type2StateProofProviderConfig.l1QueryBlockTag,
-          ),
-          finalizedStateDataProvider = finalizedStateDataProvider,
-          l2EthApiClient = l2EthApiClient,
-          vertx = vertx,
-        )
-
-      l1FinalizationMonitor.addFinalizationHandler("type 2 state proof provider finalization updates", {
+      l1FinalizationMonitor.addFinalizationHandler("shomei rpc finalization updates", {
         finalizedBlockNotifier.updateFinalizedBlock(
           BlockNumberAndHash(it.blockNumber, it.blockHash.toArray()),
         )
       })
-
-      return l1FinalizationMonitor
     }
   }
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1FinalizationMonitorApp.kt
@@ -11,6 +11,7 @@ import linea.coordinator.config.v2.CoordinatorConfig
 import linea.coordinator.config.v2.Type2StateProofManagerConfig
 import linea.coordinator.config.v2.isDisabled
 import linea.domain.BlockNumberAndHash
+import linea.ethapi.EthApiClient
 import linea.finalization.FinalizationHandler
 import linea.finalization.FinalizationMonitor
 import linea.finalization.FinalizationMonitorImpl
@@ -74,14 +75,14 @@ class L1FinalizationMonitorApp(
       measurementSupplier = it,
     )
   }
+  private val shomeiFrontendFinalizationMonitor: LongRunningService = setupL1FinalizationMonitorForShomeiFrontend(
+    type2StateProofProviderConfig = configs.type2StateProofProvider,
+    httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+    finalizedStateDataProvider = finalizedStateDataProvider,
+    vertx = vertx,
+  )
 
   init {
-    setupShomeiFrontendFinalizationNotifier(
-      l1FinalizationMonitor = l1FinalizationMonitor,
-      type2StateProofProviderConfig = configs.type2StateProofProvider,
-      httpJsonRpcClientFactory = httpJsonRpcClientFactory,
-      vertx = vertx,
-    )
     mapOf(
       "last_proven_block_provider" to FinalizationHandler { update: FinalizationMonitor.FinalizationUpdate ->
         l1FinalizationUpdateHandler(update.blockNumber.toLong())
@@ -102,28 +103,32 @@ class L1FinalizationMonitorApp(
   }
 
   override fun start(): CompletableFuture<Unit> {
-    return l1FinalizationMonitor.start()
-      .thenPeek {
-        log.info("L1FinalizationMonitorApp started")
-      }
+    return SafeFuture.allOf(
+      l1FinalizationMonitor.start(),
+      shomeiFrontendFinalizationMonitor.start(),
+    ).thenApply {
+      log.info("L1FinalizationMonitorApp started")
+    }
   }
 
   override fun stop(): CompletableFuture<Unit> {
     return SafeFuture.allOf(
       l1FinalizationMonitor.stop(),
+      shomeiFrontendFinalizationMonitor.stop(),
     )
       .thenApply { log.info("L1FinalizationMonitorApp Stopped") }
   }
 
   companion object {
-    private fun setupShomeiFrontendFinalizationNotifier(
-      l1FinalizationMonitor: FinalizationMonitor,
+    private fun setupL1FinalizationMonitorForShomeiFrontend(
       type2StateProofProviderConfig: Type2StateProofManagerConfig,
       httpJsonRpcClientFactory: VertxHttpJsonRpcClientFactory,
+      finalizedStateDataProvider: FinalizedStateDataProvider,
+      l2EthApiClient: EthApiClient,
       vertx: Vertx,
-    ) {
+    ): LongRunningService {
       if (type2StateProofProviderConfig.isDisabled()) {
-        return
+        return DisabledLongRunningService
       }
 
       val finalizedBlockNotifier = run {
@@ -140,11 +145,25 @@ class L1FinalizationMonitorApp(
         ForkChoiceUpdaterImpl(type2StateProofProviderClients)
       }
 
-      l1FinalizationMonitor.addFinalizationHandler("shomei rpc finalization updates", {
+      val l1FinalizationMonitor =
+        FinalizationMonitorImpl(
+          config =
+          FinalizationMonitorImpl.Config(
+            pollingInterval = type2StateProofProviderConfig.l1PollingInterval,
+            l1QueryBlockTag = type2StateProofProviderConfig.l1QueryBlockTag,
+          ),
+          finalizedStateDataProvider = finalizedStateDataProvider,
+          l2EthApiClient = l2EthApiClient,
+          vertx = vertx,
+        )
+
+      l1FinalizationMonitor.addFinalizationHandler("type 2 state proof provider finalization updates", {
         finalizedBlockNotifier.updateFinalizedBlock(
           BlockNumberAndHash(it.blockNumber, it.blockHash.toArray()),
         )
       })
+
+      return l1FinalizationMonitor
     }
   }
 }

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
@@ -25,11 +25,9 @@ import linea.submission.L1ShnarfBasedAlreadySubmittedBlobsFilter
 import linea.web3j.SmartContractErrors
 import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
-import net.consensys.linea.ethereum.gaspricing.BoundableFeeCalculator
 import net.consensys.linea.ethereum.gaspricing.FeesCalculator
 import net.consensys.linea.ethereum.gaspricing.FeesFetcher
 import net.consensys.linea.ethereum.gaspricing.WMAFeesCalculator
-import net.consensys.linea.ethereum.gaspricing.WMAGasProvider
 import net.consensys.linea.ethereum.gaspricing.dynamiccap.FeeHistoriesRepositoryImpl
 import net.consensys.linea.ethereum.gaspricing.dynamiccap.FeeHistoryCachingService
 import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapCalculatorImpl
@@ -86,92 +84,40 @@ class L1RelayingAppV1(
       priorityFeeWmaCoefficient = 1.0,
     ),
   ),
-
   val lineaSmartContractClientForDataSubmission: LineaSmartContractClient = run {
-    val l1DataSubmissionPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
-      BoundableFeeCalculator.Config(
-        feeUpperBound = l1SubmissionConfig.blob.gas.fallback.priorityFeePerGasUpperBound.toDouble(),
-        feeLowerBound = l1SubmissionConfig.blob.gas.fallback.priorityFeePerGasLowerBound.toDouble(),
-        feeMargin = 0.0,
-      ),
-      l1MinPriorityFeeCalculator,
-    )
-    // The below gas provider will act as the primary gas provider if L1
-    // dynamic gas pricing is disabled and will act as a fallback gas provider
-    // if L1 dynamic gas pricing is enabled
-    val primaryOrFallbackGasProvider = WMAGasProvider(
-      chainId = l1ChainId.toLong(),
-      feesFetcher = feesFetcher,
-      priorityFeeCalculator = l1DataSubmissionPriorityFeeCalculator,
-      config = WMAGasProvider.Config(
-        gasLimit = l1SubmissionConfig.blob.gas.gasLimit,
-        maxFeePerGasCap = l1SubmissionConfig.blob.gas.maxFeePerGasCap,
-        maxPriorityFeePerGasCap = l1SubmissionConfig.blob.gas.maxPriorityFeePerGasCap,
-        maxFeePerBlobGasCap = l1SubmissionConfig.blob.gas.maxFeePerBlobGasCap,
-      ),
-    )
     val l1Web3jClient = createWeb3jHttpClient(
       rpcUrl = l1SubmissionConfig.blob.l1Endpoint.toString(),
       log = LogManager.getLogger("clients.l1.eth.data-submission"),
     )
-    val transactionManager = createTransactionManager(
-      vertx,
-      signerConfig = l1SubmissionConfig.blob.signer,
-      client = l1Web3jClient,
-    )
     createLineaContractClient(
       vertx = vertx,
-      dataAvailabilityType = l1SubmissionConfig.dataAvailability,
       contractAddress = configs.protocol.l1.contractAddress,
-      transactionManager = transactionManager,
-      contractGasProvider = primaryOrFallbackGasProvider,
-      web3jClient = l1Web3jClient,
       smartContractErrors = smartContractErrors,
-      // eth_estimateGas would fail because we submit multiple blob tx
-      // and 2nd would fail with revert reason
-      useEthEstimateGas = false,
+      dataAvailabilityType = l1SubmissionConfig.dataAvailability,
+      l1Web3jClient = l1Web3jClient,
+      l1ChainId = l1ChainId,
+      l1MinPriorityFeeCalculator = l1MinPriorityFeeCalculator,
+      feesFetcher = feesFetcher,
+      signerConfig = l1SubmissionConfig.blob.signer,
+      gasConfig = l1SubmissionConfig.blob.gas,
     )
   },
   val lineaSmartContractClientForFinalization: LineaSmartContractClient = run {
-    val l1FinalizationPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
-      BoundableFeeCalculator.Config(
-        feeUpperBound = l1SubmissionConfig.aggregation.gas.fallback.priorityFeePerGasUpperBound.toDouble(),
-        feeLowerBound = l1SubmissionConfig.aggregation.gas.fallback.priorityFeePerGasLowerBound.toDouble(),
-        feeMargin = 0.0,
-      ),
-      l1MinPriorityFeeCalculator,
-    )
-    // The below gas provider will act as the primary gas provider if L1
-    // dynamic gas pricing is disabled and will act as a fallback gas provider
-    // if L1 dynamic gas pricing is enabled
-    val primaryOrFallbackGasProvider = WMAGasProvider(
-      chainId = l1ChainId.toLong(),
-      feesFetcher = feesFetcher,
-      priorityFeeCalculator = l1FinalizationPriorityFeeCalculator,
-      config = WMAGasProvider.Config(
-        gasLimit = l1SubmissionConfig.aggregation.gas.gasLimit,
-        maxFeePerGasCap = l1SubmissionConfig.aggregation.gas.maxFeePerGasCap,
-        maxPriorityFeePerGasCap = l1SubmissionConfig.aggregation.gas.maxPriorityFeePerGasCap,
-        maxFeePerBlobGasCap = 0UL, // we do not submit blobs in finalization tx
-      ),
-    )
     val l1Web3jClient = createWeb3jHttpClient(
       rpcUrl = l1SubmissionConfig.aggregation.l1Endpoint.toString(),
       log = LogManager.getLogger("clients.l1.eth.finalization"),
     )
     createLineaContractClient(
       vertx = vertx,
-      dataAvailabilityType = l1SubmissionConfig.dataAvailability,
       contractAddress = configs.protocol.l1.contractAddress,
-      transactionManager = createTransactionManager(
-        vertx = vertx,
-        signerConfig = l1SubmissionConfig.aggregation.signer,
-        client = l1Web3jClient,
-      ),
-      contractGasProvider = primaryOrFallbackGasProvider,
-      web3jClient = l1Web3jClient,
       smartContractErrors = smartContractErrors,
-      useEthEstimateGas = true,
+      dataAvailabilityType = l1SubmissionConfig.dataAvailability,
+      l1Web3jClient = l1Web3jClient,
+      l1ChainId = l1ChainId,
+      l1MinPriorityFeeCalculator = l1MinPriorityFeeCalculator,
+      feesFetcher = feesFetcher,
+      signerConfig = l1SubmissionConfig.aggregation.signer,
+      gasConfig = l1SubmissionConfig.aggregation.gas,
     )
   },
   val log: Logger = LogManager.getLogger(L1RelayingAppV1::class.java),

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
@@ -336,13 +336,6 @@ class L1RelayingAppV1(
         l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.storagePeriod
           .div(configs.protocol.l1.blockTime).toUInt()
 
-      val l1EthApiClient = createEthApiClient(
-        rpcUrl = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.l1Endpoint.toString(),
-        log = LogManager.getLogger("clients.l1.eth.feehistory-cache"),
-        vertx = vertx,
-        requestRetryConfig = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.l1RequestRetries,
-      )
-
       val l1FeeHistoryFetcher: GasPriceCapFeeHistoryFetcher = GasPriceCapFeeHistoryFetcherImpl(
         ethApiFeeClient = l1EthApiClient,
         config = GasPriceCapFeeHistoryFetcherImpl.Config(

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
@@ -1,0 +1,447 @@
+package linea.coordinator.app
+
+import io.vertx.core.Vertx
+import linea.LongRunningService
+import linea.contract.l1.LineaSmartContractClient
+import linea.coordination.EventDispatcher
+import linea.coordination.HighestULongTracker
+import linea.coordination.LatestBlobSubmittedBlockNumberTracker
+import linea.coordination.LatestFinalizationSubmittedBlockNumberTracker
+import linea.coordinator.config.v2.CoordinatorConfig
+import linea.coordinator.config.v2.L1SubmissionConfig
+import linea.coordinator.config.v2.isDisabled
+import linea.coordinator.config.v2.isEnabled
+import linea.domain.BlobSubmittedEvent
+import linea.domain.FinalizationSubmittedEvent
+import linea.ethapi.EthApiClient
+import linea.finalization.AggregationFinalizationCoordinator
+import linea.finalization.AggregationSubmitterImpl
+import linea.metrics.LineaMetricsCategory
+import linea.persistence.AggregationsRepository
+import linea.persistence.BlobsRepository
+import linea.persistence.FeeHistoriesDao
+import linea.submission.BlobSubmissionCoordinator
+import linea.submission.L1ShnarfBasedAlreadySubmittedBlobsFilter
+import linea.web3j.SmartContractErrors
+import linea.web3j.createWeb3jHttpClient
+import linea.web3j.ethapi.createEthApiClient
+import net.consensys.linea.ethereum.gaspricing.BoundableFeeCalculator
+import net.consensys.linea.ethereum.gaspricing.FeesCalculator
+import net.consensys.linea.ethereum.gaspricing.FeesFetcher
+import net.consensys.linea.ethereum.gaspricing.WMAFeesCalculator
+import net.consensys.linea.ethereum.gaspricing.WMAGasProvider
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.FeeHistoriesRepositoryImpl
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.FeeHistoryCachingService
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapCalculatorImpl
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapFeeHistoryFetcher
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapFeeHistoryFetcherImpl
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapProviderForDataSubmission
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapProviderForFinalization
+import net.consensys.linea.ethereum.gaspricing.dynamiccap.GasPriceCapProviderImpl
+import net.consensys.linea.ethereum.gaspricing.staticcap.FeeHistoryFetcherImpl
+import net.consensys.linea.metrics.MetricsFacade
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CompletableFuture
+import java.util.function.Consumer
+import kotlin.time.Clock
+
+/**
+ * Responsibilities:
+ *   - poll the database for blobs and aggregations ready for submission to L1
+ *   - submit blobs
+ *   - submit aggregations/finalizations
+ */
+class L1RelayingAppV1(
+  private val configs: CoordinatorConfig,
+  // Note/Todo: l1SubmissionConfig should be the only necessary one, however requires deeper refactor
+  private val l1SubmissionConfig: L1SubmissionConfig = configs.l1Submission!!,
+  private val vertx: Vertx,
+  private val l1ChainId: ULong,
+  private val lastFinalizedBlock: ULong,
+  private val smartContractErrors: SmartContractErrors,
+  private val metricsFacade: MetricsFacade,
+  private val feeHistoriesDao: FeeHistoriesDao,
+  private val blobsRepository: BlobsRepository,
+  private val aggregationsRepository: AggregationsRepository,
+  private val l1EthApiClient: EthApiClient = createEthApiClient(
+    rpcUrl = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.l1Endpoint.toString(),
+    log = LogManager.getLogger("clients.l1.eth.fees-fetcher"),
+    vertx = vertx,
+    requestRetryConfig = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.l1RequestRetries,
+  ),
+  private val feesFetcher: FeesFetcher = run {
+    FeeHistoryFetcherImpl(
+      ethApiClient = l1EthApiClient,
+      config = FeeHistoryFetcherImpl.Config(
+        feeHistoryBlockCount = l1SubmissionConfig.fallbackGasPrice.feeHistoryBlockCount,
+        feeHistoryRewardPercentile = l1SubmissionConfig.fallbackGasPrice.feeHistoryRewardPercentile.toDouble(),
+      ),
+    )
+  },
+  private val l1MinPriorityFeeCalculator: FeesCalculator = WMAFeesCalculator(
+    WMAFeesCalculator.Config(
+      baseFeeCoefficient = 0.0,
+      priorityFeeWmaCoefficient = 1.0,
+    ),
+  ),
+
+  val lineaSmartContractClientForDataSubmission: LineaSmartContractClient = run {
+    val l1DataSubmissionPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
+      BoundableFeeCalculator.Config(
+        feeUpperBound = l1SubmissionConfig.blob.gas.fallback.priorityFeePerGasUpperBound.toDouble(),
+        feeLowerBound = l1SubmissionConfig.blob.gas.fallback.priorityFeePerGasLowerBound.toDouble(),
+        feeMargin = 0.0,
+      ),
+      l1MinPriorityFeeCalculator,
+    )
+    // The below gas provider will act as the primary gas provider if L1
+    // dynamic gas pricing is disabled and will act as a fallback gas provider
+    // if L1 dynamic gas pricing is enabled
+    val primaryOrFallbackGasProvider = WMAGasProvider(
+      chainId = l1ChainId.toLong(),
+      feesFetcher = feesFetcher,
+      priorityFeeCalculator = l1DataSubmissionPriorityFeeCalculator,
+      config = WMAGasProvider.Config(
+        gasLimit = l1SubmissionConfig.blob.gas.gasLimit,
+        maxFeePerGasCap = l1SubmissionConfig.blob.gas.maxFeePerGasCap,
+        maxPriorityFeePerGasCap = l1SubmissionConfig.blob.gas.maxPriorityFeePerGasCap,
+        maxFeePerBlobGasCap = l1SubmissionConfig.blob.gas.maxFeePerBlobGasCap,
+      ),
+    )
+    val l1Web3jClient = createWeb3jHttpClient(
+      rpcUrl = l1SubmissionConfig.blob.l1Endpoint.toString(),
+      log = LogManager.getLogger("clients.l1.eth.data-submission"),
+    )
+    val transactionManager = createTransactionManager(
+      vertx,
+      signerConfig = l1SubmissionConfig.blob.signer,
+      client = l1Web3jClient,
+    )
+    createLineaContractClient(
+      vertx = vertx,
+      dataAvailabilityType = l1SubmissionConfig.dataAvailability,
+      contractAddress = configs.protocol.l1.contractAddress,
+      transactionManager = transactionManager,
+      contractGasProvider = primaryOrFallbackGasProvider,
+      web3jClient = l1Web3jClient,
+      smartContractErrors = smartContractErrors,
+      // eth_estimateGas would fail because we submit multiple blob tx
+      // and 2nd would fail with revert reason
+      useEthEstimateGas = false,
+    )
+  },
+  val lineaSmartContractClientForFinalization: LineaSmartContractClient = run {
+    val l1FinalizationPriorityFeeCalculator: FeesCalculator = BoundableFeeCalculator(
+      BoundableFeeCalculator.Config(
+        feeUpperBound = l1SubmissionConfig.aggregation.gas.fallback.priorityFeePerGasUpperBound.toDouble(),
+        feeLowerBound = l1SubmissionConfig.aggregation.gas.fallback.priorityFeePerGasLowerBound.toDouble(),
+        feeMargin = 0.0,
+      ),
+      l1MinPriorityFeeCalculator,
+    )
+    // The below gas provider will act as the primary gas provider if L1
+    // dynamic gas pricing is disabled and will act as a fallback gas provider
+    // if L1 dynamic gas pricing is enabled
+    val primaryOrFallbackGasProvider = WMAGasProvider(
+      chainId = l1ChainId.toLong(),
+      feesFetcher = feesFetcher,
+      priorityFeeCalculator = l1FinalizationPriorityFeeCalculator,
+      config = WMAGasProvider.Config(
+        gasLimit = l1SubmissionConfig.aggregation.gas.gasLimit,
+        maxFeePerGasCap = l1SubmissionConfig.aggregation.gas.maxFeePerGasCap,
+        maxPriorityFeePerGasCap = l1SubmissionConfig.aggregation.gas.maxPriorityFeePerGasCap,
+        maxFeePerBlobGasCap = 0UL, // we do not submit blobs in finalization tx
+      ),
+    )
+    val l1Web3jClient = createWeb3jHttpClient(
+      rpcUrl = l1SubmissionConfig.aggregation.l1Endpoint.toString(),
+      log = LogManager.getLogger("clients.l1.eth.finalization"),
+    )
+    createLineaContractClient(
+      vertx = vertx,
+      dataAvailabilityType = l1SubmissionConfig.dataAvailability,
+      contractAddress = configs.protocol.l1.contractAddress,
+      transactionManager = createTransactionManager(
+        vertx = vertx,
+        signerConfig = l1SubmissionConfig.aggregation.signer,
+        client = l1Web3jClient,
+      ),
+      contractGasProvider = primaryOrFallbackGasProvider,
+      web3jClient = l1Web3jClient,
+      smartContractErrors = smartContractErrors,
+      useEthEstimateGas = true,
+    )
+  },
+  val log: Logger = LogManager.getLogger(L1RelayingAppV1::class.java),
+) : LongRunningService {
+  init {
+    if (l1SubmissionConfig.blob.isDisabled()) {
+      log.warn("L1 submission disabled for blobs")
+    }
+    if (l1SubmissionConfig.aggregation.isDisabled()) {
+      log.warn("L1 submission disabled for aggregations")
+    }
+  }
+
+  private val highestAcceptedBlobTracker = HighestULongTracker(lastFinalizedBlock).also {
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BLOB,
+      name = "highest.accepted.block.number",
+      description = "Highest accepted blob end block number",
+      measurementSupplier = it,
+    )
+  }
+
+  private val alreadySubmittedBlobsFilter =
+    L1ShnarfBasedAlreadySubmittedBlobsFilter(
+      lineaSmartContractClientReadOnly = lineaSmartContractClientForDataSubmission,
+      acceptedBlobEndBlockNumberConsumer = { highestAcceptedBlobTracker(it) },
+    )
+
+  private val l1FeeHistoriesRepository =
+    FeeHistoriesRepositoryImpl(
+      FeeHistoriesRepositoryImpl.Config(
+        rewardPercentiles = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher
+          .rewardPercentiles.map { it.toDouble() },
+        minBaseFeePerBlobGasToCache = l1SubmissionConfig.dynamicGasPriceCap
+          .gasPriceCapCalculation.historicBaseFeePerBlobGasLowerBound,
+        fixedAverageRewardToCache = l1SubmissionConfig.dynamicGasPriceCap
+          .gasPriceCapCalculation.historicAvgRewardConstant,
+      ),
+      feeHistoriesDao = this.feeHistoriesDao,
+    )
+
+  private val gasPriceCapProvider =
+    if (l1SubmissionConfig.isEnabled() && l1SubmissionConfig.dynamicGasPriceCap.isEnabled()) {
+      val feeHistoryPercentileWindowInBlocks =
+        l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.baseFeePerGasPercentileWindow
+          .div(configs.protocol.l1.blockTime).toUInt()
+
+      val feeHistoryPercentileWindowLeewayInBlocks =
+        l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.baseFeePerGasPercentileWindowLeeway
+          .div(configs.protocol.l1.blockTime).toUInt()
+
+      val l2EthApiClient: EthApiClient =
+        createEthApiClient(
+          rpcUrl = configs.l1FinalizationMonitor.l2Endpoint.toString(),
+          log = LogManager.getLogger("clients.l2.eth.gascap-provider"),
+          vertx = vertx,
+          requestRetryConfig = configs.l1FinalizationMonitor.l2RequestRetries,
+        )
+
+      GasPriceCapProviderImpl(
+        config = GasPriceCapProviderImpl.Config(
+          enabled = l1SubmissionConfig.dynamicGasPriceCap.isEnabled(),
+          gasFeePercentile =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.baseFeePerGasPercentile.toDouble(),
+          gasFeePercentileWindowInBlocks = feeHistoryPercentileWindowInBlocks,
+          gasFeePercentileWindowLeewayInBlocks = feeHistoryPercentileWindowLeewayInBlocks,
+          timeOfDayMultipliers =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.timeOfTheDayMultipliers,
+          adjustmentConstant =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.adjustmentConstant,
+          blobAdjustmentConstant =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.blobAdjustmentConstant,
+          finalizationTargetMaxDelay =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.finalizationTargetMaxDelay,
+          gasPriceCapsCoefficient =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.gasPriceCapsCheckCoefficient,
+        ),
+        l2EthApiBlockClient = l2EthApiClient,
+        feeHistoriesRepository = l1FeeHistoriesRepository,
+        gasPriceCapCalculator = GasPriceCapCalculatorImpl(),
+      )
+    } else {
+      null
+    }
+
+  private val gasPriceCapProviderForDataSubmission =
+    gasPriceCapProvider?.let { provider ->
+      GasPriceCapProviderForDataSubmission(
+        config = GasPriceCapProviderForDataSubmission.Config(
+          maxPriorityFeePerGasCap = l1SubmissionConfig.blob.gas.maxPriorityFeePerGasCap,
+          maxFeePerGasCap = l1SubmissionConfig.blob.gas.maxFeePerGasCap,
+          maxFeePerBlobGasCap = l1SubmissionConfig.blob.gas.maxFeePerBlobGasCap,
+        ),
+        gasPriceCapProvider = provider,
+        metricsFacade = metricsFacade,
+      )
+    }
+
+  private val blobSubmissionCoordinator = run {
+    if (l1SubmissionConfig.isDisabled() || l1SubmissionConfig.blob.isDisabled()) {
+      DisabledLongRunningService
+    } else {
+      val latestBlobSubmittedBlockNumberTracker = LatestBlobSubmittedBlockNumberTracker(0UL)
+      metricsFacade.createGauge(
+        category = LineaMetricsCategory.BLOB,
+        name = "highest.submitted.on.l1",
+        description = "Highest submitted blob end block number on l1",
+        measurementSupplier = { latestBlobSubmittedBlockNumberTracker.get() },
+      )
+
+      val blobSubmissionDelayHistogram = metricsFacade.createHistogram(
+        category = LineaMetricsCategory.BLOB,
+        name = "submission.delay",
+        description = "Delay between blob submission and end block timestamps",
+        baseUnit = "seconds",
+      )
+
+      val blobSubmittedEventConsumers: Map<Consumer<BlobSubmittedEvent>, String> = mapOf(
+        Consumer<BlobSubmittedEvent> { blobSubmission ->
+          latestBlobSubmittedBlockNumberTracker(blobSubmission)
+        } to "Submitted Blob Tracker Consumer",
+        Consumer<BlobSubmittedEvent> { blobSubmission ->
+          blobSubmissionDelayHistogram.record(blobSubmission.getSubmissionDelay().toDouble())
+        } to "Blob Submission Delay Consumer",
+      )
+
+      BlobSubmissionCoordinator.create(
+        config = BlobSubmissionCoordinator.Config(
+          pollingInterval = l1SubmissionConfig.blob.submissionTickInterval,
+          proofSubmissionDelay = l1SubmissionConfig.blob.submissionDelay,
+          maxBlobsToSubmitPerTick =
+          l1SubmissionConfig.blob.maxSubmissionTransactionsPerTick *
+            l1SubmissionConfig.blob.targetBlobsPerTransaction,
+          targetBlobsToSubmitPerTx = l1SubmissionConfig.blob.targetBlobsPerTransaction,
+        ),
+        blobsRepository = blobsRepository,
+        aggregationsRepository = aggregationsRepository,
+        lineaSmartContractClient = lineaSmartContractClientForDataSubmission,
+        gasPriceCapProvider = gasPriceCapProviderForDataSubmission,
+        alreadySubmittedBlobsFilter = alreadySubmittedBlobsFilter,
+        blobSubmittedEventDispatcher = EventDispatcher(blobSubmittedEventConsumers),
+        vertx = vertx,
+        clock = Clock.System,
+      )
+    }
+  }
+
+  private val gasPriceCapProviderForFinalization =
+    gasPriceCapProvider?.let { provider ->
+      GasPriceCapProviderForFinalization(
+        config = GasPriceCapProviderForFinalization.Config(
+          maxPriorityFeePerGasCap = l1SubmissionConfig.aggregation.gas.maxPriorityFeePerGasCap,
+          maxFeePerGasCap = l1SubmissionConfig.aggregation.gas.maxFeePerGasCap,
+        ),
+        gasPriceCapProvider = provider,
+        metricsFacade = metricsFacade,
+      )
+    }
+
+  private val aggregationFinalizationCoordinator = run {
+    if (l1SubmissionConfig.isDisabled() || l1SubmissionConfig.aggregation.isDisabled()) {
+      DisabledLongRunningService
+    } else {
+      val latestFinalizationSubmittedBlockNumberTracker = LatestFinalizationSubmittedBlockNumberTracker(0UL)
+      metricsFacade.createGauge(
+        category = LineaMetricsCategory.AGGREGATION,
+        name = "highest.submitted.on.l1",
+        description = "Highest submitted finalization end block number on l1",
+        measurementSupplier = { latestFinalizationSubmittedBlockNumberTracker.get() },
+      )
+
+      val finalizationSubmissionDelayHistogram = metricsFacade.createHistogram(
+        category = LineaMetricsCategory.AGGREGATION,
+        name = "submission.delay",
+        description = "Delay between finalization submission and end block timestamps",
+        baseUnit = "seconds",
+      )
+
+      val submittedFinalizationConsumers: Map<Consumer<FinalizationSubmittedEvent>, String> = mapOf(
+        Consumer<FinalizationSubmittedEvent> { finalizationSubmission ->
+          latestFinalizationSubmittedBlockNumberTracker(finalizationSubmission)
+        } to "Finalization Submission Consumer",
+        Consumer<FinalizationSubmittedEvent> { finalizationSubmission ->
+          finalizationSubmissionDelayHistogram.record(finalizationSubmission.getSubmissionDelay().toDouble())
+        } to "Finalization Submission Delay Consumer",
+      )
+
+      AggregationFinalizationCoordinator.create(
+        config = AggregationFinalizationCoordinator.Config(
+          pollingInterval = l1SubmissionConfig.aggregation.submissionTickInterval,
+          proofSubmissionDelay = l1SubmissionConfig.aggregation.submissionDelay,
+        ),
+        aggregationsRepository = aggregationsRepository,
+        blobsRepository = blobsRepository,
+        lineaSmartContractClient = lineaSmartContractClientForFinalization,
+        alreadySubmittedBlobFilter = alreadySubmittedBlobsFilter,
+        aggregationSubmitter = AggregationSubmitterImpl(
+          lineaSmartContractClient = lineaSmartContractClientForFinalization,
+          gasPriceCapProvider = gasPriceCapProviderForFinalization,
+          aggregationSubmittedEventConsumer = EventDispatcher(submittedFinalizationConsumers),
+        ),
+        vertx = vertx,
+        clock = Clock.System,
+      )
+    }
+  }
+
+  private val l1FeeHistoryCachingService: LongRunningService =
+    if (l1SubmissionConfig.isEnabled() && l1SubmissionConfig.dynamicGasPriceCap.isEnabled()) {
+      val feeHistoryPercentileWindowInBlocks =
+        l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.baseFeePerGasPercentileWindow
+          .div(configs.protocol.l1.blockTime).toUInt()
+      val feeHistoryStoragePeriodInBlocks =
+        l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.storagePeriod
+          .div(configs.protocol.l1.blockTime).toUInt()
+
+      val l1EthApiClient = createEthApiClient(
+        rpcUrl = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.l1Endpoint.toString(),
+        log = LogManager.getLogger("clients.l1.eth.feehistory-cache"),
+        vertx = vertx,
+        requestRetryConfig = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.l1RequestRetries,
+      )
+
+      val l1FeeHistoryFetcher: GasPriceCapFeeHistoryFetcher = GasPriceCapFeeHistoryFetcherImpl(
+        ethApiFeeClient = l1EthApiClient,
+        config = GasPriceCapFeeHistoryFetcherImpl.Config(
+          maxBlockCount = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.maxBlockCount,
+          rewardPercentiles = l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.rewardPercentiles
+            .map { it.toDouble() },
+        ),
+      )
+
+      FeeHistoryCachingService(
+        config = FeeHistoryCachingService.Config(
+          pollingInterval =
+          l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.fetchInterval,
+          feeHistoryMaxBlockCount =
+          l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.maxBlockCount,
+          gasFeePercentile =
+          l1SubmissionConfig.dynamicGasPriceCap.gasPriceCapCalculation.baseFeePerGasPercentile.toDouble(),
+          feeHistoryStoragePeriodInBlocks = feeHistoryStoragePeriodInBlocks,
+          feeHistoryWindowInBlocks = feeHistoryPercentileWindowInBlocks,
+          numOfBlocksBeforeLatest =
+          l1SubmissionConfig.dynamicGasPriceCap.feeHistoryFetcher.numOfBlocksBeforeLatest,
+        ),
+        vertx = vertx,
+        ethApiBlockClient = l1EthApiClient,
+        feeHistoryFetcher = l1FeeHistoryFetcher,
+        feeHistoriesRepository = l1FeeHistoriesRepository,
+      )
+    } else {
+      DisabledLongRunningService
+    }
+
+  override fun start(): CompletableFuture<Unit> {
+    return SafeFuture.completedFuture(Unit)
+      .thenCompose { blobSubmissionCoordinator.start() }
+      .thenCompose { aggregationFinalizationCoordinator.start() }
+      .thenCompose { l1FeeHistoryCachingService.start() }
+      .thenPeek {
+        log.info("L1RelayingApp started")
+      }
+  }
+
+  override fun stop(): CompletableFuture<Unit> {
+    return SafeFuture.allOf(
+      blobSubmissionCoordinator.stop(),
+      aggregationFinalizationCoordinator.stop(),
+      l1FeeHistoryCachingService.stop(),
+    )
+      .thenApply { log.info("L1RelayingApp Stopped") }
+  }
+}

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
@@ -84,7 +84,7 @@ class L1RelayingAppV1(
       priorityFeeWmaCoefficient = 1.0,
     ),
   ),
-  val lineaSmartContractClientForDataSubmission: LineaSmartContractClient = run {
+  private val lineaSmartContractClientForDataSubmission: LineaSmartContractClient = run {
     val l1Web3jClient = createWeb3jHttpClient(
       rpcUrl = l1SubmissionConfig.blob.l1Endpoint.toString(),
       log = LogManager.getLogger("clients.l1.eth.data-submission"),
@@ -100,9 +100,10 @@ class L1RelayingAppV1(
       feesFetcher = feesFetcher,
       signerConfig = l1SubmissionConfig.blob.signer,
       gasConfig = l1SubmissionConfig.blob.gas,
+      useEthEstimateGas = false,
     )
   },
-  val lineaSmartContractClientForFinalization: LineaSmartContractClient = run {
+  private val lineaSmartContractClientForFinalization: LineaSmartContractClient = run {
     val l1Web3jClient = createWeb3jHttpClient(
       rpcUrl = l1SubmissionConfig.aggregation.l1Endpoint.toString(),
       log = LogManager.getLogger("clients.l1.eth.finalization"),
@@ -118,9 +119,10 @@ class L1RelayingAppV1(
       feesFetcher = feesFetcher,
       signerConfig = l1SubmissionConfig.aggregation.signer,
       gasConfig = l1SubmissionConfig.aggregation.gas,
+      useEthEstimateGas = true,
     )
   },
-  val log: Logger = LogManager.getLogger(L1RelayingAppV1::class.java),
+  private val log: Logger = LogManager.getLogger(L1RelayingAppV1::class.java),
 ) : LongRunningService {
   init {
     if (l1SubmissionConfig.blob.isDisabled()) {

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L2PricingApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L2PricingApp.kt
@@ -1,0 +1,132 @@
+package linea.coordinator.app
+
+import io.vertx.core.Vertx
+import linea.LongRunningService
+import linea.coordinator.config.toJsonRpcRetry
+import linea.coordinator.config.v2.L2NetworkGasPricingConfig
+import linea.ethapi.EthApiClient
+import linea.kotlin.toKWeiUInt
+import linea.web3j.ethapi.createEthApiClient
+import net.consensys.linea.ethereum.gaspricing.BoundableFeeCalculator
+import net.consensys.linea.ethereum.gaspricing.staticcap.ExtraDataV1UpdaterImpl
+import net.consensys.linea.ethereum.gaspricing.staticcap.FeeHistoryFetcherImpl
+import net.consensys.linea.ethereum.gaspricing.staticcap.L2CalldataBasedVariableFeesCalculator
+import net.consensys.linea.ethereum.gaspricing.staticcap.L2CalldataSizeAccumulatorImpl
+import net.consensys.linea.ethereum.gaspricing.staticcap.MinerExtraDataV1CalculatorImpl
+import net.consensys.linea.ethereum.gaspricing.staticcap.TransactionCostCalculator
+import net.consensys.linea.ethereum.gaspricing.staticcap.VariableFeesCalculator
+import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
+import net.consensys.linea.metrics.MetricsFacade
+import org.apache.logging.log4j.LogManager
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration
+
+/**
+ * Responsibilities:
+ *  - compute and propagate L2 network gas pricing (legacy + extra-data based)
+ */
+class L2PricingApp(
+  private val l2NetworkGasPricingConfig: L2NetworkGasPricingConfig,
+  private val vertx: Vertx,
+  private val metricsFacade: MetricsFacade,
+  private val httpJsonRpcClientFactory: VertxHttpJsonRpcClientFactory,
+  private val l2EthApiClient: EthApiClient = createEthApiClient(
+    rpcUrl = l2NetworkGasPricingConfig.l2Endpoint.toString(),
+    log = LogManager.getLogger("clients.l2.eth.l2pricing"),
+    vertx = vertx,
+    requestRetryConfig = l2NetworkGasPricingConfig.l2RequestRetries,
+  ),
+  private val l1EthApiClient: EthApiClient = createEthApiClient(
+    rpcUrl = l2NetworkGasPricingConfig.l1Endpoint.toString(),
+    log = LogManager.getLogger("clients.l1.eth.l1pricing"),
+    vertx = vertx,
+    requestRetryConfig = l2NetworkGasPricingConfig.l1RequestRetries,
+  ),
+) : LongRunningService {
+  private val log = LogManager.getLogger(this::class.java)
+
+  private val l2NetworkGasPricingService: L2NetworkGasPricingService = run {
+    val legacyConfig = L2NetworkGasPricingService.LegacyGasPricingCalculatorConfig(
+      transactionCostCalculatorConfig = TransactionCostCalculator.Config(
+        sampleTransactionCostMultiplier = l2NetworkGasPricingConfig.flatRateGasPricing.plainTransferCostMultiplier,
+        fixedCostWei = l2NetworkGasPricingConfig.gasPriceFixedCost,
+        compressedTxSize = l2NetworkGasPricingConfig.flatRateGasPricing.compressedTxSize.toInt(),
+        expectedGas = l2NetworkGasPricingConfig.flatRateGasPricing.expectedGas.toInt(),
+      ),
+      naiveGasPricingCalculatorConfig = null,
+      legacyGasPricingCalculatorBounds = BoundableFeeCalculator.Config(
+        feeUpperBound = l2NetworkGasPricingConfig.flatRateGasPricing.gasPriceUpperBound.toDouble(),
+        feeLowerBound = l2NetworkGasPricingConfig.flatRateGasPricing.gasPriceLowerBound.toDouble(),
+        feeMargin = 0.0,
+      ),
+    )
+
+    val config = L2NetworkGasPricingService.Config(
+      feeHistoryFetcherConfig = FeeHistoryFetcherImpl.Config(
+        feeHistoryBlockCount = l2NetworkGasPricingConfig.feeHistoryBlockCount,
+        feeHistoryRewardPercentile = l2NetworkGasPricingConfig.feeHistoryRewardPercentile.toDouble(),
+      ),
+      legacy = legacyConfig,
+      jsonRpcGasPriceUpdaterConfig = null,
+      // we do not use miner_setGasPrice RPC method, so we set it to infinite
+      jsonRpcPriceUpdateInterval = Duration.INFINITE,
+      // there no other way to work now without setting extra data into sequencer node
+      extraDataPricingPropagationEnabled = true,
+      extraDataUpdateInterval = l2NetworkGasPricingConfig.priceUpdateInterval,
+      variableFeesCalculatorConfig = VariableFeesCalculator.Config(
+        blobSubmissionExpectedExecutionGas = l2NetworkGasPricingConfig.dynamicGasPricing
+          .blobSubmissionExpectedExecutionGas.toUInt(),
+        bytesPerDataSubmission = l2NetworkGasPricingConfig.dynamicGasPricing.l1BlobGas.toUInt(),
+        expectedBlobGas = l2NetworkGasPricingConfig.dynamicGasPricing.l1BlobGas.toUInt(),
+        margin = l2NetworkGasPricingConfig.dynamicGasPricing.margin,
+      ),
+      variableFeesCalculatorBounds = BoundableFeeCalculator.Config(
+        feeUpperBound = l2NetworkGasPricingConfig.dynamicGasPricing.variableCostUpperBound.toDouble(),
+        feeLowerBound = l2NetworkGasPricingConfig.dynamicGasPricing.variableCostLowerBound.toDouble(),
+        feeMargin = 0.0,
+      ),
+      extraDataCalculatorConfig = MinerExtraDataV1CalculatorImpl.Config(
+        fixedCostInKWei = l2NetworkGasPricingConfig.gasPriceFixedCost.toKWeiUInt(),
+        ethGasPriceMultiplier = 1.0,
+      ),
+      extraDataUpdaterConfig = ExtraDataV1UpdaterImpl.Config(
+        sequencerEndpoint = l2NetworkGasPricingConfig.extraDataUpdateEndpoint,
+        retryConfig = l2NetworkGasPricingConfig.extraDataUpdateRequestRetries.toJsonRpcRetry(),
+      ),
+      l2CalldataPricingCalculatorConfig = l2NetworkGasPricingConfig.dynamicGasPricing.calldataBasedPricing?.let {
+        if (l2NetworkGasPricingConfig.dynamicGasPricing.calldataBasedPricing.calldataSumSizeBlockCount > 0U) {
+          L2NetworkGasPricingService.L2CalldataPricingConfig(
+            l2CalldataSizeAccumulatorConfig = L2CalldataSizeAccumulatorImpl.Config(
+              blockSizeNonCalldataOverhead = it.blockSizeNonCalldataOverhead,
+              calldataSizeBlockCount = it.calldataSumSizeBlockCount,
+            ),
+            l2CalldataBasedVariableFeesCalculatorConfig = L2CalldataBasedVariableFeesCalculator.Config(
+              feeChangeDenominator = it.feeChangeDenominator,
+              calldataSizeBlockCount = it.calldataSumSizeBlockCount,
+              maxBlockCalldataSize = it.calldataSumSizeTarget.toUInt(),
+            ),
+          )
+        } else {
+          log.debug("Calldata-based variable fee is disabled as calldataSizeBlockCount is set as 0")
+          null
+        }
+      },
+    )
+    L2NetworkGasPricingService(
+      vertx = vertx,
+      metricsFacade = metricsFacade,
+      httpJsonRpcClientFactory = httpJsonRpcClientFactory,
+      l1EthApiClient = l1EthApiClient,
+      l2EthApiBlockClient = l2EthApiClient,
+      config = config,
+    )
+  }
+
+  override fun start(): CompletableFuture<Unit> {
+    return l2NetworkGasPricingService.start()
+  }
+
+  override fun stop(): CompletableFuture<Unit> {
+    return l2NetworkGasPricingService.stop()
+  }
+}

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L2PricingApp.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L2PricingApp.kt
@@ -70,7 +70,7 @@ class L2PricingApp(
       jsonRpcGasPriceUpdaterConfig = null,
       // we do not use miner_setGasPrice RPC method, so we set it to infinite
       jsonRpcPriceUpdateInterval = Duration.INFINITE,
-      // there no other way to work now without setting extra data into sequencer node
+      // there is no other way to work now without setting extra data into the sequencer node
       extraDataPricingPropagationEnabled = true,
       extraDataUpdateInterval = l2NetworkGasPricingConfig.priceUpdateInterval,
       variableFeesCalculatorConfig = VariableFeesCalculator.Config(

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationAppV1.kt
@@ -1,0 +1,596 @@
+package linea.coordinator.app.conflation
+
+import io.vertx.core.Vertx
+import linea.LongRunningService
+import linea.clients.ExecutionProverClientV2
+import linea.clients.StateManagerV1JsonRpcClient
+import linea.conflation.ConflationService
+import linea.conflation.FixedLaggingHeadSafeBlockProvider
+import linea.conflation.calculators.CalculatorsFactory
+import linea.conflation.calculators.ConflationCalculators
+import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
+import linea.contract.l2.L2MessageServiceSmartContractClientReadOnly
+import linea.contract.l2.Web3JL2MessageServiceSmartContractClient
+import linea.coordination.HighestConflationTracker
+import linea.coordination.HighestProvenBatchTracker
+import linea.coordination.HighestProvenBlobTracker
+import linea.coordination.HighestULongTracker
+import linea.coordination.HighestUnprovenBlobTracker
+import linea.coordination.SimpleCompositeSafeFutureHandler
+import linea.coordination.aggregation.AggregationL2StateProviderImpl
+import linea.coordination.aggregation.AggregationProofHandlerImpl
+import linea.coordination.aggregation.ConsecutiveProvenBlobsProviderWithLastEndBlockNumberTracker
+import linea.coordination.aggregation.InvalidityProofProviderImpl
+import linea.coordination.aggregation.ProofAggregationCoordinatorService
+import linea.coordination.blob.BlobCompressionProofCoordinator
+import linea.coordination.blob.BlobZkStateProviderImpl
+import linea.coordination.blob.GoBackedBlobCompressorAdapter
+import linea.coordination.blob.GoBackedBlobShnarfCalculator
+import linea.coordination.blob.ParentBlobDataProviderImpl
+import linea.coordination.blob.RollingBlobShnarfCalculator
+import linea.coordination.conflation.BlockToBatchSubmissionCoordinator
+import linea.coordination.conflation.ConflationServiceImpl
+import linea.coordination.conflation.ProofGeneratingConflationHandlerImpl
+import linea.coordination.conflation.TracesConflationCoordinatorImpl
+import linea.coordination.proofcreation.BatchProofHandlerImpl
+import linea.coordination.proofcreation.ZkProofCreationCoordinatorImpl
+import linea.coordinator.app.conflation.ConflationAppHelper.cleanupDbDataAfterBlockNumbers
+import linea.coordinator.app.conflation.ConflationAppHelper.getLastConflatedAndAggregatedBlocks
+import linea.coordinator.app.conflation.TracesClientFactory.createTracesClients
+import linea.coordinator.blockcreation.BatchesRepoBasedLastProvenBlockNumberProvider
+import linea.coordinator.blockcreation.BlockCreationMonitor
+import linea.coordinator.blockcreation.ConflationTargetCheckpointPauseController
+import linea.coordinator.clients.ForcedTransactionsJsonRpcClient
+import linea.coordinator.clients.prover.ProverClientFactory
+import linea.coordinator.config.toJsonRpcRetry
+import linea.coordinator.config.v2.CoordinatorConfig
+import linea.domain.BlobRecord
+import linea.domain.BlockHeaderSummary
+import linea.domain.BlockParameter
+import linea.domain.BlocksConflation
+import linea.encoding.BlockRLPEncoder
+import linea.ethapi.EthApiClient
+import linea.ethapi.EthLogsSearcherImpl
+import linea.fileio.DirectoryCleaner
+import linea.ftx.ForcedTransactionsApp
+import linea.metrics.LineaMetricsCategory
+import linea.persistence.AggregationsRepository
+import linea.persistence.BatchesRepository
+import linea.persistence.BlobsRepository
+import linea.persistence.ForcedTransactionsDao
+import linea.timer.TimerSchedule
+import linea.timer.VertxPeriodicPollingService
+import linea.timer.VertxTimerFactory
+import linea.web3j.createWeb3jHttpClient
+import linea.web3j.ethapi.createEthApiClient
+import net.consensys.linea.jsonrpc.client.VertxHttpJsonRpcClientFactory
+import net.consensys.linea.metrics.MetricsFacade
+import org.apache.logging.log4j.LogManager
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Responsibilities:
+ *  - conflate blocks
+ *  - make the proof requests (batches, blobs, aggregations)
+ *  - update the database
+ */
+class ConflationAppV1(
+  private val vertx: Vertx,
+  private val clock: Clock,
+  private val batchesRepository: BatchesRepository,
+  private val blobsRepository: BlobsRepository,
+  private val aggregationsRepository: AggregationsRepository,
+  private val forcedTransactionsDao: ForcedTransactionsDao,
+  private val lastFinalizedBlock: ULong,
+  private val configs: CoordinatorConfig,
+  private val metricsFacade: MetricsFacade,
+  private val httpJsonRpcClientFactory: VertxHttpJsonRpcClientFactory,
+  private val proverClientFactory: ProverClientFactory = ProverClientFactory(
+    vertx = vertx,
+    config = configs.proversConfig,
+    metricsFacade = metricsFacade,
+  ),
+  val l2EthClient: EthApiClient = createEthApiClient(
+    rpcUrl = configs.conflation.l2Endpoint.toString(),
+    log = LogManager.getLogger("clients.l2.eth.conflation"),
+    requestRetryConfig = configs.conflation.l2RequestRetries,
+    vertx = vertx,
+  ),
+  private val zkStateClient: StateManagerV1JsonRpcClient = StateManagerV1JsonRpcClient.create(
+    rpcClientFactory = httpJsonRpcClientFactory,
+    endpoints = configs.stateManager.endpoints.map { it.toURI() },
+    maxInflightRequestsPerClient = configs.stateManager.requestLimitPerEndpoint,
+    requestRetry = configs.stateManager.requestRetries.toJsonRpcRetry(),
+    requestTimeout = configs.stateManager.requestTimeout?.inWholeMilliseconds,
+    logger = LogManager.getLogger("clients.StateManagerShomeiClient"),
+  ),
+  val tracesClients: TracesClients =
+    createTracesClients(
+      vertx = vertx,
+      rpcClientFactory = httpJsonRpcClientFactory,
+      configs = configs.traces,
+      fallBackTracesCounters = configs.conflation.tracesLimits.emptyTracesCounters,
+    ),
+  val l2MessageService: L2MessageServiceSmartContractClientReadOnly =
+    Web3JL2MessageServiceSmartContractClient.createReadOnly(
+      web3jClient = createWeb3jHttpClient(
+        rpcUrl = configs.conflation.l2Endpoint.toString(),
+        log = LogManager.getLogger("clients.l2.eth.conflation"),
+      ),
+      ethApiClient = l2EthClient,
+      ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l2EthClient),
+      contractAddress = configs.protocol.l2.contractAddress,
+      smartContractErrors = configs.smartContractErrors,
+      smartContractDeploymentBlockNumber = configs.protocol.l2.contractDeploymentBlockNumber?.number,
+    ),
+  private val forcedTransactionsApp: ForcedTransactionsApp = run {
+    if (configs.forcedTransactions == null || configs.forcedTransactions.disabled) {
+      ForcedTransactionsApp.createDisabled()
+    } else {
+      check(configs.proversConfig.proverA.invalidity != null) {
+        "prover.invalidity config is required for forced transactions feature to work"
+      }
+
+      val ftxConfig = configs.forcedTransactions
+      val l1EthClient = createEthApiClient(
+        rpcUrl = ftxConfig.l1Endpoint.toString(),
+        log = LogManager.getLogger("clients.l1.eth.ftx"),
+        vertx = vertx,
+        requestRetryConfig = ftxConfig.l1RequestRetries,
+      )
+      val config = ForcedTransactionsApp.Config(
+        l1PollingInterval = ftxConfig.l1EventScraping.pollingInterval,
+        l1ContractAddress = configs.protocol.l1.contractAddress,
+        l1HighestBlockTag = configs.forcedTransactions.l1HighestBlockTag,
+        l1EventSearchBlockChunk = ftxConfig.l1EventScraping.ethLogsSearchBlockChunkSize,
+        l1EventSearchMaxBlockRange = ftxConfig.l1EventScraping.ethLogsSearchMaxBlockRange,
+        ftxSequencerSendingInterval = ftxConfig.processingTickInterval,
+        maxFtxToSendToSequencer = ftxConfig.processingBatchSize,
+        ftxProcessingDelay = ftxConfig.processingDelay,
+        invalidityProofProcessingInterval = ftxConfig.invalidityProofCheckInterval,
+      )
+      val ftxClient = ForcedTransactionsJsonRpcClient(
+        vertx = vertx,
+        rpcClient = httpJsonRpcClientFactory.create(
+          endpoint = ftxConfig.sequencerEndpoint,
+          log = LogManager.getLogger("clients.l2.ftx.sequencer"),
+        ),
+        retryConfig = ftxConfig.sequencerRequestRetries.toJsonRpcRetry(),
+        log = LogManager.getLogger("clients.l2.ftx.sequencer"),
+      )
+      val l1Web3jClient = createWeb3jHttpClient(
+        rpcUrl = ftxConfig.l1Endpoint.toString(),
+        log = LogManager.getLogger("clients.l1.eth.ftx"),
+      )
+      val contractClient = Web3JLineaRollupSmartContractClientReadOnly(
+        contractAddress = configs.protocol.l1.contractAddress,
+        web3j = l1Web3jClient,
+        ethLogsSearcher = EthLogsSearcherImpl(
+          vertx = vertx,
+          ethApiClient = createEthApiClient(
+            web3jClient = l1Web3jClient,
+            requestRetryConfig = ftxConfig.l1RequestRetries,
+            vertx = vertx,
+          ),
+        ),
+        finalizedStateSearchInitialBlockParameter = configs.protocol.l1.contractDeploymentBlockNumber
+          ?: BlockParameter.Tag.EARLIEST,
+      )
+      ForcedTransactionsApp.create(
+        config = config,
+        vertx = vertx,
+        ftxDao = forcedTransactionsDao,
+        l1EthApiClient = l1EthClient,
+        l2EthApiClient = l2EthClient,
+        ftxClient = ftxClient,
+        finalizedStateProvider = contractClient,
+        contractVersionProvider = contractClient,
+        invalidityProofClient = proverClientFactory.createInvalidityProofClient(),
+        stateManagerClient = zkStateClient,
+        accountProofClient = zkStateClient,
+        tracesClient = tracesClients.tracesConflationClient,
+        clock = clock,
+        metricsFacade = metricsFacade,
+      )
+    }
+  },
+  val lastProcessedBlocks: LastProcessedBlocks = getLastConflatedAndAggregatedBlocks(
+    lastFinalizedBlock,
+    aggregationsRepository,
+    l2EthClient,
+  ).get(),
+  private val lastConflatedBlock: BlockHeaderSummary = lastProcessedBlocks.lastConflatedBlock.headerSummary,
+  private val lastAggregatedBlock: BlockHeaderSummary = lastProcessedBlocks.lastAggregatedBlock.headerSummary,
+  private val conflationCalculators: ConflationCalculators = CalculatorsFactory.create(
+    blobCompressor = GoBackedBlobCompressorAdapter.getInstance(
+      compressorVersion = configs.conflation.blobCompression.blobCompressorVersion,
+      dataLimit = configs.conflation.blobCompression.blobSizeLimit,
+      metricsFacade = metricsFacade,
+    ),
+    tracesCountersLimit = configs.conflation.tracesLimits,
+    blocksLimit = configs.conflation.blocksLimit,
+    timestampBasedHardForks = configs.conflation.proofAggregation.timestampBasedHardForks,
+    lastConflatedBlockNumber = lastConflatedBlock.number,
+    lastConflatedTimestamp = lastConflatedBlock.timestamp,
+    lastAggregatedBlockNumber = lastAggregatedBlock.number,
+    lastAggregatedTimestamp = lastAggregatedBlock.timestamp,
+    blobBatchesLimit = configs.conflation.blobCompression.batchesLimit,
+    aggregationProofsLimit = configs.conflation.proofAggregation.proofsLimit,
+    aggregationBlobLimit = configs.conflation.proofAggregation.blobsLimit,
+    aggregationSizeMultipleOf = configs.conflation.proofAggregation.aggregationSizeMultipleOf,
+    aggregationTargetEndBlockNumbers = configs.conflation.proofAggregation.targetEndBlocks?.toSet() ?: emptySet(),
+    extraSyncCalculators = listOf(forcedTransactionsApp.conflationCalculator),
+    timerFactory = VertxTimerFactory(vertx),
+    safeBlockProvider = FixedLaggingHeadSafeBlockProvider(
+      ethApiBlockClient = l2EthClient,
+      blocksToFinalization = 0UL,
+    ),
+    conflationDeadline = configs.conflation.conflationDeadline,
+    conflationDeadlineCheckInterval = configs.conflation.conflationDeadlineCheckInterval,
+    conflationDeadlineLastBlockConfirmationDelay = configs.conflation.conflationDeadlineLastBlockConfirmationDelay,
+    aggregationDeadline = configs.conflation.proofAggregation.deadline.takeUnless { it.isInfinite() },
+    aggregationDeadlineCheckInterval = configs.conflation.proofAggregation.deadlineCheckInterval,
+    aggregationDeadlineNoL2ActivityTimeout =
+    if (configs.conflation.proofAggregation.waitForNoL2ActivityToTriggerAggregation) {
+      configs.conflation.conflationDeadlineLastBlockConfirmationDelay
+    } else {
+      0.seconds
+    },
+    metricsFacade = metricsFacade,
+    clock = clock,
+  ),
+) : LongRunningService {
+  private val log = LogManager.getLogger("conflation.app")
+
+  init {
+    log.info(
+      "Resuming conflation from block={} inclusive blockTime={}",
+      lastConflatedBlock.number + 1UL,
+      lastConflatedBlock.timestamp,
+    )
+    log.info(
+      "Resuming aggregation from block={} inclusive blockTime={}",
+      lastAggregatedBlock.number + 1u,
+      lastAggregatedBlock.timestamp,
+    )
+  }
+
+  private val requestFileCleanup =
+    DirectoryCleaner(
+      vertx = vertx,
+      directories =
+      listOfNotNull(
+        configs.proversConfig.proverA.execution.requestsDirectory,
+        configs.proversConfig.proverA.blobCompression.requestsDirectory,
+        configs.proversConfig.proverA.proofAggregation.requestsDirectory,
+        configs.proversConfig.proverB?.execution?.requestsDirectory,
+        configs.proversConfig.proverB?.blobCompression?.requestsDirectory,
+        configs.proversConfig.proverB?.proofAggregation?.requestsDirectory,
+      ),
+      fileFilters =
+      DirectoryCleaner.getSuffixFileFilters(
+        listOfNotNull(
+          configs.proversConfig.proverA.execution.inprogressRequestWritingSuffix,
+          configs.proversConfig.proverA.blobCompression.inprogressRequestWritingSuffix,
+          configs.proversConfig.proverA.proofAggregation.inprogressRequestWritingSuffix,
+          configs.proversConfig.proverB?.execution?.inprogressRequestWritingSuffix,
+          configs.proversConfig.proverB?.blobCompression?.inprogressRequestWritingSuffix,
+          configs.proversConfig.proverB?.proofAggregation?.inprogressRequestWritingSuffix,
+        ),
+      ) +
+        if (configs.proversConfig.enableRequestFilesCleanup) {
+          // Will delete prover request .json files from all the directories
+          listOf(DirectoryCleaner.JSON_FILE_FILTER)
+        } else {
+          emptyList()
+        },
+    )
+
+  private val lastProvenBlockNumberProvider = run {
+    val lastProvenConsecutiveBatchBlockNumberProvider = BatchesRepoBasedLastProvenBlockNumberProvider(
+      lastConflatedBlock.number.toLong(),
+      lastFinalizedBlock.toLong(),
+      batchesRepository,
+    )
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BATCH,
+      name = "proven.highest.consecutive.block.number",
+      description = "Highest proven consecutive execution batch block number",
+      measurementSupplier = { lastProvenConsecutiveBatchBlockNumberProvider.getLastKnownProvenBlockNumber() },
+    )
+    lastProvenConsecutiveBatchBlockNumberProvider
+  }
+
+  private val targetCheckpointPauseController =
+    ConflationTargetCheckpointPauseController(
+      ConflationTargetCheckpointPauseController.Config(
+        initialLastImportedBlockTimestamp = lastConflatedBlock.timestamp,
+        targetEndBlocks = (configs.conflation.proofAggregation.targetEndBlocks ?: emptyList()).toSet(),
+        targetTimestamps = configs.conflation.proofAggregation.timestampBasedHardForks,
+        waitTargetBlockL1Finalization = configs.conflation.proofAggregation.waitTargetBlockL1Finalization,
+        waitApiResumeAfterTargetBlock = configs.conflation.proofAggregation.waitApiResumeAfterTargetBlock,
+      ),
+      latestL1FinalizedBlockProvider = lastProvenBlockNumberProvider,
+    )
+
+  private val conflationService: ConflationService =
+    ConflationServiceImpl(
+      calculator = conflationCalculators.blockConflationCalculator,
+      safeBlockNumberProvider = forcedTransactionsApp.conflationSafeBlockNumberProvider,
+      metricsFacade = metricsFacade,
+    )
+
+  private val blobCompressionProofCoordinator = run {
+    val maxProvenBlobCache = run {
+      val highestProvenBlobTracker = HighestProvenBlobTracker(lastConflatedBlock.number)
+      metricsFacade.createGauge(
+        category = LineaMetricsCategory.BLOB,
+        name = "proven.highest.block.number",
+        description = "Highest proven blob compression block number",
+        measurementSupplier = highestProvenBlobTracker,
+      )
+      highestProvenBlobTracker
+    }
+    val blobCompressionProofHandler: (BlobRecord) -> SafeFuture<*> = SimpleCompositeSafeFutureHandler(
+      listOf(
+        blobsRepository::saveNewBlob,
+        maxProvenBlobCache,
+      ),
+    )
+
+    val blobCompressionProofCoordinator = BlobCompressionProofCoordinator(
+      vertx = vertx,
+      blobCompressionProverClient = proverClientFactory.blobCompressionProverClient(),
+      rollingBlobShnarfCalculator = RollingBlobShnarfCalculator(
+        blobShnarfCalculator = GoBackedBlobShnarfCalculator(
+          version = configs.conflation.blobCompression.shnarfCalculatorVersion,
+          metricsFacade = metricsFacade,
+        ),
+        parentBlobDataProvider = ParentBlobDataProviderImpl(blobsRepository),
+        genesisShnarf = configs.protocol.genesis.genesisShnarf,
+      ),
+      blobZkStateProvider = BlobZkStateProviderImpl(
+        zkStateClient = zkStateClient,
+      ),
+      config = BlobCompressionProofCoordinator.Config(
+        pollingInterval = configs.conflation.blobCompression.handlerPollingInterval,
+      ),
+      blobCompressionProofHandler = blobCompressionProofHandler,
+      metricsFacade = metricsFacade,
+    )
+    val highestUnprovenBlobTracker = HighestUnprovenBlobTracker(lastConflatedBlock.number)
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BLOB,
+      name = "unproven.highest.block.number",
+      description = "Block number of highest unproven blob produced",
+      measurementSupplier = highestUnprovenBlobTracker,
+    )
+
+    val compositeSafeFutureHandler = SimpleCompositeSafeFutureHandler(
+      listOf(
+        blobCompressionProofCoordinator::handleBlob,
+        highestUnprovenBlobTracker,
+      ),
+    )
+    conflationCalculators.blockConflationCalculator.onBlobCreation(compositeSafeFutureHandler)
+    blobCompressionProofCoordinator
+  }
+
+  private val proofAggregationCoordinatorService: LongRunningService = run {
+    val maxBlobEndBlockNumberTracker = ConsecutiveProvenBlobsProviderWithLastEndBlockNumberTracker(
+      aggregationsRepository,
+      lastConflatedBlock.number,
+    )
+
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.BLOB,
+      name = "proven.highest.consecutive.block.number",
+      description = "Highest consecutive proven blob compression block number",
+      measurementSupplier = maxBlobEndBlockNumberTracker,
+    )
+
+    val highestAggregationTracker = HighestULongTracker(lastAggregatedBlock.number)
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.AGGREGATION,
+      name = "proven.highest.block.number",
+      description = "Highest proven aggregation block number",
+      measurementSupplier = highestAggregationTracker,
+    )
+
+    val highestConsecutiveAggregationTracker = HighestULongTracker(lastAggregatedBlock.number)
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.AGGREGATION,
+      name = "proven.highest.consecutive.block.number",
+      description = "Highest consecutive proven aggregation block number",
+      measurementSupplier = highestConsecutiveAggregationTracker,
+    )
+
+    ProofAggregationCoordinatorService
+      .create(
+        vertx = vertx,
+        aggregationCalculator = conflationCalculators.aggregationCalculator,
+        aggregationCoordinatorPollingInterval = configs.conflation.proofAggregation.coordinatorPollingInterval,
+        startBlockNumberInclusive = lastAggregatedBlock.number + 1u,
+        aggregationProofHandler = AggregationProofHandlerImpl(
+          aggregationsRepository = aggregationsRepository,
+          provenAggregationEndBlockNumberConsumer = { aggEndBlockNumber ->
+            highestAggregationTracker(
+              aggEndBlockNumber,
+            )
+          },
+          provenConsecutiveAggregationEndBlockNumberConsumer =
+          { aggEndBlockNumber -> highestConsecutiveAggregationTracker(aggEndBlockNumber) },
+          lastFinalizedBlockNumberSupplier = { lastProvenBlockNumberProvider.getLatestL1FinalizedBlock().toULong() },
+        ),
+        invalidityProofProvider = InvalidityProofProviderImpl(forcedTransactionsDao),
+        aggregationL2StateProvider = AggregationL2StateProviderImpl(
+          ethApiClient = l2EthClient,
+          messageService = l2MessageService,
+          forcedTransactionsDao = forcedTransactionsDao,
+        ),
+        consecutiveProvenBlobsProvider = maxBlobEndBlockNumberTracker,
+        proofAggregationClient = proverClientFactory.proofAggregationProverClient(),
+        metricsFacade = metricsFacade,
+      )
+  }
+
+  val proofGeneratingConflationHandlerImpl = run {
+    val maxProvenBatchCache = run {
+      val highestProvenBatchTracker = HighestProvenBatchTracker(lastConflatedBlock.number)
+      metricsFacade.createGauge(
+        category = LineaMetricsCategory.BATCH,
+        name = "proven.highest.block.number",
+        description = "Highest proven batch execution block number",
+        measurementSupplier = highestProvenBatchTracker,
+      )
+      highestProvenBatchTracker
+    }
+
+    val batchProofHandler = SimpleCompositeSafeFutureHandler(
+      listOf(
+        maxProvenBatchCache,
+        BatchProofHandlerImpl(batchesRepository)::acceptNewBatch,
+      ),
+    )
+    val executionProverClient: ExecutionProverClientV2 = proverClientFactory.executionProverClient()
+    ProofGeneratingConflationHandlerImpl(
+      tracesProductionCoordinator = TracesConflationCoordinatorImpl(
+        tracesClients.tracesConflationClient,
+        zkStateClient,
+      ),
+      zkProofProductionCoordinator = ZkProofCreationCoordinatorImpl(
+        executionProverClient = executionProverClient,
+        l2EthApiClient = createEthApiClient(
+          rpcUrl = configs.conflation.l2Endpoint.toString(),
+          log = LogManager.getLogger("clients.l2.eth.conflation"),
+          requestRetryConfig = configs.conflation.l2RequestRetries,
+          vertx = vertx,
+        ),
+        messageServiceAddress = configs.protocol.l2.contractAddress,
+      ),
+      batchProofHandler = batchProofHandler,
+      vertx = vertx,
+      config = ProofGeneratingConflationHandlerImpl.Config(
+        conflationAndProofGenerationRetryBackoffDelay = 5.seconds,
+        executionProofPollingInterval = 100.milliseconds,
+      ),
+      metricsFacade = metricsFacade,
+    )
+  }
+
+  private val block2BatchCoordinator = run {
+    val blobsConflationHandler: (BlocksConflation) -> SafeFuture<*> = run {
+      val highestConflationTracker = HighestConflationTracker(lastConflatedBlock.number)
+      metricsFacade.createGauge(
+        category = LineaMetricsCategory.CONFLATION,
+        name = "last.block.number",
+        description = "Last conflated block number",
+        measurementSupplier = highestConflationTracker,
+      )
+      val conflationsCounter = metricsFacade.createCounter(
+        category = LineaMetricsCategory.CONFLATION,
+        name = "counter",
+        description = "Counter of new conflations",
+      )
+
+      SimpleCompositeSafeFutureHandler(
+        listOf(
+          proofGeneratingConflationHandlerImpl::handleConflatedBatch,
+          highestConflationTracker,
+          {
+            conflationsCounter.increment()
+            SafeFuture.COMPLETE
+          },
+        ),
+      )
+    }
+
+    conflationService.onConflatedBatch(blobsConflationHandler)
+
+    BlockToBatchSubmissionCoordinator(
+      conflationService = conflationService,
+      tracesCountersClient = tracesClients.tracesCountersClient,
+      vertx = vertx,
+      encoder = BlockRLPEncoder,
+    )
+  }
+
+  // This object acts as an independent periodic polling service which is responsible
+  // for monitoring the highest consecutive proven block number in the batch db
+  private val provenBlockNumberMonitor = object : VertxPeriodicPollingService(
+    vertx = vertx,
+    pollingIntervalMs = 1.seconds.inWholeMilliseconds,
+    log = log,
+    name = "ProvenBlockNumberMonitor",
+    timerSchedule = TimerSchedule.FIXED_DELAY,
+  ) {
+    override fun action(): SafeFuture<*> {
+      return lastProvenBlockNumberProvider.getLastProvenBlockNumber()
+    }
+  }
+
+  private val blockCreationMonitor = BlockCreationMonitor(
+    vertx = vertx,
+    ethApi = l2EthClient,
+    startingBlockNumberExclusive = lastConflatedBlock.number.toLong(),
+    blockCreationListener = block2BatchCoordinator,
+    lastProvenBlockNumberProviderSync = lastProvenBlockNumberProvider,
+    config = BlockCreationMonitor.Config(
+      pollingInterval = configs.conflation.blocksPollingInterval,
+      blocksToFinalization = 0L,
+      blocksFetchLimit = configs.conflation.l2FetchBlocksLimit.toLong(),
+      // We need to add 1 to forceStopConflationAtBlockInclusive because conflation calculator requires
+      // block_number = forceStopConflationAtBlockInclusive + 1 to trigger conflation at
+      // forceStopConflationAtBlockInclusive
+      lastL2BlockNumberToProcessInclusive = configs.conflation.forceStopConflationAtBlockInclusive?.inc(),
+      lastL2BlockTimestampToProcessInclusive = configs.conflation.forceStopConflationAtBlockTimestampInclusive,
+    ),
+    targetCheckpointPauseController = targetCheckpointPauseController,
+  )
+
+  override fun start(): CompletableFuture<Unit> {
+    return cleanupDbDataAfterBlockNumbers(
+      lastProcessedBlockNumber = lastConflatedBlock.number,
+      lastConsecutiveAggregatedBlockNumber = lastAggregatedBlock.number,
+      batchesRepository = batchesRepository,
+      blobsRepository = blobsRepository,
+      aggregationsRepository = aggregationsRepository,
+    ).thenCompose { requestFileCleanup.cleanup() }
+      .thenCompose { proofGeneratingConflationHandlerImpl.start() }
+      .thenCompose { proofAggregationCoordinatorService.start() }
+      .thenCompose { conflationCalculators.service.start() }
+      .thenCompose { blockCreationMonitor.start() }
+      .thenCompose { blobCompressionProofCoordinator.start() }
+      .thenCompose { forcedTransactionsApp.start() }
+      .thenCompose { provenBlockNumberMonitor.start() }
+      .thenPeek {
+        log.info("Conflation started")
+      }
+  }
+
+  override fun stop(): CompletableFuture<Unit> {
+    return SafeFuture.allOf(
+      proofGeneratingConflationHandlerImpl.stop(),
+      proofAggregationCoordinatorService.stop(),
+      blockCreationMonitor.stop(),
+      conflationCalculators.service.stop(),
+      blobCompressionProofCoordinator.stop(),
+      forcedTransactionsApp.stop(),
+      provenBlockNumberMonitor.stop(),
+    )
+      .thenCompose { requestFileCleanup.cleanup() }
+      .thenApply { log.info("Conflation Stopped") }
+  }
+
+  fun updateLatestL1FinalizedBlock(blockNumber: Long): SafeFuture<Unit> {
+    return lastProvenBlockNumberProvider.updateLatestL1FinalizedBlock(blockNumber)
+  }
+
+  fun signalTargetCheckpointResumeFromApi(): Boolean {
+    return targetCheckpointPauseController.signalResumeFromApi()
+  }
+}

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationAppV1.kt
@@ -254,7 +254,7 @@ class ConflationAppV1(
     )
     log.info(
       "Resuming aggregation from block={} inclusive blockTime={}",
-      lastAggregatedBlock.number + 1u,
+      lastAggregatedBlock.number + 1UL,
       lastAggregatedBlock.timestamp,
     )
   }

--- a/coordinator/utilities/src/main/kotlin/linea/fileio/DirectoryCleaner.kt
+++ b/coordinator/utilities/src/main/kotlin/linea/fileio/DirectoryCleaner.kt
@@ -10,9 +10,9 @@ import java.nio.file.Path
 import kotlin.io.path.isDirectory
 
 class DirectoryCleaner(
-  val vertx: Vertx,
-  val directories: List<Path>,
-  val fileFilters: List<FileFilter>,
+  private val vertx: Vertx,
+  private val directories: List<Path>,
+  private val fileFilters: List<FileFilter>,
 ) {
   private val log = LogManager.getLogger(this::class.java)
 

--- a/docker/config/coordinator/log4j2-dev.xml
+++ b/docker/config/coordinator/log4j2-dev.xml
@@ -113,7 +113,7 @@
       <DebouncingFilter/>
       <appender-ref ref="console"/>
     </Logger>
-    <Logger name="linea.coordinator.clients.prover.GenericFileBasedProverClient" level="TRACE" additivity="false">
+    <Logger name="linea.coordinator.clients.prover.GenericFileBasedProverClient" level="INFO" additivity="false">
       <appender-ref ref="console"/>
     </Logger>
 <!--    <Logger name="clients.l2" level="DEBUG" additivity="false">-->
@@ -128,7 +128,7 @@
 <!--      <DebouncingFilter/>-->
 <!--      <appender-ref ref="console"/>-->
 <!--    </Logger>-->
-    <Logger name="clients.l2.ftx" level="TRACE" additivity="false">
+    <Logger name="clients.l2.ftx" level="INFO" additivity="false">
       <appender-ref ref="console"/>
     </Logger>
     <!--    <Logger name="clients.TracesCounters" level="TRACE" additivity="false">-->


### PR DESCRIPTION
This PR implements issue(s) #3088 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large structural refactor of coordinator lifecycle and L1 submission, finalization, and conflation orchestration; behavior should be equivalent but regressions in ordering or wiring could affect chain operations.
> 
> **Overview**
> Replaces the monolithic **`L1DependentApp`** wiring with **`CoordinatorAppV2`**, which composes several **`LongRunningService`** modules with explicit start/stop order instead of one large L1 bundle.
> 
> **`CoordinatorAppMain`** now boots **`CoordinatorAppV2`**. Responsibilities are split into **`L1FinalizationMonitorApp`** (L1 finalization polling, DB cleanup, conflation last-proven updates, Shomei fork choice), **`ConflationAppV1`** (block conflation, proofs, aggregation coordination), **`L1RelayingAppV1`** (blob and aggregation L1 submission, dynamic gas caps, fee-history caching), and **`L2PricingApp`** (L2 gas pricing propagation). Shared persistence and extension hooks stay at the V2 root.
> 
> **`BlockchainClientHelper`** gains a higher-level **`createLineaContractClient`** overload (WMA gas provider, transaction manager, optional **`useEthEstimateGas`** for multi-blob txs). Minor tweaks: **`DirectoryCleaner`** constructor properties are private; dev log4j levels for prover/FTX clients drop from TRACE to INFO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca2121886b2d0390c556f5ab61cc5a8fab8ea04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->