### PR TITLE
chore(arithmetization): update ZkC to version v1.2.25

### DIFF
--- a/arithmetization/Makefile
+++ b/arithmetization/Makefile
@@ -11,7 +11,7 @@ REPO_ROOT := $(abspath $(MAKEFILE_DIR)/..)
 ZKC ?= $(REPO_ROOT)/zkc
 ZKC_REPO ?= https://github.com/LFDT-Lineth/zkc.git
 # Optional: pin a commit or branch (e.g. 763f30878e5fc260f0d88863c9883c904f8fc056). Leave empty for default branch.
-ZKC_REF ?= v1.2.24
+ZKC_REF ?= v1.2.25
 
 # Used to install Sail for ACT4 host builds.
 ACT4_RISCV_DIR ?= $(HOME)/riscv

--- a/arithmetization/src/main/riscv/instruction_processing/r_type.zkc
+++ b/arithmetization/src/main/riscv/instruction_processing/r_type.zkc
@@ -7,7 +7,9 @@ include "../utils/sign_extend.zkc"
 include "../utils/signed_comparisons.zkc"
 include "../utils/multiplication.zkc"
 include "../../lib/keccak/impl.zkc"
-include "../../lib/poseidon2/ram.zkc"
+// TODO: poseidon2 is commented out for now until the "dangling register" issue
+// is resolved.
+//include "../../lib/poseidon2/ram.zkc"
 
 // Process a RISC-V R-type instruction, writing the result into the register file.
 //
@@ -39,7 +41,7 @@ include "../../lib/poseidon2/ram.zkc"
 // treat register values as two's-complement integers.  Division and remainder
 // follow RISC-V semantics: division by zero returns −1 (or the dividend for REM),
 // and signed overflow (INT_MIN / −1) returns INT_MIN (or 0 for REM).
-fn process_R_type_instruction<registers, ram, state_row0, state_row1, state_row2, state_row3, state_row4, b0, b1, b2, b3, b4, c, d, padded_input_block, poseidon2_state>(opcode:Opcode, instruction_parameters:u25) {
+fn process_R_type_instruction<registers, ram, state_row0, state_row1, state_row2, state_row3, state_row4, b0, b1, b2, b3, b4, c, d, padded_input_block>(opcode:Opcode, instruction_parameters:u25) {
     var funct7:Funct7
     var rs2:Register
     var rs1:Register
@@ -328,7 +330,9 @@ fn process_R_type_instruction<registers, ram, state_row0, state_row1, state_row2
             // Note: registers[rd] isn't changed by this instruction, it's merely read.
             // poseidon2(input_addr, output_addr) applies the permutation to the
             // STATE_WIDTH field elements at input_addr, writing the result to output_addr.
-            poseidon2(v1 as Address, registers[rd] as Address)
+
+            // TODO: poseidon2 comment out until the "dangling register" issue resolved.
+            //poseidon2(v1 as Address, registers[rd] as Address)
             return
         }
 

--- a/arithmetization/src/main/riscv/interpreter.zkc
+++ b/arithmetization/src/main/riscv/interpreter.zkc
@@ -8,7 +8,7 @@ include "instruction_processing/s_type.zkc"
 include "instruction_processing/j_type.zkc"
 include "instruction_processing/u_type.zkc"
 
-fn interpreter<registers, ram, state_row0, state_row1, state_row2, state_row3, state_row4, b0, b1, b2, b3, b4, c, d, padded_input_block, poseidon2_state>(instruction:u32, pc:Address) -> (new_pc:Address) {
+fn interpreter<registers, ram, state_row0, state_row1, state_row2, state_row3, state_row4, b0, b1, b2, b3, b4, c, d, padded_input_block>(instruction:u32, pc:Address) -> (new_pc:Address) {
 
     var instruction_parameters:u25
     var instruction_type:Type

--- a/arithmetization/src/main/riscv/main.zkc
+++ b/arithmetization/src/main/riscv/main.zkc
@@ -13,7 +13,7 @@ include "utils/register_utils.zkc"
 include "memory.zkc"
 
 // TODO @Ghost
-fn main<registers, ram, state_row0, state_row1, state_row2, state_row3, state_row4, b0, b1, b2, b3, b4, c, d, padded_input_block, poseidon2_state>() {
+fn main<registers, ram, state_row0, state_row1, state_row2, state_row3, state_row4, b0, b1, b2, b3, b4, c, d, padded_input_block>() {
     var instruction:Instruction
     var clock_cycle:u32 = 0
     var entry_point:Address


### PR DESCRIPTION
This updates ZkC to the latest version which includes key performance improvements around tracing.  In particular, it is now using significantly less memory when tracing.

This PR implements issue(s) #

### Checklist

* [ ] I wrote new tests for my new core changes.
* [ ] I have successfully ran tests, style checker and build against my new changes locally.
* [ ] If this change is deployed to any environment (including Devnet), E2E test coverage exists or is included in this
  PR.
* [ ] I have informed the team of any breaking changes if there are any.
