### PR TITLE
fix(coordinator): dead code, SSRF gap, finalization handler isolation, concurrency races

### DIFF
--- a/coordinator/app/src/main/kotlin/linea/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/api/dto/ConflationCreateProverRequestJsonDto.kt
@@ -30,6 +30,18 @@ data class ConflationCreateProverRequestJsonDto(
   )
 
   fun toDomainObject(): ConflationBacktestingConfig {
+    // startBlockNumber/endBlockNumber/batchesFixedSize are caller-supplied Longs/Ints converted to
+    // ULong/UInt below. That conversion is a bit-reinterpretation, not a range check, so a negative
+    // input silently becomes a huge unsigned value (e.g. -1 -> ULong.MAX_VALUE) instead of being
+    // rejected. Validate on the signed values first, before any unsigned arithmetic is done downstream
+    // (ConflationBacktestingApp computes startBlockNumber - 1uL, which underflows if startBlockNumber == 0).
+    require(startBlockNumber >= 1) { "startBlockNumber must be >= 1, got $startBlockNumber" }
+    require(endBlockNumber >= startBlockNumber) {
+      "endBlockNumber ($endBlockNumber) must be >= startBlockNumber ($startBlockNumber)"
+    }
+    batchesFixedSize?.let {
+      require(it > 0) { "batchesFixedSize must be > 0 when set, got $it" }
+    }
     return ConflationBacktestingConfig(
       startBlockNumber = this.startBlockNumber.toULong(),
       endBlockNumber = this.endBlockNumber.toULong(),

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/L1RelayingAppV1.kt
@@ -260,7 +260,11 @@ class L1RelayingAppV1(
         lineaSmartContractClient = lineaSmartContractClientForDataSubmission,
         gasPriceCapProvider = gasPriceCapProviderForDataSubmission,
         alreadySubmittedBlobsFilter = alreadySubmittedBlobsFilter,
-        blobSubmittedEventDispatcher = EventDispatcher(blobSubmittedEventConsumers),
+        blobSubmittedEventDispatcher = EventDispatcher(
+          consumers = blobSubmittedEventConsumers,
+          metricsFacade = metricsFacade,
+          metricsCategory = LineaMetricsCategory.BLOB,
+        ),
         vertx = vertx,
         clock = Clock.System,
       )
@@ -319,7 +323,11 @@ class L1RelayingAppV1(
         aggregationSubmitter = AggregationSubmitterImpl(
           lineaSmartContractClient = lineaSmartContractClientForFinalization,
           gasPriceCapProvider = gasPriceCapProviderForFinalization,
-          aggregationSubmittedEventConsumer = EventDispatcher(submittedFinalizationConsumers),
+          aggregationSubmittedEventConsumer = EventDispatcher(
+            consumers = submittedFinalizationConsumers,
+            metricsFacade = metricsFacade,
+            metricsCategory = LineaMetricsCategory.AGGREGATION,
+          ),
         ),
         vertx = vertx,
         clock = Clock.System,

--- a/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
+++ b/coordinator/app/src/main/kotlin/linea/coordinator/app/conflationbacktesting/ConflationBacktestingService.kt
@@ -39,6 +39,7 @@ class ConflationBacktestingService(
   private val conflationBackTestingApps: MutableMap<String, ConflationBacktestingApp> = ConcurrentHashMap()
 
   fun submitConflationBacktestingJob(conflationBacktestingConfig: ConflationBacktestingConfig): String {
+    validateRequestedApiHostsAreAllowed(conflationBacktestingConfig)
     val jobId = conflationBacktestingConfig.jobId()
     val app = ConflationBacktestingApp(
       vertx = vertx,
@@ -63,6 +64,31 @@ class ConflationBacktestingService(
       log.error("Conflation backtesting job failed: jobId={}, errorMessage={}", jobId, error.message, error)
     }
     return jobId
+  }
+
+  /**
+   * The tracesApi/shomeiApi endpoints on an incoming request are caller-supplied, and this service
+   * uses them to make outbound HTTP requests. Without this check a caller could point the coordinator
+   * at an arbitrary host (SSRF), so requests are restricted to hosts already trusted elsewhere in this
+   * coordinator's own config (configs.traces / configs.stateManager).
+   */
+  private fun validateRequestedApiHostsAreAllowed(conflationBacktestingConfig: ConflationBacktestingConfig) {
+    val allowedHosts = buildSet {
+      configs.traces.common?.endpoints?.forEach { add(it.host) }
+      configs.traces.counters?.endpoints?.forEach { add(it.host) }
+      configs.traces.conflation?.endpoints?.forEach { add(it.host) }
+      configs.stateManager.endpoints.forEach { add(it.host) }
+    }
+    val requestedHosts = listOfNotNull(
+      conflationBacktestingConfig.tracesApi.endpoint.host,
+      conflationBacktestingConfig.tracesConflationApi?.endpoint?.host,
+      conflationBacktestingConfig.shomeiApi.endpoint.host,
+    )
+    val disallowedHosts = requestedHosts.filterNot { it in allowedHosts }
+    require(disallowedHosts.isEmpty()) {
+      "Requested API host(s) are not in the allowlist of configured traces/stateManager hosts: " +
+        "disallowedHosts=$disallowedHosts allowedHosts=$allowedHosts"
+    }
   }
 
   fun getConflationBacktestingJobStatus(jobId: String): ConflationBacktestingJobStatus {

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaRollupSmartContractClient.kt
@@ -171,26 +171,6 @@ class Web3JLineaRollupSmartContractClient internal constructor(
       }
   }
 
-  override fun finalizeBlocksEthCall(
-    aggregation: ProofToFinalize,
-    aggregationLastBlob: BlobRecord,
-    parentL1RollingHash: ByteArray,
-    parentL1RollingHashMessageNumber: Long,
-  ): SafeFuture<String?> {
-    return getVersion()
-      .thenCompose { version ->
-        val function =
-          Web3JLineaRollupFunctionBuilders.buildFinalizeBlocksFunction(
-            version,
-            aggregation,
-            aggregationLastBlob,
-            parentL1RollingHash,
-            parentL1RollingHashMessageNumber,
-          )
-        web3jContractHelper.executeEthCall(function)
-      }
-  }
-
   override fun finalizeBlocksAfterEthCall(
     aggregation: ProofToFinalize,
     aggregationLastBlob: BlobRecord,

--- a/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaValidiumSmartContractClient.kt
+++ b/coordinator/clients/smart-contract-client/src/main/kotlin/net/consensys/linea/contract/l1/Web3JLineaValidiumSmartContractClient.kt
@@ -125,26 +125,6 @@ class Web3JLineaValidiumSmartContractClient(
       }
   }
 
-  override fun finalizeBlocksEthCall(
-    aggregation: ProofToFinalize,
-    aggregationLastBlob: BlobRecord,
-    parentL1RollingHash: ByteArray,
-    parentL1RollingHashMessageNumber: Long,
-  ): SafeFuture<String?> {
-    return getVersion()
-      .thenCompose { version ->
-        val function =
-          Web3JLineaValidiumFunctionBuilders.buildFinalizeBlocksFunction(
-            version,
-            aggregation,
-            aggregationLastBlob,
-            parentL1RollingHash,
-            parentL1RollingHashMessageNumber,
-          )
-        web3jContractHelper.executeEthCall(function)
-      }
-  }
-
   override fun finalizeBlocksAfterEthCall(
     aggregation: ProofToFinalize,
     aggregationLastBlob: BlobRecord,

--- a/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
+++ b/coordinator/core-interfaces/src/main/kotlin/linea/contract/l1/LineaRollupSmartContractClient.kt
@@ -171,14 +171,6 @@ interface LineaSmartContractClient : LineaSmartContractClientReadOnly {
    */
   fun updateNonceAndReferenceBlockToLastL1Block(): SafeFuture<BlockAndNonce>
 
-  // TODO: not used, shall be removed
-  fun finalizeBlocksEthCall(
-    aggregation: ProofToFinalize,
-    aggregationLastBlob: BlobRecord,
-    parentL1RollingHash: ByteArray,
-    parentL1RollingHashMessageNumber: Long,
-  ): SafeFuture<String?>
-
   fun finalizeBlocks(
     aggregation: ProofToFinalize,
     aggregationLastBlob: BlobRecord,

--- a/coordinator/core/src/main/kotlin/linea/conflation/calculators/GlobalAggregationCalculator.kt
+++ b/coordinator/core/src/main/kotlin/linea/conflation/calculators/GlobalAggregationCalculator.kt
@@ -38,12 +38,17 @@ class GlobalAggregationCalculator(
   init {
     require(syncAggregationTrigger.size + deferredAggregationTrigger.size > 0) { "Specify at least one trigger" }
     deferredAggregationTrigger.forEach { it.onAggregationTrigger(this::handleAggregationTrigger) }
+    // pendingBlobs is only mutated inside @Synchronized methods (locking on `this`), but these gauge
+    // callbacks are invoked from the metrics-scrape thread, so they must take the same lock before
+    // iterating it to avoid a ConcurrentModificationException racing with newBlob/handleAggregationTrigger.
     metricsFacade.createGauge(
       category = LineaMetricsCategory.AGGREGATION,
       name = "proofs.ready",
       description = "Number of proofs pending for aggregation",
       measurementSupplier = {
-        pendingBlobs.size + pendingBlobs.sumOf { it.numberOfBatches }.toLong()
+        synchronized(this) {
+          pendingBlobs.size + pendingBlobs.sumOf { it.numberOfBatches }.toLong()
+        }
       },
     )
     metricsFacade.createGauge(
@@ -51,7 +56,9 @@ class GlobalAggregationCalculator(
       name = "batches.ready",
       description = "Number of batches pending for aggregation",
       measurementSupplier = {
-        pendingBlobs.sumOf { it.numberOfBatches }.toLong()
+        synchronized(this) {
+          pendingBlobs.sumOf { it.numberOfBatches }.toLong()
+        }
       },
     )
     metricsFacade.createGauge(
@@ -59,7 +66,9 @@ class GlobalAggregationCalculator(
       name = "blobs.ready",
       description = "Number of blobs pending for aggregation",
       measurementSupplier = {
-        pendingBlobs.size
+        synchronized(this) {
+          pendingBlobs.size
+        }
       },
     )
   }

--- a/coordinator/core/src/main/kotlin/linea/coordination/EventDispatcher.kt
+++ b/coordinator/core/src/main/kotlin/linea/coordination/EventDispatcher.kt
@@ -1,5 +1,9 @@
 package linea.coordination
 
+import net.consensys.linea.metrics.Counter
+import net.consensys.linea.metrics.MetricsCategory
+import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.linea.metrics.Tag
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.util.function.Consumer
@@ -7,7 +11,23 @@ import java.util.function.Consumer
 class EventDispatcher<T>(
   private val consumers: Map<Consumer<T>, String>,
   private val log: Logger = LogManager.getLogger(EventDispatcher::class.java),
+  metricsFacade: MetricsFacade? = null,
+  metricsCategory: MetricsCategory? = null,
 ) : Consumer<T> {
+  private val consumerFailureCounters: Map<String, Counter>? =
+    if (metricsFacade != null && metricsCategory != null) {
+      val counterFactory = metricsFacade.createCounterFactory(
+        category = metricsCategory,
+        name = "event.consumer.failures",
+        description = "Number of failures while dispatching an event to a consumer",
+      )
+      consumers.values.associateWith { consumerName ->
+        counterFactory.create(listOf(Tag("consumer", consumerName)))
+      }
+    } else {
+      null
+    }
+
   override fun accept(event: T) {
     consumers.forEach { (consumer, name) ->
       try {
@@ -20,6 +40,7 @@ class EventDispatcher<T>(
           e.message,
           e,
         )
+        consumerFailureCounters?.get(name)?.increment()
       }
     }
   }

--- a/coordinator/core/src/main/kotlin/linea/coordination/conflation/ConflationServiceImpl.kt
+++ b/coordinator/core/src/main/kotlin/linea/coordination/conflation/ConflationServiceImpl.kt
@@ -55,7 +55,9 @@ class ConflationServiceImpl(
       category = LineaMetricsCategory.CONFLATION,
       name = "inprogress.blocks",
       description = "Number of blocks in progress of conflation",
-      measurementSupplier = { blocksInProgress.size },
+      // blocksInProgress is only mutated inside @Synchronized methods (locking on `this`); this gauge
+      // callback runs from the metrics-scrape thread, so it takes the same lock before reading.
+      measurementSupplier = { synchronized(this) { blocksInProgress.size } },
     )
     metricsFacade.createGauge(
       category = LineaMetricsCategory.CONFLATION,

--- a/coordinator/ethereum/finalization-monitor/src/main/kotlin/linea/finalization/FinalizationMonitorImpl.kt
+++ b/coordinator/ethereum/finalization-monitor/src/main/kotlin/linea/finalization/FinalizationMonitorImpl.kt
@@ -77,18 +77,21 @@ class FinalizationMonitorImpl(
           handlerName,
           finalizationUpdate.blockNumber,
         )
-        try {
+        val handlerFuture: SafeFuture<*> = try {
           finalizationHandler.handleUpdate(finalizationUpdate)
-            .thenApply { }
         } catch (th: Throwable) {
-          log.error(
-            "Finalization handler={} failed. errorMessage={}",
-            handlerName,
-            th.message,
-            th,
-          )
-          SafeFuture.completedFuture(Unit)
+          SafeFuture.failedFuture<Any?>(th)
         }
+        handlerFuture
+          .thenApply { }
+          .exceptionally { th ->
+            log.error(
+              "Finalization handler={} failed. errorMessage={}",
+              handlerName,
+              th.message,
+              th,
+            )
+          }
       }
     }.thenApply {}
   }

--- a/coordinator/ethereum/test-utils/src/main/kotlin/linea/AccountManager.kt
+++ b/coordinator/ethereum/test-utils/src/main/kotlin/linea/AccountManager.kt
@@ -159,7 +159,6 @@ private open class WhaleBasedAccountManager(
           throw RuntimeException(
             "Failed to send funds from accAddress=${whaleAccount.address}, " +
               "accBalance=$accountBalance, " +
-              "accPrivKey=0x...${whaleAccount.privateKey.takeLast(8)}, " +
               "error: ${e.message}",
           )
         }


### PR DESCRIPTION
- Removes verified-dead `finalizeBlocksEthCall` and a private-key fragment leaking into a test-utils exception message
- Fixes a real bug in `FinalizationMonitorImpl`: async handler failures bypassed the isolation try/catch, silently skipping every subsequent handler and never retrying that finalization update
- Closes an SSRF gap in `conflation_createProverRequests` by validating caller-supplied API hosts against the coordinator's own already-trusted config
- Adds input validation preventing a `ULong` underflow from caller-supplied block ranges
- Fixes two concurrency races where Prometheus gauge callbacks read mutable collections without the lock their mutators use (`GlobalAggregationCalculator`, `ConflationServiceImpl`)
- Adds an observable failure counter to `EventDispatcher`
