### PR TITLE
chore(coordinator): adds initial scafold for contract v9 RISC-V

### DIFF
--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/FunctionBuildersV9.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/FunctionBuildersV9.kt
@@ -1,0 +1,115 @@
+package net.consensys.linea.contract.l1
+
+import linea.contract.LinethRollupV9
+import linea.contract.l1.BlobsSubmissionV9
+import linea.contract.l1.FinalizationDataV9
+import linea.kotlin.encodeHex
+import linea.kotlin.toBigInteger
+import org.web3j.abi.TypeReference
+import org.web3j.abi.datatypes.DynamicArray
+import org.web3j.abi.datatypes.DynamicBytes
+import org.web3j.abi.datatypes.Function
+import org.web3j.abi.datatypes.generated.Bytes32
+import org.web3j.abi.datatypes.generated.Uint256
+
+internal object FunctionBuildersV9 {
+  /**
+   * function submitBlobs(
+   *   bytes32[] calldata _blobFinalBlockHashes,
+   *   bytes32 _parentShnarf,
+   *   bytes32 _finalBlobShnarf
+   * )
+   */
+  fun buildSubmitBlobsFunctionV9(
+    blobsSubmission: BlobsSubmissionV9,
+  ): Function {
+    return Function(
+      LinethRollupV9.FUNC_SUBMITBLOBS,
+      listOf(
+        DynamicArray(Bytes32::class.java, blobsSubmission.blobFinalBlockHashes.map(::Bytes32)),
+        Bytes32(blobsSubmission.parentShnarf),
+        Bytes32(blobsSubmission.finalBlobShnarf),
+      ),
+      emptyList<TypeReference<*>>(),
+    )
+  }
+
+  /**
+   * function finalizeBlocks(
+   *   bytes calldata _aggregatedProof,
+   *   uint256 _proofType,
+   *   FinalizationDataV5 calldata _finalizationData
+   * )
+   */
+  fun buildFinalizeBlocksFunctionV9(
+    finalization: FinalizationDataV9,
+  ): Function {
+    val shnarfData =
+      LinethRollupV9.ShnarfData(
+        // parentShnarf
+        finalization.shnarfData.parentShnarf,
+        // snarkHash
+        finalization.shnarfData.snarkHash,
+        // finalStateRootHash
+        finalization.shnarfData.finalStateRootHash,
+        // dataEvaluationPoint
+        finalization.shnarfData.dataEvaluationPoint,
+        // dataEvaluationClaim
+        finalization.shnarfData.dataEvaluationClaim,
+      )
+
+    val finalizationData =
+      LinethRollupV9.FinalizationDataV5(
+        // parentStateRootHash
+        finalization.parentStateRootHash,
+        // parentBlockHash
+        finalization.parentBlockHash,
+        // endBlockNumber
+        finalization.endBlockNumber.toBigInteger(),
+        // shnarfData
+        shnarfData,
+        // lastFinalizedTimestamp
+        finalization.lastFinalizedTimestamp.epochSeconds.toBigInteger(),
+        // finalTimestamp
+        finalization.finalTimestamp.epochSeconds.toBigInteger(),
+        // lastFinalizedL1RollingHash
+        finalization.lastFinalizedL1RollingHash,
+        // l1RollingHash
+        finalization.l1RollingHash,
+        // lastFinalizedL1RollingHashMessageNumber
+        finalization.lastFinalizedL1RollingHashMessageNumber.toBigInteger(),
+        // l1RollingHashMessageNumber
+        finalization.l1RollingHashMessageNumber.toBigInteger(),
+        // l2MerkleTreesDepth
+        finalization.l2MerkleTreesDepth.toBigInteger(),
+        // lastFinalizedForcedTransactionNumber
+        finalization.lastFinalizedForcedTransactionNumber.toBigInteger(),
+        // finalForcedTransactionNumber
+        finalization.finalForcedTransactionNumber.toBigInteger(),
+        // lastFinalizedForcedTransactionRollingHash
+        finalization.lastFinalizedForcedTransactionRollingHash,
+        // finalBlockHash
+        finalization.finalBlockHash,
+        // finalBlobHash
+        finalization.finalBlobHash,
+        // l2MerkleRoots
+        finalization.l2MerkleRoots,
+        // filteredAddresses
+        finalization.filteredAddresses.map { it.encodeHex() },
+        // verifierKeys
+        finalization.verifierKeys,
+        // l2MessagingBlocksOffsets
+        finalization.l2MessagingBlocksOffsets,
+      )
+
+    return Function(
+      LinethRollupV9.FUNC_FINALIZEBLOCKS,
+      listOf(
+        DynamicBytes(finalization.aggregatedProof),
+        Uint256(finalization.proofType.toLong()),
+        finalizationData,
+      ),
+      emptyList<TypeReference<*>>(),
+    )
+  }
+}

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/FunctionBuildersV9.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/FunctionBuildersV9.kt
@@ -95,7 +95,10 @@ internal object FunctionBuildersV9 {
         // l2MerkleRoots
         finalization.l2MerkleRoots,
         // filteredAddresses
-        finalization.filteredAddresses.map { it.encodeHex() },
+        finalization.filteredAddresses.mapIndexed { i, address ->
+          require(address.size == 20) { "filteredAddresses[$i] must be 20 bytes (address), got ${address.size}" }
+          address.encodeHex()
+        },
         // verifierKeys
         finalization.verifierKeys,
         // l2MessagingBlocksOffsets

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupFunctionBuilders.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupFunctionBuilders.kt
@@ -21,6 +21,7 @@ internal object Web3JLineaRollupFunctionBuilders {
       LineaRollupContractVersion.V7,
       LineaRollupContractVersion.V8,
       -> buildSubmitBlobsFunctionV6(blobs)
+      LineaRollupContractVersion.V9 -> TODO("Blob Submission for contract V9 (RISC-V) not implemented yet")
     }
   }
 
@@ -87,6 +88,7 @@ internal object Web3JLineaRollupFunctionBuilders {
         parentL1RollingHash,
         parentL1RollingHashMessageNumber,
       )
