### PR TITLE
feat(coordinator): GasPriceCapProviderV2

### DIFF
--- a/coordinator/core/src/main/kotlin/linea/gaspricing/GasPriceCapProvider.kt
+++ b/coordinator/core/src/main/kotlin/linea/gaspricing/GasPriceCapProvider.kt
@@ -2,9 +2,15 @@ package linea.gaspricing
 
 import linea.domain.gas.GasPriceCaps
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Instant
 
 interface GasPriceCapProvider {
   fun getGasPriceCaps(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?>
 
   fun getGasPriceCapsWithCoefficient(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?>
+}
+
+interface GasPriceCapProviderV2 {
+  fun getGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?>
+  fun getGasPriceCapsWithCoefficient(timestamp: Instant): SafeFuture<GasPriceCaps?>
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/build.gradle
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/build.gradle
@@ -10,7 +10,6 @@ dependencies {
   implementation(project(":coordinator:core-interfaces"))
   implementation(project(":coordinator:core"))
   implementation(project(":coordinator:ethereum:gas-pricing"))
-  implementation(testFixtures(project(":jvm-libs:linea:core:domain-models")))
 
-  testImplementation("io.vertx:vertx-junit5")
+  testImplementation(testFixtures(project(":jvm-libs:linea:core:domain-models")))
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/build.gradle
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation(project(":coordinator:core-interfaces"))
   implementation(project(":coordinator:core"))
   implementation(project(":coordinator:ethereum:gas-pricing"))
+  implementation(testFixtures(project(":jvm-libs:linea:core:domain-models")))
 
   testImplementation("io.vertx:vertx-junit5")
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForDataSubmission.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForDataSubmission.kt
@@ -1,80 +1,25 @@
 package net.consensys.linea.ethereum.gaspricing.dynamiccap
 
-import linea.domain.gas.GasPriceCaps
 import linea.gaspricing.GasPriceCapProvider
-import linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
-import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.util.concurrent.atomic.AtomicReference
 
 class GasPriceCapProviderForDataSubmission(
-  private val config: Config,
-  private val gasPriceCapProvider: GasPriceCapProvider,
+  config: Config,
+  gasPriceCapProvider: GasPriceCapProvider,
   metricsFacade: MetricsFacade,
-) : GasPriceCapProvider {
+) : GasPriceCapProvider by GasPriceCapProviderWithHardCaps(
+  config = GasPriceCapProviderWithHardCaps.Config(
+    maxPriorityFeePerGasCap = config.maxPriorityFeePerGasCap,
+    maxFeePerGasCap = config.maxFeePerGasCap,
+    maxFeePerBlobGasCap = config.maxFeePerBlobGasCap,
+    metricsPrefix = "l1.blobsubmission",
+  ),
+  delegate = gasPriceCapProvider,
+  metricsFacade = metricsFacade,
+) {
   data class Config(
     val maxPriorityFeePerGasCap: ULong,
     val maxFeePerGasCap: ULong,
     val maxFeePerBlobGasCap: ULong,
   )
-  private var lastGasPriceCap: AtomicReference<GasPriceCaps?> = AtomicReference(null)
-
-  init {
-    metricsFacade.createGauge(
-      category = LineaMetricsCategory.GAS_PRICE_CAP,
-      name = "l1.blobsubmission.maxpriorityfeepergascap",
-      description = "Max priority fee per gas cap for blob submission on L1",
-      measurementSupplier = { lastGasPriceCap.get()?.maxPriorityFeePerGasCap?.toLong() ?: 0 },
-    )
-    metricsFacade.createGauge(
-      category = LineaMetricsCategory.GAS_PRICE_CAP,
-      name = "l1.blobsubmission.maxfeepergascap",
-      description = "Max fee per gas cap for blob submission on L1",
-      measurementSupplier = { lastGasPriceCap.get()?.maxFeePerGasCap?.toLong() ?: 0 },
-    )
-    metricsFacade.createGauge(
-      category = LineaMetricsCategory.GAS_PRICE_CAP,
-      name = "l1.blobsubmission.maxfeeperblobgascap",
-      description = "Max fee per blob gas cap for blob submission on L1",
-      measurementSupplier = { lastGasPriceCap.get()?.maxFeePerBlobGasCap?.toLong() ?: 0 },
-    )
-  }
-
-  private fun ULong.coerceWithFallback(cap: ULong): ULong = coerceAtMost(cap).let { if (it <= 0uL) cap else it }
-
-  private fun coerceGasPriceCaps(gasPriceCaps: GasPriceCaps): GasPriceCaps {
-    val maxPriorityFeePerGasCap = gasPriceCaps.maxPriorityFeePerGasCap
-      .coerceWithFallback(config.maxPriorityFeePerGasCap)
-
-    val maxFeePerGasCap = (
-      gasPriceCaps.maxBaseFeePerGasCap?.let { it + maxPriorityFeePerGasCap }
-        ?: gasPriceCaps.maxFeePerGasCap
-      )
-      .coerceWithFallback(config.maxFeePerGasCap)
-
-    val maxFeePerBlobGasCap = gasPriceCaps.maxFeePerBlobGasCap
-      .coerceWithFallback(config.maxFeePerBlobGasCap)
-
-    return GasPriceCaps(
-      maxFeePerGasCap = maxFeePerGasCap,
-      maxPriorityFeePerGasCap = maxPriorityFeePerGasCap,
-      maxFeePerBlobGasCap = maxFeePerBlobGasCap,
-    )
-  }
-
-  override fun getGasPriceCaps(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber)
-      .thenApply { it?.run(this::coerceGasPriceCaps) }
-      .thenPeek {
-        this.lastGasPriceCap.set(it)
-      }
-  }
-
-  override fun getGasPriceCapsWithCoefficient(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber)
-      .thenApply { it?.run(this::coerceGasPriceCaps) }
-      .thenPeek {
-        this.lastGasPriceCap.set(it)
-      }
-  }
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForFinalization.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderForFinalization.kt
@@ -1,79 +1,26 @@
 package net.consensys.linea.ethereum.gaspricing.dynamiccap
 
-import linea.domain.gas.GasPriceCaps
 import linea.gaspricing.GasPriceCapProvider
-import linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
-import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.util.concurrent.atomic.AtomicReference
 
 class GasPriceCapProviderForFinalization(
-  private val config: Config,
-  private val gasPriceCapProvider: GasPriceCapProvider,
+  config: Config,
+  gasPriceCapProvider: GasPriceCapProvider,
   metricsFacade: MetricsFacade,
-) : GasPriceCapProvider {
+) : GasPriceCapProvider by GasPriceCapProviderWithHardCaps(
+  config = GasPriceCapProviderWithHardCaps.Config(
+    maxPriorityFeePerGasCap = config.maxPriorityFeePerGasCap,
+    maxFeePerGasCap = config.maxFeePerGasCap,
+    maxFeePerBlobGasCap = null,
+    capMultiplier = config.gasPriceCapMultiplier,
+    metricsPrefix = "l1.finalization",
+  ),
+  delegate = gasPriceCapProvider,
+  metricsFacade = metricsFacade,
+) {
   data class Config(
     val maxPriorityFeePerGasCap: ULong,
     val maxFeePerGasCap: ULong,
     val gasPriceCapMultiplier: Double = 1.0,
   )
-  private var lastGasPriceCap: AtomicReference<GasPriceCaps?> = AtomicReference(null)
-
-  init {
-    require(config.gasPriceCapMultiplier >= 0.0) {
-      "gasPriceCapMultiplier must be no less than 0. Value=${config.gasPriceCapMultiplier}"
-    }
-
-    metricsFacade.createGauge(
-      category = LineaMetricsCategory.GAS_PRICE_CAP,
-      name = "l1.finalization.maxpriorityfeepergascap",
-      description = "Max priority fee per gas cap for finalization on L1",
-      measurementSupplier = { lastGasPriceCap.get()?.maxPriorityFeePerGasCap?.toLong() ?: 0 },
-    )
-
-    metricsFacade.createGauge(
-      category = LineaMetricsCategory.GAS_PRICE_CAP,
-      name = "l1.finalization.maxfeepergascap",
-      description = "Max fee per gas cap for finalization on L1",
-      measurementSupplier = { lastGasPriceCap.get()?.maxFeePerGasCap?.toLong() ?: 0 },
-    )
-  }
-
-  private fun coerceGasPriceCaps(gasPriceCaps: GasPriceCaps): GasPriceCaps {
-    val amplifiedMaxPriorityFeePerGasCap = (config.maxPriorityFeePerGasCap.toDouble() * config.gasPriceCapMultiplier)
-      .toULong()
-    val maxPriorityFeePerGasCap = gasPriceCaps.maxPriorityFeePerGasCap
-      .coerceAtMost(amplifiedMaxPriorityFeePerGasCap)
-      .run { if (this <= 0uL) amplifiedMaxPriorityFeePerGasCap else this }
-
-    val amplifiedMaxFeePerGasCap = (config.maxFeePerGasCap.toDouble() * config.gasPriceCapMultiplier).toULong()
-    val maxFeePerGasCap = (
-      gasPriceCaps.maxBaseFeePerGasCap?.let { it + maxPriorityFeePerGasCap }
-        ?: gasPriceCaps.maxFeePerGasCap
-      )
-      .coerceAtMost(amplifiedMaxFeePerGasCap)
-      .run { if (this <= 0uL) amplifiedMaxFeePerGasCap else this }
-
-    return GasPriceCaps(
-      maxPriorityFeePerGasCap = maxPriorityFeePerGasCap,
-      maxFeePerGasCap = maxFeePerGasCap,
-      maxFeePerBlobGasCap = 0uL,
-    )
-  }
-
-  override fun getGasPriceCaps(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber)
-      .thenApply { it?.run(this::coerceGasPriceCaps) }
-      .thenPeek {
-        this.lastGasPriceCap.set(it)
-      }
-  }
-
-  override fun getGasPriceCapsWithCoefficient(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber)
-      .thenApply { it?.run(this::coerceGasPriceCaps) }
-      .thenPeek {
-        this.lastGasPriceCap.set(it)
-      }
-  }
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -12,7 +12,7 @@ import kotlin.time.Duration
 import kotlin.time.Instant
 
 class GasPriceCapProviderImpl(
-  val config: Config,
+  private val config: Config,
   private val l2EthApiBlockClient: EthApiBlockClient,
   feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
   gasPriceCapCalculator: GasPriceCapCalculator,

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -81,7 +81,7 @@ class GasPriceCapProviderImpl(
           "Gas price caps will default to null because it could not fetch block={}, errorMessage={}",
           targetL2BlockNumber,
           th.message,
-          th.cause,
+          th,
         )
         null
       }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -69,7 +69,7 @@ class GasPriceCapProviderImpl(
     targetL2BlockNumber: Long,
     capsProvider: (Instant) -> SafeFuture<GasPriceCaps?>,
   ): SafeFuture<GasPriceCaps?> {
-    if (!config.enabled || !delegate.isEnoughDataForGasPriceCapCalculation()) {
+    if (!config.enabled || !delegate.hasEnoughDataForGasPriceCapCalculation()) {
       return SafeFuture.completedFuture(null)
     }
 

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -17,10 +17,12 @@ class GasPriceCapProviderImpl(
   feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
   gasPriceCapCalculator: GasPriceCapCalculator,
   clock: Clock = Clock.System,
+  private val log: Logger = LogManager.getLogger(GasPriceCapProviderImpl::class.java),
   val delegate: GasPriceCapProviderImplV2 = GasPriceCapProviderImplV2(
     gasPriceCapCalculator = gasPriceCapCalculator,
     feeHistoriesRepository = feeHistoriesRepository,
     clock = clock,
+    log = log,
     config = GasPriceCapProviderImplV2.Config(
       enabled = config.enabled,
       gasFeePercentile = config.gasFeePercentile,
@@ -45,8 +47,6 @@ class GasPriceCapProviderImpl(
     val finalizationTargetMaxDelay: Duration,
     val gasPriceCapsCoefficient: Double,
   )
-
-  private val log: Logger = LogManager.getLogger(this::class.java)
 
   init {
     require(config.gasFeePercentile >= 0.0) {

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -4,24 +4,35 @@ import linea.domain.gas.GasPriceCaps
 import linea.domain.toBlockParameter
 import linea.ethapi.EthApiBlockClient
 import linea.gaspricing.GasPriceCapProvider
-import linea.kotlin.toGWei
-import linea.kotlin.toULong
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.math.BigInteger
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Instant
 
 class GasPriceCapProviderImpl(
-  private val config: Config,
+  val config: Config,
   private val l2EthApiBlockClient: EthApiBlockClient,
-  private val feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
-  private val gasPriceCapCalculator: GasPriceCapCalculator,
-  private val clock: Clock = Clock.System,
+  feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
+  gasPriceCapCalculator: GasPriceCapCalculator,
+  clock: Clock = Clock.System,
+  val delegate: GasPriceCapProviderImplV2 = GasPriceCapProviderImplV2(
+    gasPriceCapCalculator = gasPriceCapCalculator,
+    feeHistoriesRepository = feeHistoriesRepository,
+    clock = clock,
+    config = GasPriceCapProviderImplV2.Config(
+      enabled = config.enabled,
+      gasFeePercentile = config.gasFeePercentile,
+      gasFeePercentileWindowInBlocks = config.gasFeePercentileWindowInBlocks,
+      gasFeePercentileWindowLeewayInBlocks = config.gasFeePercentileWindowLeewayInBlocks,
+      timeOfDayMultipliers = config.timeOfDayMultipliers,
+      adjustmentConstant = config.adjustmentConstant,
+      blobAdjustmentConstant = config.blobAdjustmentConstant,
+      finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
+      gasPriceCapsCoefficient = config.gasPriceCapsCoefficient,
+    ),
+  ),
 ) : GasPriceCapProvider {
   data class Config(
     val enabled: Boolean,
@@ -54,122 +65,33 @@ class GasPriceCapProviderImpl(
     }
   }
 
-  private fun isEnoughDataForGasPriceCapCalculation(): Boolean {
-    val minNumOfFeeHistoriesNeeded = BigInteger.valueOf(config.gasFeePercentileWindowInBlocks.toLong())
-      .minus(BigInteger.valueOf(config.gasFeePercentileWindowLeewayInBlocks.toLong()))
-      .coerceAtLeast(BigInteger.ZERO).toULong()
-
-    val numOfValidFeeHistories = feeHistoriesRepository.getCachedNumOfFeeHistoriesFromBlockNumber()
-    val isEnoughData = numOfValidFeeHistories.toULong() >= minNumOfFeeHistoriesNeeded
-    if (!isEnoughData) {
-      log.warn(
-        "Not enough fee history data for gas price cap update: numOfValidFeeHistoriesInDb={}, " +
-          "minNumOfFeeHistoriesNeeded={}",
-        numOfValidFeeHistories,
-        minNumOfFeeHistoriesNeeded,
-      )
+  private fun getGasPriceCaps(
+    targetL2BlockNumber: Long,
+    capsProvider: (Instant) -> SafeFuture<GasPriceCaps?>,
+  ): SafeFuture<GasPriceCaps?> {
+    if (!config.enabled || !delegate.isEnoughDataForGasPriceCapCalculation()) {
+      return SafeFuture.completedFuture(null)
     }
-    return isEnoughData
-  }
 
-  private fun getElapsedTimeSinceBlockTimestamp(blockTimestamp: Instant): Duration {
-    return (clock.now() - blockTimestamp).coerceAtLeast(Duration.ZERO)
-  }
-
-  private fun getTimeOfDayMultiplierForNow(timeOfDayMultipliers: TimeOfDayMultipliers): Double {
-    val dateTime = LocalDateTime.ofEpochSecond(clock.now().epochSeconds, 0, ZoneOffset.UTC)
-    val tdmKey = getTimeOfDayKey(dateTime.dayOfWeek, dateTime.hour)
-    return timeOfDayMultipliers[tdmKey]!!
-  }
-
-  private fun calculateGasPriceCapsHelper(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return if (isEnoughDataForGasPriceCapCalculation()) {
-      l2EthApiBlockClient.ethGetBlockByNumberTxHashes(targetL2BlockNumber.toBlockParameter())
-        .thenApply { it.timestamp }
-        .thenApply {
-          val targetL2BlockTimestamp = Instant.fromEpochSeconds(it.toLong())
-          val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(targetL2BlockTimestamp)
-          val percentileGasFees = feeHistoriesRepository.getCachedPercentileGasFees()
-          val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers)
-          val maxPriorityFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
-            adjustmentConstant = config.adjustmentConstant,
-            finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
-            historicGasPriceCap = percentileGasFees.percentileAvgReward,
-            elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
-            timeOfDayMultiplier = timeOfDayMultiplier,
-          )
-          val maxBaseFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
-            adjustmentConstant = config.adjustmentConstant,
-            finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
-            historicGasPriceCap = percentileGasFees.percentileBaseFeePerGas,
-            elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
-            timeOfDayMultiplier = timeOfDayMultiplier,
-          )
-          val maxFeePerBlobGasCap = gasPriceCapCalculator.calculateGasPriceCap(
-            adjustmentConstant = config.blobAdjustmentConstant,
-            finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
-            historicGasPriceCap = percentileGasFees.percentileBaseFeePerBlobGas,
-            elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
-          )
-          GasPriceCaps(
-            maxBaseFeePerGasCap = maxBaseFeePerGasCap,
-            maxPriorityFeePerGasCap = maxPriorityFeePerGasCap,
-            maxFeePerGasCap = maxPriorityFeePerGasCap + maxBaseFeePerGasCap,
-            maxFeePerBlobGasCap = maxFeePerBlobGasCap,
-          )
-        }.thenPeek { gasPriceCaps ->
-          log.debug(
-            "Calculated raw gas price caps: " +
-              "maxBaseFeePerGasCap={} GWei, maxPriorityFeePerGasCap={} GWei, " +
-              "maxFeePerGasCap={} GWei, maxFeePerBlobGasCap={} GWei, percentile={}",
-            gasPriceCaps.maxBaseFeePerGasCap?.toGWei(),
-            gasPriceCaps.maxPriorityFeePerGasCap.toGWei(),
-            gasPriceCaps.maxFeePerGasCap.toGWei(),
-            gasPriceCaps.maxFeePerBlobGasCap.toGWei(),
-            config.gasFeePercentile,
-          )
-        }.exceptionallyCompose { th ->
-          log.error(
-            "Gas price caps returned as null due to failure occurred: " +
-              "errorMessage={}",
-            th.message,
-            th,
-          )
-          SafeFuture.completedFuture(null)
-        }
-    } else {
-      SafeFuture.completedFuture(null)
-    }
-  }
-
-  private fun calculateGasPriceCaps(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return if (config.enabled) {
-      calculateGasPriceCapsHelper(
-        targetL2BlockNumber = targetL2BlockNumber,
-      )
-    } else {
-      SafeFuture.completedFuture(null)
-    }
+    return l2EthApiBlockClient
+      .ethGetBlockByNumberTxHashes(targetL2BlockNumber.toBlockParameter())
+      .thenCompose { block -> capsProvider(Instant.fromEpochSeconds(block.timestamp.toLong())) }
+      .exceptionally { th ->
+        log.warn(
+          "Gas price caps will default to null because it could not fetch block={}, errorMessage={}",
+          targetL2BlockNumber,
+          th.message,
+          th.cause,
+        )
+        null
+      }
   }
 
   override fun getGasPriceCaps(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return calculateGasPriceCaps(targetL2BlockNumber)
+    return getGasPriceCaps(targetL2BlockNumber, delegate::getGasPriceCaps)
   }
 
   override fun getGasPriceCapsWithCoefficient(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> {
-    return calculateGasPriceCaps(targetL2BlockNumber).thenApply {
-      it?.run {
-        val multipliedMaxBaseFeePerGasCap = it.maxBaseFeePerGasCap!!.toDouble() * config.gasPriceCapsCoefficient
-        val multipliedMaxPriorityFeePerGas = it.maxPriorityFeePerGasCap.toDouble() * config.gasPriceCapsCoefficient
-        val multipliedMaxFeePerBlobGasCap = (it.maxFeePerBlobGasCap.toDouble() * config.gasPriceCapsCoefficient)
-          .coerceAtLeast(1.0)
-        GasPriceCaps(
-          maxBaseFeePerGasCap = multipliedMaxBaseFeePerGasCap.toULong(),
-          maxPriorityFeePerGasCap = multipliedMaxPriorityFeePerGas.toULong(),
-          maxFeePerGasCap = (multipliedMaxBaseFeePerGasCap + multipliedMaxPriorityFeePerGas).toULong(),
-          maxFeePerBlobGasCap = multipliedMaxFeePerBlobGasCap.toULong(),
-        )
-      }
-    }
+    return getGasPriceCaps(targetL2BlockNumber, delegate::getGasPriceCapsWithCoefficient)
   }
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImpl.kt
@@ -18,7 +18,7 @@ class GasPriceCapProviderImpl(
   gasPriceCapCalculator: GasPriceCapCalculator,
   clock: Clock = Clock.System,
   private val log: Logger = LogManager.getLogger(GasPriceCapProviderImpl::class.java),
-  val delegate: GasPriceCapProviderImplV2 = GasPriceCapProviderImplV2(
+  private val delegate: GasPriceCapProviderImplV2 = GasPriceCapProviderImplV2(
     gasPriceCapCalculator = gasPriceCapCalculator,
     feeHistoriesRepository = feeHistoriesRepository,
     clock = clock,

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -19,6 +19,7 @@ class GasPriceCapProviderImplV2(
   private val feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
   private val gasPriceCapCalculator: GasPriceCapCalculator,
   private val clock: Clock = Clock.System,
+  private val log: Logger = LogManager.getLogger(GasPriceCapProviderImplV2::class.java),
 ) : GasPriceCapProviderV2 {
   data class Config(
     val enabled: Boolean,
@@ -31,8 +32,6 @@ class GasPriceCapProviderImplV2(
     val finalizationTargetMaxDelay: Duration,
     val gasPriceCapsCoefficient: Double,
   )
-
-  private val log: Logger = LogManager.getLogger(this::class.java)
 
   init {
     require(config.gasFeePercentile >= 0.0) {
@@ -79,7 +78,7 @@ class GasPriceCapProviderImplV2(
     return timeOfDayMultipliers[tdmKey]!!
   }
 
-  private fun calculateGasPriceCapsHelper(timestamp: Instant): GasPriceCaps {
+  private fun calculateGasPriceCaps(timestamp: Instant): GasPriceCaps {
     val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(timestamp)
     val percentileGasFees = feeHistoriesRepository.getCachedPercentileGasFees()
     val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers)
@@ -124,16 +123,12 @@ class GasPriceCapProviderImplV2(
     return gasPriceCaps
   }
 
-  private fun calculateGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
+  override fun getGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
     return if (config.enabled && hasEnoughDataForGasPriceCapCalculation()) {
-      calculateGasPriceCapsHelper(timestamp)
+      calculateGasPriceCaps(timestamp)
     } else {
       null
     }.let { SafeFuture.completedFuture(it) }
-  }
-
-  override fun getGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
-    return calculateGasPriceCaps(timestamp)
   }
 
   override fun getGasPriceCapsWithCoefficient(timestamp: Instant): SafeFuture<GasPriceCaps?> {

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -2,12 +2,13 @@ package net.consensys.linea.ethereum.gaspricing.dynamiccap
 
 import linea.domain.gas.GasPriceCaps
 import linea.gaspricing.GasPriceCapProviderV2
+import linea.kotlin.minusCoercingUnderflow
+import linea.kotlin.toBigDecimal
 import linea.kotlin.toGWei
-import linea.kotlin.toULong
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
-import java.math.BigInteger
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import kotlin.time.Clock
@@ -51,13 +52,14 @@ class GasPriceCapProviderImplV2(
   }
 
   internal fun hasEnoughDataForGasPriceCapCalculation(): Boolean {
-    val minNumOfFeeHistoriesNeeded = BigInteger.valueOf(config.gasFeePercentileWindowInBlocks.toLong())
-      .minus(BigInteger.valueOf(config.gasFeePercentileWindowLeewayInBlocks.toLong()))
-      .coerceAtLeast(BigInteger.ZERO).toULong()
+    val minNumOfFeeHistoriesNeeded =
+      config.gasFeePercentileWindowInBlocks
+        .minusCoercingUnderflow(config.gasFeePercentileWindowLeewayInBlocks)
+        .toInt()
 
     val numOfValidFeeHistories = feeHistoriesRepository.getCachedNumOfFeeHistoriesFromBlockNumber()
-    val isEnoughData = numOfValidFeeHistories.toULong() >= minNumOfFeeHistoriesNeeded
-    if (!isEnoughData) {
+    val hasEnoughData = numOfValidFeeHistories >= minNumOfFeeHistoriesNeeded
+    if (!hasEnoughData) {
       log.warn(
         "Not enough fee history data for gas price cap update: numOfValidFeeHistoriesInDb={}, " +
           "minNumOfFeeHistoriesNeeded={}",
@@ -65,7 +67,7 @@ class GasPriceCapProviderImplV2(
         minNumOfFeeHistoriesNeeded,
       )
     }
-    return isEnoughData
+    return hasEnoughData
   }
 
   private fun getElapsedTimeSinceBlockTimestamp(blockTimestamp: Instant, referenceTime: Instant): Duration {
@@ -131,7 +133,9 @@ class GasPriceCapProviderImplV2(
       return SafeFuture.completedFuture(null)
     }
 
-    val gasPriceCaps = runCatching { calculateGasPriceCaps(timestamp, clock.now()) }
+    val gasPriceCaps = runCatching {
+      calculateGasPriceCaps(timestamp, clock.now())
+    }
       .onFailure { th ->
         log.warn("Gas price caps returned as null due to calculation failure: errorMessage={}", th.message, th)
       }
@@ -141,19 +145,26 @@ class GasPriceCapProviderImplV2(
   }
 
   override fun getGasPriceCapsWithCoefficient(timestamp: Instant): SafeFuture<GasPriceCaps?> {
-    return getGasPriceCaps(timestamp).thenApply {
-      it?.run {
-        val multipliedMaxBaseFeePerGasCap = it.maxBaseFeePerGasCap!!.toDouble() * config.gasPriceCapsCoefficient
-        val multipliedMaxPriorityFeePerGas = it.maxPriorityFeePerGasCap.toDouble() * config.gasPriceCapsCoefficient
-        val multipliedMaxFeePerBlobGasCap = (it.maxFeePerBlobGasCap.toDouble() * config.gasPriceCapsCoefficient)
-          .coerceAtLeast(1.0)
-        GasPriceCaps(
-          maxBaseFeePerGasCap = multipliedMaxBaseFeePerGasCap.toULong(),
-          maxPriorityFeePerGasCap = multipliedMaxPriorityFeePerGas.toULong(),
-          maxFeePerGasCap = (multipliedMaxBaseFeePerGasCap + multipliedMaxPriorityFeePerGas).toULong(),
-          maxFeePerBlobGasCap = multipliedMaxFeePerBlobGasCap.toULong(),
-        )
+    return getGasPriceCaps(timestamp)
+      .thenApply { caps ->
+        caps?.let {
+          val coeff = config.gasPriceCapsCoefficient.toBigDecimal()
+          val multipliedMaxBaseFeePerGasCap =
+            // NOTE: at this stage maxBaseFeePerGasCap is always defined
+            // on upper classes (e.g GasPriceCapProviderForDataSubmission) may be nullified
+            (it.maxBaseFeePerGasCap!!.toBigDecimal() * coeff).toLong().toULong()
+          val multipliedMaxPriorityFeePerGas =
+            (it.maxPriorityFeePerGasCap.toBigDecimal() * coeff).toLong().toULong()
+          val multipliedMaxFeePerBlobGasCap =
+            (it.maxFeePerBlobGasCap.toBigDecimal() * coeff)
+              .coerceAtLeast(BigDecimal.ONE).toLong().toULong()
+          GasPriceCaps(
+            maxBaseFeePerGasCap = multipliedMaxBaseFeePerGasCap,
+            maxPriorityFeePerGasCap = multipliedMaxPriorityFeePerGas,
+            maxFeePerGasCap = multipliedMaxBaseFeePerGasCap + multipliedMaxPriorityFeePerGas,
+            maxFeePerBlobGasCap = multipliedMaxFeePerBlobGasCap,
+          )
+        }
       }
-    }
   }
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -76,7 +76,7 @@ class GasPriceCapProviderImplV2(
     val dateTime = LocalDateTime.ofEpochSecond(clock.now().epochSeconds, 0, ZoneOffset.UTC)
     val tdmKey = getTimeOfDayKey(dateTime.dayOfWeek, dateTime.hour)
     return timeOfDayMultipliers[tdmKey] ?: run {
-      log.info("Not multiplier found with key={} for date={}", tdmKey, dateTime)
+      log.info("No multiplier found for key={} date={} defaulting to 1.0", tdmKey, dateTime)
       1.0
     }
   }
@@ -127,16 +127,17 @@ class GasPriceCapProviderImplV2(
   }
 
   override fun getGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
-    return if (config.enabled && hasEnoughDataForGasPriceCapCalculation()) {
-      try {
-        calculateGasPriceCaps(timestamp)
-      } catch (e: Exception) {
-        log.warn("Gas price caps will default to null due to calculation error: errorMessage={}", e.message, e)
-        null
+    if (!config.enabled || !hasEnoughDataForGasPriceCapCalculation()) {
+      return SafeFuture.completedFuture(null)
+    }
+
+    val gasPriceCaps = runCatching { calculateGasPriceCaps(timestamp) }
+      .onFailure { th ->
+        log.warn("Gas price caps returned as null due to calculation failure: errorMessage={}", th.message, th)
       }
-    } else {
-      null
-    }.let { SafeFuture.completedFuture(it) }
+      .getOrNull()
+
+    return SafeFuture.completedFuture(gasPriceCaps)
   }
 
   override fun getGasPriceCapsWithCoefficient(timestamp: Instant): SafeFuture<GasPriceCaps?> {

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -1,0 +1,159 @@
+package net.consensys.linea.ethereum.gaspricing.dynamiccap
+
+import linea.domain.gas.GasPriceCaps
+import linea.gaspricing.GasPriceCapProviderV2
+import linea.kotlin.toGWei
+import linea.kotlin.toULong
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.math.BigInteger
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+class GasPriceCapProviderImplV2(
+  private val config: Config,
+  private val feeHistoriesRepository: FeeHistoriesRepositoryWithCache,
+  private val gasPriceCapCalculator: GasPriceCapCalculator,
+  private val clock: Clock = Clock.System,
+) : GasPriceCapProviderV2 {
+  data class Config(
+    val enabled: Boolean,
+    val gasFeePercentile: Double,
+    val gasFeePercentileWindowInBlocks: UInt,
+    val gasFeePercentileWindowLeewayInBlocks: UInt,
+    val timeOfDayMultipliers: TimeOfDayMultipliers,
+    val adjustmentConstant: UInt,
+    val blobAdjustmentConstant: UInt,
+    val finalizationTargetMaxDelay: Duration,
+    val gasPriceCapsCoefficient: Double,
+  )
+
+  private val log: Logger = LogManager.getLogger(this::class.java)
+
+  init {
+    require(config.gasFeePercentile >= 0.0) {
+      "gasFeePercentile must be no less than 0.0." +
+        " Value=${config.gasFeePercentile}"
+    }
+
+    require(config.finalizationTargetMaxDelay > Duration.ZERO) {
+      "finalizationTargetMaxDelay duration must be longer than zero second." +
+        " Value=${config.finalizationTargetMaxDelay}"
+    }
+
+    require(config.gasPriceCapsCoefficient > 0.0) {
+      "gasPriceCapsCoefficient must be greater than 0.0." +
+        " Value=${config.gasPriceCapsCoefficient}"
+    }
+  }
+
+  internal fun isEnoughDataForGasPriceCapCalculation(): Boolean {
+    val minNumOfFeeHistoriesNeeded = BigInteger.valueOf(config.gasFeePercentileWindowInBlocks.toLong())
+      .minus(BigInteger.valueOf(config.gasFeePercentileWindowLeewayInBlocks.toLong()))
+      .coerceAtLeast(BigInteger.ZERO).toULong()
+
+    val numOfValidFeeHistories = feeHistoriesRepository.getCachedNumOfFeeHistoriesFromBlockNumber()
+    val isEnoughData = numOfValidFeeHistories.toULong() >= minNumOfFeeHistoriesNeeded
+    if (!isEnoughData) {
+      log.warn(
+        "Not enough fee history data for gas price cap update: numOfValidFeeHistoriesInDb={}, " +
+          "minNumOfFeeHistoriesNeeded={}",
+        numOfValidFeeHistories,
+        minNumOfFeeHistoriesNeeded,
+      )
+    }
+    return isEnoughData
+  }
+
+  private fun getElapsedTimeSinceBlockTimestamp(blockTimestamp: Instant): Duration {
+    return (clock.now() - blockTimestamp).coerceAtLeast(Duration.ZERO)
+  }
+
+  private fun getTimeOfDayMultiplierForNow(timeOfDayMultipliers: TimeOfDayMultipliers): Double {
+    val dateTime = LocalDateTime.ofEpochSecond(clock.now().epochSeconds, 0, ZoneOffset.UTC)
+    val tdmKey = getTimeOfDayKey(dateTime.dayOfWeek, dateTime.hour)
+    return timeOfDayMultipliers[tdmKey]!!
+  }
+
+  private fun calculateGasPriceCapsHelper(timestamp: Instant): GasPriceCaps? {
+    if (!isEnoughDataForGasPriceCapCalculation()) {
+      return null
+    }
+
+    val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(timestamp)
+    val percentileGasFees = feeHistoriesRepository.getCachedPercentileGasFees()
+    val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers)
+    val maxPriorityFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
+      adjustmentConstant = config.adjustmentConstant,
+      finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
+      historicGasPriceCap = percentileGasFees.percentileAvgReward,
+      elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
+      timeOfDayMultiplier = timeOfDayMultiplier,
+    )
+    val maxBaseFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
+      adjustmentConstant = config.adjustmentConstant,
+      finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
+      historicGasPriceCap = percentileGasFees.percentileBaseFeePerGas,
+      elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
+      timeOfDayMultiplier = timeOfDayMultiplier,
+    )
+    val maxFeePerBlobGasCap = gasPriceCapCalculator.calculateGasPriceCap(
+      adjustmentConstant = config.blobAdjustmentConstant,
+      finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
+      historicGasPriceCap = percentileGasFees.percentileBaseFeePerBlobGas,
+      elapsedTimeSinceBlockTimestamp = elapsedTimeSinceBlockTimestamp,
+    )
+    val gasPriceCaps = GasPriceCaps(
+      maxBaseFeePerGasCap = maxBaseFeePerGasCap,
+      maxPriorityFeePerGasCap = maxPriorityFeePerGasCap,
+      maxFeePerGasCap = maxPriorityFeePerGasCap + maxBaseFeePerGasCap,
+      maxFeePerBlobGasCap = maxFeePerBlobGasCap,
+    )
+
+    log.debug(
+      "Calculated raw gas price caps: " +
+        "maxBaseFeePerGasCap={} GWei, maxPriorityFeePerGasCap={} GWei, " +
+        "maxFeePerGasCap={} GWei, maxFeePerBlobGasCap={} GWei, percentile={}",
+      gasPriceCaps.maxBaseFeePerGasCap?.toGWei(),
+      gasPriceCaps.maxPriorityFeePerGasCap.toGWei(),
+      gasPriceCaps.maxFeePerGasCap.toGWei(),
+      gasPriceCaps.maxFeePerBlobGasCap.toGWei(),
+      config.gasFeePercentile,
+    )
+
+    return gasPriceCaps
+  }
+
+  private fun calculateGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
+    return if (config.enabled) {
+      calculateGasPriceCapsHelper(timestamp)
+    } else {
+      null
+    }.let { SafeFuture.completedFuture(it) }
+  }
+
+  override fun getGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
+    return calculateGasPriceCaps(timestamp)
+  }
+
+  override fun getGasPriceCapsWithCoefficient(timestamp: Instant): SafeFuture<GasPriceCaps?> {
+    return calculateGasPriceCaps(timestamp).thenApply {
+      it?.run {
+        val multipliedMaxBaseFeePerGasCap = it.maxBaseFeePerGasCap!!.toDouble() * config.gasPriceCapsCoefficient
+        val multipliedMaxPriorityFeePerGas = it.maxPriorityFeePerGasCap.toDouble() * config.gasPriceCapsCoefficient
+        val multipliedMaxFeePerBlobGasCap = (it.maxFeePerBlobGasCap.toDouble() * config.gasPriceCapsCoefficient)
+          .coerceAtLeast(1.0)
+        GasPriceCaps(
+          maxBaseFeePerGasCap = multipliedMaxBaseFeePerGasCap.toULong(),
+          maxPriorityFeePerGasCap = multipliedMaxPriorityFeePerGas.toULong(),
+          maxFeePerGasCap = (multipliedMaxBaseFeePerGasCap + multipliedMaxPriorityFeePerGas).toULong(),
+          maxFeePerBlobGasCap = multipliedMaxFeePerBlobGasCap.toULong(),
+        )
+      }
+    }
+  }
+}

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -125,7 +125,12 @@ class GasPriceCapProviderImplV2(
 
   override fun getGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
     return if (config.enabled && hasEnoughDataForGasPriceCapCalculation()) {
-      calculateGasPriceCaps(timestamp)
+      try {
+        calculateGasPriceCaps(timestamp)
+      } catch (e: Exception) {
+        log.warn("Gas price caps will default to null due to calculation error: errorMessage={}", e.message, e)
+        null
+      }
     } else {
       null
     }.let { SafeFuture.completedFuture(it) }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -51,7 +51,7 @@ class GasPriceCapProviderImplV2(
     }
   }
 
-  internal fun isEnoughDataForGasPriceCapCalculation(): Boolean {
+  internal fun hasEnoughDataForGasPriceCapCalculation(): Boolean {
     val minNumOfFeeHistoriesNeeded = BigInteger.valueOf(config.gasFeePercentileWindowInBlocks.toLong())
       .minus(BigInteger.valueOf(config.gasFeePercentileWindowLeewayInBlocks.toLong()))
       .coerceAtLeast(BigInteger.ZERO).toULong()
@@ -79,11 +79,7 @@ class GasPriceCapProviderImplV2(
     return timeOfDayMultipliers[tdmKey]!!
   }
 
-  private fun calculateGasPriceCapsHelper(timestamp: Instant): GasPriceCaps? {
-    if (!isEnoughDataForGasPriceCapCalculation()) {
-      return null
-    }
-
+  private fun calculateGasPriceCapsHelper(timestamp: Instant): GasPriceCaps {
     val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(timestamp)
     val percentileGasFees = feeHistoriesRepository.getCachedPercentileGasFees()
     val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers)
@@ -129,7 +125,7 @@ class GasPriceCapProviderImplV2(
   }
 
   private fun calculateGasPriceCaps(timestamp: Instant): SafeFuture<GasPriceCaps?> {
-    return if (config.enabled) {
+    return if (config.enabled && hasEnoughDataForGasPriceCapCalculation()) {
       calculateGasPriceCapsHelper(timestamp)
     } else {
       null
@@ -141,7 +137,7 @@ class GasPriceCapProviderImplV2(
   }
 
   override fun getGasPriceCapsWithCoefficient(timestamp: Instant): SafeFuture<GasPriceCaps?> {
-    return calculateGasPriceCaps(timestamp).thenApply {
+    return getGasPriceCaps(timestamp).thenApply {
       it?.run {
         val multipliedMaxBaseFeePerGasCap = it.maxBaseFeePerGasCap!!.toDouble() * config.gasPriceCapsCoefficient
         val multipliedMaxPriorityFeePerGas = it.maxPriorityFeePerGasCap.toDouble() * config.gasPriceCapsCoefficient

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -75,7 +75,10 @@ class GasPriceCapProviderImplV2(
   private fun getTimeOfDayMultiplierForNow(timeOfDayMultipliers: TimeOfDayMultipliers): Double {
     val dateTime = LocalDateTime.ofEpochSecond(clock.now().epochSeconds, 0, ZoneOffset.UTC)
     val tdmKey = getTimeOfDayKey(dateTime.dayOfWeek, dateTime.hour)
-    return timeOfDayMultipliers[tdmKey]!!
+    return timeOfDayMultipliers[tdmKey] ?: run {
+      log.info("Not multiplier found with key={} for date={}", tdmKey, dateTime)
+      1.0
+    }
   }
 
   private fun calculateGasPriceCaps(timestamp: Instant): GasPriceCaps {

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -55,7 +55,7 @@ class GasPriceCapProviderImplV2(
     val minNumOfFeeHistoriesNeeded =
       config.gasFeePercentileWindowInBlocks
         .minusCoercingUnderflow(config.gasFeePercentileWindowLeewayInBlocks)
-        .toInt()
+        .toLong()
 
     val numOfValidFeeHistories = feeHistoriesRepository.getCachedNumOfFeeHistoriesFromBlockNumber()
     val hasEnoughData = numOfValidFeeHistories >= minNumOfFeeHistoriesNeeded

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -5,6 +5,7 @@ import linea.gaspricing.GasPriceCapProviderV2
 import linea.kotlin.minusCoercingUnderflow
 import linea.kotlin.toBigDecimal
 import linea.kotlin.toGWei
+import linea.kotlin.toULong
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
@@ -152,12 +153,12 @@ class GasPriceCapProviderImplV2(
           val multipliedMaxBaseFeePerGasCap =
             // NOTE: at this stage maxBaseFeePerGasCap is always defined
             // on upper classes (e.g GasPriceCapProviderForDataSubmission) may be nullified
-            (it.maxBaseFeePerGasCap!!.toBigDecimal() * coeff).toLong().toULong()
+            (it.maxBaseFeePerGasCap!!.toBigDecimal() * coeff).toULong()
           val multipliedMaxPriorityFeePerGas =
-            (it.maxPriorityFeePerGasCap.toBigDecimal() * coeff).toLong().toULong()
+            (it.maxPriorityFeePerGasCap.toBigDecimal() * coeff).toULong()
           val multipliedMaxFeePerBlobGasCap =
             (it.maxFeePerBlobGasCap.toBigDecimal() * coeff)
-              .coerceAtLeast(BigDecimal.ONE).toLong().toULong()
+              .coerceAtLeast(BigDecimal.ONE).toULong()
           GasPriceCaps(
             maxBaseFeePerGasCap = multipliedMaxBaseFeePerGasCap,
             maxPriorityFeePerGasCap = multipliedMaxPriorityFeePerGas,

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2.kt
@@ -68,23 +68,23 @@ class GasPriceCapProviderImplV2(
     return isEnoughData
   }
 
-  private fun getElapsedTimeSinceBlockTimestamp(blockTimestamp: Instant): Duration {
-    return (clock.now() - blockTimestamp).coerceAtLeast(Duration.ZERO)
+  private fun getElapsedTimeSinceBlockTimestamp(blockTimestamp: Instant, referenceTime: Instant): Duration {
+    return (referenceTime - blockTimestamp).coerceAtLeast(Duration.ZERO)
   }
 
-  private fun getTimeOfDayMultiplierForNow(timeOfDayMultipliers: TimeOfDayMultipliers): Double {
-    val dateTime = LocalDateTime.ofEpochSecond(clock.now().epochSeconds, 0, ZoneOffset.UTC)
+  private fun getTimeOfDayMultiplierForNow(referenceTime: Instant): Double {
+    val dateTime = LocalDateTime.ofEpochSecond(referenceTime.epochSeconds, 0, ZoneOffset.UTC)
     val tdmKey = getTimeOfDayKey(dateTime.dayOfWeek, dateTime.hour)
-    return timeOfDayMultipliers[tdmKey] ?: run {
+    return config.timeOfDayMultipliers[tdmKey] ?: run {
       log.info("No multiplier found for key={} date={} defaulting to 1.0", tdmKey, dateTime)
       1.0
     }
   }
 
-  private fun calculateGasPriceCaps(timestamp: Instant): GasPriceCaps {
-    val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(timestamp)
+  private fun calculateGasPriceCaps(blockTimestamp: Instant, referenceTime: Instant): GasPriceCaps {
+    val elapsedTimeSinceBlockTimestamp = getElapsedTimeSinceBlockTimestamp(blockTimestamp, referenceTime)
     val percentileGasFees = feeHistoriesRepository.getCachedPercentileGasFees()
-    val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(config.timeOfDayMultipliers)
+    val timeOfDayMultiplier = getTimeOfDayMultiplierForNow(referenceTime)
     val maxPriorityFeePerGasCap = gasPriceCapCalculator.calculateGasPriceCap(
       adjustmentConstant = config.adjustmentConstant,
       finalizationTargetMaxDelay = config.finalizationTargetMaxDelay,
@@ -131,7 +131,7 @@ class GasPriceCapProviderImplV2(
       return SafeFuture.completedFuture(null)
     }
 
-    val gasPriceCaps = runCatching { calculateGasPriceCaps(timestamp) }
+    val gasPriceCaps = runCatching { calculateGasPriceCaps(timestamp, clock.now()) }
       .onFailure { th ->
         log.warn("Gas price caps returned as null due to calculation failure: errorMessage={}", th.message, th)
       }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderWithHardCaps.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderWithHardCaps.kt
@@ -1,0 +1,86 @@
+package net.consensys.linea.ethereum.gaspricing.dynamiccap
+
+import linea.domain.gas.GasPriceCaps
+import linea.gaspricing.GasPriceCapProvider
+import linea.metrics.LineaMetricsCategory
+import net.consensys.linea.metrics.MetricsFacade
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.atomic.AtomicReference
+
+class GasPriceCapProviderWithHardCaps(
+  private val config: Config,
+  private val delegate: GasPriceCapProvider,
+  metricsFacade: MetricsFacade,
+) : GasPriceCapProvider {
+
+  data class Config(
+    val maxPriorityFeePerGasCap: ULong,
+    val maxFeePerGasCap: ULong,
+    // null means no blob transactions (e.g. finalization): blob cap is forced to 0
+    val maxFeePerBlobGasCap: ULong?,
+    val capMultiplier: Double = 1.0,
+    val metricsPrefix: String,
+  )
+
+  private val lastGasPriceCap: AtomicReference<GasPriceCaps?> = AtomicReference(null)
+
+  init {
+    require(config.capMultiplier >= 0.0) {
+      "capMultiplier must be no less than 0. Value=${config.capMultiplier}"
+    }
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.GAS_PRICE_CAP,
+      name = "${config.metricsPrefix}.maxpriorityfeepergascap",
+      description = "Max priority fee per gas cap for ${config.metricsPrefix} on L1",
+      measurementSupplier = { lastGasPriceCap.get()?.maxPriorityFeePerGasCap?.toLong() ?: 0 },
+    )
+    metricsFacade.createGauge(
+      category = LineaMetricsCategory.GAS_PRICE_CAP,
+      name = "${config.metricsPrefix}.maxfeepergascap",
+      description = "Max fee per gas cap for ${config.metricsPrefix} on L1",
+      measurementSupplier = { lastGasPriceCap.get()?.maxFeePerGasCap?.toLong() ?: 0 },
+    )
+    if (config.maxFeePerBlobGasCap != null) {
+      metricsFacade.createGauge(
+        category = LineaMetricsCategory.GAS_PRICE_CAP,
+        name = "${config.metricsPrefix}.maxfeeperblobgascap",
+        description = "Max fee per blob gas cap for ${config.metricsPrefix} on L1",
+        measurementSupplier = { lastGasPriceCap.get()?.maxFeePerBlobGasCap?.toLong() ?: 0 },
+      )
+    }
+  }
+
+  // If the value after coercion is 0, fall back to the hard cap so transactions are never priced out.
+  private fun ULong.coerceWithFallback(cap: ULong): ULong =
+    coerceAtMost(cap).let { if (it == 0uL) cap else it }
+
+  private fun effectiveCap(base: ULong): ULong =
+    (base.toString().toBigDecimal() * config.capMultiplier.toBigDecimal()).toLong().toULong()
+
+  private fun coerce(caps: GasPriceCaps): GasPriceCaps {
+    val priorityCap = effectiveCap(config.maxPriorityFeePerGasCap)
+    val feeCap = effectiveCap(config.maxFeePerGasCap)
+
+    val priority = caps.maxPriorityFeePerGasCap.coerceWithFallback(priorityCap)
+    val fee = (caps.maxBaseFeePerGasCap?.let { it + priority } ?: caps.maxFeePerGasCap)
+      .coerceWithFallback(feeCap)
+    val blobFee = config.maxFeePerBlobGasCap
+      ?.let { hardCap -> caps.maxFeePerBlobGasCap.coerceWithFallback(hardCap) }
+      ?: 0uL
+
+    return GasPriceCaps(
+      maxPriorityFeePerGasCap = priority,
+      maxFeePerGasCap = fee,
+      maxFeePerBlobGasCap = blobFee,
+    )
+  }
+
+  private fun SafeFuture<GasPriceCaps?>.coerceAndTrack(): SafeFuture<GasPriceCaps?> =
+    thenApply { it?.let(::coerce) }.thenPeek { lastGasPriceCap.set(it) }
+
+  override fun getGasPriceCaps(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> =
+    delegate.getGasPriceCaps(targetL2BlockNumber).coerceAndTrack()
+
+  override fun getGasPriceCapsWithCoefficient(targetL2BlockNumber: Long): SafeFuture<GasPriceCaps?> =
+    delegate.getGasPriceCapsWithCoefficient(targetL2BlockNumber).coerceAndTrack()
+}

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderWithHardCaps.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderWithHardCaps.kt
@@ -57,7 +57,7 @@ class GasPriceCapProviderWithHardCaps(
     coerceAtMost(cap).let { if (it == 0uL) cap else it }
 
   private fun effectiveCap(base: ULong): ULong =
-    (base.toBigDecimal() * config.capMultiplier.toBigDecimal()).toBigInteger().toULong()
+    (base.toBigDecimal() * config.capMultiplier.toBigDecimal()).toULong()
 
   private fun coerce(caps: GasPriceCaps): GasPriceCaps {
     val priorityCap = effectiveCap(config.maxPriorityFeePerGasCap)

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderWithHardCaps.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/main/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderWithHardCaps.kt
@@ -2,6 +2,8 @@ package net.consensys.linea.ethereum.gaspricing.dynamiccap
 
 import linea.domain.gas.GasPriceCaps
 import linea.gaspricing.GasPriceCapProvider
+import linea.kotlin.toBigDecimal
+import linea.kotlin.toULong
 import linea.metrics.LineaMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import tech.pegasys.teku.infrastructure.async.SafeFuture
@@ -55,7 +57,7 @@ class GasPriceCapProviderWithHardCaps(
     coerceAtMost(cap).let { if (it == 0uL) cap else it }
 
   private fun effectiveCap(base: ULong): ULong =
-    (base.toString().toBigDecimal() * config.capMultiplier.toBigDecimal()).toLong().toULong()
+    (base.toBigDecimal() * config.capMultiplier.toBigDecimal()).toBigInteger().toULong()
 
   private fun coerce(caps: GasPriceCaps): GasPriceCaps {
     val priorityCap = effectiveCap(config.maxPriorityFeePerGasCap)

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplTest.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplTest.kt
@@ -33,7 +33,7 @@ class GasPriceCapProviderImplTest {
   )
   private val p10BaseFeeGas = 1000000000uL // 1GWei
   private val p10BaseFeeBlobGas = 100000000uL // 0.1GWei
-  private val avgP10Reward = 200000000uL // 2GWei
+  private val avgP10Reward = 200000000uL // 0.2GWei
   private val storedFeeHistoriesNum = 100
   private val adjustmentConstant = 25U
   private val finalizationTargetMaxDelay = 6.hours

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
@@ -33,7 +33,7 @@ class GasPriceCapProviderImplV2Test {
   )
   private val p10BaseFeeGas = 1000000000uL // 1GWei
   private val p10BaseFeeBlobGas = 100000000uL // 0.1GWei
-  private val avgP10Reward = 200000000uL // 2GWei
+  private val avgP10Reward = 200000000uL // 0.2GWei
   private val storedFeeHistoriesNum = 100
   private val adjustmentConstant = 25U
   private val finalizationTargetMaxDelay = 6.hours

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import java.math.BigDecimal
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -148,9 +149,11 @@ class GasPriceCapProviderImplV2Test {
   @Test
   fun `gas price caps with coefficient should be returned correctly`() {
     val gasPriceCapProvider = createGasPriceCapProvider()
-    val expectedMaxBaseFeePerGasCap = (1694444444 * gasPriceCapsCoefficient).toULong()
-    val expectedMaxPriorityFeePerGasCap = (338888888 * gasPriceCapsCoefficient).toULong()
-    val expectedMaxFeePerBlobGasCap = (169444444 * gasPriceCapsCoefficient).toULong()
+    val coeff = gasPriceCapsCoefficient.toBigDecimal()
+    val expectedMaxBaseFeePerGasCap = (1694444444.toBigDecimal() * coeff).toLong().toULong()
+    val expectedMaxPriorityFeePerGasCap = (338888888.toBigDecimal() * coeff).toLong().toULong()
+    val expectedMaxFeePerBlobGasCap =
+      (169444444.toBigDecimal() * coeff).coerceAtLeast(BigDecimal.ONE).toLong().toULong()
 
     assertThat(
       gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
@@ -20,7 +20,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
 @ExtendWith(VertxExtension::class)
-class GasPriceCapProviderImplTest {
+class GasPriceCapProviderImplV2Test {
   private val currentTime = Instant.parse("2024-03-20T00:00:00Z") // Wednesday
   private val gasFeePercentile = 10.0
   private val gasFeePercentileWindowInBlocks = 100U
@@ -55,13 +55,12 @@ class GasPriceCapProviderImplTest {
     blobAdjustmentConstant: UInt = this.adjustmentConstant,
     finalizationTargetMaxDelay: Duration = this.finalizationTargetMaxDelay,
     gasPriceCapsCoefficient: Double = this.gasPriceCapsCoefficient,
-    l2EthApiBlockClient: EthApiBlockClient = mockedL2EthApiBlockClient,
     feeHistoriesRepository: FeeHistoriesRepositoryWithCache = mockedL1FeeHistoriesRepository,
     gasPriceCapCalculator: GasPriceCapCalculator = this.gasPriceCapCalculator,
     clock: Clock = mockedClock,
-  ): GasPriceCapProviderImpl {
-    return GasPriceCapProviderImpl(
-      config = GasPriceCapProviderImpl.Config(
+  ): GasPriceCapProviderImplV2 {
+    return GasPriceCapProviderImplV2(
+      config = GasPriceCapProviderImplV2.Config(
         enabled = enabled,
         gasFeePercentile = gasFeePercentile,
         gasFeePercentileWindowInBlocks = gasFeePercentileWindowInBlocks,
@@ -72,7 +71,6 @@ class GasPriceCapProviderImplTest {
         finalizationTargetMaxDelay = finalizationTargetMaxDelay,
         gasPriceCapsCoefficient = gasPriceCapsCoefficient,
       ),
-      l2EthApiBlockClient = l2EthApiBlockClient,
       feeHistoriesRepository = feeHistoriesRepository,
       gasPriceCapCalculator = gasPriceCapCalculator,
       clock = clock,
@@ -147,11 +145,10 @@ class GasPriceCapProviderImplTest {
 
   @Test
   fun `gas price caps should be returned correctly`() {
-    val targetL2BlockNumber = 100L
     val gasPriceCapProvider = createGasPriceCapProvider()
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCaps(targetBlockTime).get(),
     ).isEqualTo(
       GasPriceCaps(
         maxBaseFeePerGasCap = 1694444444uL,
@@ -164,14 +161,13 @@ class GasPriceCapProviderImplTest {
 
   @Test
   fun `gas price caps with coefficient should be returned correctly`() {
-    val targetL2BlockNumber = 100L
     val gasPriceCapProvider = createGasPriceCapProvider()
     val expectedMaxBaseFeePerGasCap = (1694444444 * gasPriceCapsCoefficient).toULong()
     val expectedMaxPriorityFeePerGasCap = (338888888 * gasPriceCapsCoefficient).toULong()
     val expectedMaxFeePerBlobGasCap = (169444444 * gasPriceCapsCoefficient).toULong()
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),
     ).isEqualTo(
       GasPriceCaps(
         maxBaseFeePerGasCap = expectedMaxBaseFeePerGasCap,
@@ -184,75 +180,49 @@ class GasPriceCapProviderImplTest {
 
   @Test
   fun `gas price caps should be null if disabled`() {
-    val targetL2BlockNumber = 100L
     val gasPriceCapProvider = createGasPriceCapProvider(
       enabled = false,
     )
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCaps(targetBlockTime).get(),
     ).isNull()
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),
     ).isNull()
   }
 
   @Test
   fun `gas price caps should be null if not enough fee history data`() {
-    val targetL2BlockNumber = 100L
     val gasPriceCapProvider = createGasPriceCapProvider(
       gasFeePercentileWindowInBlocks = 200U,
     )
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCaps(targetBlockTime).get(),
     ).isNull()
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),
     ).isNull()
   }
 
   @Test
   fun `gas price caps should be null if error on feeHistoriesRepository`() {
-    val targetL2BlockNumber = 100L
     mockedL1FeeHistoriesRepository = mock<FeeHistoriesRepositoryWithCache> {
       on { getNumOfFeeHistoriesFromBlockNumber(any(), any()) } doReturn SafeFuture.failedFuture(
         Error("Throw error for testing"),
       )
     }
-    val gasPriceCapProvider = createGasPriceCapProvider(
-      l2EthApiBlockClient = mockedL2EthApiBlockClient,
-    )
+    val gasPriceCapProvider = createGasPriceCapProvider()
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCaps(targetBlockTime).get(),
     ).isNull()
 
     assertThat(
-      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber).get(),
-    ).isNull()
-  }
-
-  @Test
-  fun `gas price caps should be null if error on l2ExtendedWeb3JClient`() {
-    val targetL2BlockNumber = 100L
-    mockedL2EthApiBlockClient = mock<EthApiBlockClient> {
-      on { ethGetBlockByNumberTxHashes(any()) } doReturn SafeFuture.failedFuture(
-        Error("Throw error for testing"),
-      )
-    }
-    val gasPriceCapProvider = createGasPriceCapProvider(
-      l2EthApiBlockClient = mockedL2EthApiBlockClient,
-    )
-
-    assertThat(
-      gasPriceCapProvider.getGasPriceCaps(targetL2BlockNumber).get(),
-    ).isNull()
-
-    assertThat(
-      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetL2BlockNumber).get(),
+      gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),
     ).isNull()
   }
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
@@ -210,4 +210,15 @@ class GasPriceCapProviderImplV2Test {
       gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),
     ).isNull()
   }
+  @Test
+  fun `time of day multiplier should default to 1_0 when key is missing`() {
+    val baselineCaps = createGasPriceCapProvider().getGasPriceCaps(targetBlockTime).get()
+    val gasPriceCapProvider = createGasPriceCapProvider(
+      timeOfDayMultipliers = emptyMap(),
+    )
+
+    assertThat(
+      gasPriceCapProvider.getGasPriceCaps(targetBlockTime).get(),
+    ).isEqualTo(baselineCaps)
+  }
 }

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
@@ -210,6 +210,7 @@ class GasPriceCapProviderImplV2Test {
       gasPriceCapProvider.getGasPriceCapsWithCoefficient(targetBlockTime).get(),
     ).isNull()
   }
+
   @Test
   fun `time of day multiplier should default to 1_0 when key is missing`() {
     val baselineCaps = createGasPriceCapProvider().getGasPriceCaps(targetBlockTime).get()

--- a/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
+++ b/coordinator/ethereum/gas-pricing/dynamic-cap/src/test/kotlin/net/consensys/linea/ethereum/gaspricing/dynamiccap/GasPriceCapProviderImplV2Test.kt
@@ -1,19 +1,15 @@
 package net.consensys.linea.ethereum.gaspricing.dynamiccap
 
 import io.vertx.junit5.VertxExtension
-import linea.domain.createBlock
 import linea.domain.gas.GasPriceCaps
-import linea.domain.toBlockWithRandomTxHashes
-import linea.ethapi.EthApiBlockClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
-import tech.pegasys.teku.infrastructure.async.SafeFuture
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -41,7 +37,6 @@ class GasPriceCapProviderImplV2Test {
   private val gasPriceCapCalculator = GasPriceCapCalculatorImpl()
 
   private lateinit var targetBlockTime: Instant
-  private lateinit var mockedL2EthApiBlockClient: EthApiBlockClient
   private lateinit var mockedL1FeeHistoriesRepository: FeeHistoriesRepositoryWithCache
   private lateinit var mockedClock: Clock
 
@@ -80,15 +75,6 @@ class GasPriceCapProviderImplV2Test {
   @BeforeEach
   fun beforeEach() {
     targetBlockTime = currentTime - 1.hours
-    val mockBlock = createBlock(
-      timestamp = targetBlockTime,
-    ).toBlockWithRandomTxHashes()
-
-    mockedL2EthApiBlockClient = mock<EthApiBlockClient> {
-      on { ethGetBlockByNumberTxHashes(any()) } doReturn SafeFuture.completedFuture(
-        mockBlock,
-      )
-    }
 
     mockedL1FeeHistoriesRepository = mock<FeeHistoriesRepositoryWithCache> {
       on { getCachedNumOfFeeHistoriesFromBlockNumber() } doReturn storedFeeHistoriesNum
@@ -211,9 +197,8 @@ class GasPriceCapProviderImplV2Test {
   @Test
   fun `gas price caps should be null if error on feeHistoriesRepository`() {
     mockedL1FeeHistoriesRepository = mock<FeeHistoriesRepositoryWithCache> {
-      on { getNumOfFeeHistoriesFromBlockNumber(any(), any()) } doReturn SafeFuture.failedFuture(
-        Error("Throw error for testing"),
-      )
+      on { getCachedNumOfFeeHistoriesFromBlockNumber() } doReturn storedFeeHistoriesNum
+      on { getCachedPercentileGasFees() } doThrow RuntimeException("Throw error for testing")
     }
     val gasPriceCapProvider = createGasPriceCapProvider()
 

--- a/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/TypingsExtensions.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/TypingsExtensions.kt
@@ -17,10 +17,11 @@ fun Double.tokWeiUInt(): UInt = (this / OneKWei).toUInt()
 fun Double.toKWei(): Double = this / OneKWei
 
 // BigDecimal extensions
-fun BigDecimal.roundUpToBigInteger(): BigInteger = this.setScale(0, RoundingMode.HALF_UP).toBigInteger()
+fun BigDecimal.toBigIntegerHalfUp(): BigInteger = this.setScale(0, RoundingMode.HALF_UP).toBigInteger()
 fun BigDecimal.toGWei(): BigDecimal = this.divide(OneGWeiBigDecimal, MathContext.DECIMAL128)
 fun BigDecimal.toKWei(): BigDecimal = this.divide(OneKWeiBigDecimal, MathContext.DECIMAL128)
-fun BigDecimal.toUInt(): UInt = this.roundUpToBigInteger().toUInt()
+fun BigDecimal.toUInt(): UInt = this.toBigIntegerHalfUp().toUInt()
+fun BigDecimal.toULong(): ULong = this.toBigIntegerHalfUp().toULong()
 
 // BigInteger extensions
 fun BigInteger.multiply(multiplicand: Double): BigInteger = this.toBigDecimal()

--- a/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/UIntExtensions.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/UIntExtensions.kt
@@ -1,0 +1,9 @@
+package linea.kotlin
+
+fun UInt.minusCoercingUnderflow(other: UInt): UInt {
+  return if (this > other) {
+    this - other
+  } else {
+    0U
+  }
+}

--- a/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/ULongExtensions.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/main/kotlin/linea/kotlin/ULongExtensions.kt
@@ -2,6 +2,7 @@ package linea.kotlin
 
 import linea.OneEth
 import linea.OneGWei
+import java.math.BigDecimal
 import java.math.BigInteger
 
 fun ULong.toKWeiUInt(): UInt = this.toDouble().tokWeiUInt()
@@ -27,6 +28,7 @@ private fun ULong.toByteArray(): ByteArray =
  */
 fun ULong.Companion.fromHexString(value: String): ULong = value.removePrefix("0x").toULong(16)
 fun ULong.toBigInteger(): BigInteger = BigInteger(this.toString())
+fun ULong.toBigDecimal(): BigDecimal = BigDecimal(this.toString())
 fun ULong.toHexString(hexPrefix: Boolean = true): String = this.toString(16).let {
   if (hexPrefix) {
     "0x$it"

--- a/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/TypingsExtensionsTest.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/TypingsExtensionsTest.kt
@@ -3,6 +3,7 @@ package linea.kotlin
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
 import java.math.BigInteger
 
 class TypingsExtensionsTest {
@@ -19,6 +20,31 @@ class TypingsExtensionsTest {
     assertThat(0UL.toBigInteger()).isEqualTo(BigInteger.valueOf(0))
     assertThat(123UL.toBigInteger()).isEqualTo(BigInteger.valueOf(123))
     assertThat(ULong.MAX_VALUE.toBigInteger()).isEqualTo(BigInteger(ULong.MAX_VALUE.toString(), 10))
+  }
+
+  @Test
+  fun `BigDecimal#toBigIntegerHalfUp rounds half-up`() {
+    // exact integers are unchanged
+    assertThat(BigDecimal("0").toBigIntegerHalfUp()).isEqualTo(BigInteger.ZERO)
+    assertThat(BigDecimal("1").toBigIntegerHalfUp()).isEqualTo(BigInteger.ONE)
+    assertThat(BigDecimal("-1").toBigIntegerHalfUp()).isEqualTo(BigInteger.valueOf(-1))
+
+    // values with fractional part < 0.5 round down
+    assertThat(BigDecimal("1.4").toBigIntegerHalfUp()).isEqualTo(BigInteger.ONE)
+    assertThat(BigDecimal("-1.4").toBigIntegerHalfUp()).isEqualTo(BigInteger.valueOf(-1))
+
+    // values exactly at 0.5 round up (HALF_UP)
+    assertThat(BigDecimal("1.5").toBigIntegerHalfUp()).isEqualTo(BigInteger.TWO)
+    assertThat(BigDecimal("-1.5").toBigIntegerHalfUp()).isEqualTo(BigInteger.valueOf(-2))
+
+    // values with fractional part > 0.5 round up
+    assertThat(BigDecimal("1.6").toBigIntegerHalfUp()).isEqualTo(BigInteger.TWO)
+    assertThat(BigDecimal("-1.6").toBigIntegerHalfUp()).isEqualTo(BigInteger.valueOf(-2))
+
+    // large value
+    val large = BigDecimal("${ULong.MAX_VALUE}.5")
+    assertThat(large.toBigIntegerHalfUp())
+      .isEqualTo(BigInteger(ULong.MAX_VALUE.toString()) + BigInteger.ONE)
   }
 
   @Test

--- a/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/UIntExtensionsTest.kt
+++ b/jvm-libs/generic/extensions/kotlin/src/test/kotlin/linea/kotlin/UIntExtensionsTest.kt
@@ -1,0 +1,20 @@
+package linea.kotlin
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UIntExtensionsTest {
+  @Test
+  fun `minusCoercingUnderflow should return the difference when minuend is greater than subtrahend`() {
+    assertThat(10U.minusCoercingUnderflow(5U)).isEqualTo(5U)
+  }
+
+  @Test
+  fun `minusCoercingUnderflow should return zero when minuend is less than subtrahend`() {
+    assertThat(5U.minusCoercingUnderflow(10U)).isEqualTo(0U)
+  }
+
+  @Test
+  fun `minusCoercingUnderflow should return zero when minuend is equal to subtrahend`() {
+    assertThat(5U.minusCoercingUnderflow(5U)).isEqualTo(0U)
+  }
+}

--- a/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/gas/GasPriceCaps.kt
+++ b/jvm-libs/linea/core/domain-models/src/main/kotlin/linea/domain/gas/GasPriceCaps.kt
@@ -10,11 +10,7 @@ data class GasPriceCaps(
 ) {
   override fun toString(): String {
     return "maxPriorityFeePerGasCap=${maxPriorityFeePerGasCap.toGWei()} GWei," +
-      if (maxBaseFeePerGasCap != null) {
-        " maxBaseFeePerGasCap=${maxBaseFeePerGasCap.toGWei()} GWei,"
-      } else {
-        ""
-      } +
+      " maxBaseFeePerGasCap=${maxBaseFeePerGasCap?.toGWei()?.let { "$it GWei" }} " +
       " maxFeePerGasCap=${maxFeePerGasCap.toGWei()} GWei," +
       " maxFeePerBlobGasCap=${maxFeePerBlobGasCap.toGWei()} GWei"
   }


### PR DESCRIPTION
This PR implements issue(s) #3088 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes L1 gas price cap calculation and coercion paths used for blob submission and finalization; behavior shifts (logging, multiplier defaults, zero coercion) could affect fee limits in edge cases.
> 
> **Overview**
> Introduces **`GasPriceCapProviderV2`** with **`Instant`**-based cap lookup and moves dynamic cap math into **`GasPriceCapProviderImplV2`**. **`GasPriceCapProviderImpl`** now resolves the L2 block timestamp and delegates to that V2 implementation; block fetch failures log at **warn** and return **null** instead of failing the whole future.
> 
> **`GasPriceCapProviderWithHardCaps`** centralizes hard-cap coercion, optional **`capMultiplier`**, and metrics. **`GasPriceCapProviderForDataSubmission`** and **`GasPriceCapProviderForFinalization`** are thin delegates over it (finalization still forces blob cap to **0**).
> 
> V2 behavior tweaks: missing time-of-day multiplier keys default to **1.0** (with info log); coefficient scaling uses **`BigDecimal`** via new **`toULong`/`toBigDecimal`** helpers and **`UInt.minusCoercingUnderflow`** for the fee-history window check. Zero-after-coerce hard-cap fallback now treats only **`0uL`** as invalid (not **`<= 0`**). Tests add **`GasPriceCapProviderImplV2Test`** and adjust **`GasPriceCapProviderImpl`** fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be01d7393208e509abcb1f33e519b687dd0114a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->