### PR TITLE
ci(coordinator): enforce config docs in CI/pre-commit and publish docs artifact on release

### DIFF
--- a/.github/workflows/coordinator-build-and-publish.yml
+++ b/.github/workflows/coordinator-build-and-publish.yml
@@ -65,6 +65,26 @@ jobs:
       - name: Build dist
         run: ./gradlew coordinator:app:installDist
 
+      # For published images (releases and develop): verify the config is documented and
+      # regenerate the reference docs so they can be attached to the image as an artifact.
+      - name: Generate coordinator config docs
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        run: |
+          ./gradlew -V :coordinator:app:checkConfigDocs :coordinator:app:generateConfigDocs
+          # Stage flat so the files sit at the artifact root (not under docs/tech/components/).
+          mkdir -p "${{ runner.temp }}/coordinator-config-docs"
+          cp docs/tech/components/coordinator-config-reference.md \
+             docs/tech/components/coordinator-config-schema.json \
+             "${{ runner.temp }}/coordinator-config-docs/"
+
+      - name: Upload coordinator config docs
+        if: ${{ env.PUSH_IMAGE == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coordinator-config-docs-${{ env.IMAGE_TAG_WITH_SUFFIX != '' && env.IMAGE_TAG_WITH_SUFFIX || env.IMAGE_TAG }}
+          path: ${{ runner.temp }}/coordinator-config-docs
+          if-no-files-found: error
+
       - name: Build and publish Docker image
         uses: ./.github/actions/docker-build-publish
         with:

--- a/.github/workflows/coordinator-testing.yml
+++ b/.github/workflows/coordinator-testing.yml
@@ -46,6 +46,15 @@ jobs:
       - name: Build coordinator and Unit tests
         run: |
           ./gradlew -V coordinator:app:buildNeeded
+      - name: Verify generated coordinator config docs are up to date
+        run: |
+          ./gradlew -V :coordinator:app:generateConfigDocs
+          if ! git diff --exit-code -- \
+              docs/tech/components/coordinator-config-reference.md \
+              docs/tech/components/coordinator-config-schema.json; then
+            echo "::error::Coordinator config docs are out of date. Run './gradlew :coordinator:app:generateConfigDocs' and commit the changes."
+            exit 1
+          fi
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0

--- a/.husky/pre-commit.js
+++ b/.husky/pre-commit.js
@@ -88,6 +88,15 @@ const FOLDER_RUNTIME = {
     [FOLDER["SDK-VIEM"]]: RUNTIME.NODEJS,
 };
 
+// Paths that affect whether every Coordinator config key is documented. When any of these change,
+// the pre-commit hook verifies documentation completeness so undocumented keys never get committed.
+const COORDINATOR_CONFIG_DOCS_PATHS = [
+    "^coordinator/app/src/main/kotlin/linea/coordinator/config/v2/toml/",
+    "^coordinator/app/src/configDocs/",
+    "^jvm-libs/linea/config-docs/",
+    "^buildSrc/src/main/groovy/ConfigDocs",
+];
+
 /**
  * MAIN FUNCTION
  */
@@ -108,7 +117,29 @@ function main() {
         executeCommand(folder, changedFileExtensions, FILE_EXTENSION_DOCUMENTATION_UPDATING_COMMAND);
     }
 
+    checkCoordinatorConfigDocs(changedFileList);
+
     updateGitIndex();
+}
+
+/**
+ * Runs `:coordinator:app:checkConfigDocs` when any config schema / config-docs tooling file
+ * changed, aborting the commit if a config key is missing @ConfigDoc / @ConfigSection.
+ * @param {string[]} _changedFileList
+ */
+function checkCoordinatorConfigDocs(_changedFileList) {
+    const relevant = _changedFileList.some(
+        file => COORDINATOR_CONFIG_DOCS_PATHS.some(pattern => file.match(new RegExp(pattern))));
+    if (!relevant) return;
+
+    console.log("Coordinator config changed, verifying documentation (checkConfigDocs)...");
+    try {
+        execSync("./gradlew :coordinator:app:checkConfigDocs", { stdio: 'inherit' });
+    } catch (error) {
+        console.error("checkConfigDocs failed: every config key must have @ConfigDoc / @ConfigSection.");
+        console.error("Exiting...");
+        process.exit(1);
+    }
 }
 
 /**

--- a/buildSrc/src/main/groovy/ConfigDocsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ConfigDocsPlugin.groovy
@@ -42,13 +42,16 @@ class ConfigDocsPlugin implements Plugin<Project> {
       spec
     }
 
-    project.tasks.register('checkConfigDocs', JavaExec) {
+    def checkConfigDocs = project.tasks.register('checkConfigDocs', JavaExec) {
       it.group = 'verification'
       it.description = 'Verifies that every config key is documented.'
       it.classpath = configDocs.runtimeClasspath
       it.mainClass.set('linea.config.docs.ConfigDocsCheckMain')
       it.argumentProviders.add({ [specProvider.get()] } as org.gradle.process.CommandLineArgumentProvider)
     }
+
+    // Enforce documentation completeness as part of `check` (and therefore CI's buildNeeded).
+    project.tasks.matching { it.name == 'check' }.configureEach { it.dependsOn(checkConfigDocs) }
 
     project.tasks.register('generateConfigDocs', JavaExec) {
       it.group = 'documentation'


### PR DESCRIPTION
## Summary

Enforce Coordinator config documentation in CI and locally, and attach the generated reference to published images. Builds on the merged `config-docs` tooling (module + `linea.config-docs` plugin + annotations + committed `docs/tech/components/coordinator-config-{reference.md,schema.json}`).

## Changes

**Validation on every PR** — the `linea.config-docs` plugin now wires `checkConfigDocs` into `check`. The existing `coordinator-testing` job runs `coordinator:app:buildNeeded` → `check`, so it fails any coordinator PR that adds an undocumented config key. No new workflow; gated by the existing `coordinator` path filter.

**Stale-check on every PR** — `coordinator-testing.yml` regenerates the docs and fails if the committed `coordinator-config-reference.md` / `coordinator-config-schema.json` are out of date, pointing the author at `./gradlew :coordinator:app:generateConfigDocs`.

**Pre-commit hook** — runs `checkConfigDocs` locally, but only when config schema or config-docs tooling files change (`coordinator/app/src/main/.../config/v2/toml/`, `.../configDocs/`, `jvm-libs/linea/config-docs/`, `buildSrc/.../ConfigDocs*`), so ordinary commits stay fast.

**Release artifact** — in `coordinator-build-and-publish.yml`, for published images (`push_image == true`; local/e2e builds skipped) the job runs `checkConfigDocs` + `generateConfigDocs` before publishing and uploads the JSON + Markdown as `coordinator-config-docs-<image-tag>` (uses `image_tag_with_suffix` when set). Files are staged flat so they sit at the artifact root.

## Test plan

- `./gradlew :coordinator:app:check --dry-run` — `checkConfigDocs` is in the `check` graph.
- `./gradlew :coordinator:app:generateConfigDocs` — reports "Up to date" (stale-check passes on a clean tree).
- Pre-commit hook exercised on commit: ran `checkConfigDocs` → "Config docs OK: 451 keys, all documented".
- Both workflow YAMLs validated.

## Notes

- The doc check runs before the docker publish, so a documentation failure blocks the image.
- No changes to `main.yml` (its `coordinator` path filter already covers `coordinator/**`, `jvm-libs/**`, `buildSrc/**`).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI, pre-commit, and Gradle wiring only; no runtime coordinator behavior or production config handling changes.
> 
> **Overview**
> **Coordinator config documentation** is now enforced end-to-end: every key must be annotated, generated reference files must match the repo, and release builds attach the docs as a CI artifact.
> 
> The `linea.config-docs` plugin **hooks `checkConfigDocs` into Gradle `check`**, so existing `coordinator:app:buildNeeded` in PR CI already fails on undocumented keys. **`coordinator-testing`** adds a follow-up step that runs `generateConfigDocs` and fails if `coordinator-config-reference.md` / `coordinator-config-schema.json` drift from what Gradle would produce.
> 
> **Pre-commit** runs `checkConfigDocs` only when config schema or config-docs tooling paths change, avoiding extra Gradle work on unrelated commits.
> 
> For **published images** (`PUSH_IMAGE`), the build-and-publish workflow runs `checkConfigDocs` + `generateConfigDocs` before Docker publish and uploads the Markdown and JSON as a flat `coordinator-config-docs-<tag>` artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef06e50829c339e70065599613348838f30708eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->