+      LineaRollupContractVersion.V9 -> TODO("Finalization for contract V9 (RISC-V) not implemented yet")
     }
   }
 

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupFunctionBuilders.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupFunctionBuilders.kt
@@ -21,7 +21,9 @@ internal object Web3JLineaRollupFunctionBuilders {
       LineaRollupContractVersion.V7,
       LineaRollupContractVersion.V8,
       -> buildSubmitBlobsFunctionV6(blobs)
-      LineaRollupContractVersion.V9 -> TODO("Blob Submission for contract V9 (RISC-V) not implemented yet")
+
+      LineaRollupContractVersion.V9 ->
+        throw UnsupportedOperationException("version=$version not supported, please use submitBlobsV9 instead")
     }
   }
 
@@ -88,7 +90,9 @@ internal object Web3JLineaRollupFunctionBuilders {
         parentL1RollingHash,
         parentL1RollingHashMessageNumber,
       )
-      LineaRollupContractVersion.V9 -> TODO("Finalization for contract V9 (RISC-V) not implemented yet")
+
+      LineaRollupContractVersion.V9 ->
+        throw UnsupportedOperationException("version=$version not supported, please use finalizeBlocksV9 instead")
     }
   }
 

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -213,6 +213,21 @@ class Web3JLineaRollupSmartContractClient internal constructor(
       }
   }
 
