### PR TITLE
chore(coordinator): add riscv enablement config

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/ConflationConfig.kt
@@ -32,6 +32,7 @@ data class ConflationConfig(
   val proofAggregation: ProofAggregation = ProofAggregation(),
   val tracesLimits: TracesCounters,
   val backtestingDirectory: Path? = null,
+  val riscvStartingBlockTimestampInclusive: Instant? = null,
 ) : FeatureToggle {
   data class BlobCompression(
     val blobSizeLimit: UInt = 102400u,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/ConflationToml.kt
@@ -27,6 +27,7 @@ data class ConflationToml(
   val blobCompression: BlobCompressionToml = BlobCompressionToml(),
   val proofAggregation: ProofAggregationToml = ProofAggregationToml(),
   val backtestingDirectory: Path? = null,
+  val riscvStartingBlockTimestampInclusive: Instant? = null,
 ) {
   init {
     require(proofAggregation.proofsLimit >= (blobCompression.batchesLimit ?: 1u) + 1u) {
@@ -119,6 +120,7 @@ data class ConflationToml(
           "either tracesCountersLimitsV4 or tracesCountersLimitsV5 must be set"
         },
       backtestingDirectory = backtestingDirectory,
+      riscvStartingBlockTimestampInclusive = this.riscvStartingBlockTimestampInclusive,
     )
   }
 }

--- a/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
+++ b/coordinator/app/src/test/kotlin/linea/coordinator/config/v2/ConflationParsingTest.kt
@@ -4,8 +4,10 @@ import com.sksamuel.hoplite.ConfigException
 import linea.blob.BlobCompressorVersion
 import linea.blob.ShnarfCalculatorVersion
 import linea.coordinator.config.v2.toml.ConflationToml
+import linea.coordinator.config.v2.toml.DefaultsToml
 import linea.coordinator.config.v2.toml.parseConfig
 import linea.kotlin.toURL
+import net.consensys.linea.traces.TracesCountersV5
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -32,6 +34,7 @@ class ConflationParsingTest {
       consistent-number-of-blocks-on-l1-to-wait = 1
       force-stop-conflation-at-block-inclusive = 5000
       force-stop-conflation-at-block-timestamp-inclusive= 1758083130
+      riscv-starting-block-timestamp-inclusive = 1758083131
 
 
       [conflation.blob-compression]
@@ -65,6 +68,7 @@ class ConflationParsingTest {
         consistentNumberOfBlocksOnL1ToWait = 1u,
         forceStopConflationAtBlockInclusive = 5000u,
         forceStopConflationAtBlockTimestampInclusive = Instant.fromEpochSeconds(1758083130),
+        riscvStartingBlockTimestampInclusive = Instant.fromEpochSeconds(1758083131),
         blobCompression =
         ConflationToml.BlobCompressionToml(
           blobSizeLimit = 102_400U,
@@ -186,6 +190,24 @@ class ConflationParsingTest {
 
     assertThat(reifiedBlobCompression).isEqualTo(expectedBlobCompression)
     assertThat(reifiedBlobCompression.shnarfCalculatorVersion).isEqualTo(expectedShnarfCalculatorVersion)
+  }
+
+  @Test
+  fun `should reify riscvStartingBlockTimestampInclusive into domain config`() {
+    val domainConfig = config.reified(
+      defaults = DefaultsToml(),
+      tracesCountersLimitsV4 = null,
+      tracesCountersLimitsV5 = TracesCountersV5.EMPTY_TRACES_COUNT,
+    )
+    assertThat(domainConfig.riscvStartingBlockTimestampInclusive)
+      .isEqualTo(Instant.fromEpochSeconds(1758083131))
+
+    val domainConfigMinimal = configMinimal.copy(l2Endpoint = "http://l2-node:8545".toURL()).reified(
+      defaults = DefaultsToml(),
+      tracesCountersLimitsV4 = null,
+      tracesCountersLimitsV5 = TracesCountersV5.EMPTY_TRACES_COUNT,
+    )
+    assertThat(domainConfigMinimal.riscvStartingBlockTimestampInclusive).isNull()
   }
 
   @Test

--- a/docker/config/coordinator/coordinator-config-v2.toml
+++ b/docker/config/coordinator/coordinator-config-v2.toml
@@ -27,7 +27,8 @@ conflation-deadline-last-block-confirmation-delay = "PT2S" # recommended: at lea
 l2-fetch-blocks-limit = 4000
 backtesting-directory = "/data/conflation-backtesting"
 force-stop-conflation-at-block-inclusive=100_000_000
-#force-stop-conflation-at-block-timestamp-inclusive=2000000000
+# force-stop-conflation-at-block-timestamp-inclusive=2000000000
+# riscv-starting-block-timestamp-inclusive=2000000000
 
 # This is to prevent inflight trasactions that may change Smart contract state while coordinator is restarted.
 # Queries SMC for last finalised block, and keeps polling until this number of blocks observe the same state.


### PR DESCRIPTION
This PR implements issue(s) #3088

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and test-only changes with a nullable default; behavior is unchanged until future code consumes the new field.
> 
> **Overview**
> Introduces an optional **`riscvStartingBlockTimestampInclusive`** on conflation configuration so operators can declare when RISC-V behavior should start, using the same timestamp style as existing conflation cutoffs.
> 
> The field is wired through **`ConflationToml`** → **`ConflationConfig.reified()`**, covered by **`ConflationParsingTest`** (TOML parse + reify, default `null`), and documented in **`coordinator-config-v2.toml`** as a commented example. No coordinator runtime logic reads this setting yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ccab7e19509d2df2e7540bf1d34f607f44f47e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->