### PR TITLE
chore(misc): seed gradle cache on main and clean up stale pr caches

### DIFF
--- a/.github/gradle/resolve-all-dependencies.init.gradle
+++ b/.github/gradle/resolve-all-dependencies.init.gradle
@@ -1,0 +1,16 @@
+// Registers a resolveAllDependencies task in every project so the cache seed
+// workflow can download the full dependency graph without compiling anything.
+allprojects {
+  tasks.register("resolveAllDependencies") {
+    notCompatibleWithConfigurationCache("resolves configurations eagerly")
+    doLast {
+      configurations.matching { it.canBeResolved }.each { cfg ->
+        try {
+          cfg.incoming.artifactView { lenient(true) }.files.each { }
+        } catch (Exception e) {
+          logger.lifecycle("Skipped ${project.path}:${cfg.name}: ${e.message}")
+        }
+      }
+    }
+  }
+}

--- a/.github/gradle/resolve-all-dependencies.init.gradle
+++ b/.github/gradle/resolve-all-dependencies.init.gradle
@@ -1,5 +1,7 @@
 // Registers a resolveAllDependencies task in every project so the cache seed
-// workflow can download the full dependency graph without compiling anything.
+// workflow can download every configuration's dependency artifacts without
+// running any compilation. Only loaded when passed via --init-script, so it
+// has no effect on regular builds.
 allprojects {
   tasks.register("resolveAllDependencies") {
     notCompatibleWithConfigurationCache("resolves configurations eagerly")

--- a/.github/workflows/actions-cache-cleanup.yml
+++ b/.github/workflows/actions-cache-cleanup.yml
@@ -1,0 +1,49 @@
+name: actions-cache-cleanup
+
+permissions:
+  actions: write
+  contents: read
+
+# The repo's Actions cache sits at the 10GB cap, mostly duplicated per-PR
+# zig, CodeQL and node entries, which evicts the shared Gradle cache within
+# hours of it being written. Frees PR cache entries so main's caches survive.
+on:
+  pull_request_target:
+    types:
+      - closed
+  schedule:
+    - cron: "43 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  cleanup-closed-pr:
+    if: github.event_name == 'pull_request_target'
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
+    timeout-minutes: 10
+    steps:
+      - name: Delete caches of the closed PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          for ref in "refs/pull/${PR}/merge" "refs/pull/${PR}/head"; do
+            gh cache list --repo "$REPO" --ref "$ref" --limit 100 --json id --jq '.[].id' \
+              | while read -r id; do gh cache delete "$id" --repo "$REPO" || true; done
+          done
+
+  sweep-stale-pr-caches:
+    if: github.event_name != 'pull_request_target'
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-small
+    timeout-minutes: 10
+    steps:
+      - name: Delete PR caches not accessed for 3 days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --paginate "repos/${REPO}/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | select(.ref | startswith("refs/pull/")) | select((.last_accessed_at | fromdateiso8601) < (now - 259200)) | .id' \
+            | while read -r id; do
+                gh api -X DELETE "repos/${REPO}/actions/caches/${id}" || true
+              done

--- a/.github/workflows/gradle-cache-seed.yml
+++ b/.github/workflows/gradle-cache-seed.yml
@@ -1,0 +1,41 @@
+name: gradle-cache-seed
+
+permissions:
+  contents: read
+  actions: read
+
+# Keeps a warm Gradle dependency cache available on main at all times.
+# PR jobs restore it read-only, so without this workflow the cache disappears
+# whenever the repo's 10GB Actions cache budget evicts it, and every job then
+# downloads the full dependency graph from Maven Central and hits 429 rate limits.
+on:
+  schedule:
+    - cron: "17 */4 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - "gradle/**"
+      - "gradle.properties"
+      - "settings.gradle"
+      - "**/*.gradle"
+      - "**/*.gradle.kts"
+  workflow_dispatch:
+
+concurrency:
+  group: gradle-cache-seed
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-and-gradle
+
+      - name: Resolve all dependencies
+        run: ./gradlew --init-script .github/gradle/resolve-all-dependencies.init.gradle resolveAllDependencies


### PR DESCRIPTION
## Problem

All PRs are failing with `Received status code 429 from server: Too Many Requests` from `repo.maven.apache.org` during dependency resolution.

Root cause chain:

1. The repo's Actions cache sits at exactly **10.0 GB, the hard GitHub cap**, dominated by duplicated per-PR entries (5x 344MB zig caches, 2x 677MB CodeQL, 3x 229MB node caches on `refs/pull/*` refs).
2. GitHub LRU-evicts to stay under the cap, and the Gradle caches get wiped within hours of being written. This morning's PR jobs logged `Gradle User Home cache not found. Will initialize empty` while **zero** Gradle cache entries existed in the repo, even though yesterday's main run at 20:53 UTC saved them successfully.
3. Every job then downloads the full dependency graph from Maven Central. The self-hosted runner fleet egresses through shared NAT IPs, so Sonatype's per-IP rate limit trips fleet-wide.
4. Once evicted, the cache cannot come back on its own: PR jobs are read-only, and main only writes when a push touches Gradle-built paths. #3629 set `cache-read-only` to setup-gradle's existing default, and its own merge commit skipped the Gradle test jobs entirely, so nothing changed.

## Fix

**`gradle-cache-seed.yml`** reseeds a warm Gradle cache from main every 4 hours (plus on pushes touching Gradle files, plus manual dispatch). It uses a lenient resolve-only init script that downloads every resolvable configuration of every project without compiling, covering runtime and test configurations too. Validated with `--dry-run`: the task registers across all projects including the linea-besu tree.

**`actions-cache-cleanup.yml`** reduces the eviction pressure itself: deletes a PR's caches when it closes (`pull_request_target` on the closed event runs in base context with no PR code checked out), and a daily sweep removes any `refs/pull/*` cache not accessed for 3 days. This frees several GB so main's caches stop being evicted.

## After merging

Trigger `gradle-cache-seed` once via workflow_dispatch to seed immediately instead of waiting for the first cron tick.