### PR TITLE
chore(e2e): bump Web3Signer to 26.7.0-RC1

### DIFF
--- a/docker/compose-spec-l2-services.yml
+++ b/docker/compose-spec-l2-services.yml
@@ -429,7 +429,7 @@ services:
   web3signer:
     hostname: web3signer
     container_name: web3signer
-    image: consensys/web3signer:develop
+    image: consensys/web3signer:26.7.0-RC1
     profiles: [ "l2", "debug", "external-to-monorepo" ]
     ports:
       - "9000:9000"


### PR DESCRIPTION
Update the Web3Signer image used by the monorepo E2E environment from `develop` to the `26.7.0-RC1` release.

Release: https://github.com/Consensys/web3signer/releases/tag/26.7.0-RC1