### PR TITLE
test(jvm-libs): fix unit test failure due to unmatched connection ref…

### DIFF
--- a/jvm-libs/generic/json-rpc/src/test/kotlin/net/consensys/linea/jsonrpc/client/JsonRpcV2ClientImplTest.kt
+++ b/jvm-libs/generic/json-rpc/src/test/kotlin/net/consensys/linea/jsonrpc/client/JsonRpcV2ClientImplTest.kt
@@ -536,14 +536,14 @@ class JsonRpcV2ClientImplTest {
       assertThatThrownBy { reqFuture.get() }
         .isInstanceOfSatisfying(ExecutionException::class.java) {
           assertThat(it.cause).isInstanceOfSatisfying(ConnectException::class.java) {
-            assertThat(it.message).matches("Connection refused.*: localhost/127.0.0.1:.*")
+            assertThat(it.message).matches("Connection refused.*: localhost/127\\.0\\.0\\.1:\\d+.*")
           }
         }
 
       assertThat(retryPredicateCalls.size).isEqualTo(2)
       assertThatThrownBy { retryPredicateCalls[0].orElseThrow() }
         .isInstanceOfSatisfying(ConnectException::class.java) {
-          assertThat(it.message).matches("Connection refused.*: localhost/127.0.0.1:.*")
+          assertThat(it.message).matches("Connection refused.*: localhost/127\\.0\\.0\\.1:\\d+.*")
         }
     }
   }
@@ -569,7 +569,7 @@ class JsonRpcV2ClientImplTest {
       assertThatThrownBy { reqFuture.get() }
         .isInstanceOfSatisfying(ExecutionException::class.java) {
           assertThat(it.cause).isInstanceOfSatisfying(ConnectException::class.java) {
-            assertThat(it.message).matches("Connection refused.*: /127.0.0.1:19472.*")
+            assertThat(it.message).matches("Connection refused.*: /127\\.0\\.0\\.1:19472.*")
           }
         }
       assertThat(retryPredicateCalls).hasSizeBetween(1, 3)

--- a/jvm-libs/generic/json-rpc/src/test/kotlin/net/consensys/linea/jsonrpc/client/JsonRpcV2ClientImplTest.kt
+++ b/jvm-libs/generic/json-rpc/src/test/kotlin/net/consensys/linea/jsonrpc/client/JsonRpcV2ClientImplTest.kt
@@ -536,14 +536,14 @@ class JsonRpcV2ClientImplTest {
       assertThatThrownBy { reqFuture.get() }
         .isInstanceOfSatisfying(ExecutionException::class.java) {
           assertThat(it.cause).isInstanceOfSatisfying(ConnectException::class.java) {
-            assertThat(it.message).contains("Connection refused: localhost/127.0.0.1:")
+            assertThat(it.message).matches("Connection refused.*: localhost/127.0.0.1:.*")
           }
         }
 
       assertThat(retryPredicateCalls.size).isEqualTo(2)
       assertThatThrownBy { retryPredicateCalls[0].orElseThrow() }
         .isInstanceOfSatisfying(ConnectException::class.java) {
-          assertThat(it.message).contains("Connection refused: localhost/127.0.0.1:")
+          assertThat(it.message).matches("Connection refused.*: localhost/127.0.0.1:.*")
         }
     }
   }
@@ -569,7 +569,7 @@ class JsonRpcV2ClientImplTest {
       assertThatThrownBy { reqFuture.get() }
         .isInstanceOfSatisfying(ExecutionException::class.java) {
           assertThat(it.cause).isInstanceOfSatisfying(ConnectException::class.java) {
-            assertThat(it.message).contains("Connection refused: /127.0.0.1:19472")
+            assertThat(it.message).matches("Connection refused.*: /127.0.0.1:19472.*")
           }
         }
       assertThat(retryPredicateCalls).hasSizeBetween(1, 3)


### PR DESCRIPTION
Recent failure on coordinator unit testing workflow (from `JsonRpcV2ClientImplTest`): https://github.com/LFDT-Lineth/lineth-monorepo/actions/runs/30534486439/job/90844638596?pr=3421

What was happening:

  - The ConnectException is thrown from JDK native code (Net.c / the socket connect() path) when the OS returns ECONNREFUSED.
  - On macOS, the JDK produces just the strerror text: Connection refused.
  - On Linux, the JDK appends its own detail string to the errno message, giving Connection refused (connect failed) — the (connect failed) is the
  JDK's default "operation" label combined with the errno description via JNU_ThrowByNameWithMessageAndLastError.

  So the stable, common part across both is Connection refused, then some optional platform-specific suffix, then : localhost/127.0.0.1:<port>.

 The right fix:

  assertThat(it.message).matches("Connection refused.*: localhost/127.0.0.1:.*")

  - Connection refused — matches both platforms
  - .* — absorbs the  (connect failed) that Linux/CI adds
  - : localhost/127.0.0.1: — the host part
  - trailing .* — matches the dynamic port (needed because AssertJ's matches() requires a full-string match)

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion changes with no production or runtime behavior impact.
> 
> **Overview**
> Fixes flaky **`JsonRpcV2ClientImplTest`** failures on Linux CI by loosening how **`ConnectException`** messages are asserted when simulating connection refused errors.
> 
> Assertions that previously required an exact substring (e.g. `Connection refused: localhost/127.0.0.1:`) now use full-string regex **`matches()`** patterns so they tolerate JDK-specific suffixes such as **`(connect failed)`** on Linux while still checking the host/port (including dynamic WireMock ports via `\d+`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7032e9a832ef0de3472b8c9d80b8c8a2e8dbac78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->