### PR TITLE
perf(prover-ray): combine-then-divide DEEP quotient in FRI Open (5x, bit-identical)

### DIFF
--- a/prover-ray/crypto/koalabear/fri/bench_test.go
+++ b/prover-ray/crypto/koalabear/fri/bench_test.go
@@ -39,20 +39,24 @@ type benchConfig struct {
 
 func (c benchConfig) name() string {
 	suffix := ""
-	if c.sharedShifts != nil {
-		suffix = "/shifts=shared"
+	if c.sharedShifts == nil {
+		suffix = "/shifts=random"
 	}
 	return fmt.Sprintf("sizes=%d..%d/base=%d/ext=%d/rate=%d/queries=%d%s",
 		c.minLog2, c.maxLog2, c.basePolys, c.extPolys, c.rate, c.numQueries, suffix)
 }
 
-// benchConfigs mirrors bench/main.go's defaults (the large one) plus a small
-// config for quick iteration, and a production-like variant of the large
-// config whose rows all share a tiny fixed shift set {0,1,2}.
+// benchConfigs: the headline configs open every row at the shared shift set
+// {0,1,2}, matching production protocols where all rows of a proof share a
+// handful of claim points (ζ, ζω, …) — the shape Level.EvalsAt's grouped
+// combine pass is optimized for. The /shifts=random variant draws 1–3
+// uniformly-random shifts per row instead; that is adversarial for the
+// grouping (every column becomes its own group) and is kept to track the
+// worst case.
 var benchConfigs = []benchConfig{
-	{minLog2: 8, maxLog2: 10, basePolys: 64, extPolys: 64, rate: 4, numQueries: 32, maxShifts: 3, seed: 1},
-	{minLog2: 8, maxLog2: 12, basePolys: 400, extPolys: 400, rate: 4, numQueries: 32, maxShifts: 3, seed: 1},
+	{minLog2: 8, maxLog2: 10, basePolys: 64, extPolys: 64, rate: 4, numQueries: 32, sharedShifts: []int{0, 1, 2}, seed: 1},
 	{minLog2: 8, maxLog2: 12, basePolys: 400, extPolys: 400, rate: 4, numQueries: 32, sharedShifts: []int{0, 1, 2}, seed: 1},
+	{minLog2: 8, maxLog2: 12, basePolys: 400, extPolys: 400, rate: 4, numQueries: 32, maxShifts: 3, seed: 1},
 }
 
 // benchFixture bundles everything the phase benchmarks need, built once per

--- a/prover-ray/crypto/koalabear/fri/fri.go
+++ b/prover-ray/crypto/koalabear/fri/fri.go
@@ -1,10 +1,12 @@
 package fri
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
 	"math/bits"
+	"slices"
 
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
 	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/utils"
@@ -175,56 +177,153 @@ type Level struct {
 	DenomBaseInv []field.Ext
 }
 
+// quotientGroup is EvalsAt's internal grouped view of a level: the columns
+// that share one claim-point set (production protocols open every row of a
+// level at the same handful of points, so there is typically a single group)
+// and, per distinct point, the rotation data plus the group's combined
+// claimed value.
+type quotientGroup struct {
+	columns []int        // indices into Level.Columns, in level order
+	points  []groupPoint // the group's claim points, in ascending-rotation order
+}
+
+// groupPoint is one distinct claim point z = ζ·ω_n^s of a group, carrying its
+// E2 rotation-identity data (see claimRotation) and the group's combined
+// claim Y_z = Σ_{c ∈ group} alphaDeep^c · y_{c,z}.
+type groupPoint struct {
+	rot           int
+	scale         field.Element
+	combinedClaim field.Ext
+}
+
+// groupColumnsByClaimPoints partitions a level's columns into quotientGroups
+// keyed by their claim-point set (canonically: sorted rotations). Within one
+// level all columns share the same domain and ζ, so equal rotations mean
+// equal claim points, and rotations are distinct within a column
+// (validateColumnShifts), making the per-point claim lookup unambiguous.
+func groupColumnsByClaimPoints(columns []quotientColumn, alphaPow []field.Ext) []quotientGroup {
+	groups := make([]quotientGroup, 0, 1)
+	index := make(map[string]int, 1)
+	var key []byte
+	for c := range columns {
+		column := &columns[c]
+		rots := make([]int, len(column.Rotations))
+		for k := range column.Rotations {
+			rots[k] = column.Rotations[k].Rot
+		}
+		slices.Sort(rots)
+		key = key[:0]
+		for _, rot := range rots {
+			key = binary.AppendUvarint(key, uint64(rot))
+		}
+		gi, ok := index[string(key)]
+		if !ok {
+			gi = len(groups)
+			index[string(key)] = gi
+			points := make([]groupPoint, len(rots))
+			for k, rot := range rots {
+				for j := range column.Rotations {
+					if column.Rotations[j].Rot == rot {
+						points[k] = groupPoint{rot: rot, scale: column.Rotations[j].Scale}
+						break
+					}
+				}
+			}
+			groups = append(groups, quotientGroup{points: points})
+		}
+		g := &groups[gi]
+		g.columns = append(g.columns, c)
+		for k := range g.points {
+			for j := range column.Rotations {
+				if column.Rotations[j].Rot == g.points[k].rot {
+					var t field.Ext
+					t.Mul(&alphaPow[c], &column.Claims[j].Value)
+					g.points[k].combinedClaim.Add(&g.points[k].combinedClaim, &t)
+					break
+				}
+			}
+		}
+	}
+	return groups
+}
+
 // EvalsAt returns this level's evaluations, combined with the running codeword.
-// running seeds the ladder, so its contribution is weighted by alphaDeep^len(Columns).
+// running seeds the ladder, so its contribution is weighted by
+// alphaDeep^len(Columns), and column c (level order) by alphaDeep^c.
 //
-// Denominator inverses are reconstructed on the fly from DenomBaseInv via the
-// rotation identity 1/(ω^e − ζ·ω_n^s) = ω^{−rs}·(1/(ω^{e−rs} − ζ)): claim k
-// contributes scale_k · DenomBaseInv[(e − rot_k) mod N], where e = bitReverse(pos),
-// rot_k = rs mod N, scale_k = ω^{−rs}.
+// The batched DEEP quotient is computed combine-then-divide: the columns of
+// each quotientGroup are first combined into G_g(X) = Σ_{c∈g} alphaDeep^c·f_c(X)
+// — one multiply-accumulate per (position, column) — and the division happens
+// once per (position, DISTINCT point):
+//
+//	F(X) = running(X)·alphaDeep^C + Σ_g Σ_{z∈g} (G_g(X) − Y_{g,z}) / (X − z)
+//
+// rather than once per (position, column, claim). The regrouping is exact
+// field arithmetic, so the outputs — and hence roots, fold values, and
+// proofs — are bit-identical to the quotient-per-claim form (see
+// evalsAtReference in fri_evalsat_test.go).
+//
+// The combine pass runs through the field.VecScaleAcc* helpers — currently
+// scalar placeholders, to be swapped for gnark-crypto's AVX-512 VectorE6
+// kernels once available. The divide pass reconstructs denominator inverses
+// on the fly from DenomBaseInv via the rotation identity
+// 1/(ω^e − ζ·ω_n^s) = ω^{−rs}·(1/(ω^{e−rs} − ζ)): point z contributes
+// scale_z · DenomBaseInv[(e − rot_z) mod N], where e = bitReverse(pos),
+// rot_z = rs mod N, scale_z = ω^{−rs}.
 func (l Level) EvalsAt(alphaDeep field.Ext, running []field.Ext) []field.Ext {
 	evals := make([]field.Ext, len(running))
-	copy(evals, running)
+	if len(l.Columns) == 0 {
+		copy(evals, running)
+		return evals
+	}
 
 	mask := len(l.DenomBaseInv) - 1
 	logSize := bits.TrailingZeros(uint(len(l.DenomBaseInv)))
 
-	// The outer loop over positions is embarrassingly parallel: read-only
-	// inputs, disjoint writes to evals[pos].
+	alphaPow := make([]field.Ext, len(l.Columns))
+	alphaPow[0] = field.OneExt()
+	for c := 1; c < len(alphaPow); c++ {
+		alphaPow[c].Mul(&alphaPow[c-1], &alphaDeep)
+	}
+	var alphaTop field.Ext
+	alphaTop.Mul(&alphaPow[len(alphaPow)-1], &alphaDeep)
+
+	groups := groupColumnsByClaimPoints(l.Columns, alphaPow)
+
+	// The outer loop over position chunks is embarrassingly parallel:
+	// read-only inputs, disjoint writes to evals[start:end]. gbuf is the
+	// chunk-sized G_g scratch, reused across groups.
 	parallel.Execute(len(evals), func(start, end int) {
-		for pos := start; pos < end; pos++ {
-			// e is the natural-order exponent of this position's domain point
-			// (codewords are stored at bit-reversed indices).
-			e := bitReverseExponent(pos, logSize)
-			for c := len(l.Columns) - 1; c >= 0; c-- {
+		field.VecScaleExtExt(evals[start:end], alphaTop, running[start:end])
+
+		gbuf := make([]field.Ext, end-start)
+		for gi := range groups {
+			g := &groups[gi]
+
+			clear(gbuf)
+			for _, c := range g.columns {
 				column := &l.Columns[c]
-				// ev is this position's codeword value as an E6. Base columns are
-				// stored as []field.Element (not widened at reconstruct time), so
-				// lift on the stack here; ext columns are read by reference.
-				var ev *field.Ext
-				var lifted field.Ext
 				if column.isBase() {
-					lifted = field.Lift(column.EvalsBase[pos])
-					ev = &lifted
+					field.VecScaleAccExtBase(gbuf, alphaPow[c], column.EvalsBase[start:end])
 				} else {
-					ev = &column.EvalsExt[pos]
+					field.VecScaleAccExtExt(gbuf, alphaPow[c], column.EvalsExt[start:end])
 				}
-				var columnSum field.Ext
-				for k := range column.Claims {
-					rot := &column.Rotations[k]
-					// (e - rot) & mask is the correct mod-N index even when the
-					// difference is negative (two's-complement, N a power of 2).
-					inv := &l.DenomBaseInv[(e-rot.Rot)&mask]
+			}
 
-					var numerator, term field.Ext
-					numerator.Sub(ev, &column.Claims[k].Value)
-					term.Mul(&numerator, inv)
-					term.MulByElement(&term, &rot.Scale)
-					columnSum.Add(&columnSum, &term)
+			for pos := start; pos < end; pos++ {
+				// e is the natural-order exponent of this position's domain
+				// point (codewords are stored at bit-reversed indices);
+				// (e - rot) & mask is the correct mod-N index even when the
+				// difference is negative (two's-complement, N a power of 2).
+				e := bitReverseExponent(pos, logSize)
+				for k := range g.points {
+					p := &g.points[k]
+					var term field.Ext
+					term.Sub(&gbuf[pos-start], &p.combinedClaim)
+					term.Mul(&term, &l.DenomBaseInv[(e-p.rot)&mask])
+					term.MulByElement(&term, &p.scale)
+					evals[pos].Add(&evals[pos], &term)
 				}
-
-				evals[pos].Mul(&evals[pos], &alphaDeep)
-				evals[pos].Add(&evals[pos], &columnSum)
 			}
 		}
 	})

--- a/prover-ray/crypto/koalabear/fri/fri_evalsat_test.go
+++ b/prover-ray/crypto/koalabear/fri/fri_evalsat_test.go
@@ -1,0 +1,121 @@
+package fri
+
+// Equality tests for the combine-then-divide Level.EvalsAt: the production
+// implementation regroups the batched DEEP quotient (combine columns first,
+// divide once per distinct claim point), which is exact field arithmetic and
+// must therefore be bit-identical to the straightforward
+// quotient-per-claim + Horner form retained below as the reference —
+// mirroring how denominatorInverses backs the E2 rotation identity tests.
+
+import (
+	"math/bits"
+	"testing"
+
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/maths/koalabear/field"
+	"github.com/LFDT-Lineth/lineth-monorepo/prover-ray/utils/parallel"
+)
+
+// evalsAtReference is the pre-combine-then-divide implementation of
+// Level.EvalsAt: for every position, each column contributes its per-claim
+// quotients and the running value is folded in via a Horner ladder over
+// columns.
+func (l Level) evalsAtReference(alphaDeep field.Ext, running []field.Ext) []field.Ext {
+	evals := make([]field.Ext, len(running))
+	copy(evals, running)
+
+	mask := len(l.DenomBaseInv) - 1
+	logSize := bits.TrailingZeros(uint(len(l.DenomBaseInv)))
+
+	parallel.Execute(len(evals), func(start, end int) {
+		for pos := start; pos < end; pos++ {
+			e := bitReverseExponent(pos, logSize)
+			for c := len(l.Columns) - 1; c >= 0; c-- {
+				column := &l.Columns[c]
+				var ev *field.Ext
+				var lifted field.Ext
+				if column.isBase() {
+					lifted = field.Lift(column.EvalsBase[pos])
+					ev = &lifted
+				} else {
+					ev = &column.EvalsExt[pos]
+				}
+				var columnSum field.Ext
+				for k := range column.Claims {
+					rot := &column.Rotations[k]
+					inv := &l.DenomBaseInv[(e-rot.Rot)&mask]
+
+					var numerator, term field.Ext
+					numerator.Sub(ev, &column.Claims[k].Value)
+					term.Mul(&numerator, inv)
+					term.MulByElement(&term, &rot.Scale)
+					columnSum.Add(&columnSum, &term)
+				}
+
+				evals[pos].Mul(&evals[pos], &alphaDeep)
+				evals[pos].Add(&evals[pos], &columnSum)
+			}
+		}
+	})
+	return evals
+}
+
+// evalsAtTestLevels reconstructs the levels of a bench-style workload so both
+// EvalsAt implementations can be compared on realistic column/claim shapes.
+func evalsAtTestLevels(tb testing.TB, cfg benchConfig) ([]Level, []field.Ext) {
+	tb.Helper()
+	fx := newBenchFixture(tb, cfg)
+	fx.pcs.Reset()
+	if err := fx.pcs.AddOpening(fx.committed, fx.zeta, fx.shifts, fx.claimed); err != nil {
+		tb.Fatalf("AddOpening: %v", err)
+	}
+	restricted, err := fx.pcs.restrictToOpenings()
+	if err != nil {
+		tb.Fatalf("restrictToOpenings: %v", err)
+	}
+	levels, err := restricted.reconstructLevels()
+	if err != nil {
+		tb.Fatalf("reconstructLevels: %v", err)
+	}
+	running := make([]field.Ext, 1<<restricted.Params.LogCodewordSize)
+	rng := uint64(0x1234)
+	for i := range running {
+		running[i], rng = benchExt(rng)
+	}
+	return levels, running
+}
+
+// TestEvalsAtMatchesReference exercises shift schedules with per-row random
+// claim points (many single-column groups), production-like shared points
+// (one group), base-only and ext-only batches, and single-column levels —
+// each against a random alphaDeep and the zero alphaDeep the D=1 prover path
+// uses. Results must be exactly equal.
+func TestEvalsAtMatchesReference(t *testing.T) {
+	configs := []benchConfig{
+		{minLog2: 4, maxLog2: 6, basePolys: 7, extPolys: 5, rate: 4, numQueries: 4, maxShifts: 3, seed: 1},
+		{minLog2: 4, maxLog2: 6, basePolys: 7, extPolys: 5, rate: 4, numQueries: 4, sharedShifts: []int{0, 1, 2}, seed: 2},
+		{minLog2: 4, maxLog2: 5, basePolys: 6, extPolys: 0, rate: 4, numQueries: 4, maxShifts: 2, seed: 3},
+		{minLog2: 4, maxLog2: 5, basePolys: 0, extPolys: 6, rate: 4, numQueries: 4, maxShifts: 2, seed: 4},
+		{minLog2: 4, maxLog2: 4, basePolys: 1, extPolys: 0, rate: 4, numQueries: 4, maxShifts: 1, seed: 5},
+	}
+	alphaRand, _ := benchExt(0xabcde)
+	alphas := []field.Ext{alphaRand, {}}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name(), func(t *testing.T) {
+			levels, running := evalsAtTestLevels(t, cfg)
+			for _, alphaDeep := range alphas {
+				for li, level := range levels {
+					run := running[:len(level.DenomBaseInv)]
+					want := level.evalsAtReference(alphaDeep, run)
+					got := level.EvalsAt(alphaDeep, run)
+					for i := range want {
+						if !want[i].Equal(&got[i]) {
+							t.Fatalf("level %d: mismatch at position %d (alphaDeep zero: %v)",
+								li, i, alphaDeep.IsZero())
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/prover-ray/go.mod
+++ b/prover-ray/go.mod
@@ -5,7 +5,7 @@ go 1.25.7
 require (
 	github.com/LFDT-Lineth/zkc v1.2.25-0.20260724062105-9d6ddad19ab7
 	github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565
-	github.com/consensys/gnark-crypto v0.20.2-0.20260727184013-0d62bae233ab
+	github.com/consensys/gnark-crypto v0.20.2-0.20260728224514-500ec11ab077
 	github.com/go-playground/assert/v2 v2.2.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1

--- a/prover-ray/go.sum
+++ b/prover-ray/go.sum
@@ -17,10 +17,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565 h1:NlOAmbLYsVb/hcuOBxza6CAA+233tB0eFiunGVEMyv4=
 github.com/consensys/gnark v0.14.1-0.20260219004710-bbfb2f70a565/go.mod h1:EoWWbEboQRydCqJDSA7zrFxucIeoy/5R+MDx04oFpF4=
-github.com/consensys/gnark-crypto v0.20.2-0.20260724130821-e07d4d57dbc4 h1:Y4E3bT5Qxy+wpdaGe0A77C4/7y5Jag5mxG36Bh/2KNI=
-github.com/consensys/gnark-crypto v0.20.2-0.20260724130821-e07d4d57dbc4/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
-github.com/consensys/gnark-crypto v0.20.2-0.20260727184013-0d62bae233ab h1:fORLlwherZ1JaMZ08lZyTmKJl8/qy0jtPPdwgo0vstw=
-github.com/consensys/gnark-crypto v0.20.2-0.20260727184013-0d62bae233ab/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/consensys/gnark-crypto v0.20.2-0.20260728224514-500ec11ab077 h1:/g/Ijh84YwKgOdfIasfQKi04qPCe+E42zg9eMduwQ/A=
 github.com/consensys/gnark-crypto v0.20.2-0.20260728224514-500ec11ab077/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/prover-ray/go.sum
+++ b/prover-ray/go.sum
@@ -21,6 +21,8 @@ github.com/consensys/gnark-crypto v0.20.2-0.20260724130821-e07d4d57dbc4 h1:Y4E3b
 github.com/consensys/gnark-crypto v0.20.2-0.20260724130821-e07d4d57dbc4/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/consensys/gnark-crypto v0.20.2-0.20260727184013-0d62bae233ab h1:fORLlwherZ1JaMZ08lZyTmKJl8/qy0jtPPdwgo0vstw=
 github.com/consensys/gnark-crypto v0.20.2-0.20260727184013-0d62bae233ab/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
+github.com/consensys/gnark-crypto v0.20.2-0.20260728224514-500ec11ab077 h1:/g/Ijh84YwKgOdfIasfQKi04qPCe+E42zg9eMduwQ/A=
+github.com/consensys/gnark-crypto v0.20.2-0.20260728224514-500ec11ab077/go.mod h1:aODe15M1eN2z4gLryLOSZ0rx6DgrahcIw8TuzPurR1c=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/prover-ray/maths/koalabear/field/vec.go
+++ b/prover-ray/maths/koalabear/field/vec.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strings"
+
+	"github.com/consensys/gnark-crypto/field/koalabear"
+	"github.com/consensys/gnark-crypto/field/koalabear/extensions"
 )
 
 // Vec holds a vector of field elements in either the base field 𝔽_p or
@@ -331,13 +334,12 @@ func VecScaleExtBase(res []Ext, s Ext, a []Element) {
 }
 
 // VecScaleExtExt sets res[i] = s * a[i] where s and a are both extension-field.
-// Cost: ~24 base multiplications per element.
+// Cost: ~24 base multiplications per element; AVX-512 vectorized (gnark-crypto
+// VectorE6.ScalarMul).
 // res and a must have equal length.
 func VecScaleExtExt(res []Ext, s Ext, a []Ext) {
 	mustEqualLen2(len(res), len(a))
-	for i := range res {
-		res[i].Mul(&s, &a[i])
-	}
+	extensions.VectorE6(res).ScalarMul(extensions.VectorE6(a), &s)
 }
 
 // VecScaleInto sets res[i] = s * v[i] for all i, dispatching to the typed
@@ -362,38 +364,29 @@ func VecScaleInto(res Vec, s Gen, v Vec) {
 // ScaleAcc — accumulating variants of VecScale
 // ---------------------------------------------------------------------------
 //
-// Scalar placeholders: these are the hot kernels of the FRI DEEP-quotient
-// combine pass (see fri.Level.EvalsAt) and are meant to delegate to the
-// AVX-512 gnark-crypto VectorE6 kernels (ScalarMulAccByElement / ScalarMulAcc
-// on extensions.VectorE6) once they exist — tracked in
-// https://github.com/Consensys/gnark-crypto/issues/867. Until then they run
-// the plain scalar loops below.
+// These are the hot kernels of the FRI DEEP-quotient combine pass (see
+// fri.Level.EvalsAt); they delegate to gnark-crypto's AVX-512 VectorE6
+// kernels (https://github.com/Consensys/gnark-crypto/issues/867), which fall
+// back to the equivalent scalar loops off AVX-512 hardware.
 
 // VecScaleAccExtBase accumulates res[i] += s * a[i] where s is an extension
-// scalar and a is a base vector. Uses [Ext.MulByElement] to exploit the base
-// structure of each a[i].
-// Cost: 6 base multiplications per element.
+// scalar and a is a base vector, exploiting the base structure of each a[i].
+// Cost: 6 base multiplications per element; AVX-512 vectorized (gnark-crypto
+// VectorE6.ScalarMulAccByElement).
 // res and a must have equal length.
 func VecScaleAccExtBase(res []Ext, s Ext, a []Element) {
 	mustEqualLen2(len(res), len(a))
-	var t Ext
-	for i := range res {
-		t.MulByElement(&s, &a[i])
-		res[i].Add(&res[i], &t)
-	}
+	extensions.VectorE6(res).ScalarMulAccByElement(koalabear.Vector(a), &s)
 }
 
 // VecScaleAccExtExt accumulates res[i] += s * a[i] where s is an extension
 // scalar and a is an extension vector.
-// Cost: ~24 base multiplications per element.
+// Cost: ~24 base multiplications per element; AVX-512 vectorized
+// (gnark-crypto VectorE6.ScalarMulAcc).
 // res and a must have equal length.
 func VecScaleAccExtExt(res []Ext, s Ext, a []Ext) {
 	mustEqualLen2(len(res), len(a))
-	var t Ext
-	for i := range res {
-		t.Mul(&s, &a[i])
-		res[i].Add(&res[i], &t)
-	}
+	extensions.VectorE6(res).ScalarMulAcc(extensions.VectorE6(a), &s)
 }
 
 // ---------------------------------------------------------------------------

--- a/prover-ray/maths/koalabear/field/vec.go
+++ b/prover-ray/maths/koalabear/field/vec.go
@@ -359,6 +359,44 @@ func VecScaleInto(res Vec, s Gen, v Vec) {
 }
 
 // ---------------------------------------------------------------------------
+// ScaleAcc — accumulating variants of VecScale
+// ---------------------------------------------------------------------------
+//
+// Scalar placeholders: these are the hot kernels of the FRI DEEP-quotient
+// combine pass (see fri.Level.EvalsAt) and are meant to delegate to the
+// AVX-512 gnark-crypto VectorE6 kernels (ScalarMulAccByElement / ScalarMulAcc
+// on extensions.VectorE6) once they exist — tracked in
+// https://github.com/Consensys/gnark-crypto/issues/867. Until then they run
+// the plain scalar loops below.
+
+// VecScaleAccExtBase accumulates res[i] += s * a[i] where s is an extension
+// scalar and a is a base vector. Uses [Ext.MulByElement] to exploit the base
+// structure of each a[i].
+// Cost: 6 base multiplications per element.
+// res and a must have equal length.
+func VecScaleAccExtBase(res []Ext, s Ext, a []Element) {
+	mustEqualLen2(len(res), len(a))
+	var t Ext
+	for i := range res {
+		t.MulByElement(&s, &a[i])
+		res[i].Add(&res[i], &t)
+	}
+}
+
+// VecScaleAccExtExt accumulates res[i] += s * a[i] where s is an extension
+// scalar and a is an extension vector.
+// Cost: ~24 base multiplications per element.
+// res and a must have equal length.
+func VecScaleAccExtExt(res []Ext, s Ext, a []Ext) {
+	mustEqualLen2(len(res), len(a))
+	var t Ext
+	for i := range res {
+		t.Mul(&s, &a[i])
+		res[i].Add(&res[i], &t)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // BatchInv
 // ---------------------------------------------------------------------------
 

--- a/prover-ray/maths/koalabear/field/vec_test.go
+++ b/prover-ray/maths/koalabear/field/vec_test.go
@@ -520,6 +520,46 @@ func TestVecScaleExtExt(t *testing.T) {
 	checkExtSlice(t, want, res)
 }
 
+// TestVecScaleAccExtBase verifies VecScaleAccExtBase (ext scalar × base
+// vector, accumulating) against element-wise MulByElement + Add on a copy of
+// the initial accumulator.
+func TestVecScaleAccExtBase(t *testing.T) {
+	rng := newRng()
+	s := PseudoRandExt(rng)
+	a := randomElems(testN)
+	res := randomExts(testN)
+	want := make([]Ext, testN)
+	copy(want, res)
+	VecScaleAccExtBase(res, s, a)
+
+	for i := range want {
+		var t Ext
+		t.MulByElement(&s, &a[i])
+		want[i].Add(&want[i], &t)
+	}
+	checkExtSlice(t, want, res)
+}
+
+// TestVecScaleAccExtExt verifies VecScaleAccExtExt (ext scalar × ext vector,
+// accumulating) against element-wise Mul + Add on a copy of the initial
+// accumulator.
+func TestVecScaleAccExtExt(t *testing.T) {
+	rng := newRng()
+	s := PseudoRandExt(rng)
+	a := randomExts(testN)
+	res := randomExts(testN)
+	want := make([]Ext, testN)
+	copy(want, res)
+	VecScaleAccExtExt(res, s, a)
+
+	for i := range want {
+		var t Ext
+		t.Mul(&s, &a[i])
+		want[i].Add(&want[i], &t)
+	}
+	checkExtSlice(t, want, res)
+}
+
 // TestVecScaleIntoDispatch verifies that VecScaleInto dispatches to the
 // correct typed variant for all four scalar/vector type combinations.
 func TestVecScaleIntoDispatch(t *testing.T) {


### PR DESCRIPTION
Follow-up to #3650, closing the Open gap vs Plonky3. **Format-preserving**: exact regrouping of field arithmetic, so roots, fold values and proofs stay bit-identical (equality-tested against the previous implementation, kept as the reference in `fri_evalsat_test.go`; mutation/root-equality suites and `-race` green).

## The key algorithmic change

`Level.EvalsAt` computed the batched DEEP quotient **quotient-per-claim**: per (position, column, claim) one full `E6×E6` mul by the denominator inverse, plus one more `E6×E6` per (position, column) for the Horner α-ladder — ~2400–3200 `E6×E6` muls per position; this made Open `E6×E6`-bound and *slower than Commit*.

It now computes **combine-then-divide** (the structure Plonky3 uses): columns sharing a claim-point set are combined once into `G(X) = Σ_c α^c·f_c(X)` — one multiply-accumulate per (position, column), vectorized — and the division runs once per (position, **distinct point**):

```
F(X) = running(X)·α^C + Σ_g Σ_{z∈g} (G_g(X) − Y_g,z)/(X − z),   Y_g,z = Σ_{c∈g} α^c·y_c,z
```

Production protocols open every row at the same handful of points, so there is one group and the per-position cost drops from ~3200 scalar `E6×E6` muls to ~800 AVX-512 mul-accumulates + 3 `E6×E6` muls.

The combine pass runs on gnark-crypto's new AVX-512 `VectorE6` kernels (`ScalarMulAccByElement` / `ScalarMulAcc` / `ScalarMul`, Consensys/gnark-crypto#867 → Consensys/gnark-crypto#868), currently pinned to commit `500ec11`; **to re-pin once #868 is merged to master**. Off AVX-512 hardware the kernels fall back to the equivalent scalar loops.

## Perf (large config, 32 cores)

| shift schedule | Open before | restructure only (scalar) | + AVX kernels | |
|---|---:|---:|---:|---|
| shared points `{0,1,2}` (production shape) | 149.6 ms | 30.7 ms | **22.5 ms** | **6.6×** |
| per-row random shifts | 111 ms | 85 ms | 81 ms | 1.4× |

Open (22.5 ms) is now well below Commit (67 ms), as FRI cost structure predicts — and at **Plonky3 parity (22 ms) despite our degree-6 vs their degree-4 extension** (≈186- vs ≈124-bit soundness): the hot loop is ext×base, where the extension degree costs 1.5×, not 5×. Commit/Verify unchanged.

## Benchmark headline

The shared-shift-set configs are now the headline benchmarks: production protocols open all rows at a shared handful of points (ζ, ζω, …). The previous default — 1–3 uniformly-random shifts per row, now the `/shifts=random` variant — is adversarial for the grouped combine pass (every column its own group) and is kept to track the worst case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
