### PR TITLE
fix(coordinator): small fix on start/stop handlers

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppV2.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppV2.kt
@@ -325,14 +325,13 @@ class CoordinatorAppV2(
   fun stop(): Int {
     return try {
       l1FinalizationMonitorApp.stop()
+        .thenCompose { conflationApp.stop() }
         .thenCompose {
-          conflationApp.stop()
           SafeFuture.allOf(
             SafeFuture.allOf(*extensionServices.map { it.stop().toSafeFuture() }.toTypedArray()),
             l2PricingApp.stop(),
             messageAnchoringApp.stop(),
             l1RelayingAppV1.stop(),
-            conflationApp.stop(),
             api.stop(),
             conflationBacktestingService.stop(),
           )

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppV2.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/CoordinatorAppV2.kt
@@ -324,22 +324,25 @@ class CoordinatorAppV2(
 
   fun stop(): Int {
     return try {
-      SafeFuture.allOf(
-        SafeFuture.allOf(*extensionServices.map { it.stop().toSafeFuture() }.toTypedArray()),
-        l2PricingApp.stop(),
-        messageAnchoringApp.stop(),
-        l1RelayingAppV1.stop(),
-        conflationApp.stop(),
-        l1FinalizationMonitorApp.stop(),
-        api.stop(),
-        conflationBacktestingService.stop(),
-      ).thenApply {
-        LoadBalancingJsonRpcClient.stop()
-      }.thenCompose {
-        vertx.close().toSafeFuture().thenApply { log.info("vertx Stopped") }
-      }.thenApply {
-        log.info("CoordinatorApp Stopped")
-      }.get()
+      l1FinalizationMonitorApp.stop()
+        .thenCompose {
+          conflationApp.stop()
+          SafeFuture.allOf(
+            SafeFuture.allOf(*extensionServices.map { it.stop().toSafeFuture() }.toTypedArray()),
+            l2PricingApp.stop(),
+            messageAnchoringApp.stop(),
+            l1RelayingAppV1.stop(),
+            conflationApp.stop(),
+            api.stop(),
+            conflationBacktestingService.stop(),
+          )
+        }.thenApply {
+          LoadBalancingJsonRpcClient.stop()
+        }.thenCompose {
+          vertx.close().toSafeFuture().thenApply { log.info("vertx Stopped") }
+        }.thenApply {
+          log.info("CoordinatorApp Stopped")
+        }.get()
       0
     } catch (e: Exception) {
       log.error("CoordinatorApp Stopped with error: errorMessage={}", e.message, e)

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflation/ConflationAppV1.kt
@@ -464,12 +464,7 @@ class ConflationAppV1(
       ),
       zkProofProductionCoordinator = ZkProofCreationCoordinatorImpl(
         executionProverClient = executionProverClient,
-        l2EthApiClient = createEthApiClient(
-          rpcUrl = configs.conflation.l2Endpoint.toString(),
-          log = LogManager.getLogger("clients.l2.eth.conflation"),
-          requestRetryConfig = configs.conflation.l2RequestRetries,
-          vertx = vertx,
-        ),
+        l2EthApiClient = l2EthClient,
         messageServiceAddress = configs.protocol.l2.contractAddress,
       ),
       batchProofHandler = batchProofHandler,

--- a/coordinator/utilities/src/main/kotlin/linea/fileio/DirectoryCleaner.kt
+++ b/coordinator/utilities/src/main/kotlin/linea/fileio/DirectoryCleaner.kt
@@ -31,7 +31,7 @@ class DirectoryCleaner(
 
   internal fun cleanDirectory(path: Path): SafeFuture<*> {
     return vertx.fileSystem().readDir(path.toString()).toSafeFuture()
-      .thenApply { filePaths ->
+      .thenCompose { filePaths ->
         val deletions = mutableListOf<SafeFuture<*>>()
         filePaths.forEach { filePath ->
           val file = File(filePath)

--- a/coordinator/utilities/src/main/kotlin/linea/fileio/DirectoryCleaner.kt
+++ b/coordinator/utilities/src/main/kotlin/linea/fileio/DirectoryCleaner.kt
@@ -40,10 +40,9 @@ class DirectoryCleaner(
               vertx.fileSystem()
                 .delete(filePath)
                 .toSafeFuture()
-                .whenComplete { _, deleteException ->
-                  deleteException?.also { log.warn("Failed to delete $filePath", it) }
+                .handleException { deleteException ->
+                  log.warn("Failed to delete $filePath", deleteException)
                 }
-                .thenApply { }
             deletions.add(deletion)
           }
         }


### PR DESCRIPTION
This PR implements issue(s) #3088

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Ordered coordinator shutdown affects production teardown timing and could surface latent stop-order bugs; directory cleanup now correctly waits on deletes, changing when conflation stop completes.
> 
> **Overview**
> **Coordinator shutdown** now mirrors startup order instead of stopping everything at once: `l1FinalizationMonitorApp` stops first, then `conflationApp`, then the remaining services run in parallel before JSON-RPC client teardown and Vertx close.
> 
> **Conflation** wires `ZkProofCreationCoordinatorImpl` to the existing `l2EthClient` instead of creating a second L2 eth API client for the same endpoint.
> 
> **Directory cleanup** fixes async chaining in `DirectoryCleaner.cleanDirectory` by using `thenCompose` so deletion futures are awaited, and simplifies per-file delete error handling with `handleException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f25ab621d64839329591d85824448cd6888ee1e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->