### PR TITLE
fix(e2e): run jest teardown on SIGINT and SIGTERM

### DIFF
--- a/e2e/src/config/jest/global-setup.ts
+++ b/e2e/src/config/jest/global-setup.ts
@@ -9,15 +9,15 @@ import { globalTeardown } from "./global-teardown";
 
 const logger = createTestLogger();
 
-let isForcefullyShuttingDown = false;
+let shutdownAlreadyTried = false;
 async function handleForcedShutdown(signal: NodeJS.Signals) {
   // In case of a forced shutdown, prevent another cleanup being run
-  if (isForcefullyShuttingDown) {
+  if (shutdownAlreadyTried) {
     process.exit(constants.signals[signal] ?? 1);
   }
 
   logger.info("Forcefully shutting down, stopping background processes...");
-  isForcefullyShuttingDown = true;
+  shutdownAlreadyTried = true;
 
   try {
     await globalTeardown();

--- a/e2e/src/config/jest/global-setup.ts
+++ b/e2e/src/config/jest/global-setup.ts
@@ -1,10 +1,32 @@
+import { constants } from "node:os";
+
 import { createTestLogger } from "../logger";
 import { ensureOnceOffPrerequisites } from "./prerequisites";
 import { startL2TrafficGeneration } from "./traffic";
 import { setStopL2TrafficGeneration } from "./traffic-state";
 import { createTestContext } from "../setup";
+import { globalTeardown } from "./global-teardown";
 
 const logger = createTestLogger();
+
+let isForcefullyShuttingDown = false;
+async function handleForcedShutdown(signal: NodeJS.Signals) {
+  // In case of a forced shutdown, prevent another cleanup being run
+  if (isForcefullyShuttingDown) {
+    process.exit(constants.signals[signal] ?? 1);
+  }
+
+  logger.info("Forcefully shutting down, stopping background processes...");
+  isForcefullyShuttingDown = true;
+
+  try {
+    await globalTeardown();
+  } catch (error) {
+    logger.error(`Failed to run teardown successfully, ${error}`);
+  } finally {
+    process.exit(constants.signals[signal] ?? 1);
+  }
+}
 
 export default async (): Promise<void> => {
   const context = createTestContext();
@@ -16,4 +38,7 @@ export default async (): Promise<void> => {
   logger.info("L2 traffic generation started.");
 
   setStopL2TrafficGeneration(stopPolling);
+
+  process.on("SIGINT", (signal) => handleForcedShutdown(signal));
+  process.on("SIGTERM", (signal) => handleForcedShutdown(signal));
 };

--- a/e2e/src/config/jest/global-teardown.ts
+++ b/e2e/src/config/jest/global-teardown.ts
@@ -4,10 +4,14 @@ import { createTestLogger } from "../logger";
 const logger = createTestLogger();
 
 export default async (): Promise<void> => {
+  await globalTeardown();
+};
+
+export async function globalTeardown() {
   try {
     await stopL2TrafficGeneration();
   } catch (error) {
     logger.error(`Error stopping L2 traffic generation: ${error}`);
     // Don't throw - teardown failures shouldn't mask test failures
   }
-};
+}


### PR DESCRIPTION
This PR implements issue(s) #3631

### Details

When e2e tests are ran, during the [global setup](https://github.com/LFDT-Lineth/lineth-monorepo/blob/cf75766ec29006561528f4d7f031c4afbb86613b/e2e/src/config/jest/global-setup.ts) inside Jest, a background service for generating traffic on the L2 is started.
This background process currently ends only after Jest finishes with the whole test suite and runs the `stopL2TrafficGeneration()` function inside [`global-teardown.ts`](https://github.com/LFDT-Lineth/lineth-monorepo/blob/cf75766ec29006561528f4d7f031c4afbb86613b/e2e/src/config/jest/global-teardown.ts).

The test suite should be aware of forced process cancellations such as SIGTERM and SIGINT. Only these two are explicitly handled on purpose as they are the only termination signals which leave room for proper resource cleanup, others lead to forced termination. (see more [here](https://nodejs.org/api/process.html#signal-events))

In case of a hurry and repeated initiation of SIGINT (CTRL+C spamming), the code allows for termination without proper cleanup [here](https://github.com/LFDT-Lineth/lineth-monorepo/blob/cf75766ec29006561528f4d7f031c4afbb86613b/e2e/src/config/jest/global-setup.ts#L15).

### Checklist

* [ ] I wrote new tests for my new core changes.
* [x] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