+  private fun ensureMinVersion(
+    nimVersion: LineaRollupContractVersion,
+  ): SafeFuture<LineaRollupContractVersion> {
+    return getVersion()
+      .thenCompose { version ->
+        if (version < nimVersion) {
+          SafeFuture.failedFuture(
+            RuntimeException("Contract version=$version is lower than required version=$nimVersion"),
+          )
+        } else {
+          SafeFuture.completedFuture(version)
+        }
+      }
+  }
+
   override fun submitBlobsV9(
     blobData: BlobsSubmissionV9,
     gasPriceCaps: GasPriceCaps?,
@@ -220,11 +235,8 @@ class Web3JLineaRollupSmartContractClient internal constructor(
   ): SafeFuture<String> {
     val function = FunctionBuildersV9.buildSubmitBlobsFunctionV9(blobData)
 
-    return getVersion()
-      .thenCompose { version ->
-        if (version < LineaRollupContractVersion.V9) {
-          SafeFuture.failedFuture<String>(RuntimeException("Contract version=$version not supported"))
-        }
+    return ensureMinVersion(LineaRollupContractVersion.V9)
+      .thenCompose {
         if (preflightWithEthCall) {
           web3jContractHelper.executeBlobEthCall(
             function = function,
@@ -250,12 +262,8 @@ class Web3JLineaRollupSmartContractClient internal constructor(
   ): SafeFuture<String> {
     val function = FunctionBuildersV9.buildFinalizeBlocksFunctionV9(data)
 
-    return getVersion()
-      .thenCompose { version ->
-        if (version < LineaRollupContractVersion.V9) {
-          SafeFuture.failedFuture<String>(RuntimeException("Contract version=$version not supported"))
-        }
-
+    return ensureMinVersion(LineaRollupContractVersion.V9)
+      .thenCompose {
         if (preflightWithEthCall) {
           web3jContractHelper.sendTransactionAfterEthCallAsync(function, BigInteger.ZERO, gasPriceCaps)
         } else {

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -214,13 +214,13 @@ class Web3JLineaRollupSmartContractClient internal constructor(
   }
 
   private fun ensureMinVersion(
-    nimVersion: LineaRollupContractVersion,
+    minVersion: LineaRollupContractVersion,
   ): SafeFuture<LineaRollupContractVersion> {
     return getVersion()
       .thenCompose { version ->
-        if (version < nimVersion) {
+        if (version < minVersion) {
           SafeFuture.failedFuture(
-            RuntimeException("Contract version=$version is lower than required version=$nimVersion"),
+            RuntimeException("Contract version=$version is lower than required version=$minVersion"),
           )
         } else {
           SafeFuture.completedFuture(version)

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -245,7 +245,7 @@ class Web3JLineaRollupSmartContractClient internal constructor(
             gasPriceCaps = gasPriceCaps,
           )
         } else {
-          SafeFuture.completedFuture<String>(null)
+          SafeFuture.completedFuture(null)
         }.thenCompose {
           web3jContractHelper.sendBlobCarryingTransactionAndGetTxHash(
             function = function,

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -2,7 +2,10 @@ package net.consensys.linea.contract.l1
 
 import linea.EthLogsSearcher
 import linea.contract.LineaRollupV6
+import linea.contract.l1.BlobsSubmissionV9
 import linea.contract.l1.BlockAndNonce
+import linea.contract.l1.FinalizationDataV9
+import linea.contract.l1.LineaRollupContractVersion
 import linea.contract.l1.LineaRollupSmartContractClient
 import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
 import linea.domain.BlobRecord
@@ -206,6 +209,58 @@ class Web3JLineaRollupSmartContractClient internal constructor(
             parentL1RollingHashMessageNumber,
           )
         web3jContractHelper.sendTransactionAfterEthCallAsync(function, BigInteger.ZERO, gasPriceCaps)
+          .thenApply { result -> result.transactionHash }
+      }
+  }
+
+  override fun submitBlobsV9(
+    blobData: BlobsSubmissionV9,
+    gasPriceCaps: GasPriceCaps?,
+    preflightWithEthCall: Boolean,
+  ): SafeFuture<String> {
+    val function = FunctionBuildersV9.buildSubmitBlobsFunctionV9(blobData)
+
+    return getVersion()
+      .thenCompose { version ->
+        if (version < LineaRollupContractVersion.V9) {
+          SafeFuture.failedFuture<String>(RuntimeException("Contract version=$version not supported"))
+        }
+        if (preflightWithEthCall) {
+          web3jContractHelper.executeBlobEthCall(
+            function = function,
+            blobs = blobData.blobs,
+            gasPriceCaps = gasPriceCaps,
+          )
+        } else {
+          SafeFuture.completedFuture<String>(null)
+        }
+      }.thenCompose {
+        web3jContractHelper.sendBlobCarryingTransactionAndGetTxHash(
+          function = function,
+          blobs = blobData.blobs,
+          gasPriceCaps = gasPriceCaps,
+        )
+      }
+  }
+
+  override fun finalizeBlocksV9(
+    data: FinalizationDataV9,
+    gasPriceCaps: GasPriceCaps?,
+    preflightWithEthCall: Boolean,
+  ): SafeFuture<String> {
+    val function = FunctionBuildersV9.buildFinalizeBlocksFunctionV9(data)
+
+    return getVersion()
+      .thenCompose { version ->
+        if (version < LineaRollupContractVersion.V9) {
+          SafeFuture.failedFuture<String>(RuntimeException("Contract version=$version not supported"))
+        }
+
+        if (preflightWithEthCall) {
+          web3jContractHelper.sendTransactionAfterEthCallAsync(function, BigInteger.ZERO, gasPriceCaps)
+        } else {
+          web3jContractHelper.sendTransactionAsync(function, BigInteger.ZERO, gasPriceCaps)
+        }
           .thenApply { result -> result.transactionHash }
       }
   }

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -220,7 +220,7 @@ class Web3JLineaRollupSmartContractClient internal constructor(
       .thenCompose { version ->
         if (version < minVersion) {
           SafeFuture.failedFuture(
-            RuntimeException("Contract version=$version is lower than required version=$minVersion"),
+            RuntimeException("Contract version=$version is lower than minimum required version=$minVersion"),
           )
         } else {
           SafeFuture.completedFuture(version)
@@ -233,10 +233,11 @@ class Web3JLineaRollupSmartContractClient internal constructor(
     gasPriceCaps: GasPriceCaps?,
     preflightWithEthCall: Boolean,
   ): SafeFuture<String> {
-    val function = FunctionBuildersV9.buildSubmitBlobsFunctionV9(blobData)
-
     return ensureMinVersion(LineaRollupContractVersion.V9)
-      .thenCompose {
+      .thenApply {
+        FunctionBuildersV9.buildSubmitBlobsFunctionV9(blobData)
+      }
+      .thenCompose { function ->
         if (preflightWithEthCall) {
           web3jContractHelper.executeBlobEthCall(
             function = function,
@@ -245,13 +246,13 @@ class Web3JLineaRollupSmartContractClient internal constructor(
           )
         } else {
           SafeFuture.completedFuture<String>(null)
+        }.thenCompose {
+          web3jContractHelper.sendBlobCarryingTransactionAndGetTxHash(
+            function = function,
+            blobs = blobData.blobs,
+            gasPriceCaps = gasPriceCaps,
+          )
         }
-      }.thenCompose {
-        web3jContractHelper.sendBlobCarryingTransactionAndGetTxHash(
-          function = function,
-          blobs = blobData.blobs,
-          gasPriceCaps = gasPriceCaps,
-        )
       }
   }
 
@@ -260,10 +261,11 @@ class Web3JLineaRollupSmartContractClient internal constructor(
     gasPriceCaps: GasPriceCaps?,
     preflightWithEthCall: Boolean,
   ): SafeFuture<String> {
-    val function = FunctionBuildersV9.buildFinalizeBlocksFunctionV9(data)
-
     return ensureMinVersion(LineaRollupContractVersion.V9)
-      .thenCompose {
+      .thenApply {
+        FunctionBuildersV9.buildFinalizeBlocksFunctionV9(data)
+      }
+      .thenCompose { function ->
         if (preflightWithEthCall) {
           web3jContractHelper.sendTransactionAfterEthCallAsync(function, BigInteger.ZERO, gasPriceCaps)
         } else {

--- a/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
@@ -16,7 +16,29 @@ data class BlobsSubmissionV9(
   val blobFinalBlockHashes: List<ByteArray>,
   val parentShnarf: ByteArray,
   val finalBlobShnarf: ByteArray,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as BlobsSubmissionV9
+
+    if (blobs != other.blobs) return false
+    if (blobFinalBlockHashes != other.blobFinalBlockHashes) return false
+    if (!parentShnarf.contentEquals(other.parentShnarf)) return false
+    if (!finalBlobShnarf.contentEquals(other.finalBlobShnarf)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = blobs.hashCode()
+    result = 31 * result + blobFinalBlockHashes.hashCode()
+    result = 31 * result + parentShnarf.contentHashCode()
+    result = 31 * result + finalBlobShnarf.contentHashCode()
+    return result
+  }
+}
 
 data class ShnarfDataV9(
   val parentShnarf: ByteArray,
@@ -24,7 +46,31 @@ data class ShnarfDataV9(
   val finalStateRootHash: ByteArray,
   val dataEvaluationPoint: ByteArray,
   val dataEvaluationClaim: ByteArray,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as ShnarfDataV9
+
+    if (!parentShnarf.contentEquals(other.parentShnarf)) return false
+    if (!snarkHash.contentEquals(other.snarkHash)) return false
+    if (!finalStateRootHash.contentEquals(other.finalStateRootHash)) return false
+    if (!dataEvaluationPoint.contentEquals(other.dataEvaluationPoint)) return false
+    if (!dataEvaluationClaim.contentEquals(other.dataEvaluationClaim)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = parentShnarf.contentHashCode()
+    result = 31 * result + snarkHash.contentHashCode()
+    result = 31 * result + finalStateRootHash.contentHashCode()
+    result = 31 * result + dataEvaluationPoint.contentHashCode()
+    result = 31 * result + dataEvaluationClaim.contentHashCode()
+    return result
+  }
+}
 
 data class FinalizationDataV9(
   val aggregatedProof: ByteArray,
@@ -49,7 +95,65 @@ data class FinalizationDataV9(
   val filteredAddresses: List<ByteArray>,
   val verifierKeys: List<ByteArray>,
   val l2MessagingBlocksOffsets: ByteArray,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as FinalizationDataV9
+
+    if (proofType != other.proofType) return false
+    if (l2MerkleTreesDepth != other.l2MerkleTreesDepth) return false
+    if (!aggregatedProof.contentEquals(other.aggregatedProof)) return false
+    if (!parentStateRootHash.contentEquals(other.parentStateRootHash)) return false
+    if (!parentBlockHash.contentEquals(other.parentBlockHash)) return false
+    if (endBlockNumber != other.endBlockNumber) return false
+    if (shnarfData != other.shnarfData) return false
+    if (lastFinalizedTimestamp != other.lastFinalizedTimestamp) return false
+    if (finalTimestamp != other.finalTimestamp) return false
+    if (!lastFinalizedL1RollingHash.contentEquals(other.lastFinalizedL1RollingHash)) return false
+    if (!l1RollingHash.contentEquals(other.l1RollingHash)) return false
+    if (lastFinalizedL1RollingHashMessageNumber != other.lastFinalizedL1RollingHashMessageNumber) return false
+    if (l1RollingHashMessageNumber != other.l1RollingHashMessageNumber) return false
+    if (lastFinalizedForcedTransactionNumber != other.lastFinalizedForcedTransactionNumber) return false
+    if (finalForcedTransactionNumber != other.finalForcedTransactionNumber) return false
+    if (!lastFinalizedForcedTransactionRollingHash.contentEquals(other.lastFinalizedForcedTransactionRollingHash)) return false
+    if (!finalBlockHash.contentEquals(other.finalBlockHash)) return false
+    if (!finalBlobHash.contentEquals(other.finalBlobHash)) return false
+    if (l2MerkleRoots != other.l2MerkleRoots) return false
+    if (filteredAddresses != other.filteredAddresses) return false
+    if (verifierKeys != other.verifierKeys) return false
+    if (!l2MessagingBlocksOffsets.contentEquals(other.l2MessagingBlocksOffsets)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = proofType
+    result = 31 * result + l2MerkleTreesDepth
+    result = 31 * result + aggregatedProof.contentHashCode()
+    result = 31 * result + parentStateRootHash.contentHashCode()
+    result = 31 * result + parentBlockHash.contentHashCode()
+    result = 31 * result + endBlockNumber.hashCode()
+    result = 31 * result + shnarfData.hashCode()
+    result = 31 * result + lastFinalizedTimestamp.hashCode()
+    result = 31 * result + finalTimestamp.hashCode()
+    result = 31 * result + lastFinalizedL1RollingHash.contentHashCode()
+    result = 31 * result + l1RollingHash.contentHashCode()
+    result = 31 * result + lastFinalizedL1RollingHashMessageNumber.hashCode()
+    result = 31 * result + l1RollingHashMessageNumber.hashCode()
+    result = 31 * result + lastFinalizedForcedTransactionNumber.hashCode()
+    result = 31 * result + finalForcedTransactionNumber.hashCode()
+    result = 31 * result + lastFinalizedForcedTransactionRollingHash.contentHashCode()
+    result = 31 * result + finalBlockHash.contentHashCode()
+    result = 31 * result + finalBlobHash.contentHashCode()
+    result = 31 * result + l2MerkleRoots.hashCode()
+    result = 31 * result + filteredAddresses.hashCode()
+    result = 31 * result + verifierKeys.hashCode()
+    result = 31 * result + l2MessagingBlocksOffsets.contentHashCode()
+    return result
+  }
+}
 
 interface LineaSmartContractClient : LineaSmartContractClientReadOnly {
   fun currentNonce(): ULong

--- a/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
@@ -76,7 +76,7 @@ data class ShnarfDataV9(
 
 data class FinalizationDataV9(
   val aggregatedProof: ByteArray,
-  val proofType: Int,
+  val proofType: UInt,
   val parentStateRootHash: ByteArray,
   val parentBlockHash: ByteArray,
   val endBlockNumber: ULong,
@@ -87,7 +87,7 @@ data class FinalizationDataV9(
   val l1RollingHash: ByteArray,
   val lastFinalizedL1RollingHashMessageNumber: ULong,
   val l1RollingHashMessageNumber: ULong,
-  val l2MerkleTreesDepth: Int,
+  val l2MerkleTreesDepth: UInt,
   val lastFinalizedForcedTransactionNumber: ULong,
   val finalForcedTransactionNumber: ULong,
   val lastFinalizedForcedTransactionRollingHash: ByteArray,
@@ -136,8 +136,8 @@ data class FinalizationDataV9(
   }
 
   override fun hashCode(): Int {
-    var result = proofType
-    result = 31 * result + l2MerkleTreesDepth
+    var result = proofType.toInt()
+    result = 31 * result + l2MerkleTreesDepth.toInt()
     result = 31 * result + aggregatedProof.contentHashCode()
     result = 31 * result + parentStateRootHash.contentHashCode()
     result = 31 * result + parentBlockHash.contentHashCode()

--- a/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
@@ -3,6 +3,8 @@ package linea.contract.l1
 import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize
 import linea.domain.gas.GasPriceCaps
+import linea.kotlin.byteArrayListEquals
+import linea.kotlin.byteArrayListHashCode
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Instant
 
@@ -23,8 +25,8 @@ data class BlobsSubmissionV9(
 
     other as BlobsSubmissionV9
 
-    if (blobs != other.blobs) return false
-    if (blobFinalBlockHashes != other.blobFinalBlockHashes) return false
+    if (!blobs.byteArrayListEquals(other.blobs)) return false
+    if (!blobFinalBlockHashes.byteArrayListEquals(other.blobFinalBlockHashes)) return false
     if (!parentShnarf.contentEquals(other.parentShnarf)) return false
     if (!finalBlobShnarf.contentEquals(other.finalBlobShnarf)) return false
 
@@ -32,8 +34,8 @@ data class BlobsSubmissionV9(
   }
 
   override fun hashCode(): Int {
-    var result = blobs.hashCode()
-    result = 31 * result + blobFinalBlockHashes.hashCode()
+    var result = blobs.byteArrayListHashCode()
+    result = 31 * result + blobFinalBlockHashes.byteArrayListHashCode()
     result = 31 * result + parentShnarf.contentHashCode()
     result = 31 * result + finalBlobShnarf.contentHashCode()
     return result
@@ -117,12 +119,17 @@ data class FinalizationDataV9(
     if (l1RollingHashMessageNumber != other.l1RollingHashMessageNumber) return false
     if (lastFinalizedForcedTransactionNumber != other.lastFinalizedForcedTransactionNumber) return false
     if (finalForcedTransactionNumber != other.finalForcedTransactionNumber) return false
-    if (!lastFinalizedForcedTransactionRollingHash.contentEquals(other.lastFinalizedForcedTransactionRollingHash)) return false
+    if (!lastFinalizedForcedTransactionRollingHash.contentEquals(
+        other.lastFinalizedForcedTransactionRollingHash,
+      )
+    ) {
+      return false
+    }
     if (!finalBlockHash.contentEquals(other.finalBlockHash)) return false
     if (!finalBlobHash.contentEquals(other.finalBlobHash)) return false
-    if (l2MerkleRoots != other.l2MerkleRoots) return false
-    if (filteredAddresses != other.filteredAddresses) return false
-    if (verifierKeys != other.verifierKeys) return false
+    if (!l2MerkleRoots.byteArrayListEquals(other.l2MerkleRoots)) return false
+    if (!filteredAddresses.byteArrayListEquals(other.filteredAddresses)) return false
+    if (!verifierKeys.byteArrayListEquals(other.verifierKeys)) return false
     if (!l2MessagingBlocksOffsets.contentEquals(other.l2MessagingBlocksOffsets)) return false
 
     return true
@@ -147,9 +154,9 @@ data class FinalizationDataV9(
     result = 31 * result + lastFinalizedForcedTransactionRollingHash.contentHashCode()
     result = 31 * result + finalBlockHash.contentHashCode()
     result = 31 * result + finalBlobHash.contentHashCode()
-    result = 31 * result + l2MerkleRoots.hashCode()
-    result = 31 * result + filteredAddresses.hashCode()
-    result = 31 * result + verifierKeys.hashCode()
+    result = 31 * result + l2MerkleRoots.byteArrayListHashCode()
+    result = 31 * result + filteredAddresses.byteArrayListHashCode()
+    result = 31 * result + verifierKeys.byteArrayListHashCode()
     result = 31 * result + l2MessagingBlocksOffsets.contentHashCode()
     return result
   }

--- a/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
@@ -4,10 +4,51 @@ import linea.domain.BlobRecord
 import linea.domain.ProofToFinalize
 import linea.domain.gas.GasPriceCaps
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Instant
 
 data class BlockAndNonce(
   val blockNumber: ULong,
   val nonce: ULong,
+)
+
+data class BlobsSubmissionV9(
+  val blobs: List<ByteArray>,
+  val blobFinalBlockHashes: List<ByteArray>,
+  val parentShnarf: ByteArray,
+  val finalBlobShnarf: ByteArray,
+)
+
+data class ShnarfDataV9(
+  val parentShnarf: ByteArray,
+  val snarkHash: ByteArray,
+  val finalStateRootHash: ByteArray,
+  val dataEvaluationPoint: ByteArray,
+  val dataEvaluationClaim: ByteArray,
+)
+
+data class FinalizationDataV9(
+  val aggregatedProof: ByteArray,
+  val proofType: Int,
+  val parentStateRootHash: ByteArray,
+  val parentBlockHash: ByteArray,
+  val endBlockNumber: ULong,
+  val shnarfData: ShnarfDataV9,
+  val lastFinalizedTimestamp: Instant,
+  val finalTimestamp: Instant,
+  val lastFinalizedL1RollingHash: ByteArray,
+  val l1RollingHash: ByteArray,
+  val lastFinalizedL1RollingHashMessageNumber: ULong,
+  val l1RollingHashMessageNumber: ULong,
+  val l2MerkleTreesDepth: Int,
+  val lastFinalizedForcedTransactionNumber: ULong,
+  val finalForcedTransactionNumber: ULong,
+  val lastFinalizedForcedTransactionRollingHash: ByteArray,
+  val finalBlockHash: ByteArray,
+  val finalBlobHash: ByteArray,
+  val l2MerkleRoots: List<ByteArray>,
+  val filteredAddresses: List<ByteArray>,
+  val verifierKeys: List<ByteArray>,
+  val l2MessagingBlocksOffsets: ByteArray,
 )
 
 interface LineaSmartContractClient : LineaSmartContractClientReadOnly {
@@ -19,6 +60,7 @@ interface LineaSmartContractClient : LineaSmartContractClientReadOnly {
    */
   fun updateNonceAndReferenceBlockToLastL1Block(): SafeFuture<BlockAndNonce>
 
+  // TODO: not used, shall be removed
   fun finalizeBlocksEthCall(
     aggregation: ProofToFinalize,
     aggregationLastBlob: BlobRecord,
@@ -55,6 +97,26 @@ interface LineaRollupSmartContractClient :
    * Submit a list of blobs to the smart contract, with EIP4844 transaction
    */
   fun submitBlobs(blobs: List<BlobRecord>, gasPriceCaps: GasPriceCaps?): SafeFuture<String>
+
+  /**
+   * Submits blocks for V9 (RISC-V arithmetization)
+   * @param preflightWithEthCall when true will call eth_call to prevalidate the transaction does not revert
+   */
+  fun submitBlobsV9(
+    blobData: BlobsSubmissionV9,
+    gasPriceCaps: GasPriceCaps?,
+    preflightWithEthCall: Boolean = true,
+  ): SafeFuture<String>
+
+  /**
+   * Finalizes blocks for V9 (RISC-V arithmetization)
+   * @param preflightWithEthCall when true will call eth_call to prevalidate the transaction does not revert
+   */
+  fun finalizeBlocksV9(
+    data: FinalizationDataV9,
+    gasPriceCaps: GasPriceCaps?,
+    preflightWithEthCall: Boolean = true,
+  ): SafeFuture<String>
 }
 
 interface LineaValidiumSmartContractClient :

--- a/coordinator/ethereum/test-utils/src/main/kotlin/linea/MakefileContractDeploymentHelper.kt
+++ b/coordinator/ethereum/test-utils/src/main/kotlin/linea/MakefileContractDeploymentHelper.kt
@@ -81,6 +81,7 @@ fun makeDeployLineaRollup(
     LineaRollupContractVersion.V6 -> "make deploy-linea-rollup-v6"
     LineaRollupContractVersion.V7 -> "make deploy-linea-rollup-v7"
     LineaRollupContractVersion.V8 -> "make deploy-linea-rollup-v8"
+    LineaRollupContractVersion.V9 -> "make deploy-lineth-rollup-v9-stub"
     // else -> throw IllegalArgumentException("Unsupported contract version: $contractVersion")
   }
 

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
@@ -9,6 +9,7 @@ enum class LineaRollupContractVersion : Comparable<LineaRollupContractVersion> {
   V6, // more efficient data submission and new events for state recovery
   V7, // Native Yield (no practical changes for the coordinator)
   V8, // Forced Transactions
+  V9, // RISC-V
 }
 
 enum class LineaValidiumContractVersion : Comparable<LineaValidiumContractVersion> {

--- a/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
+++ b/jvm-libs/linea/clients/interfaces/src/main/kotlin/linea/contract/l1/LineaSmartContractClient.kt
@@ -9,7 +9,12 @@ enum class LineaRollupContractVersion : Comparable<LineaRollupContractVersion> {
   V6, // more efficient data submission and new events for state recovery
   V7, // Native Yield (no practical changes for the coordinator)
   V8, // Forced Transactions
-  V9, // RISC-V
+  V9, // RISCV
+  ;
+
+  companion object {
+    val latest: LineaRollupContractVersion = entries.last()
+  }
 }
 
 enum class LineaValidiumContractVersion : Comparable<LineaValidiumContractVersion> {

--- a/jvm-libs/linea/clients/linea-contract-clients/build.gradle
+++ b/jvm-libs/linea/clients/linea-contract-clients/build.gradle
@@ -24,4 +24,5 @@ dependencies {
   testImplementation "org.wiremock:wiremock:${libs.versions.wiremock.get()}"
   testImplementation project(':jvm-libs:linea:clients:eth-logs-searcher')
   testImplementation testFixtures(project(':jvm-libs:linea:clients:interfaces'))
+  testImplementation testFixtures(project(':jvm-libs:generic:extensions:kotlin'))
 }

--- a/jvm-libs/linea/clients/linea-contract-clients/build.gradle
+++ b/jvm-libs/linea/clients/linea-contract-clients/build.gradle
@@ -10,7 +10,6 @@ dependencies {
   api project(':jvm-libs:linea:clients:interfaces')
   api project(':jvm-libs:generic:extensions:futures')
   api project(':jvm-libs:generic:extensions:kotlin')
-  // api 'build.linea:l1-rollup-contract-client:6.0.0-rc2'
   api project(':jvm-libs:linea:linea-contracts:l1-rollup')
   api 'build.linea:l2-message-service-contract-client:0.1.0'
   api project(':jvm-libs:linea:linea-contracts:l1-validium')

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -66,7 +66,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
         StaticGasProvider(BigInteger.ZERO, BigInteger.ZERO),
       )
 
-      else -> throw IllegalArgumentException("Unsupported contract type: ${contract::class.java}")
+      else -> throw IllegalArgumentException("Unsupported contract type: ${contract.name}")
     } as T
   }
 
@@ -110,7 +110,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
       .thenApply(::parseContractVersion)
   }
 
-  private fun parseContractVersion(version: String): LineaRollupContractVersion {
+  internal fun parseContractVersion(version: String): LineaRollupContractVersion {
     return when {
       version.startsWith("6") -> LineaRollupContractVersion.V6
       version.startsWith("7") -> LineaRollupContractVersion.V7

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -5,6 +5,7 @@ import linea.SearchDirection
 import linea.contract.FAKE_READ_ONLY_CREDENTIALS
 import linea.contract.LineaRollupV6
 import linea.contract.LineaRollupV8
+import linea.contract.LinethRollupV9
 import linea.contract.events.FinalizedStateUpdatedEvent
 import linea.domain.BlockParameter
 import linea.domain.EthLogEvent
@@ -37,6 +38,10 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
     return contractClientAtBlock(blockParameter, LineaRollupV8::class.java)
   }
 
+  protected fun contractClientV9AtBlock(blockParameter: BlockParameter): LinethRollupV9 {
+    return contractClientAtBlock(blockParameter, LinethRollupV9::class.java)
+  }
+
   protected fun <T : Contract> loadContractClient(contract: Class<T>): T {
     @Suppress("UNCHECKED_CAST")
     return when {
@@ -48,6 +53,13 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
       )
 
       LineaRollupV8::class.java.isAssignableFrom(contract) -> LineaRollupV8.load(
+        contractAddress,
+        web3j,
+        FAKE_READ_ONLY_CREDENTIALS,
+        StaticGasProvider(BigInteger.ZERO, BigInteger.ZERO),
+      )
+
+      LinethRollupV9::class.java.isAssignableFrom(contract) -> LinethRollupV9.load(
         contractAddress,
         web3j,
         FAKE_READ_ONLY_CREDENTIALS,
@@ -103,6 +115,7 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
       version.startsWith("6") -> LineaRollupContractVersion.V6
       version.startsWith("7") -> LineaRollupContractVersion.V7
       version.startsWith("8") -> LineaRollupContractVersion.V8
+      version.startsWith("9") -> LineaRollupContractVersion.V9
       else -> throw IllegalStateException("Unsupported contract version: $version")
     }
   }
@@ -140,6 +153,8 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
           LineaRollupContractVersion.V7,
           LineaRollupContractVersion.V8,
           -> contractClientV8AtBlock(blockParameter).blobShnarfExists(shnarf)
+          LineaRollupContractVersion.V9 -> // just ensure not regression while WIP
+            contractClientV9AtBlock(blockParameter).blobShnarfExists(shnarf)
         }
           .sendAsync()
           .thenApply { it != BigInteger.ZERO }
@@ -201,7 +216,9 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
               ),
             )
 
-          LineaRollupContractVersion.V8 ->
+          LineaRollupContractVersion.V8,
+          LineaRollupContractVersion.V9,
+          ->
             findFinalizedStateEvent(blockParameter, finalizedBlockNumber)
               .thenApply { finalizedState ->
                 val forcedTransactionNumber = finalizedState?.forcedTransactionNumber ?: 0UL

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -104,15 +104,20 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
 
       else ->
         fetchSmartContractVersion()
-          .thenPeek { contractLatestVersion ->
-            if (cached != null && contractLatestVersion != cached.version) {
-              log.info(
-                "Smart contract upgraded: prevVersion={} upgradedVersion={}",
-                cached.version,
-                contractLatestVersion,
-              )
+          .thenPeek { fetchedVersion ->
+            val current = smartContractVersionCache.get()
+            // prevent inflight request to override and rollback
+            if (current == null || fetchedVersion >= current.version) {
+              smartContractVersionCache.set(CachedVersion(fetchedVersion, clock.now()))
+
+              if (current != null && fetchedVersion != current.version) {
+                log.info(
+                  "Smart contract upgraded: prevVersion={} upgradedVersion={}",
+                  current.version,
+                  fetchedVersion,
+                )
+              }
             }
-            smartContractVersionCache.set(CachedVersion(contractLatestVersion, clock.now()))
           }
     }
   }

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -80,9 +80,9 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   private val smartContractVersionCache = AtomicReference<LineaRollupContractVersion>(null)
 
   private fun getSmartContractVersion(): SafeFuture<LineaRollupContractVersion> {
-    return if (smartContractVersionCache.get() == LineaRollupContractVersion.V8) {
+    return if (smartContractVersionCache.get() == LineaRollupContractVersion.latest) {
       // once upgraded, it's not downgraded
-      SafeFuture.completedFuture(LineaRollupContractVersion.V8)
+      SafeFuture.completedFuture(LineaRollupContractVersion.latest)
     } else {
       fetchSmartContractVersion()
         .thenPeek { contractLatestVersion ->

--- a/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/main/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnly.kt
@@ -22,6 +22,10 @@ import org.web3j.tx.gas.StaticGasProvider
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.math.BigInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 open class Web3JLineaRollupSmartContractClientReadOnly(
   val web3j: Web3j,
@@ -29,6 +33,8 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
   private val ethLogsSearcher: EthLogsSearcher,
   private val l1EventSearchMaxBlockRange: UInt = 10_000u,
   private val finalizedStateSearchInitialBlockParameter: BlockParameter = BlockParameter.Tag.EARLIEST,
+  private val versionRefreshInterval: Duration = 6.seconds,
+  private val clock: Clock = Clock.System,
   private val log: Logger = LogManager.getLogger(Web3JLineaRollupSmartContractClientReadOnly::class.java),
 ) : LineaRollupSmartContractClientReadOnly,
   LineaRollupSmartContractClientReadOnlyFinalizedStateProvider,
@@ -77,30 +83,41 @@ open class Web3JLineaRollupSmartContractClientReadOnly(
     }
   }
 
-  private val smartContractVersionCache = AtomicReference<LineaRollupContractVersion>(null)
+  private data class CachedVersion(
+    val version: LineaRollupContractVersion,
+    val fetchedAt: Instant,
+  )
+
+  private val smartContractVersionCache = AtomicReference<CachedVersion>(null)
 
   private fun getSmartContractVersion(): SafeFuture<LineaRollupContractVersion> {
-    return if (smartContractVersionCache.get() == LineaRollupContractVersion.latest) {
+    val cached = smartContractVersionCache.get()
+    return when {
       // once upgraded, it's not downgraded
-      SafeFuture.completedFuture(LineaRollupContractVersion.latest)
-    } else {
-      fetchSmartContractVersion()
-        .thenPeek { contractLatestVersion ->
-          if (smartContractVersionCache.get() != null &&
-            contractLatestVersion != smartContractVersionCache.get()
-          ) {
-            log.info(
-              "Smart contract upgraded: prevVersion={} upgradedVersion={}",
-              smartContractVersionCache.get(),
-              contractLatestVersion,
-            )
+      cached?.version == LineaRollupContractVersion.latest ->
+        SafeFuture.completedFuture(LineaRollupContractVersion.latest)
+
+      // below latest: serve from cache within the refresh interval so repeated getVersion calls
+      // don't refetch on every call, while still detecting an upgrade within versionRefreshInterval
+      cached != null && clock.now() < cached.fetchedAt + versionRefreshInterval ->
+        SafeFuture.completedFuture(cached.version)
+
+      else ->
+        fetchSmartContractVersion()
+          .thenPeek { contractLatestVersion ->
+            if (cached != null && contractLatestVersion != cached.version) {
+              log.info(
+                "Smart contract upgraded: prevVersion={} upgradedVersion={}",
+                cached.version,
+                contractLatestVersion,
+              )
+            }
+            smartContractVersionCache.set(CachedVersion(contractLatestVersion, clock.now()))
           }
-          smartContractVersionCache.set(contractLatestVersion)
-        }
     }
   }
 
-  private fun fetchSmartContractVersion(
+  internal open fun fetchSmartContractVersion(
     blockParameter: BlockParameter = BlockParameter.Tag.LATEST,
   ): SafeFuture<LineaRollupContractVersion> {
     return contractClientAtBlock(blockParameter, LineaRollupV6::class.java)

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
@@ -6,6 +6,7 @@ import linea.domain.BlockParameter
 import linea.domain.toBlockParameter
 import linea.ethapi.EthLogsSearcherImpl
 import linea.ethapi.FakeEthApiClient
+import net.consensys.FakeFixedClock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.web3j.protocol.Web3j
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Duration.Companion.seconds
 
 class Web3JLineaRollupSmartContractClientReadOnlyTest {
   private val contractAddress = "0x" + "aa".repeat(20)
@@ -49,6 +52,47 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
     assertThatThrownBy { client.parseContractVersion("5.0") }
       .isInstanceOf(IllegalStateException::class.java)
       .hasMessageContaining("Unsupported contract version: 5.0")
+  }
+
+  @Test
+  fun `getVersion caches below-latest versions for the refresh interval and short-circuits at latest`() {
+    val fakeClock = FakeFixedClock()
+    var onChainVersion = LineaRollupContractVersion.V8
+    var fetchCount = 0
+    val client = object : Web3JLineaRollupSmartContractClientReadOnly(
+      web3j = mock<Web3j>(),
+      contractAddress = contractAddress,
+      ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1Client),
+      versionRefreshInterval = 30.seconds,
+      clock = fakeClock,
+    ) {
+      override fun fetchSmartContractVersion(
+        blockParameter: BlockParameter,
+      ): SafeFuture<LineaRollupContractVersion> {
+        fetchCount++
+        return SafeFuture.completedFuture(onChainVersion)
+      }
+    }
+
+    // first call fetches and caches
+    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V8)
+    assertThat(fetchCount).isEqualTo(1)
+
+    // within the refresh interval: served from cache, no RPC
+    fakeClock.advanceBy(29.seconds)
+    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V8)
+    assertThat(fetchCount).isEqualTo(1)
+
+    // after the refresh interval: refetches and detects the upgrade
+    fakeClock.advanceBy(2.seconds)
+    onChainVersion = LineaRollupContractVersion.V9
+    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V9)
+    assertThat(fetchCount).isEqualTo(2)
+
+    // at the latest known version: short-circuits forever, even after the interval elapses
+    fakeClock.advanceBy(300.seconds)
+    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V9)
+    assertThat(fetchCount).isEqualTo(2)
   }
 
   @Test

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
@@ -59,7 +59,7 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
     val fakeClock = FakeFixedClock()
     var onChainVersion = LineaRollupContractVersion.V8
     var fetchCount = 0
-    val client = object : Web3JLineaRollupSmartContractClientReadOnly(
+    val fakeClient = object : Web3JLineaRollupSmartContractClientReadOnly(
       web3j = mock<Web3j>(),
       contractAddress = contractAddress,
       ethLogsSearcher = EthLogsSearcherImpl(vertx = vertx, ethApiClient = l1Client),
@@ -75,23 +75,23 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
     }
 
     // first call fetches and caches
-    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V8)
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaRollupContractVersion.V8)
     assertThat(fetchCount).isEqualTo(1)
 
     // within the refresh interval: served from cache, no RPC
     fakeClock.advanceBy(29.seconds)
-    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V8)
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaRollupContractVersion.V8)
     assertThat(fetchCount).isEqualTo(1)
 
     // after the refresh interval: refetches and detects the upgrade
     fakeClock.advanceBy(2.seconds)
     onChainVersion = LineaRollupContractVersion.V9
-    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V9)
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaRollupContractVersion.V9)
     assertThat(fetchCount).isEqualTo(2)
 
     // at the latest known version: short-circuits forever, even after the interval elapses
     fakeClock.advanceBy(300.seconds)
-    assertThat(client.getVersion().get()).isEqualTo(LineaRollupContractVersion.V9)
+    assertThat(fakeClient.getVersion().get()).isEqualTo(LineaRollupContractVersion.V9)
     assertThat(fetchCount).isEqualTo(2)
   }
 

--- a/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
+++ b/jvm-libs/linea/clients/linea-contract-clients/src/test/kotlin/linea/contract/l1/Web3JLineaRollupSmartContractClientReadOnlyTest.kt
@@ -7,6 +7,7 @@ import linea.domain.toBlockParameter
 import linea.ethapi.EthLogsSearcherImpl
 import linea.ethapi.FakeEthApiClient
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,6 +36,19 @@ class Web3JLineaRollupSmartContractClientReadOnlyTest {
   @AfterEach
   fun tearDown() {
     vertx.close()
+  }
+
+  @Test
+  fun `parseContractVersion maps major version prefixes and rejects unsupported versions`() {
+    assertThat(client.parseContractVersion("6.0")).isEqualTo(LineaRollupContractVersion.V6)
+    assertThat(client.parseContractVersion("7.1")).isEqualTo(LineaRollupContractVersion.V7)
+    assertThat(client.parseContractVersion("8.0")).isEqualTo(LineaRollupContractVersion.V8)
+    assertThat(client.parseContractVersion("9.0")).isEqualTo(LineaRollupContractVersion.V9)
+    assertThat(client.parseContractVersion("9.0.0-rc.1")).isEqualTo(LineaRollupContractVersion.V9)
+
+    assertThatThrownBy { client.parseContractVersion("5.0") }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("Unsupported contract version: 5.0")
   }
 
   @Test

--- a/jvm-libs/linea/linea-contracts/l1-rollup/build.gradle
+++ b/jvm-libs/linea/linea-contracts/l1-rollup/build.gradle
@@ -21,10 +21,12 @@ web3jContractWrappers {
   def contractsDir = layout.buildDirectory.dir("${rootProject.projectDir}/contracts/abi").get()
   def contractV6Abi = contractsDir.file("LineaRollupV6.0.abi").asFile.absolutePath
   def contractV8Abi = contractsDir.file("LineaRollupV8.0.abi").asFile.absolutePath
+  def contractV9Abi = contractsDir.file("LinethRollupV9-rc.abi").asFile.absolutePath
 
   contractsPackage = "linea.contract"
   contracts = [
     "$contractV6Abi": "LineaRollupV6",
-    "$contractV8Abi": "LineaRollupV8"
+    "$contractV8Abi": "LineaRollupV8",
+    "$contractV9Abi": "LinethRollupV9",
   ]
 }


### PR DESCRIPTION
This PR implements issue(s) #3088 

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches L1 blob submission and block finalization encoding for a new rollup version; mistakes could cause failed or incorrect on-chain transactions, though this is scaffold-level with explicit V9 entry points and version guards.
> 
> **Overview**
> Adds **Linea rollup V9** support across the coordinator and JVM contract clients: `LineaRollupContractVersion.V9`, a `LinethRollupV9` Web3j wrapper from `LinethRollupV9-rc.abi`, and test deployment via `deploy-lineth-rollup-v9-stub`.
> 
> **V9-specific L1 calls** are exposed as dedicated APIs instead of extending the V6–V8 blob/finalize builders: `BlobsSubmissionV9`, `FinalizationDataV9` / `ShnarfDataV9`, `FunctionBuildersV9`, and `submitBlobsV9` / `finalizeBlocksV9` on the Web3J client (with optional eth_call preflight and a minimum on-chain version check). Generic `buildSubmitBlobsFunction` / `buildFinalizeBlocksFunction` now **reject V9** and direct callers to those V9 methods.
> 
> Read-only behavior is extended for V9: version parsing, `blobShnarfExists` via the V9 contract, and finalized-state lookup aligned with V8. Contract version caching is reworked to use a **time-based refresh** and `LineaRollupContractVersion.latest`, with tests for parsing and cache/upgrade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb5803b99eaf2faab1137e1dd99a96d6c4e05f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->