### PR TITLE
ci(coordinator): attach config docs artifact to the coordinator GitHub release

### DIFF
--- a/.github/workflows/reusable-component-gh-release.yml
+++ b/.github/workflows/reusable-component-gh-release.yml
@@ -189,6 +189,30 @@ jobs:
             fi
           fi
 
+      - name: Download Coordinator config docs artifact
+        if: inputs.component-name == 'coordinator' && !inputs.dry_run_release
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coordinator-config-docs-${{ needs.compute-docker-tag.outputs.docker_tag_with_suffix }}
+          path: release/config-docs
+
+      - name: Append Coordinator config reference to release note
+        if: inputs.component-name == 'coordinator' && !inputs.dry_run_release
+        shell: bash
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.release-push-tag-changelog.outputs.release_tag }}
+        run: |
+          {
+            echo ""
+            echo "### Configuration Reference"
+            echo ""
+            echo "Generated config documentation attached to this release:"
+            echo ""
+            echo "- [coordinator-config-reference.md](https://github.com/${REPO}/releases/download/${TAG}/coordinator-config-reference.md)"
+            echo "- [coordinator-config-schema.json](https://github.com/${REPO}/releases/download/${TAG}/coordinator-config-schema.json)"
+          } >> release/output.md
+
       - name: Set capitalized component name
         env:
           COMPONENT_NAME: ${{ inputs.component-name }}
@@ -201,6 +225,8 @@ jobs:
           name: ${{ env.COMPONENT_CAP }} v${{ needs.release-push-tag-changelog.outputs.release_version }}
           tag_name: ${{ needs.release-push-tag-changelog.outputs.release_tag }}
           body_path: release/output.md
+          # Attach the coordinator config docs (downloaded above) as release assets.
+          files: ${{ (inputs.component-name == 'coordinator' && !inputs.dry_run_release) && 'release/config-docs/*' || '' }}
           draft: ${{ inputs.draft_release }}
           prerelease: ${{ inputs.pre_release }}
           generate_release_notes: false


### PR DESCRIPTION

In the gh-release job, download the coordinator-config-docs-<tag> artifact and attach the JSON schema + Markdown reference as release assets, and add a 'Configuration Reference' section to the release notes linking to those assets. Gated to the coordinator component and non-dry-run releases.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes gated to coordinator non-dry-run releases; artifact naming matches the existing upload step.
> 
> **Overview**
> For **coordinator** releases (not dry-run), the reusable `gh-release` job now pulls the `coordinator-config-docs-<docker tag>` artifact produced by the coordinator build workflow, uploads those files as release assets, and appends a **Configuration Reference** section to `release/output.md` with download links for `coordinator-config-reference.md` and `coordinator-config-schema.json`.
> 
> Other components are unchanged: `files` stays empty and the new steps are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5547684de5f108a6da7c8c42d1c2317e296e76f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->