### PR TITLE
chore(misc): try to improv gradle cache issues

### DIFF
--- a/.github/actions/setup-java-and-gradle/action.yml
+++ b/.github/actions/setup-java-and-gradle/action.yml
@@ -23,6 +23,10 @@ runs:
         # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
         # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Non-main branches read from the main branch's warm cache but don't write new entries,
+          # reducing Maven Central dependency fetches and avoiding 429 rate-limit errors.
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
 
 


### PR DESCRIPTION
This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application code or runtime behavior changes, with the main tradeoff being slightly less cache freshness on non-main branches.
> 
> **Overview**
> Updates the shared **Setup Java and Gradle** composite action so `gradle/actions/setup-gradle` runs with **`cache-read-only: true` on every ref except `main`**.
> 
> **`main`** keeps read/write cache behavior so it can warm entries for the rest of the repo. **Feature branches and PRs** only consume that cache, which is intended to cut repeated Maven Central downloads and reduce **HTTP 429** rate-limit failures in CI.
> 
> Every workflow that uses `./.github/actions/setup-java-and-gradle` (tests, CodeQL, coordinator builds, releases, etc.) picks up this behavior automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa78a1984348a7835d711fb631ac52d642d1a33a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->