### PR TITLE
perf(prover-ray): cut FRI PCS Open −69% and Commit −37% (copy elimination + SIMD-aligned leaf hashing)

### DIFF
--- a/prover-ray/crypto/koalabear/fri/commitment_simd.go
+++ b/prover-ray/crypto/koalabear/fri/commitment_simd.go
@@ -148,20 +148,30 @@ func hashSizedLeaves(t SizedTable, paired bool, out []field.Octuplet) {
 	l := newLeafLayout(t, paired)
 	nbLeaves := len(out)
 
-	parallel.Execute(nbLeaves, func(start, end int) {
-		matrix := make([]field.Element, simdLanes*l.colSize)
-		var hasher *poseidon2.MDHasher
-
-		j := start
-		for ; j+simdLanes <= end; j += simdLanes {
-			l.fillGroup(matrix, t, j)
-			poseidon2.Compressx16Columns(matrix, l.colSize, out[j:j+simdLanes])
-		}
-		for ; j < end; j++ {
-			if hasher == nil {
-				hasher = poseidon2.NewMDHasher()
+	// Parallelize over SIMD groups, not individual leaves: parallel.Execute
+	// splits its range across GOMAXPROCS workers, so parallelizing over leaves
+	// gives each worker a chunk of nbLeaves/GOMAXPROCS. On a many-core machine
+	// that chunk is often < simdLanes, which sent whole sizes down the scalar
+	// path and never touched the AVX-512 batch permutation. Making the group
+	// (16 leaves) the unit of work keeps every full group on the SIMD path and
+	// leaves a single scalar tail of nbLeaves%16 for the whole array.
+	nbGroups := nbLeaves / simdLanes
+	if nbGroups > 0 {
+		parallel.Execute(nbGroups, func(start, end int) {
+			matrix := make([]field.Element, simdLanes*l.colSize)
+			for g := start; g < end; g++ {
+				j := g * simdLanes
+				l.fillGroup(matrix, t, j)
+				poseidon2.Compressx16Columns(matrix, l.colSize, out[j:j+simdLanes])
 			}
+		})
+	}
+
+	// Scalar tail: the final nbLeaves%16 leaves that do not fill a group.
+	if tail := nbGroups * simdLanes; tail < nbLeaves {
+		hasher := poseidon2.NewMDHasher()
+		for j := tail; j < nbLeaves; j++ {
 			out[j] = l.hashLeafScalar(hasher, t, j)
 		}
-	})
+	}
 }

--- a/prover-ray/crypto/koalabear/fri/fri.go
+++ b/prover-ray/crypto/koalabear/fri/fri.go
@@ -159,7 +159,7 @@ type QueryLayerRoots []field.Octuplet
 type RunningQuery []QueryLayer
 
 // Level holds one polynomial introduced at the folding round where the running
-// polynomial's codeword length matches len(Columns[0].Evals). Trees are the
+// polynomial's codeword length matches Columns[0].codewordLen(). Trees are the
 // pre-built paired-leaf Merkle trees backing it.
 type Level struct {
 	Trees []*Tree
@@ -198,7 +198,17 @@ func (l Level) EvalsAt(alphaDeep field.Ext, running []field.Ext) []field.Ext {
 			e := bitReverseExponent(pos, logSize)
 			for c := len(l.Columns) - 1; c >= 0; c-- {
 				column := &l.Columns[c]
-				ev := &column.Evals[pos]
+				// ev is this position's codeword value as an E6. Base columns are
+				// stored as []field.Element (not widened at reconstruct time), so
+				// lift on the stack here; ext columns are read by reference.
+				var ev *field.Ext
+				var lifted field.Ext
+				if column.isBase() {
+					lifted = field.Lift(column.EvalsBase[pos])
+					ev = &lifted
+				} else {
+					ev = &column.EvalsExt[pos]
+				}
 				var columnSum field.Ext
 				for k := range column.Claims {
 					rot := &column.Rotations[k]
@@ -264,7 +274,7 @@ func buildProvePlan(p Params, levels []Level) (provePlan, error) {
 		if len(levels[l].Columns) == 0 {
 			return plan, fmt.Errorf("fri: Prove: levels[%d] has no columns", l)
 		}
-		logCodewordLen := uint8(utils.Log2Ceil(len(levels[l].Columns[0].Evals)))
+		logCodewordLen := uint8(utils.Log2Ceil(levels[l].Columns[0].codewordLen()))
 		if logCodewordLen > p.LogCodewordSize {
 			return plan,
 				fmt.Errorf("fri: Prove: levels[%d] codeword length 2^%d exceeds p.LogCodewordSize=%d",

--- a/prover-ray/crypto/koalabear/fri/pcs.go
+++ b/prover-ray/crypto/koalabear/fri/pcs.go
@@ -408,10 +408,30 @@ type claimRotation struct {
 // Level.EvalsAt). Rotations runs parallel to Claims and lives here — rather than
 // on quotientClaim — so the verifier's claim type (which also instantiates
 // quotientClaim, via claimsForEntry) stays free of prover-only state.
+// quotientColumn holds one opened column's codeword over the domain. To avoid
+// allocating (and, for base columns, widening) a fresh 4N-length []E6 per
+// column in reconstructLevels — the dominant cost of Open — the codeword is
+// aliased directly from the committed table: ext columns keep their []field.Ext
+// in EvalsExt, base columns keep their []field.Element in EvalsBase. Exactly one
+// is non-nil; isBase reports which. Level.EvalsAt lifts base elements to E6 on
+// the stack as it reads them.
 type quotientColumn struct {
-	Evals     []field.Ext // Evals over the codeword domain
+	EvalsExt  []field.Ext     // set for ext columns; nil for base
+	EvalsBase []field.Element // set for base columns; nil for ext
 	Claims    []quotientClaim
 	Rotations []claimRotation
+}
+
+// isBase reports whether this column's codeword is stored as base elements.
+func (c *quotientColumn) isBase() bool { return c.EvalsBase != nil }
+
+// codewordLen returns the number of evaluations in the column's codeword,
+// regardless of whether it is stored as base or ext.
+func (c *quotientColumn) codewordLen() int {
+	if c.EvalsBase != nil {
+		return len(c.EvalsBase)
+	}
+	return len(c.EvalsExt)
 }
 
 func reconstructDomainSize(domain domainLight) (int, error) {
@@ -767,11 +787,11 @@ func (pcs *PCS) reconstructLevels() ([]Level, error) {
 				}
 				trees = append(trees, opening.committed.Tree)
 				for _, entry := range bundle.Entries {
-					evals, err := encodedColumnEvals(opening.committed, entry)
+					column, err := encodedColumnEvals(opening.committed, entry)
 					if err != nil {
 						return nil, err
 					}
-					claims, err := pcs.openingClaimsForEntry(opening, entry)
+					column.Claims, err = pcs.openingClaimsForEntry(opening, entry)
 					if err != nil {
 						return nil, err
 					}
@@ -786,11 +806,8 @@ func (pcs *PCS) reconstructLevels() ([]Level, error) {
 						expo := (size - rot) & (size - 1)
 						rotations[i].Scale.Exp(domain.generator, big.NewInt(int64(expo)))
 					}
-					columns = append(columns, quotientColumn{
-						Evals:     evals,
-						Claims:    claims,
-						Rotations: rotations,
-					})
+					column.Rotations = rotations
+					columns = append(columns, column)
 				}
 			}
 		}
@@ -799,9 +816,9 @@ func (pcs *PCS) reconstructLevels() ([]Level, error) {
 		}
 
 		for columnIdx, column := range columns {
-			if len(column.Evals) != size {
+			if column.codewordLen() != size {
 				return nil, fmt.Errorf("fri: reconstructLevels: column %d has %d evals, want %d",
-					columnIdx, len(column.Evals), size)
+					columnIdx, column.codewordLen(), size)
 			}
 			if err = checkColumnClaimPoints(columnIdx, column.Claims); err != nil {
 				return nil, err
@@ -830,32 +847,33 @@ func (pcs *PCS) roundForSize(sizeLog2 uint8) (uint8, error) {
 	return logD - sizeLog2, nil
 }
 
-func encodedColumnEvals(committed CommitterState, entry deepEntry) ([]field.Ext, error) {
+// encodedColumnEvals aliases the entry's codeword from the committed table into
+// a quotientColumn (populating exactly one of EvalsExt / EvalsBase). The
+// committed table is never mutated after Commit, and both consumers of these
+// slices — Level.EvalsAt during folding and the query phase — read them
+// read-only, so aliasing rather than copying is safe. This avoids allocating a
+// fresh 4N-length []E6 per column (and, for base columns, widening every
+// element to E6) — the dominant cost of reconstructLevels. EvalsAt lifts base
+// elements to E6 on the stack as it reads them.
+func encodedColumnEvals(committed CommitterState, entry deepEntry) (quotientColumn, error) {
 	table := committed.EncodedTable
 	if int(entry.SizeLog2) >= len(table) {
-		return nil, fmt.Errorf("fri: reconstructLevels: missing encoded size %d", entry.SizeLog2)
+		return quotientColumn{}, fmt.Errorf("fri: reconstructLevels: missing encoded size %d", entry.SizeLog2)
 	}
 	sized := table[entry.SizeLog2]
 	if entry.IsExt {
 		if entry.RowIdx >= len(sized.Ext) {
-			return nil, fmt.Errorf("fri: reconstructLevels: size %d missing ext row %d",
+			return quotientColumn{}, fmt.Errorf("fri: reconstructLevels: size %d missing ext row %d",
 				entry.SizeLog2, entry.RowIdx)
 		}
-		evals := make([]field.Ext, len(sized.Ext[entry.RowIdx]))
-		copy(evals, sized.Ext[entry.RowIdx])
-		return evals, nil
+		return quotientColumn{EvalsExt: sized.Ext[entry.RowIdx]}, nil
 	}
 
 	if entry.RowIdx >= len(sized.Base) {
-		return nil, fmt.Errorf("fri: reconstructLevels: size %d missing base row %d",
+		return quotientColumn{}, fmt.Errorf("fri: reconstructLevels: size %d missing base row %d",
 			entry.SizeLog2, entry.RowIdx)
 	}
-	base := sized.Base[entry.RowIdx]
-	evals := make([]field.Ext, len(base))
-	for i := range base {
-		evals[i] = field.Lift(base[i])
-	}
-	return evals, nil
+	return quotientColumn{EvalsBase: sized.Base[entry.RowIdx]}, nil
 }
 
 func (pcs *PCS) claimsForEntry(


### PR DESCRIPTION
## Optimize 1: reconstructLevels

`PCS.Open` was spending around 70% of its wall-clock time in `reconstructLevels`.

Profiling showed that this phase was allocation- and copy-bound rather than arithmetic-bound. For every opened column, it allocated a new `4N`-length `[]field.Ext` and copied the committed codeword into it. For base columns, it also widened every element to `E6` up front, using 6× the storage.

Both copies are unnecessary. The committed table is never mutated after `Commit`, and all consumers of these slices—`Level.EvalsAt` during folding and the query phase—only read from them.

So `quotientColumn` now aliases the committed codeword directly:

- Extension columns keep their existing `[]field.Ext` through `EvalsExt`.
- Base columns keep their existing `[]field.Element` through `EvalsBase`, with no up-front widening.
- `Level.EvalsAt` lifts each base element to `E6` on the stack when it is read, inside the existing parallel loop.

The arithmetic stays the same, but we avoid the large allocations, copies, and serial `[]E6` fill.

`reconstructLevels` itself: 236 ms → 5.8 ms, 613 MB → 3.9 MB.

---

## Optimize 2: Parallelize Leaf Hashing over SIMD Groups, not Individual Leaves (`commitment_simd.go`)

`hashSizedLeaves` parallelized over individual leaves. `parallel.Execute` splits the range across all cores, so on a 192-core machine each worker received a chunk of `nbLeaves/192` leaves — smaller than the AVX-512 batch width (16) for every leaf array up to size 2048. Those sizes never hit the batch Poseidon2 permutation (`Compressx16Columns`) and fell entirely to the scalar `MDHasher`, which also allocates per leaf. Measured: sizes ≤ 2048 were 100% scalar; 4096/8192 were 25% scalar.

Fix: make the 16-leaf SIMD group the unit of parallel work, with one scalar tail of `nbLeaves % 16` for the whole array. Digests are bit-identical (Merkle roots verified in-bench). This removes the scalar leaf-hashing allocations entirely (`allocs/op` 52k → ~7.6k, −85%).

---

## Benchmarks
"large" = sizes=8..12, base=400, ext=400, rate=4, queries=32; Xeon Platinum 8488C, 192 cores.


| Phase | Before | After | Δ time | Δ alloc |
| --- | --- | --- | --- | --- |
| Open (large) | 383 ms | 109 ms | −69% | 621 MB → 12 MB (−98%) |
| Commit (large) | 147 ms | 93 ms | −37% | 1.07 GB → 543 MB (−49%) |

---

## Re-benchmark after merge into `perf/fri`

Merged into `perf/fri` (merge commit `72b761f61`) and re-benchmarked end-to-end on a smaller box.
Config: "large" = sizes=8..12, base=400, ext=400, rate=4, queries=32; **AMD EPYC 9R45, 32 cores**, Go 1.26.0. Means of 3×30 runs; `go test -bench=BenchmarkPCS -benchmem`.

| Phase | Before | After | Δ time | Δ alloc |
| --- | --- | --- | --- | --- |
| Open (large) | 150 ms | 106 ms | −29% | 621 MB → 11.9 MB (−98%) |
| Open (large, shared shifts) | 170 ms | 121 ms | −29% | 622 MB → 12.4 MB (−98%) |
| Commit (large) | 66 ms | 67 ms | ~0% | 410 MB → 410 MB (unchanged) |

Notes:
- The **Open** allocation reduction (−98%, 621 MB → 11.9 MB) reproduces exactly and is the dominant win — it is core-count independent, driven by the copy/widen elimination in `reconstructLevels`. Wall-clock is −29% here vs −69% on 192 cores (the serial `[]E6` fill and scalar hashing scale with core count).
- **Commit** is neutral on 32 cores (no regression). Its speedup is core-count dependent: with only 32 workers, `parallel.Execute(nbLeaves, …)` already handed each worker ≥16 leaves for the large arrays, so the old code already reached the SIMD path. The SIMD-group win manifests on many-core machines (e.g. 192 cores) where `nbLeaves/GOMAXPROCS < 16` had forced the scalar path. The new single-tail code performs at most `nbLeaves % 16` scalar hashes total, so it is never worse than before.

Correctness re-verified on the merge: full `fri` test suite passes (`Verify` end-to-end), `go vet` clean, and `go test -race` passes — the read-only aliasing of the committed table across the parallel `EvalsAt`/query phases is race-free.
