### PR TITLE
feat(verifier-ray): deriving pcs challenges from Fiat-Shamir

### DIFF
--- a/verifier-ray/src/crypto/fiat_shamir.zig
+++ b/verifier-ray/src/crypto/fiat_shamir.zig
@@ -70,6 +70,10 @@ pub const Transcript = struct {
     /// exactly. Squeezing continues from the current transcript state, so callers
     /// must have absorbed everything up to the query-derivation point.
     pub fn randomManyIntegers(self: *Transcript, out: []usize, comptime upper_bound: usize) void {
+        comptime {
+            if (upper_bound == 0 or (upper_bound & (upper_bound - 1)) != 0)
+                @compileError("fiat_shamir.randomManyIntegers: upper_bound must be a non-zero power of two");
+        }
         var i: usize = 0;
         while (i < out.len) {
             const digest = self.randomDigest();

--- a/verifier-ray/src/crypto/fiat_shamir.zig
+++ b/verifier-ray/src/crypto/fiat_shamir.zig
@@ -1,4 +1,3 @@
-const std = @import("std");
 const field = @import("../field/koalabear.zig");
 const ext = @import("../field/koalabear_ext.zig");
 const field_value = @import("../field/value.zig");
@@ -62,14 +61,15 @@ pub const Transcript = struct {
         };
     }
 
-    /// Fills `out` with integers uniformly reduced modulo `upper_bound` (which
-    /// must be a power of two), consuming one Poseidon2 digest at a time and
-    /// taking its eight base limbs in order. Mirrors prover-ray's
-    /// `RandomManyIntegers`, used to derive FRI query positions from the live
-    /// transcript. Squeezing continues from the current transcript state, so
-    /// callers must have absorbed everything up to the query-derivation point.
-    pub fn randomManyIntegers(self: *Transcript, out: []usize, upper_bound: usize) void {
-        std.debug.assert(upper_bound != 0 and (upper_bound & (upper_bound - 1)) == 0);
+    /// Fills `out` with integers reduced into `[0, upper_bound)`, consuming one
+    /// Poseidon2 digest at a time and taking its eight base limbs in order.
+    /// `upper_bound` must be a power of two, so `% upper_bound` is uniform and
+    /// (being a comptime power-of-two divisor) lowers to a single mask — this
+    /// mirrors prover-ray's `RandomManyIntegers` expression line-for-line. We
+    /// derive FRI query positions and must reproduce the prover's transcript
+    /// exactly. Squeezing continues from the current transcript state, so callers
+    /// must have absorbed everything up to the query-derivation point.
+    pub fn randomManyIntegers(self: *Transcript, out: []usize, comptime upper_bound: usize) void {
         var i: usize = 0;
         while (i < out.len) {
             const digest = self.randomDigest();

--- a/verifier-ray/src/crypto/fiat_shamir.zig
+++ b/verifier-ray/src/crypto/fiat_shamir.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const field = @import("../field/koalabear.zig");
 const ext = @import("../field/koalabear_ext.zig");
 const field_value = @import("../field/value.zig");
@@ -59,5 +60,24 @@ pub const Transcript = struct {
             .B1 = .{ .a0 = challenge[2], .a1 = challenge[3] },
             .B2 = .{ .a0 = challenge[4], .a1 = challenge[5] },
         };
+    }
+
+    /// Fills `out` with integers uniformly reduced modulo `upper_bound` (which
+    /// must be a power of two), consuming one Poseidon2 digest at a time and
+    /// taking its eight base limbs in order. Mirrors prover-ray's
+    /// `RandomManyIntegers`, used to derive FRI query positions from the live
+    /// transcript. Squeezing continues from the current transcript state, so
+    /// callers must have absorbed everything up to the query-derivation point.
+    pub fn randomManyIntegers(self: *Transcript, out: []usize, upper_bound: usize) void {
+        std.debug.assert(upper_bound != 0 and (upper_bound & (upper_bound - 1)) == 0);
+        var i: usize = 0;
+        while (i < out.len) {
+            const digest = self.randomDigest();
+            for (digest) |element| {
+                out[i] = @as(usize, element.value) % upper_bound;
+                i += 1;
+                if (i >= out.len) break;
+            }
+        }
     }
 };

--- a/verifier-ray/src/protocol/root.zig
+++ b/verifier-ray/src/protocol/root.zig
@@ -25,7 +25,7 @@ pub const Spec = struct {
 };
 
 /// All protocol-level data derived from a proof by the higher-level verifier.
-/// Produced by `replay`; consumed by sub-verifiers.
+/// Produced by `replayWithTranscript`; consumed by sub-verifiers.
 pub const Context = struct {
     /// All Fiat-Shamir coins derived across every round, laid out flat.
     /// Indexed by the compiled system's `round_coin_offsets`.
@@ -35,18 +35,26 @@ pub const Context = struct {
     rounds: []const RoundMessage,
 };
 
-/// Replays the prover–verifier transcript to derive all Fiat-Shamir coins.
+/// Replays the prover–verifier transcript to derive all Fiat-Shamir coins,
+/// using a *caller-owned* `transcript`.
 ///
 /// For each message round, absorbs the round's oracle commitments, public
 /// columns, and cell scalars into the Poseidon2 Merkle-Damgård transcript, then
 /// squeezes that round's coins into `all_coins` at the position fixed by `spec`.
-/// This is the only function that touches the Fiat-Shamir transcript.
+///
+/// The transcript is passed in by pointer and left in place after the last
+/// protocol coin is squeezed, so a transcript-continuing sub-verifier (e.g. PCS,
+/// which derives its own FRI challenges from the same Fiat-Shamir state) can
+/// resume from exactly here. The protocol layer stays sub-verifier-agnostic: it
+/// only knows about round messages and protocol coins, never the FRI squeeze
+/// schedule.
 ///
 /// `spec.round_coin_counts[0]` is the pre-round-1 phase and is always 0, so the
 /// message rounds are `round_coin_counts[1..]`; `rounds` must have that length.
 /// `spec` is comptime-validated for internal consistency, so its callers — both
 /// `verifier.verify` and direct test callers — get the same guarantees.
-pub fn replay(
+pub fn replayWithTranscript(
+    transcript: *fiat_shamir.Transcript,
     comptime spec: Spec,
     rounds: []const RoundMessage,
 ) Error![spec.total_round_coins]Coin {
@@ -71,7 +79,6 @@ pub fn replay(
     // round per remaining entry.
     if (rounds.len != spec.round_coin_counts.len - 1) return error.InvalidRoundCount;
 
-    var transcript = fiat_shamir.Transcript.init();
     var all_coins: [spec.total_round_coins]Coin = undefined;
 
     inline for (1..spec.round_coin_counts.len) |round_index| {

--- a/verifier-ray/src/query/pcs.zig
+++ b/verifier-ray/src/query/pcs.zig
@@ -141,7 +141,7 @@ pub fn deriveChallenges(
 
     transcript.updateExt(fri_proof.final_poly);
 
-    const codeword_size = @as(usize, 1) << @intCast(system.params.log_codeword_size);
+    const codeword_size = comptime @as(usize, 1) << @intCast(system.params.log_codeword_size);
     transcript.randomManyIntegers(&challenges.query_positions, codeword_size);
     return challenges;
 }

--- a/verifier-ray/src/query/pcs.zig
+++ b/verifier-ray/src/query/pcs.zig
@@ -110,12 +110,21 @@ pub fn PcsChallenges(comptime system: System) type {
 ///
 /// This is the transcript-touching counterpart of `verify`, which then checks
 /// the proof against these challenges without touching the transcript.
+///
+/// `fri_proof.round_roots` must hold exactly `num_rounds - 1` intermediate-layer
+/// roots (the shape `verify` later re-checks). This is validated up front rather
+/// than trusted: the absorb loop indexes the fixed-size `fold_alphas` buffer by
+/// root position, so an over-long `round_roots` would otherwise write past it —
+/// a stack overflow in release builds, where bounds checks are disabled.
 pub fn deriveChallenges(
     comptime system: System,
     transcript: *fiat_shamir.Transcript,
     fri_proof: fri.Proof,
-) PcsChallenges(system) {
+) fri.Error!PcsChallenges(system) {
     const num_rounds = comptime system.params.numRounds();
+    const want_round_roots = if (num_rounds > 0) num_rounds - 1 else 0;
+    if (fri_proof.round_roots.len != want_round_roots) return fri.Error.InvalidRoundRootCount;
+
     var challenges = PcsChallenges(system){};
 
     // One challenge per intermediate layer root, absorbing the root between

--- a/verifier-ray/src/query/pcs.zig
+++ b/verifier-ray/src/query/pcs.zig
@@ -3,6 +3,7 @@ const field = @import("../field/koalabear.zig");
 const ext = @import("../field/koalabear_ext.zig");
 const poseidon2 = @import("../crypto/poseidon2.zig");
 const merkle = @import("../crypto/merkle.zig");
+const fiat_shamir = @import("../crypto/fiat_shamir.zig");
 const fri = @import("fri.zig");
 
 /// The PCS/DEEP-quotient layer: input-tree authentication, per-level Horner
@@ -62,6 +63,7 @@ pub const SizeBundle = struct {
 pub const System = struct {
     params: fri.Params,
     layout: []const SizeBundle,
+    zeta_coin_index: usize = 0,
 };
 
 pub const OpeningProof = struct {
@@ -85,6 +87,55 @@ pub const VerifyInput = struct {
     query_positions: []const usize,
     proof: OpeningProof,
 };
+
+/// The Fiat-Shamir–derived PCS challenges consumed by `verify`: the per-round
+/// fold challenges and the FRI query positions. Both are sized by the System's
+/// comptime `params`, so nothing allocates. Produced by `deriveChallenges` (the
+/// transcript-touching half) and passed to `verify` (pure arithmetic) — this
+/// separation lets the caller thread one transcript through replay → PCS.
+pub fn PcsChallenges(comptime system: System) type {
+    const num_rounds = comptime system.params.numRounds();
+    return struct {
+        fold_alphas: [num_rounds]ext.Ext = undefined,
+        query_positions: [system.params.num_queries]usize = undefined,
+    };
+}
+
+/// Derives the FRI fold challenges and query positions by continuing
+/// `transcript` — the live Fiat-Shamir state `protocol.replayWithTranscript`
+/// left after squeezing the protocol coins (mirroring prover-ray's
+/// `fs := rt.GetFS()`), so the proof cannot dictate them. Only the running-layer
+/// roots and the final polynomial are absorbed; the challenges are pure squeezes
+/// returned as a value. `transcript` is caller-owned and advanced in place.
+///
+/// This is the transcript-touching counterpart of `verify`, which then checks
+/// the proof against these challenges without touching the transcript.
+pub fn deriveChallenges(
+    comptime system: System,
+    transcript: *fiat_shamir.Transcript,
+    fri_proof: fri.Proof,
+) PcsChallenges(system) {
+    const num_rounds = comptime system.params.numRounds();
+    var challenges = PcsChallenges(system){};
+
+    // One challenge per intermediate layer root, absorbing the root between
+    // squeezes; then the final round's challenge, with no root after it. When a
+    // protocol never folds (num_rounds == 0) the buffer is empty and this whole
+    // block is elided at comptime rather than indexing into a [0]ext.Ext.
+    if (comptime num_rounds > 0) {
+        for (fri_proof.round_roots, 0..) |root, i| {
+            challenges.fold_alphas[i] = transcript.randomExt();
+            transcript.updateElements(&root);
+        }
+        challenges.fold_alphas[num_rounds - 1] = transcript.randomExt();
+    }
+
+    transcript.updateExt(fri_proof.final_poly);
+
+    const codeword_size = @as(usize, 1) << @intCast(system.params.log_codeword_size);
+    transcript.randomManyIntegers(&challenges.query_positions, codeword_size);
+    return challenges;
+}
 
 pub fn verify(comptime system: System, input: VerifyInput) Error!void {
     const params = system.params;

--- a/verifier-ray/src/verifier.zig
+++ b/verifier-ray/src/verifier.zig
@@ -1,9 +1,12 @@
 const protocol = @import("protocol/root.zig");
 const vanishing = @import("query/vanishing.zig");
 const logderivativesum = @import("query/logderivativesum.zig");
+const pcs = @import("query/pcs.zig");
+const fiat_shamir = @import("crypto/fiat_shamir.zig");
+const poseidon2 = @import("crypto/poseidon2.zig");
 const ext = @import("field/koalabear_ext.zig");
-const profiling = @import("profiling.zig");
 // TODO(new-sub-verifier): add import here — step 1 below.
+const profiling = @import("profiling.zig");
 
 // ── Adding a new sub-verifier ─────────────────────────────────────────────────
 //
@@ -31,7 +34,7 @@ const profiling = @import("profiling.zig");
 //           .claims = proof.sub_verifier_claims,
 //       });
 //
-//  Nothing else changes: protocol.Spec, protocol.replay, and all existing
+//  Nothing else changes: protocol.Spec, protocol.replayWithTranscript, and all existing
 //  sub-verifiers are untouched.
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -40,6 +43,12 @@ const profiling = @import("profiling.zig");
 pub const Systems = struct {
     vanishing: vanishing.System,
     logderivativesum: logderivativesum.System = .{},
+    /// FRI/PCS opening verifier. Optional: `null` for protocols with no
+    /// polynomial commitment (the pre-PCS shape, still used by many test
+    /// fixtures). When present, `verify` derives the PCS opening coins (zeta,
+    /// fold challenges, query positions) from the shared Fiat-Shamir transcript
+    /// and checks the opening — the coins are never taken from the proof.
+    pcs: ?pcs.System = null,
     // TODO(new-sub-verifier): add compiled system field here — step 2 above.
 };
 
@@ -50,7 +59,7 @@ pub const Systems = struct {
 /// Protocol-level round messages (public columns + cells) are shared across
 /// every sub-verifier. Sub-verifier-specific claim slices are routed only to
 /// the verifier that registered them. Coins are not stored here — they are
-/// re-derived deterministically by `protocol.replay` from the round messages.
+/// re-derived deterministically by `protocol.replayWithTranscript` from the round messages.
 pub const Proof = struct {
     rounds: []const protocol.RoundMessage,
     // vanishing claims
@@ -61,7 +70,21 @@ pub const Proof = struct {
     /// defaults to an empty slice, which produces `MissingDynamicModuleSize`
     /// if any dynamic module is present.
     module_sizes: []const usize = &.{},
+    /// The PCS opening, present iff `Systems.pcs` is set. Carries only the data
+    /// the verifier is entitled to trust from the prover — the batch roots, the
+    /// claimed evaluations, and the opening proof. The opening COINS (zeta, fold
+    /// challenges, query positions) are NOT here: `verify` derives them from the
+    /// transcript so the prover cannot choose them.
+    pcs_opening: ?PcsOpening = null,
     // TODO(new-sub-verifier): add claim fields here if needed — step 3 above.
+};
+
+/// The prover-supplied half of a PCS opening (everything except the
+/// Fiat-Shamir-derived coins). See `Proof.pcs_opening`.
+pub const PcsOpening = struct {
+    roots: []const poseidon2.Digest,
+    claimed_values: []const ext.Ext,
+    proof: pcs.OpeningProof,
 };
 
 /// Verifies a proof against the compiled protocol in three steps:
@@ -85,9 +108,14 @@ pub fn verify(
     profiling.reset();
     if (comptime profiling.r5_marks) profiling.markR5Value(profiling.Mark.verify_start, 0);
 
-    // Step 1 — replay transcript, derive all coins. `replay` comptime-validates
-    // `spec` internal consistency and returns the stack-allocated coin array.
-    const all_coins = try protocol.replay(spec, proof.rounds);
+    // Step 1 — replay transcript, derive all coins. The transcript is owned here
+    // and threaded by pointer: `protocol` absorbs the round messages + squeezes
+    // the protocol coins, leaving it at the state a transcript-continuing
+    // sub-verifier (PCS, below) resumes from. `replayWithTranscript`
+    // comptime-validates `spec` internal consistency and returns the
+    // stack-allocated coin array.
+    var transcript = fiat_shamir.Transcript.init();
+    const all_coins = try protocol.replayWithTranscript(&transcript, spec, proof.rounds);
     if (comptime profiling.r5_marks) profiling.markR5Value(profiling.Mark.transcript_done, 0);
 
     // Step 2 — assemble the shared context routed to every sub-verifier.
@@ -98,6 +126,26 @@ pub fn verify(
 
     // Step 3 — dispatch each sub-verifier with ctx + its own claims.
     // TODO(new-sub-verifier): add dispatch call here — step 4 above.
+
+    // PCS (when present): continue the SAME transcript to derive the opening
+    // challenges — zeta (the shared opening point), the FRI fold challenges, and
+    // the query positions — then check the opening. Deriving them here (not
+    // reading them from the proof) is the whole point: the prover cannot choose
+    // the Fiat-Shamir challenges. Challenge derivation touches the transcript;
+    // the check is pure arithmetic.
+    if (comptime systems.pcs) |pcs_system| {
+        const opening = proof.pcs_opening orelse return error.MissingPcsOpening;
+        const pcs_challenges = pcs.deriveChallenges(pcs_system, &transcript, opening.proof.fri_proof);
+        try pcs.verify(pcs_system, .{
+            .roots = opening.roots,
+            .claimed_values = opening.claimed_values,
+            .zeta = all_coins[pcs_system.zeta_coin_index],
+            .fold_alphas = &pcs_challenges.fold_alphas,
+            .query_positions = &pcs_challenges.query_positions,
+            .proof = opening.proof,
+        });
+    }
+
     if (comptime profiling.r5_marks) profiling.markR5Value(profiling.Mark.vanishing_start, 0);
     try vanishing.verify(systems.vanishing, .{
         .ctx = ctx,

--- a/verifier-ray/src/verifier.zig
+++ b/verifier-ray/src/verifier.zig
@@ -5,8 +5,8 @@ const pcs = @import("query/pcs.zig");
 const fiat_shamir = @import("crypto/fiat_shamir.zig");
 const poseidon2 = @import("crypto/poseidon2.zig");
 const ext = @import("field/koalabear_ext.zig");
-// TODO(new-sub-verifier): add import here — step 1 below.
 const profiling = @import("profiling.zig");
+// TODO(new-sub-verifier): add import here — step 1 below.
 
 // ── Adding a new sub-verifier ─────────────────────────────────────────────────
 //
@@ -135,7 +135,7 @@ pub fn verify(
     // the check is pure arithmetic.
     if (comptime systems.pcs) |pcs_system| {
         const opening = proof.pcs_opening orelse return error.MissingPcsOpening;
-        const pcs_challenges = pcs.deriveChallenges(pcs_system, &transcript, opening.proof.fri_proof);
+        const pcs_challenges = try pcs.deriveChallenges(pcs_system, &transcript, opening.proof.fri_proof);
         try pcs.verify(pcs_system, .{
             .roots = opening.roots,
             .claimed_values = opening.claimed_values,

--- a/verifier-ray/test/golden_test.zig
+++ b/verifier-ray/test/golden_test.zig
@@ -192,7 +192,7 @@ test "fiat-shamir transcript matches prover-ray golden cases" {
 
 test "transcript derives round coins matching prover-ray golden vectors" {
     for (vectors.runtime_trace_cases) |case| {
-        // protocol.replay is parametric on a comptime Spec; the golden vectors
+        // protocol.replayWithTranscript is parametric on a comptime Spec; the golden vectors
         // carry runtime coin counts, so drive fiat_shamir.Transcript directly
         // and compare against the prover-ray expected values.
         var transcript = fiat_shamir.Transcript.init();

--- a/verifier-ray/test/transcript_test.zig
+++ b/verifier-ray/test/transcript_test.zig
@@ -45,7 +45,8 @@ test "replay absorbs commitments, public columns, and cells, then squeezes coins
         .round_coin_offsets = &[_]usize{ 0, 0 },
         .total_round_coins = 2,
     };
-    const coins = try protocol.replay(spec, &rounds);
+    var transcript = fiat_shamir.Transcript.init();
+    const coins = try protocol.replayWithTranscript(&transcript, spec, &rounds);
 
     // Consecutive coins must be distinct: randomDigest() absorbs a zero
     // separator between squeezes, so identical back-to-back outputs indicate

--- a/verifier-ray/test/vanishing_test.zig
+++ b/verifier-ray/test/vanishing_test.zig
@@ -8,6 +8,7 @@ const protocol = verifier_ray.protocol;
 const vanishing = verifier_ray.query.vanishing;
 const logderivativesum = verifier_ray.query.logderivativesum;
 const commitment_mod = verifier_ray.crypto.commitment;
+const fiat_shamir = verifier_ray.crypto.fiat_shamir;
 
 test "vanishing quotient honest scenarios match prover-ray" {
     try std.testing.expect(fixtures.scenarios.len > 0);
@@ -17,7 +18,8 @@ test "vanishing quotient honest scenarios match prover-ray" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
         const proof = try buildProofData(arena.allocator(), case.honest);
-        const coins = try protocol.replay(spec, proof.rounds);
+        var transcript = fiat_shamir.Transcript.init();
+        const coins = try protocol.replayWithTranscript(&transcript, spec, proof.rounds);
         const ctx = protocol.Context{ .all_coins = &coins, .rounds = proof.rounds };
         try vanishing.verify(system, .{
             .ctx = ctx,
@@ -41,7 +43,8 @@ test "vanishing quotient invalid scenarios fail identity" {
         var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
         defer arena.deinit();
         const proof = try buildProofData(arena.allocator(), invalid);
-        const coins = try protocol.replay(spec, proof.rounds);
+        var transcript = fiat_shamir.Transcript.init();
+        const coins = try protocol.replayWithTranscript(&transcript, spec, proof.rounds);
         const ctx = protocol.Context{ .all_coins = &coins, .rounds = proof.rounds };
         try std.testing.expectError(
             error.QuotientIdentityMismatch,
@@ -69,7 +72,8 @@ test "dynamic vanishing module sizes are required and validated" {
         defer arena.deinit();
 
         const valid = try buildProofData(arena.allocator(), case.honest);
-        const coins = try protocol.replay(spec, valid.rounds);
+        var transcript = fiat_shamir.Transcript.init();
+        const coins = try protocol.replayWithTranscript(&transcript, spec, valid.rounds);
         const ctx = protocol.Context{ .all_coins = &coins, .rounds = valid.rounds };
 
         try vanishing.verify(system, .{ .ctx = ctx, .witness_claims = valid.witness_claims, .quotient_claims = valid.quotient_claims, .module_sizes = valid.module_sizes });

--- a/verifier-ray/test/verifier_test.zig
+++ b/verifier-ray/test/verifier_test.zig
@@ -56,7 +56,7 @@ test "verify rejects proof with wrong round count" {
 
 // numRounds = log_plaintext_size - log_final_poly_size = 2, so fold_alphas has
 // length 2 and the FRI proof carries numRounds-1 = 1 running-layer root.
-const coin_system = pcs.System{
+const challenge_system = pcs.System{
     .params = .{ .log_codeword_size = 4, .log_plaintext_size = 2, .num_queries = 3 },
     .layout = &.{},
 };
@@ -67,7 +67,9 @@ fn digest(seed: u32) poseidon2.Digest {
     return d;
 }
 
-fn coinFriProof(root_seed: u32) fri.Proof {
+// A well-shaped FRI proof for `challenge_system`: exactly num_rounds-1 == 1
+// running-layer root.
+fn challengeFriProof(root_seed: u32) fri.Proof {
     const S = struct {
         var round_roots: [1]poseidon2.Digest = undefined;
         var final_poly = [_]ext.Ext{ext.Ext.zero()};
@@ -78,7 +80,7 @@ fn coinFriProof(root_seed: u32) fri.Proof {
 
 test "deriveChallenges produces the comptime-sized shape" {
     var transcript = fiat_shamir.Transcript.init();
-    const challenges = pcs.deriveChallenges(coin_system, &transcript, coinFriProof(1));
+    const challenges = try pcs.deriveChallenges(challenge_system, &transcript, challengeFriProof(1));
     try std.testing.expectEqual(@as(usize, 2), challenges.fold_alphas.len);
     try std.testing.expectEqual(@as(usize, 3), challenges.query_positions.len);
     // Query positions are reduced into the codeword domain (2^4 = 16).
@@ -88,8 +90,8 @@ test "deriveChallenges produces the comptime-sized shape" {
 test "deriveChallenges is deterministic for the same transcript and proof" {
     var t1 = fiat_shamir.Transcript.init();
     var t2 = fiat_shamir.Transcript.init();
-    const a = pcs.deriveChallenges(coin_system, &t1, coinFriProof(7));
-    const b = pcs.deriveChallenges(coin_system, &t2, coinFriProof(7));
+    const a = try pcs.deriveChallenges(challenge_system, &t1, challengeFriProof(7));
+    const b = try pcs.deriveChallenges(challenge_system, &t2, challengeFriProof(7));
     for (a.fold_alphas, b.fold_alphas) |x, y| try std.testing.expect(x.eql(y));
     try std.testing.expectEqualSlices(usize, &a.query_positions, &b.query_positions);
 }
@@ -102,8 +104,8 @@ test "deriveChallenges depends on the absorbed transcript state" {
     var t2 = fiat_shamir.Transcript.init();
     t1.updateExt(&.{ext.Ext.fromUints(.{ 1, 0, 0, 0, 0, 0 })});
     t2.updateExt(&.{ext.Ext.fromUints(.{ 2, 0, 0, 0, 0, 0 })});
-    const a = pcs.deriveChallenges(coin_system, &t1, coinFriProof(9));
-    const b = pcs.deriveChallenges(coin_system, &t2, coinFriProof(9));
+    const a = try pcs.deriveChallenges(challenge_system, &t1, challengeFriProof(9));
+    const b = try pcs.deriveChallenges(challenge_system, &t2, challengeFriProof(9));
     var any_alpha_differs = false;
     for (a.fold_alphas, b.fold_alphas) |x, y| {
         if (!x.eql(y)) any_alpha_differs = true;

--- a/verifier-ray/test/verifier_test.zig
+++ b/verifier-ray/test/verifier_test.zig
@@ -4,6 +4,11 @@ const verifier_ray = @import("verifier_ray");
 const protocol = verifier_ray.protocol;
 const verifier = verifier_ray.verifier;
 const vanishing = verifier_ray.query.vanishing;
+const pcs = verifier_ray.query.pcs;
+const fri = verifier_ray.query.fri;
+const fiat_shamir = verifier_ray.crypto.fiat_shamir;
+const ext = verifier_ray.field.koalabear_ext;
+const poseidon2 = verifier_ray.crypto.poseidon2;
 
 test "verify completes replay, routing, and dispatch on a minimal proof" {
     const spec = protocol.Spec{
@@ -38,4 +43,70 @@ test "verify rejects proof with wrong round count" {
             .quotient_claims = &.{},
         }),
     );
+}
+
+// ── PCS challenge derivation ──────────────────────────────────────────────────
+//
+// `deriveChallenges` squeezes the FRI fold challenges + query positions from a
+// caller-owned transcript. There is no golden vector for these on this branch
+// (the pcs.zig fixtures carry synthetic challenges, not transcript-derived
+// ones), so these tests pin the properties that must hold regardless of the
+// exact values: correct shape, determinism, and sensitivity to the absorbed
+// transcript state.
+
+// numRounds = log_plaintext_size - log_final_poly_size = 2, so fold_alphas has
+// length 2 and the FRI proof carries numRounds-1 = 1 running-layer root.
+const coin_system = pcs.System{
+    .params = .{ .log_codeword_size = 4, .log_plaintext_size = 2, .num_queries = 3 },
+    .layout = &.{},
+};
+
+fn digest(seed: u32) poseidon2.Digest {
+    var d: poseidon2.Digest = undefined;
+    for (&d, 0..) |*limb, i| limb.* = verifier_ray.field.koalabear.Element.init(seed +% @as(u32, @intCast(i)));
+    return d;
+}
+
+fn coinFriProof(root_seed: u32) fri.Proof {
+    const S = struct {
+        var round_roots: [1]poseidon2.Digest = undefined;
+        var final_poly = [_]ext.Ext{ext.Ext.zero()};
+    };
+    S.round_roots[0] = digest(root_seed);
+    return .{ .round_roots = &S.round_roots, .final_poly = &S.final_poly, .running_queries = &.{} };
+}
+
+test "deriveChallenges produces the comptime-sized shape" {
+    var transcript = fiat_shamir.Transcript.init();
+    const challenges = pcs.deriveChallenges(coin_system, &transcript, coinFriProof(1));
+    try std.testing.expectEqual(@as(usize, 2), challenges.fold_alphas.len);
+    try std.testing.expectEqual(@as(usize, 3), challenges.query_positions.len);
+    // Query positions are reduced into the codeword domain (2^4 = 16).
+    for (challenges.query_positions) |p| try std.testing.expect(p < 16);
+}
+
+test "deriveChallenges is deterministic for the same transcript and proof" {
+    var t1 = fiat_shamir.Transcript.init();
+    var t2 = fiat_shamir.Transcript.init();
+    const a = pcs.deriveChallenges(coin_system, &t1, coinFriProof(7));
+    const b = pcs.deriveChallenges(coin_system, &t2, coinFriProof(7));
+    for (a.fold_alphas, b.fold_alphas) |x, y| try std.testing.expect(x.eql(y));
+    try std.testing.expectEqualSlices(usize, &a.query_positions, &b.query_positions);
+}
+
+test "deriveChallenges depends on the absorbed transcript state" {
+    // Two transcripts diverging before derivation must yield different
+    // challenges: they are a function of the live Fiat-Shamir state, not just
+    // the proof. (Absorb one differing element up front.)
+    var t1 = fiat_shamir.Transcript.init();
+    var t2 = fiat_shamir.Transcript.init();
+    t1.updateExt(&.{ext.Ext.fromUints(.{ 1, 0, 0, 0, 0, 0 })});
+    t2.updateExt(&.{ext.Ext.fromUints(.{ 2, 0, 0, 0, 0, 0 })});
+    const a = pcs.deriveChallenges(coin_system, &t1, coinFriProof(9));
+    const b = pcs.deriveChallenges(coin_system, &t2, coinFriProof(9));
+    var any_alpha_differs = false;
+    for (a.fold_alphas, b.fold_alphas) |x, y| {
+        if (!x.eql(y)) any_alpha_differs = true;
+    }
+    try std.testing.expect(any_alpha_differs);
 }


### PR DESCRIPTION
Building on top of #3655.

This PR derives the PCS opening challenges—`zeta`, the FRI fold challenges, and the query positions—from the verifier’s Fiat–Shamir transcript, then wires them into `verifier.verify`.

Previously, the PCS layer in `query/pcs.zig` only exposed a `verify` function that received these challenges as caller-supplied inputs. In tests, they were read directly from the golden vectors.

### PCS integration Follow-ups

* Make PCS mandatory in `verifier.zig` by removing the optional `Systems.pcs` and `Proof.pcs_opening` fields once every protocol includes a commitment.
* Prove the link between the PCS and vanishing claims. `witness_claims` and `quotient_claims` should be re-sliced from the FRI-authenticated `entry_claims`, rather than supplied independently by the proof.
* Double-check whether the PCS batch roots need to be bound explicitly to the transcript. `pcs.verify` currently authenticates against the prover-supplied `pcs_opening.roots`, but those roots are not yet tied to the oracle commitments absorbed by the transcript. As a result, `zeta` may not be provably bound to the root used for the opening. --> Wire verifier.zig PCS path to use bound roots instead of proof-supplied roots; remove roots from PcsOpening
* Cleanup tests

